### PR TITLE
NIFI-14951 Aligned those processors and controller services whose property names do not match the human-friendly display names in extended bundle nifi-azure-bundle.

### DIFF
--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
@@ -53,9 +53,10 @@ import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR
 
 public abstract class AbstractAzureBlobProcessor_v12 extends AbstractProcessor {
 
+    public static final String OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME = "blob-name";
+
     public static final PropertyDescriptor BLOB_NAME = new PropertyDescriptor.Builder()
-            .name("blob-name")
-            .displayName("Blob Name")
+            .name("Blob Name")
             .description("The full name of the blob")
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureDataLakeStorageProcessor.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureDataLakeStorageProcessor.java
@@ -21,6 +21,7 @@ import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Relationship;
@@ -77,5 +78,10 @@ public abstract class AbstractAzureDataLakeStorageProcessor extends AbstractProc
         final ADLSCredentialsDetails credentialsDetails = credentialsService.getCredentialsDetails(attributes);
 
         return clientFactory.getStorageClient(credentialsDetails);
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(AzureStorageUtils.OLD_ADLS_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.ADLS_CREDENTIALS_SERVICE.getName());
     }
 }

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/AbstractAzureCosmosDBProcessor.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/AbstractAzureCosmosDBProcessor.java
@@ -33,6 +33,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Relationship;
@@ -56,32 +57,28 @@ public abstract class AbstractAzureCosmosDBProcessor extends AbstractProcessor {
         .build();
 
     static final PropertyDescriptor CONNECTION_SERVICE = new PropertyDescriptor.Builder()
-        .name("azure-cosmos-db-connection-service")
-        .displayName("Cosmos DB Connection Service")
+        .name("Cosmos DB Connection Service")
         .description("If configured, the controller service used to obtain the connection string and access key")
         .required(false)
         .identifiesControllerService(AzureCosmosDBConnectionService.class)
         .build();
 
     static final PropertyDescriptor DATABASE_NAME = new PropertyDescriptor.Builder()
-        .name("azure-cosmos-db-name")
-        .displayName("Cosmos DB Name")
+        .name("Cosmos DB Name")
         .description("The database name or id. This is used as the namespace for document collections or containers")
         .required(true)
         .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
         .build();
 
     static final PropertyDescriptor CONTAINER_ID = new PropertyDescriptor.Builder()
-        .name("azure-cosmos-db-container-id")
-        .displayName("Cosmos DB Container ID")
+        .name("Cosmos DB Container ID")
         .description("The unique identifier for the container")
         .required(true)
         .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
         .build();
 
     static final PropertyDescriptor PARTITION_KEY = new PropertyDescriptor.Builder()
-        .name("azure-cosmos-db-partition-key")
-        .displayName("Cosmos DB Partition Key")
+        .name("Cosmos DB Partition Key")
         .description("The partition key used to distribute data among servers")
         .required(true)
         .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
@@ -172,6 +169,17 @@ public abstract class AbstractAzureCosmosDBProcessor extends AbstractProcessor {
                 this.cosmosClient = null;
             }
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(AzureCosmosDBUtils.OLD_URI_DESCRIPTOR_NAME, AzureCosmosDBUtils.URI.getName());
+        config.renameProperty(AzureCosmosDBUtils.OLD_DB_ACCESS_KEY_DESCRIPTOR_NAME, AzureCosmosDBUtils.DB_ACCESS_KEY.getName());
+        config.renameProperty(AzureCosmosDBUtils.OLD_CONSISTENCY_DESCRIPTOR_NAME, AzureCosmosDBUtils.CONSISTENCY.getName());
+        config.renameProperty("azure-cosmos-db-connection-service", CONNECTION_SERVICE.getName());
+        config.renameProperty("azure-cosmos-db-name", DATABASE_NAME.getName());
+        config.renameProperty("azure-cosmos-db-container-id", CONTAINER_ID.getName());
+        config.renameProperty("azure-cosmos-db-partition-key", PARTITION_KEY.getName());
     }
 
     protected String getURI(final ProcessContext context) {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/AzureCosmosDBUtils.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/AzureCosmosDBUtils.java
@@ -28,10 +28,12 @@ public final class AzureCosmosDBUtils {
     public static final String CONSISTENCY_SESSION = "SESSION";
     public static final String CONSISTENCY_CONSISTENT_PREFIX = "CONSISTENT_PREFIX";
     public static final String CONSISTENCY_EVENTUAL = "EVENTUAL";
+    public static final String OLD_URI_DESCRIPTOR_NAME = "azure-cosmos-db-uri";
+    public static final String OLD_DB_ACCESS_KEY_DESCRIPTOR_NAME = "azure-cosmos-db-key";
+    public static final String OLD_CONSISTENCY_DESCRIPTOR_NAME = "azure-cosmos-db-consistency-level";
 
     public static final PropertyDescriptor URI = new PropertyDescriptor.Builder()
-        .name("azure-cosmos-db-uri")
-        .displayName("Cosmos DB URI")
+        .name("Cosmos DB URI")
         .description("Cosmos DB URI, typically in the form of https://{databaseaccount}.documents.azure.com:443/"
             + " Note this host URL is for Cosmos DB with Core SQL API"
             + " from Azure Portal (Overview->URI)")
@@ -41,8 +43,7 @@ public final class AzureCosmosDBUtils {
         .build();
 
     public static final PropertyDescriptor DB_ACCESS_KEY = new PropertyDescriptor.Builder()
-        .name("azure-cosmos-db-key")
-        .displayName("Cosmos DB Access Key")
+        .name("Cosmos DB Access Key")
         .description("Cosmos DB Access Key from Azure Portal (Settings->Keys). "
             + "Choose a read-write key to enable database or container creation at run time")
         .required(false)
@@ -51,8 +52,7 @@ public final class AzureCosmosDBUtils {
         .build();
 
     public static final PropertyDescriptor CONSISTENCY = new PropertyDescriptor.Builder()
-        .name("azure-cosmos-db-consistency-level")
-        .displayName("Cosmos DB Consistency Level")
+        .name("Cosmos DB Consistency Level")
         .description("Choose from five consistency levels on the consistency spectrum. "
             + "Refer to Cosmos DB documentation for their differences")
         .required(false)

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/PutAzureCosmosDBRecord.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/PutAzureCosmosDBRecord.java
@@ -30,6 +30,7 @@ import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
@@ -66,16 +67,14 @@ public class PutAzureCosmosDBRecord extends AbstractAzureCosmosDBProcessor {
     static final AllowableValue UPSERT_CONFLICT = new AllowableValue("UPSERT", "Upsert", "Conflicting records will be upserted, and FlowFile will not be routed to failure");
 
     static final PropertyDescriptor RECORD_READER_FACTORY = new PropertyDescriptor.Builder()
-            .name("record-reader")
-            .displayName("Record Reader")
+            .name("Record Reader")
             .description("Specifies the Controller Service to use for parsing incoming data and determining the data's schema")
             .identifiesControllerService(RecordReaderFactory.class)
             .required(true)
             .build();
 
     static final PropertyDescriptor INSERT_BATCH_SIZE = new PropertyDescriptor.Builder()
-            .name("insert-batch-size")
-            .displayName("Insert Batch Size")
+            .name("Insert Batch Size")
             .description("The number of records to group together for one single insert operation against Cosmos DB")
             .defaultValue("20")
             .required(false)
@@ -83,8 +82,7 @@ public class PutAzureCosmosDBRecord extends AbstractAzureCosmosDBProcessor {
             .build();
 
     static final PropertyDescriptor CONFLICT_HANDLE_STRATEGY = new PropertyDescriptor.Builder()
-            .name("azure-cosmos-db-conflict-handling-strategy")
-            .displayName("Cosmos DB Conflict Handling Strategy")
+            .name("Cosmos DB Conflict Handling Strategy")
             .description("Choose whether to ignore or upsert when conflict error occurs during insertion")
             .required(false)
             .allowableValues(IGNORE_CONFLICT, UPSERT_CONFLICT)
@@ -200,6 +198,14 @@ public class PutAzureCosmosDBRecord extends AbstractAzureCosmosDBProcessor {
                 session.transfer(flowFile, REL_FAILURE);
             }
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        super.migrateProperties(config);
+        config.renameProperty("record-reader", RECORD_READER_FACTORY.getName());
+        config.renameProperty("insert-batch-size", INSERT_BATCH_SIZE.getName());
+        config.renameProperty("azure-cosmos-db-conflict-handling-strategy", CONFLICT_HANDLE_STRATEGY.getName());
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
@@ -129,16 +129,14 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
     private static final String FORMAT_STORAGE_CONNECTION_STRING_FOR_SAS_TOKEN = "BlobEndpoint=https://%s.blob.core.%s/;SharedAccessSignature=%s";
 
     static final PropertyDescriptor NAMESPACE = new PropertyDescriptor.Builder()
-            .name("event-hub-namespace")
-            .displayName("Event Hub Namespace")
+            .name("Event Hub Namespace")
             .description("The namespace that the Azure Event Hubs is assigned to. This is generally equal to <Event Hub Names>-ns.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .required(true)
             .build();
     static final PropertyDescriptor EVENT_HUB_NAME = new PropertyDescriptor.Builder()
-            .name("event-hub-name")
-            .displayName("Event Hub Name")
+            .name("Event Hub Name")
             .description("The name of the event hub to pull messages from.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -146,21 +144,16 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .build();
     static final PropertyDescriptor SERVICE_BUS_ENDPOINT = AzureEventHubUtils.SERVICE_BUS_ENDPOINT;
     static final PropertyDescriptor ACCESS_POLICY_NAME = new PropertyDescriptor.Builder()
-            .name("event-hub-shared-access-policy-name")
-            .displayName("Shared Access Policy Name")
+            .name("Shared Access Policy Name")
             .description("The name of the shared access policy. This policy must have Listen claims.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .required(false)
             .build();
-    static final PropertyDescriptor POLICY_PRIMARY_KEY = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(AzureEventHubUtils.POLICY_PRIMARY_KEY)
-            .name("event-hub-shared-access-policy-primary-key")
-            .build();
+    static final PropertyDescriptor POLICY_PRIMARY_KEY = AzureEventHubUtils.POLICY_PRIMARY_KEY;
     static final PropertyDescriptor USE_MANAGED_IDENTITY = AzureEventHubUtils.USE_MANAGED_IDENTITY;
     static final PropertyDescriptor CONSUMER_GROUP = new PropertyDescriptor.Builder()
-            .name("event-hub-consumer-group")
-            .displayName("Consumer Group")
+            .name("Consumer Group")
             .description("The name of the consumer group to use.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -169,8 +162,7 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .build();
 
     static final PropertyDescriptor RECORD_READER = new PropertyDescriptor.Builder()
-            .name("record-reader")
-            .displayName("Record Reader")
+            .name("Record Reader")
             .description("The Record Reader to use for reading received messages." +
                     " The event hub name can be referred by Expression Language '${eventhub.name}' to access a schema.")
             .identifiesControllerService(RecordReaderFactory.class)
@@ -178,8 +170,7 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .required(false)
             .build();
     static final PropertyDescriptor RECORD_WRITER = new PropertyDescriptor.Builder()
-            .name("record-writer")
-            .displayName("Record Writer")
+            .name("Record Writer")
             .description("The Record Writer to use for serializing Records to an output FlowFile." +
                     " The event hub name can be referred by Expression Language '${eventhub.name}' to access a schema." +
                     " If not specified, each message will create a FlowFile.")
@@ -194,16 +185,14 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             "end-of-stream", "End of stream",
             "Ignore old retained messages even if exist, start reading new ones from now.");
     static final PropertyDescriptor INITIAL_OFFSET = new PropertyDescriptor.Builder()
-            .name("event-hub-initial-offset")
-            .displayName("Initial Offset")
+            .name("Initial Offset")
             .description("Specify where to start receiving messages if offset is not yet stored in the checkpoint store.")
             .required(true)
             .allowableValues(INITIAL_OFFSET_START_OF_STREAM, INITIAL_OFFSET_END_OF_STREAM)
             .defaultValue(INITIAL_OFFSET_END_OF_STREAM)
             .build();
     static final PropertyDescriptor PREFETCH_COUNT = new PropertyDescriptor.Builder()
-            .name("event-hub-prefetch-count")
-            .displayName("Prefetch Count")
+            .name("Prefetch Count")
             .defaultValue("The number of messages to fetch from the event hub before processing." +
                     " This parameter affects throughput." +
                     " The more prefetch count, the better throughput in general, but consumes more resources (RAM)." +
@@ -217,8 +206,7 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .required(true)
             .build();
     static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
-            .name("event-hub-batch-size")
-            .displayName("Batch Size")
+            .name("Batch Size")
             .description("The number of messages to process within a NiFi session." +
                     " This parameter affects throughput and consistency." +
                     " NiFi commits its session and Event Hubs checkpoints after processing this number of messages." +
@@ -231,8 +219,7 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .required(true)
             .build();
     static final PropertyDescriptor RECEIVE_TIMEOUT = new PropertyDescriptor.Builder()
-            .name("event-hub-message-receive-timeout")
-            .displayName("Message Receive Timeout")
+            .name("Message Receive Timeout")
             .description("The amount of time this consumer should wait to receive the Batch Size before returning.")
             .defaultValue("1 min")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
@@ -241,8 +228,7 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .build();
 
     static final PropertyDescriptor CHECKPOINT_STRATEGY = new PropertyDescriptor.Builder()
-            .name("checkpoint-strategy")
-            .displayName("Checkpoint Strategy")
+            .name("Checkpoint Strategy")
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .required(true)
             .allowableValues(CheckpointStrategy.class)
@@ -251,8 +237,7 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .build();
 
     static final PropertyDescriptor STORAGE_ACCOUNT_NAME = new PropertyDescriptor.Builder()
-            .name("storage-account-name")
-            .displayName("Storage Account Name")
+            .name("Storage Account Name")
             .description("Name of the Azure Storage account to store event hub consumer group state.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -260,8 +245,7 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .dependsOn(CHECKPOINT_STRATEGY, CheckpointStrategy.AZURE_BLOB_STORAGE)
             .build();
     static final PropertyDescriptor STORAGE_ACCOUNT_KEY = new PropertyDescriptor.Builder()
-            .name("storage-account-key")
-            .displayName("Storage Account Key")
+            .name("Storage Account Key")
             .description("The Azure Storage account key to store event hub consumer group state.")
             .sensitive(true)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
@@ -270,8 +254,7 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .dependsOn(CHECKPOINT_STRATEGY, CheckpointStrategy.AZURE_BLOB_STORAGE)
             .build();
     static final PropertyDescriptor STORAGE_SAS_TOKEN = new PropertyDescriptor.Builder()
-            .name("storage-sas-token")
-            .displayName("Storage SAS Token")
+            .name("Storage SAS Token")
             .description("The Azure Storage SAS token to store Event Hub consumer group state. Always starts with a ? character.")
             .sensitive(true)
             .addValidator(StandardValidators.createRegexMatchingValidator(SAS_TOKEN_PATTERN, true,
@@ -281,8 +264,7 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .dependsOn(CHECKPOINT_STRATEGY, CheckpointStrategy.AZURE_BLOB_STORAGE)
             .build();
     static final PropertyDescriptor STORAGE_CONTAINER_NAME = new PropertyDescriptor.Builder()
-            .name("storage-container-name")
-            .displayName("Storage Container Name")
+            .name("Storage Container Name")
             .description("Name of the Azure Storage container to store the event hub consumer group state." +
                     " If not specified, event hub name is used.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
@@ -358,6 +340,23 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
     @Override
     public void migrateProperties(final PropertyConfiguration config) {
         config.removeProperty("event-hub-consumer-hostname");
+        config.renameProperty("event-hub-namespace", NAMESPACE.getName());
+        config.renameProperty("event-hub-name", EVENT_HUB_NAME.getName());
+        config.renameProperty("event-hub-shared-access-policy-name", ACCESS_POLICY_NAME.getName());
+        config.renameProperty("event-hub-consumer-group", CONSUMER_GROUP.getName());
+        config.renameProperty("record-reader", RECORD_READER.getName());
+        config.renameProperty("record-writer", RECORD_WRITER.getName());
+        config.renameProperty("event-hub-initial-offset", INITIAL_OFFSET.getName());
+        config.renameProperty("event-hub-prefetch-count", PREFETCH_COUNT.getName());
+        config.renameProperty("event-hub-batch-size", BATCH_SIZE.getName());
+        config.renameProperty("event-hub-message-receive-timeout", RECEIVE_TIMEOUT.getName());
+        config.renameProperty("checkpoint-strategy", CHECKPOINT_STRATEGY.getName());
+        config.renameProperty("storage-account-name", STORAGE_ACCOUNT_NAME.getName());
+        config.renameProperty("storage-account-key", STORAGE_ACCOUNT_KEY.getName());
+        config.renameProperty("storage-sas-token", STORAGE_SAS_TOKEN.getName());
+        config.renameProperty("storage-container-name", STORAGE_CONTAINER_NAME.getName());
+        config.renameProperty("event-hub-shared-access-policy-primary-key", POLICY_PRIMARY_KEY.getName());
+        config.renameProperty(AzureEventHubUtils.OLD_USE_MANAGED_IDENTITY_DESCRIPTOR_NAME, USE_MANAGED_IDENTITY.getName());
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
@@ -46,6 +46,7 @@ import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
@@ -121,8 +122,7 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
     static final PropertyDescriptor USE_MANAGED_IDENTITY = AzureEventHubUtils.USE_MANAGED_IDENTITY;
 
     static final PropertyDescriptor CONSUMER_GROUP = new PropertyDescriptor.Builder()
-            .name("Event Hub Consumer Group")
-            .displayName("Consumer Group")
+            .name("Consumer Group")
             .description("The name of the consumer group to use when pulling events")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
@@ -131,8 +131,7 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
             .build();
 
     static final PropertyDescriptor ENQUEUE_TIME = new PropertyDescriptor.Builder()
-            .name("Event Hub Message Enqueue Time")
-            .displayName("Message Enqueue Time")
+            .name("Message Enqueue Time")
             .description("A timestamp (ISO-8601 Instant) formatted as YYYY-MM-DDThhmmss.sssZ (2016-01-01T01:01:01.000Z) from which messages "
                     + "should have been enqueued in the Event Hub to start reading from")
             .addValidator(StandardValidators.ISO8601_INSTANT_VALIDATOR)
@@ -140,16 +139,14 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
             .required(false)
             .build();
     static final PropertyDescriptor RECEIVER_FETCH_SIZE = new PropertyDescriptor.Builder()
-            .name("Partition Recivier Fetch Size")
-            .displayName("Partition Receiver Fetch Size")
+            .name("Partition Receiver Fetch Size")
             .description("The number of events that a receiver should fetch from an Event Hubs partition before returning. The default is " + DEFAULT_FETCH_SIZE)
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .required(false)
             .build();
     static final PropertyDescriptor RECEIVER_FETCH_TIMEOUT = new PropertyDescriptor.Builder()
-            .name("Partition Receiver Timeout (millseconds)")
-            .displayName("Partition Receiver Timeout")
+            .name("Partition Receiver Timeout")
             .description("The amount of time in milliseconds a Partition Receiver should wait to receive the Fetch Size before returning. The default is " + DEFAULT_FETCH_TIMEOUT.toMillis())
             .addValidator(StandardValidators.POSITIVE_LONG_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
@@ -309,6 +306,16 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
         } finally {
             partitionIds.offer(partitionId);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty("Event Hub Consumer Group", CONSUMER_GROUP.getName());
+        config.renameProperty("Event Hub Message Enqueue Time", ENQUEUE_TIME.getName());
+        config.renameProperty("Partition Recivier Fetch Size", RECEIVER_FETCH_SIZE.getName());
+        config.renameProperty("Partition Receiver Timeout (millseconds)", RECEIVER_FETCH_TIMEOUT.getName());
+        config.renameProperty(AzureEventHubUtils.OLD_POLICY_PRIMARY_KEY_DESCRIPTOR_NAME, POLICY_PRIMARY_KEY.getName());
+        config.renameProperty(AzureEventHubUtils.OLD_USE_MANAGED_IDENTITY_DESCRIPTOR_NAME, USE_MANAGED_IDENTITY.getName());
     }
 
     /**

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
@@ -39,6 +39,7 @@ import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
@@ -93,16 +94,14 @@ public class PutAzureEventHub extends AbstractProcessor implements AzureEventHub
     static final PropertyDescriptor USE_MANAGED_IDENTITY = AzureEventHubUtils.USE_MANAGED_IDENTITY;
 
     static final PropertyDescriptor PARTITIONING_KEY_ATTRIBUTE_NAME = new PropertyDescriptor.Builder()
-            .name("partitioning-key-attribute-name")
-            .displayName("Partitioning Key Attribute Name")
+            .name("Partitioning Key Attribute Name")
             .description("If specified, the value from argument named by this field will be used as a partitioning key to be used by event hub.")
             .required(false)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .addValidator(StandardValidators.ATTRIBUTE_KEY_VALIDATOR)
             .build();
     static final PropertyDescriptor MAX_BATCH_SIZE = new PropertyDescriptor.Builder()
-            .name("max-batch-size")
-            .displayName("Maximum Batch Size")
+            .name("Maximum Batch Size")
             .description("Maximum number of FlowFiles processed for each Processor invocation")
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
@@ -184,6 +183,14 @@ public class PutAzureEventHub extends AbstractProcessor implements AzureEventHub
         }
 
         processFlowFileResults(context, session, stopWatch, flowFileResults);
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty("partitioning-key-attribute-name", PARTITIONING_KEY_ATTRIBUTE_NAME.getName());
+        config.renameProperty("max-batch-size", MAX_BATCH_SIZE.getName());
+        config.renameProperty(AzureEventHubUtils.OLD_POLICY_PRIMARY_KEY_DESCRIPTOR_NAME, POLICY_PRIMARY_KEY.getName());
+        config.renameProperty(AzureEventHubUtils.OLD_USE_MANAGED_IDENTITY_DESCRIPTOR_NAME, USE_MANAGED_IDENTITY.getName());
     }
 
     protected EventHubProducerClient createEventHubProducerClient(final ProcessContext context) throws ProcessException {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/AzureEventHubUtils.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/AzureEventHubUtils.java
@@ -43,10 +43,11 @@ public final class AzureEventHubUtils {
     public static final AllowableValue AZURE_CHINA_ENDPOINT = new AllowableValue(".servicebus.chinacloudapi.cn", "Azure China", "Servicebus endpoint for China");
     public static final AllowableValue AZURE_GERMANY_ENDPOINT = new AllowableValue(".servicebus.cloudapi.de", "Azure Germany", "Servicebus endpoint for Germany");
     public static final AllowableValue AZURE_US_GOV_ENDPOINT = new AllowableValue(".servicebus.usgovcloudapi.net", "Azure US Government", "Servicebus endpoint for US Government");
+    public static final String OLD_POLICY_PRIMARY_KEY_DESCRIPTOR_NAME = "Shared Access Policy Primary Key";
+    public static final String OLD_USE_MANAGED_IDENTITY_DESCRIPTOR_NAME = "use-managed-identity";
 
     public static final PropertyDescriptor POLICY_PRIMARY_KEY = new PropertyDescriptor.Builder()
-            .name("Shared Access Policy Primary Key")
-            .displayName("Shared Access Policy Key")
+            .name("Shared Access Policy Key")
             .description("The key of the shared access policy. Either the primary or the secondary key can be used.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
@@ -55,8 +56,7 @@ public final class AzureEventHubUtils {
             .build();
 
     public static final PropertyDescriptor USE_MANAGED_IDENTITY = new PropertyDescriptor.Builder()
-            .name("use-managed-identity")
-            .displayName("Use Azure Managed Identity")
+            .name("Use Azure Managed Identity")
             .description("Choose whether or not to use the managed identity of Azure VM/VMSS")
             .required(true).defaultValue("false").allowableValues("true", "false")
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR).build();

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -51,6 +51,7 @@ import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
@@ -79,7 +80,6 @@ import static com.azure.storage.blob.specialized.BlockBlobClient.MAX_STAGE_BLOCK
 import static com.azure.storage.blob.specialized.BlockBlobClient.MAX_UPLOAD_BLOB_BYTES_LONG;
 import static com.azure.storage.common.implementation.Constants.STORAGE_SCOPE;
 import static java.net.HttpURLConnection.HTTP_ACCEPTED;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBNAME;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBTYPE;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_CONTAINER;
@@ -146,21 +146,25 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             .build();
 
     public static final PropertyDescriptor DESTINATION_STORAGE_CREDENTIALS_SERVICE = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(BLOB_STORAGE_CREDENTIALS_SERVICE)
-            .displayName("Destination Storage Credentials")
+            .name("Destination Storage Credentials")
+            .description("Controller Service used to obtain Azure Blob Storage Credentials.")
+            .identifiesControllerService(AzureStorageCredentialsService_v12.class)
+            .required(true)
             .build();
 
     public static final PropertyDescriptor DESTINATION_CONTAINER_NAME = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(AzureStorageUtils.CONTAINER)
-            .displayName("Destination Container Name")
+            .name("Destination Container Name")
             .description("Name of the Azure storage container destination defaults to the Source Container Name when not specified")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .required(false)
             .build();
 
     public static final PropertyDescriptor DESTINATION_BLOB_NAME = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(BLOB_NAME)
-            .displayName("Destination Blob Name")
+            .name("Destination Blob Name")
             .description("The full name of the destination blob defaults to the Source Blob Name when not specified")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .required(false)
             .build();
 
@@ -273,6 +277,15 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, DESTINATION_BLOB_NAME.getName());
+        config.renameProperty(AzureStorageUtils.OLD_CONFLICT_RESOLUTION_DESCRIPTOR_NAME, AzureStorageUtils.CONFLICT_RESOLUTION.getName());
+        config.renameProperty(AzureStorageUtils.OLD_CREATE_CONTAINER_DESCRIPTOR_NAME, AzureStorageUtils.CREATE_CONTAINER.getName());
+        config.renameProperty(AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, DESTINATION_CONTAINER_NAME.getName());
+        config.renameProperty(AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, DESTINATION_STORAGE_CREDENTIALS_SERVICE.getName());
     }
 
     private void copy(final BlobClient destinationBlobClient,

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureBlobStorage_v12.java
@@ -28,6 +28,7 @@ import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
@@ -64,8 +65,7 @@ public class DeleteAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             .build();
 
     public static final PropertyDescriptor DELETE_SNAPSHOTS_OPTION = new PropertyDescriptor.Builder()
-            .name("delete-snapshots-option")
-            .displayName("Delete Snapshots Option")
+            .name("Delete Snapshots Option")
             .description("Specifies the snapshot deletion options to be used when deleting a blob.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .allowableValues(DELETE_SNAPSHOTS_NONE, DELETE_SNAPSHOTS_ALSO, DELETE_SNAPSHOTS_ONLY)
@@ -121,6 +121,14 @@ public class DeleteAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(AbstractAzureBlobProcessor_v12.OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, BLOB_NAME.getName());
+        config.renameProperty("delete-snapshots-option", DELETE_SNAPSHOTS_OPTION.getName());
+        config.renameProperty(AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, CONTAINER.getName());
+        config.renameProperty(AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.getName());
     }
 
     private DeleteSnapshotsOptionType getDeleteSnapshotsOptionType(String deleteSnapshotOption) {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureDataLakeStorage.java
@@ -30,6 +30,7 @@ import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
@@ -56,8 +57,7 @@ public class DeleteAzureDataLakeStorage extends AbstractAzureDataLakeStorageProc
     public static final AllowableValue FS_TYPE_DIRECTORY = new AllowableValue("directory", "Directory", "The object to be deleted is a directory.");
 
     public static final PropertyDescriptor FILESYSTEM_OBJECT_TYPE = new PropertyDescriptor.Builder()
-            .name("filesystem-object-type")
-            .displayName("Filesystem Object Type")
+            .name("Filesystem Object Type")
             .description("They type of the file system object to be deleted. It can be either folder or file.")
             .allowableValues(FS_TYPE_FILE, FS_TYPE_DIRECTORY)
             .defaultValue(FS_TYPE_FILE)
@@ -110,6 +110,15 @@ public class DeleteAzureDataLakeStorage extends AbstractAzureDataLakeStorageProc
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        super.migrateProperties(config);
+        config.renameProperty(AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName());
+        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, DIRECTORY.getName());
+        config.renameProperty("filesystem-object-type", FILESYSTEM_OBJECT_TYPE.getName());
+        config.renameProperty(AzureStorageUtils.OLD_FILE_DESCRIPTOR_NAME, FILE.getName());
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureBlobStorage_v12.java
@@ -34,6 +34,7 @@ import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
@@ -121,8 +122,7 @@ public class FetchAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 im
             .build();
 
     public static final PropertyDescriptor RANGE_START = new PropertyDescriptor.Builder()
-            .name("range-start")
-            .displayName("Range Start")
+            .name("Range Start")
             .description("The byte position at which to start reading from the blob. An empty value or a value of " +
                     "zero will start reading at the beginning of the blob.")
             .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
@@ -131,8 +131,7 @@ public class FetchAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 im
             .build();
 
     public static final PropertyDescriptor RANGE_LENGTH = new PropertyDescriptor.Builder()
-            .name("range-length")
-            .displayName("Range Length")
+            .name("Range Length")
             .description("The number of bytes to download from the blob, starting from the Range Start. An empty " +
                     "value or a value that extends beyond the end of the blob will read to the end of the blob.")
             .addValidator(StandardValidators.createDataSizeBoundsValidator(1, Long.MAX_VALUE))
@@ -203,5 +202,14 @@ public class FetchAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 im
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(AbstractAzureBlobProcessor_v12.OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, BLOB_NAME.getName());
+        config.renameProperty(AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, CONTAINER.getName());
+        config.renameProperty(AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.getName());
+        config.renameProperty("range-start", RANGE_START.getName());
+        config.renameProperty("range-length", RANGE_LENGTH.getName());
     }
 }

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureDataLakeStorage.java
@@ -36,6 +36,7 @@ import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
@@ -96,8 +97,7 @@ import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.e
 public class FetchAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcessor {
 
     public static final PropertyDescriptor RANGE_START = new PropertyDescriptor.Builder()
-            .name("range-start")
-            .displayName("Range Start")
+            .name("Range Start")
             .description("The byte position at which to start reading from the object. An empty value or a value of " +
                     "zero will start reading at the beginning of the object.")
             .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
@@ -106,8 +106,7 @@ public class FetchAzureDataLakeStorage extends AbstractAzureDataLakeStorageProce
             .build();
 
     public static final PropertyDescriptor RANGE_LENGTH = new PropertyDescriptor.Builder()
-            .name("range-length")
-            .displayName("Range Length")
+            .name("Range Length")
             .description("The number of bytes to download from the object, starting from the Range Start. An empty " +
                     "value or a value that extends beyond the end of the object will read to the end of the object.")
             .addValidator(StandardValidators.createDataSizeBoundsValidator(1, Long.MAX_VALUE))
@@ -116,8 +115,7 @@ public class FetchAzureDataLakeStorage extends AbstractAzureDataLakeStorageProce
             .build();
 
     public static final PropertyDescriptor NUM_RETRIES = new PropertyDescriptor.Builder()
-            .name("number-of-retries")
-            .displayName("Number of Retries")
+            .name("Number of Retries")
             .description("The number of automatic retries to perform if the download fails.")
             .addValidator(StandardValidators.createLongValidator(0L, Integer.MAX_VALUE, true))
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
@@ -189,5 +187,16 @@ public class FetchAzureDataLakeStorage extends AbstractAzureDataLakeStorageProce
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        super.migrateProperties(config);
+        config.renameProperty(AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName());
+        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, DIRECTORY.getName());
+        config.renameProperty(AzureStorageUtils.OLD_FILE_DESCRIPTOR_NAME, FILE.getName());
+        config.renameProperty("number-of-retries", NUM_RETRIES.getName());
+        config.renameProperty("range-start", RANGE_START.getName());
+        config.renameProperty("range-length", RANGE_LENGTH.getName());
     }
 }

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureBlobStorage_v12.java
@@ -40,6 +40,7 @@ import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processor.util.list.ListedEntityTracker;
@@ -111,8 +112,7 @@ public class ListAzureBlobStorage_v12 extends AbstractListAzureProcessor<BlobInf
             .build();
 
     public static final PropertyDescriptor BLOB_NAME_PREFIX = new PropertyDescriptor.Builder()
-            .name("blob-name-prefix")
-            .displayName("Blob Name Prefix")
+            .name("Blob Name Prefix")
             .description("Search prefix for listing")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -165,6 +165,14 @@ public class ListAzureBlobStorage_v12 extends AbstractListAzureProcessor<BlobInf
     @OnStopped
     public void onStopped() {
         clientFactory = null;
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        super.migrateProperties(config);
+        config.renameProperty(AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, CONTAINER.getName());
+        config.renameProperty(AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.getName());
+        config.renameProperty("blob-name-prefix", BLOB_NAME_PREFIX.getName());
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureDataLakeStorage.java
@@ -40,6 +40,7 @@ import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.azure.storage.utils.ADLSFileInfo;
@@ -107,8 +108,7 @@ import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.g
 public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFileInfo> {
 
     public static final PropertyDescriptor RECURSE_SUBDIRECTORIES = new PropertyDescriptor.Builder()
-            .name("recurse-subdirectories")
-            .displayName("Recurse Subdirectories")
+            .name("Recurse Subdirectories")
             .description("Indicates whether to list files from subdirectories of the directory")
             .required(true)
             .allowableValues("true", "false")
@@ -116,8 +116,7 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
             .build();
 
     public static final PropertyDescriptor FILE_FILTER = new PropertyDescriptor.Builder()
-            .name("file-filter")
-            .displayName("File Filter")
+            .name("File Filter")
             .description("Only files whose names match the given regular expression will be listed")
             .required(false)
             .addValidator(StandardValidators.REGULAR_EXPRESSION_WITH_EL_VALIDATOR)
@@ -125,8 +124,7 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
             .build();
 
     public static final PropertyDescriptor PATH_FILTER = new PropertyDescriptor.Builder()
-            .name("path-filter")
-            .displayName("Path Filter")
+            .name("Path Filter")
             .description(String.format("When '%s' is true, then only subdirectories whose paths match the given regular expression will be scanned", RECURSE_SUBDIRECTORIES.getDisplayName()))
             .required(false)
             .addValidator(StandardValidators.REGULAR_EXPRESSION_WITH_EL_VALIDATOR)
@@ -134,8 +132,7 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
             .build();
 
     public static final PropertyDescriptor INCLUDE_TEMPORARY_FILES = new PropertyDescriptor.Builder()
-            .name("include-temporary-files")
-            .displayName("Include Temporary Files")
+            .name("Include Temporary Files")
             .description("Whether to include temporary files when listing the contents of configured directory paths.")
             .required(true)
             .allowableValues(Boolean.TRUE.toString(), Boolean.FALSE.toString())
@@ -194,6 +191,18 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
         filePattern = null;
         pathPattern = null;
         clientFactory = null;
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        super.migrateProperties(config);
+        config.renameProperty(AzureStorageUtils.OLD_ADLS_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.ADLS_CREDENTIALS_SERVICE.getName());
+        config.renameProperty(AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName());
+        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, DIRECTORY.getName());
+        config.renameProperty("recurse-subdirectories", RECURSE_SUBDIRECTORIES.getName());
+        config.renameProperty("file-filter", FILE_FILTER.getName());
+        config.renameProperty("path-filter", PATH_FILTER.getName());
+        config.renameProperty("include-temporary-files", INCLUDE_TEMPORARY_FILES.getName());
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage_v12.java
@@ -39,6 +39,7 @@ import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.fileresource.service.api.FileResource;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
@@ -208,6 +209,16 @@ public class PutAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 impl
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(AbstractAzureBlobProcessor_v12.OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, BLOB_NAME.getName());
+        config.renameProperty(AzureStorageUtils.OLD_CONFLICT_RESOLUTION_DESCRIPTOR_NAME, AzureStorageUtils.CONFLICT_RESOLUTION.getName());
+        config.renameProperty(AzureStorageUtils.OLD_CREATE_CONTAINER_DESCRIPTOR_NAME, AzureStorageUtils.CREATE_CONTAINER.getName());
+        config.renameProperty(AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, AzureStorageUtils.CONTAINER.getName());
+        config.renameProperty(AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.getName());
+
     }
 
     private static void applyUploadResultAttributes(final Map<String, String> attributes, final BlockBlobItem blob, final BlobType blobType, final long length) {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
@@ -36,6 +36,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.fileresource.service.api.FileResource;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
@@ -95,8 +96,7 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
     public static long MAX_CHUNK_SIZE = 100 * 1024 * 1024; // current chunk limit is 100 MiB on Azure
 
     public static final PropertyDescriptor CONFLICT_RESOLUTION = new PropertyDescriptor.Builder()
-            .name("conflict-resolution-strategy")
-            .displayName("Conflict Resolution Strategy")
+            .name("Conflict Resolution Strategy")
             .description("Indicates what should happen when a file with the same name already exists in the output directory")
             .required(true)
             .defaultValue(FAIL_RESOLUTION)
@@ -104,8 +104,7 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
             .build();
 
     protected static final PropertyDescriptor WRITING_STRATEGY = new PropertyDescriptor.Builder()
-            .name("writing-strategy")
-            .displayName("Writing Strategy")
+            .name("Writing Strategy")
             .description("Defines the approach for writing the Azure file.")
             .required(true)
             .allowableValues(WritingStrategy.class)
@@ -113,8 +112,7 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
             .build();
 
     public static final PropertyDescriptor BASE_TEMPORARY_PATH = new PropertyDescriptor.Builder()
-            .name("base-temporary-path")
-            .displayName("Base Temporary Path")
+            .name("Base Temporary Path")
             .description("The Path where the temporary directory will be created. The Path name cannot contain a leading '/'." +
                     " The root directory can be designated by the empty string value. Non-existing directories will be created." +
                     "The Temporary File Directory name is " + TEMP_FILE_DIRECTORY)
@@ -202,6 +200,17 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        super.migrateProperties(config);
+        config.renameProperty(AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName());
+        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, DIRECTORY.getName());
+        config.renameProperty(AzureStorageUtils.OLD_FILE_DESCRIPTOR_NAME, FILE.getName());
+        config.renameProperty("conflict-resolution-strategy", CONFLICT_RESOLUTION.getName());
+        config.renameProperty("writing-strategy", WRITING_STRATEGY.getName());
+        config.renameProperty("base-temporary-path", BASE_TEMPORARY_PATH.getName());
     }
 
     private DataLakeFileSystemClient getFileSystemClient(final ProcessContext context, final FlowFile flowFile, final String fileSystem) {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/AbstractAzureQueueStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/AbstractAzureQueueStorage_v12.java
@@ -32,6 +32,7 @@ import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Relationship;
@@ -104,6 +105,11 @@ public abstract class AbstractAzureQueueStorage_v12 extends AbstractProcessor {
     @Override
     public Set<Relationship> getRelationships() {
         return RELATIONSHIPS;
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(AzureStorageUtils.STORAGE_ENDPOINT_SUFFIX_PROPERTY_DESCRIPTOR_NAME, ENDPOINT_SUFFIX.getName());
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/AzureStorageUtils.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/AzureStorageUtils.java
@@ -49,26 +49,36 @@ public final class AzureStorageUtils {
     public static final String STORAGE_ACCOUNT_KEY_PROPERTY_DESCRIPTOR_NAME = "storage-account-key";
     public static final String STORAGE_SAS_TOKEN_PROPERTY_DESCRIPTOR_NAME = "storage-sas-token";
     public static final String STORAGE_ENDPOINT_SUFFIX_PROPERTY_DESCRIPTOR_NAME = "storage-endpoint-suffix";
+    public static final String OLD_CONFLICT_RESOLUTION_DESCRIPTOR_NAME = "conflict-resolution-strategy";
+    public static final String OLD_CREATE_CONTAINER_DESCRIPTOR_NAME = "create-container";
+    public static final String OLD_CONTAINER_DESCRIPTOR_NAME = "container-name";
+    public static final String OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME = "storage-credentials-service";
+    public static final String OLD_ADLS_CREDENTIALS_SERVICE_DESCRIPTOR_NAME = "adls-credentials-service";
+    public static final String OLD_FILESYSTEM_DESCRIPTOR_NAME = "filesystem-name";
+    public static final String OLD_DIRECTORY_DESCRIPTOR_NAME = "directory-name";
+    public static final String OLD_FILE_DESCRIPTOR_NAME = "file-name";
+    public static final String OLD_CREDENTIALS_TYPE_DESCRIPTOR_NAME = "credentials-type";
+    public static final String OLD_MANAGED_IDENTITY_CLIENT_ID_DESCRIPTOR_NAME = "managed-identity-client-id";
+    public static final String OLD_SERVICE_PRINCIPAL_TENANT_ID_DESCRIPTOR_NAME = "service-principal-tenant-id";
+    public static final String OLD_SERVICE_PRINCIPAL_CLIENT_ID_DESCRIPTOR_NAME = "service-principal-client-id";
+    public static final String OLD_SERVICE_PRINCIPAL_CLIENT_SECRET_DESCRIPTOR_NAME = "service-principal-client-secret";
 
     public static final PropertyDescriptor ADLS_CREDENTIALS_SERVICE = new PropertyDescriptor.Builder()
-            .name("adls-credentials-service")
-            .displayName("ADLS Credentials")
+            .name("ADLS Credentials")
             .description("Controller Service used to obtain Azure Credentials.")
             .identifiesControllerService(ADLSCredentialsService.class)
             .required(true)
             .build();
 
     public static final PropertyDescriptor BLOB_STORAGE_CREDENTIALS_SERVICE = new PropertyDescriptor.Builder()
-            .name("storage-credentials-service")
-            .displayName("Storage Credentials")
+            .name("Storage Credentials")
             .description("Controller Service used to obtain Azure Blob Storage Credentials.")
             .identifiesControllerService(AzureStorageCredentialsService_v12.class)
             .required(true)
             .build();
 
     public static final PropertyDescriptor CREDENTIALS_TYPE = new PropertyDescriptor.Builder()
-            .name("credentials-type")
-            .displayName("Credentials Type")
+            .name("Credentials Type")
             .description("Credentials type to be used for authenticating to Azure")
             .required(true)
             .allowableValues(EnumSet.of(
@@ -80,7 +90,7 @@ public final class AzureStorageUtils {
             .build();
 
     public static final PropertyDescriptor FILESYSTEM = new PropertyDescriptor.Builder()
-            .name("filesystem-name").displayName("Filesystem Name")
+            .name("Filesystem Name")
             .description("Name of the Azure Storage File System (also called Container). It is assumed to be already existing.")
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
@@ -88,8 +98,7 @@ public final class AzureStorageUtils {
             .build();
 
     public static final PropertyDescriptor DIRECTORY = new PropertyDescriptor.Builder()
-            .name("directory-name")
-            .displayName("Directory Name")
+            .name("Directory Name")
             .description("Name of the Azure Storage Directory. The Directory Name cannot contain a leading '/'. The root directory can be designated by the empty string value. " +
                     "In case of the PutAzureDataLakeStorage processor, the directory will be created if not already existing.")
             .addValidator(new DirectoryValidator())
@@ -98,7 +107,7 @@ public final class AzureStorageUtils {
             .build();
 
     public static final PropertyDescriptor FILE = new PropertyDescriptor.Builder()
-            .name("file-name").displayName("File Name")
+            .name("File Name")
             .description("The filename")
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
@@ -118,8 +127,7 @@ public final class AzureStorageUtils {
             "In addition, the provenance repositories may be put on encrypted disk partitions.";
 
     public static final PropertyDescriptor ACCOUNT_KEY = new PropertyDescriptor.Builder()
-            .name(STORAGE_ACCOUNT_KEY_PROPERTY_DESCRIPTOR_NAME)
-            .displayName("Account Key")
+            .name("Account Key")
             .description(ACCOUNT_KEY_BASE_DESCRIPTION)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
@@ -138,8 +146,7 @@ public final class AzureStorageUtils {
             "In addition, the provenance repositories may be put on encrypted disk partitions.";
 
     public static final PropertyDescriptor ACCOUNT_NAME = new PropertyDescriptor.Builder()
-            .name(STORAGE_ACCOUNT_NAME_PROPERTY_DESCRIPTOR_NAME)
-            .displayName("Storage Account Name")
+            .name("Storage Account Name")
             .description(ACCOUNT_NAME_BASE_DESCRIPTION)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
@@ -148,8 +155,7 @@ public final class AzureStorageUtils {
             .build();
 
     public static final PropertyDescriptor ENDPOINT_SUFFIX = new PropertyDescriptor.Builder()
-            .name(STORAGE_ENDPOINT_SUFFIX_PROPERTY_DESCRIPTOR_NAME)
-            .displayName("Endpoint Suffix")
+            .name("Endpoint Suffix")
             .description("Storage accounts in public Azure always use a common FQDN suffix. " +
                     "Override this endpoint suffix with a different suffix in certain circumstances (like Azure Stack or non-public Azure regions).")
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
@@ -158,8 +164,7 @@ public final class AzureStorageUtils {
             .build();
 
     public static final PropertyDescriptor CONTAINER = new PropertyDescriptor.Builder()
-            .name("container-name")
-            .displayName("Container Name")
+            .name("Container Name")
             .description("Name of the Azure storage container. In case of PutAzureBlobStorage processor, container can be created if it does not exist.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
@@ -167,8 +172,7 @@ public final class AzureStorageUtils {
             .build();
 
     public static final PropertyDescriptor CREATE_CONTAINER = new PropertyDescriptor.Builder()
-            .name("create-container")
-            .displayName("Create Container")
+            .name("Create Container")
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .required(true)
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
@@ -180,8 +184,7 @@ public final class AzureStorageUtils {
             .build();
 
     public static final PropertyDescriptor CONFLICT_RESOLUTION = new PropertyDescriptor.Builder()
-            .name("conflict-resolution-strategy")
-            .displayName("Conflict Resolution Strategy")
+            .name("Conflict Resolution Strategy")
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .required(true)
             .allowableValues(AzureStorageConflictResolutionStrategy.class)
@@ -199,8 +202,7 @@ public final class AzureStorageUtils {
             "In addition, the provenance repositories may be put on encrypted disk partitions.";
 
     public static final PropertyDescriptor SAS_TOKEN = new PropertyDescriptor.Builder()
-            .name(STORAGE_SAS_TOKEN_PROPERTY_DESCRIPTOR_NAME)
-            .displayName("SAS Token")
+            .name("SAS Token")
             .description(SAS_TOKEN_BASE_DESCRIPTION)
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
@@ -210,8 +212,7 @@ public final class AzureStorageUtils {
             .build();
 
     public static final PropertyDescriptor MANAGED_IDENTITY_CLIENT_ID = new PropertyDescriptor.Builder()
-            .name("managed-identity-client-id")
-            .displayName("Managed Identity Client ID")
+            .name("Managed Identity Client ID")
             .description("Client ID of the managed identity. The property is required when User Assigned Managed Identity is used for authentication. " +
                     "It must be empty in case of System Assigned Managed Identity.")
             .sensitive(true)
@@ -222,8 +223,7 @@ public final class AzureStorageUtils {
             .build();
 
     public static final PropertyDescriptor SERVICE_PRINCIPAL_TENANT_ID = new PropertyDescriptor.Builder()
-            .name("service-principal-tenant-id")
-            .displayName("Service Principal Tenant ID")
+            .name("Service Principal Tenant ID")
             .description("Tenant ID of the Azure Active Directory hosting the Service Principal.")
             .sensitive(true)
             .required(true)
@@ -233,8 +233,7 @@ public final class AzureStorageUtils {
             .build();
 
     public static final PropertyDescriptor SERVICE_PRINCIPAL_CLIENT_ID = new PropertyDescriptor.Builder()
-            .name("service-principal-client-id")
-            .displayName("Service Principal Client ID")
+            .name("Service Principal Client ID")
             .description("Client ID (or Application ID) of the Client/Application having the Service Principal.")
             .sensitive(true)
             .required(true)
@@ -244,8 +243,7 @@ public final class AzureStorageUtils {
             .build();
 
     public static final PropertyDescriptor SERVICE_PRINCIPAL_CLIENT_SECRET = new PropertyDescriptor.Builder()
-            .name("service-principal-client-secret")
-            .displayName("Service Principal Client Secret")
+            .name("Service Principal Client Secret")
             .description("Password of the Client/Application.")
             .sensitive(true)
             .required(true)

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/StandardAzureCredentialsControllerService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/StandardAzureCredentialsControllerService.java
@@ -27,6 +27,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 
@@ -47,8 +48,7 @@ public class StandardAzureCredentialsControllerService extends AbstractControlle
             "Managed Identity",
             "Azure Virtual Machine Managed Identity (it can only be used when NiFi is running on Azure)");
     public static final PropertyDescriptor CREDENTIAL_CONFIGURATION_STRATEGY = new PropertyDescriptor.Builder()
-            .name("credential-configuration-strategy")
-            .displayName("Credential Configuration Strategy")
+            .name("Credential Configuration Strategy")
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .required(true)
             .sensitive(false)
@@ -57,8 +57,7 @@ public class StandardAzureCredentialsControllerService extends AbstractControlle
             .build();
 
     public static final PropertyDescriptor MANAGED_IDENTITY_CLIENT_ID = new PropertyDescriptor.Builder()
-            .name("managed-identity-client-id")
-            .displayName("Managed Identity Client ID")
+            .name("Managed Identity Client ID")
             .description("Client ID of the managed identity. The property is required when User Assigned Managed Identity is used for authentication. " +
                     "It must be empty in case of System Assigned Managed Identity.")
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
@@ -98,6 +97,12 @@ public class StandardAzureCredentialsControllerService extends AbstractControlle
             getLogger().error(errorMsg);
             throw new ProcessException(errorMsg);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty("credential-configuration-strategy", CREDENTIAL_CONFIGURATION_STRATEGY.getName());
+        config.renameProperty("managed-identity-client-id", MANAGED_IDENTITY_CLIENT_ID.getName());
     }
 
     private TokenCredential getDefaultAzureCredential() {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/cosmos/document/AzureCosmosDBClientService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/cosmos/document/AzureCosmosDBClientService.java
@@ -30,6 +30,7 @@ import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processors.azure.cosmos.document.AzureCosmosDBUtils;
 import org.apache.nifi.services.azure.cosmos.AzureCosmosDBConnectionService;
 import org.apache.nifi.util.StringUtils;
@@ -114,6 +115,13 @@ public class AzureCosmosDBClientService extends AbstractControllerService implem
     }
     public void setCosmosClient(CosmosClient client) {
         this.cosmosClient = client;
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(AzureCosmosDBUtils.OLD_URI_DESCRIPTOR_NAME, AzureCosmosDBUtils.URI.getName());
+        config.renameProperty(AzureCosmosDBUtils.OLD_DB_ACCESS_KEY_DESCRIPTOR_NAME, AzureCosmosDBUtils.DB_ACCESS_KEY.getName());
+        config.renameProperty(AzureCosmosDBUtils.OLD_CONSISTENCY_DESCRIPTOR_NAME, AzureCosmosDBUtils.CONSISTENCY.getName());
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/ADLSCredentialsControllerService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/ADLSCredentialsControllerService.java
@@ -99,6 +99,16 @@ public class ADLSCredentialsControllerService extends AbstractControllerService 
 
     @Override
     public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(AzureStorageUtils.OLD_CREDENTIALS_TYPE_DESCRIPTOR_NAME, AzureStorageUtils.CREDENTIALS_TYPE.getName());
+        config.renameProperty(AzureStorageUtils.STORAGE_ACCOUNT_KEY_PROPERTY_DESCRIPTOR_NAME, ACCOUNT_KEY.getName());
+        config.renameProperty(AzureStorageUtils.STORAGE_ACCOUNT_NAME_PROPERTY_DESCRIPTOR_NAME, ACCOUNT_NAME.getName());
+        config.renameProperty(AzureStorageUtils.STORAGE_ENDPOINT_SUFFIX_PROPERTY_DESCRIPTOR_NAME, ENDPOINT_SUFFIX.getName());
+        config.renameProperty(AzureStorageUtils.STORAGE_SAS_TOKEN_PROPERTY_DESCRIPTOR_NAME, SAS_TOKEN.getName());
+        config.renameProperty(AzureStorageUtils.OLD_MANAGED_IDENTITY_CLIENT_ID_DESCRIPTOR_NAME, MANAGED_IDENTITY_CLIENT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_TENANT_ID_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_TENANT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_ID_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_CLIENT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_SECRET_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_CLIENT_SECRET.getName());
+
         if (!config.hasProperty(CREDENTIALS_TYPE)) {
             final String propNameUseManagedIdentity = "storage-use-managed-identity";
 

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureBlobStorageFileResourceService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureBlobStorageFileResourceService.java
@@ -31,6 +31,7 @@ import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.fileresource.service.api.FileResource;
 import org.apache.nifi.fileresource.service.api.FileResourceService;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.azure.AbstractAzureBlobProcessor_v12;
 import org.apache.nifi.processors.azure.storage.FetchAzureBlobStorage_v12;
@@ -106,6 +107,13 @@ public class AzureBlobStorageFileResourceService extends AbstractControllerServi
         } catch (final BlobStorageException | IOException e) {
             throw new ProcessException("Failed to fetch blob from Azure Blob Storage", e);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(AbstractAzureBlobProcessor_v12.OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, BLOB_NAME.getName());
+        config.renameProperty(AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, CONTAINER.getName());
+        config.renameProperty(AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.getName());
     }
 
     protected BlobServiceClient getStorageClient(Map<String, String> attributes) {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureDataLakeStorageFileResourceService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureDataLakeStorageFileResourceService.java
@@ -32,6 +32,7 @@ import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.fileresource.service.api.FileResource;
 import org.apache.nifi.fileresource.service.api.FileResourceService;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.azure.storage.FetchAzureDataLakeStorage;
 import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
@@ -111,6 +112,13 @@ public class AzureDataLakeStorageFileResourceService extends AbstractControllerS
         } catch (final DataLakeStorageException | IOException e) {
             throw new ProcessException("Failed to fetch file from ADLS Storage", e);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(AzureStorageUtils.OLD_ADLS_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.ADLS_CREDENTIALS_SERVICE.getName());
+        config.renameProperty(AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName());
+        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, DIRECTORY.getName());
     }
 
     protected DataLakeServiceClient getStorageClient(Map<String, String> attributes) {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureStorageCredentialsControllerService_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureStorageCredentialsControllerService_v12.java
@@ -23,6 +23,7 @@ import org.apache.nifi.annotation.lifecycle.OnEnabled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processors.azure.AzureServiceEndpoints;
 import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 
@@ -108,5 +109,18 @@ public class AzureStorageCredentialsControllerService_v12 extends AbstractContro
             default:
                 throw new IllegalArgumentException("Unhandled credentials type: " + credentialsType);
         }
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.renameProperty(AzureStorageUtils.OLD_CREDENTIALS_TYPE_DESCRIPTOR_NAME, AzureStorageUtils.CREDENTIALS_TYPE.getName());
+        config.renameProperty(AzureStorageUtils.STORAGE_ACCOUNT_KEY_PROPERTY_DESCRIPTOR_NAME, ACCOUNT_KEY.getName());
+        config.renameProperty(AzureStorageUtils.STORAGE_ACCOUNT_NAME_PROPERTY_DESCRIPTOR_NAME, ACCOUNT_NAME.getName());
+        config.renameProperty(AzureStorageUtils.STORAGE_ENDPOINT_SUFFIX_PROPERTY_DESCRIPTOR_NAME, ENDPOINT_SUFFIX.getName());
+        config.renameProperty(AzureStorageUtils.STORAGE_SAS_TOKEN_PROPERTY_DESCRIPTOR_NAME, SAS_TOKEN.getName());
+        config.renameProperty(AzureStorageUtils.OLD_MANAGED_IDENTITY_CLIENT_ID_DESCRIPTOR_NAME, MANAGED_IDENTITY_CLIENT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_TENANT_ID_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_TENANT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_ID_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_CLIENT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_SECRET_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_CLIENT_SECRET.getName());
     }
 }

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/cosmos/document/PutAzureCosmosDBRecordTest.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/cosmos/document/PutAzureCosmosDBRecordTest.java
@@ -37,6 +37,7 @@ import org.apache.nifi.serialization.record.MockSchemaRegistry;
 import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.util.PropertyMigrationResult;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -252,6 +253,26 @@ public class PutAzureCosmosDBRecordTest extends MockTestBase {
         Object[] check  = (Object[]) arrayTestResult.get("arrayTest");
         assertArrayEquals(new Object[]{"a", "b", "c"}, check);
     }
+
+    @Test
+    void testMigration() {
+        final PropertyMigrationResult propertyMigrationResult = testRunner.migrateProperties();
+        final Map<String, String> expected = Map.of(
+                AzureCosmosDBUtils.OLD_URI_DESCRIPTOR_NAME, AzureCosmosDBUtils.URI.getName(),
+                AzureCosmosDBUtils.OLD_DB_ACCESS_KEY_DESCRIPTOR_NAME, AzureCosmosDBUtils.DB_ACCESS_KEY.getName(),
+                AzureCosmosDBUtils.OLD_CONSISTENCY_DESCRIPTOR_NAME, AzureCosmosDBUtils.CONSISTENCY.getName(),
+                "azure-cosmos-db-connection-service", AbstractAzureCosmosDBProcessor.CONNECTION_SERVICE.getName(),
+                "azure-cosmos-db-name", AbstractAzureCosmosDBProcessor.DATABASE_NAME.getName(),
+                "azure-cosmos-db-container-id", AbstractAzureCosmosDBProcessor.CONTAINER_ID.getName(),
+                "azure-cosmos-db-partition-key", AbstractAzureCosmosDBProcessor.PARTITION_KEY.getName(),
+                "record-reader", PutAzureCosmosDBRecord.RECORD_READER_FACTORY.getName(),
+                "insert-batch-size", PutAzureCosmosDBRecord.INSERT_BATCH_SIZE.getName(),
+                "azure-cosmos-db-conflict-handling-strategy", PutAzureCosmosDBRecord.CONFLICT_HANDLE_STRATEGY.getName()
+        );
+
+        assertEquals(expected, propertyMigrationResult.getPropertiesRenamed());
+    }
+
     private void prepareMockTest() throws Exception {
         // this setup connection service and basic mock properties
         setBasicMockProperties(true);

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHubTest.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHubTest.java
@@ -19,10 +19,12 @@ package org.apache.nifi.processors.azure.eventhub;
 import com.azure.messaging.eventhubs.EventHubProducerClient;
 import com.azure.messaging.eventhubs.models.SendOptions;
 import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processors.azure.eventhub.utils.AzureEventHubUtils;
 import org.apache.nifi.proxy.ProxyConfiguration;
 import org.apache.nifi.proxy.ProxyConfigurationService;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.shared.azure.eventhubs.AzureEventHubTransportType;
+import org.apache.nifi.util.PropertyMigrationResult;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,6 +85,20 @@ public class PutAzureEventHubTest {
         testRunner.assertValid();
         configureProxyControllerService();
         testRunner.assertValid();
+    }
+
+    @Test
+    void testMigration() {
+        TestRunner testRunner = TestRunners.newTestRunner(PutAzureEventHub.class);
+        final PropertyMigrationResult propertyMigrationResult = testRunner.migrateProperties();
+        final Map<String, String> expected = Map.of(
+                "partitioning-key-attribute-name", PutAzureEventHub.PARTITIONING_KEY_ATTRIBUTE_NAME.getName(),
+                "max-batch-size", PutAzureEventHub.MAX_BATCH_SIZE.getName(),
+                AzureEventHubUtils.OLD_POLICY_PRIMARY_KEY_DESCRIPTOR_NAME, PutAzureEventHub.POLICY_PRIMARY_KEY.getName(),
+                AzureEventHubUtils.OLD_USE_MANAGED_IDENTITY_DESCRIPTOR_NAME, PutAzureEventHub.USE_MANAGED_IDENTITY.getName()
+        );
+
+        assertEquals(expected, propertyMigrationResult.getPropertiesRenamed());
     }
 
     private void configureProxyControllerService() throws InitializationException {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/TestConsumeAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/TestConsumeAzureEventHub.java
@@ -25,6 +25,7 @@ import com.azure.messaging.eventhubs.models.PartitionContext;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processors.azure.eventhub.checkpoint.CheckpointStrategy;
+import org.apache.nifi.processors.azure.eventhub.utils.AzureEventHubUtils;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.proxy.ProxyConfiguration;
@@ -45,6 +46,7 @@ import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.shared.azure.eventhubs.AzureEventHubTransportType;
 import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.PropertyMigrationResult;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
@@ -407,6 +409,33 @@ public class TestConsumeAzureEventHub {
         final ProvenanceEventRecord provenanceEvent2 = provenanceEvents.get(1);
         assertEquals(ProvenanceEventType.RECEIVE, provenanceEvent2.getEventType());
         assertEquals(EXPECTED_TRANSIT_URI, provenanceEvent2.getTransitUri());
+    }
+
+    @Test
+    void testMigration() {
+        TestRunner testRunner = TestRunners.newTestRunner(ConsumeAzureEventHub.class);
+        final PropertyMigrationResult propertyMigrationResult = testRunner.migrateProperties();
+        final Map<String, String> expected = Map.ofEntries(
+                Map.entry("event-hub-namespace", ConsumeAzureEventHub.NAMESPACE.getName()),
+                Map.entry("event-hub-name", ConsumeAzureEventHub.EVENT_HUB_NAME.getName()),
+                Map.entry("event-hub-shared-access-policy-name", ConsumeAzureEventHub.ACCESS_POLICY_NAME.getName()),
+                Map.entry("event-hub-consumer-group", ConsumeAzureEventHub.CONSUMER_GROUP.getName()),
+                Map.entry("record-reader", ConsumeAzureEventHub.RECORD_READER.getName()),
+                Map.entry("record-writer", ConsumeAzureEventHub.RECORD_WRITER.getName()),
+                Map.entry("event-hub-initial-offset", ConsumeAzureEventHub.INITIAL_OFFSET.getName()),
+                Map.entry("event-hub-prefetch-count", ConsumeAzureEventHub.PREFETCH_COUNT.getName()),
+                Map.entry("event-hub-batch-size", ConsumeAzureEventHub.BATCH_SIZE.getName()),
+                Map.entry("event-hub-message-receive-timeout", ConsumeAzureEventHub.RECEIVE_TIMEOUT.getName()),
+                Map.entry("checkpoint-strategy", ConsumeAzureEventHub.CHECKPOINT_STRATEGY.getName()),
+                Map.entry("storage-account-name", ConsumeAzureEventHub.STORAGE_ACCOUNT_NAME.getName()),
+                Map.entry("storage-account-key", ConsumeAzureEventHub.STORAGE_ACCOUNT_KEY.getName()),
+                Map.entry("storage-sas-token", ConsumeAzureEventHub.STORAGE_SAS_TOKEN.getName()),
+                Map.entry("storage-container-name", ConsumeAzureEventHub.STORAGE_CONTAINER_NAME.getName()),
+                Map.entry("event-hub-shared-access-policy-primary-key", ConsumeAzureEventHub.POLICY_PRIMARY_KEY.getName()),
+                Map.entry(AzureEventHubUtils.OLD_USE_MANAGED_IDENTITY_DESCRIPTOR_NAME, ConsumeAzureEventHub.USE_MANAGED_IDENTITY.getName())
+        );
+
+        assertEquals(expected, propertyMigrationResult.getPropertiesRenamed());
     }
 
     private void setProperties() {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestCopyAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestCopyAzureBlobStorage_v12.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import org.apache.nifi.processors.azure.AbstractAzureBlobProcessor_v12;
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.util.PropertyMigrationResult;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestCopyAzureBlobStorage_v12 {
+    @Test
+    void testMigration() {
+        TestRunner runner = TestRunners.newTestRunner(CopyAzureBlobStorage_v12.class);
+        final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
+        final Map<String, String> expectedRenamed =
+                Map.of(AbstractAzureBlobProcessor_v12.OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, CopyAzureBlobStorage_v12.DESTINATION_BLOB_NAME.getName(),
+                        AzureStorageUtils.OLD_CONFLICT_RESOLUTION_DESCRIPTOR_NAME, AzureStorageUtils.CONFLICT_RESOLUTION.getName(),
+                        AzureStorageUtils.OLD_CREATE_CONTAINER_DESCRIPTOR_NAME, AzureStorageUtils.CREATE_CONTAINER.getName(),
+                        AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, CopyAzureBlobStorage_v12.DESTINATION_CONTAINER_NAME.getName(),
+                        AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, CopyAzureBlobStorage_v12.DESTINATION_STORAGE_CREDENTIALS_SERVICE.getName());
+        assertEquals(expectedRenamed, propertyMigrationResult.getPropertiesRenamed());
+    }
+}

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestDeleteAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestDeleteAzureBlobStorage_v12.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import org.apache.nifi.processors.azure.AbstractAzureBlobProcessor_v12;
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.util.PropertyMigrationResult;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestDeleteAzureBlobStorage_v12 {
+    @Test
+    void testMigration() {
+        TestRunner runner = TestRunners.newTestRunner(DeleteAzureBlobStorage_v12.class);
+        final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
+        final Map<String, String> expectedRenamed =
+                Map.of(AbstractAzureBlobProcessor_v12.OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, DeleteAzureBlobStorage_v12.BLOB_NAME.getName(),
+                        "delete-snapshots-option", DeleteAzureBlobStorage_v12.DELETE_SNAPSHOTS_OPTION.getName(),
+                        AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, DeleteAzureBlobStorage_v12.CONTAINER.getName(),
+                        AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.getName());
+        assertEquals(expectedRenamed, propertyMigrationResult.getPropertiesRenamed());
+    }
+}

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestDeleteAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestDeleteAzureDataLakeStorage.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.util.PropertyMigrationResult;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestDeleteAzureDataLakeStorage {
+    @Test
+    void testMigration() {
+        TestRunner runner = TestRunners.newTestRunner(DeleteAzureDataLakeStorage.class);
+        final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
+        final Map<String, String> expectedRenamed =
+                Map.of(AzureStorageUtils.OLD_ADLS_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.ADLS_CREDENTIALS_SERVICE.getName(),
+                        AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName(),
+                        AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, AzureStorageUtils.DIRECTORY.getName(),
+                        "filesystem-object-type", DeleteAzureDataLakeStorage.FILESYSTEM_OBJECT_TYPE.getName(),
+                        AzureStorageUtils.OLD_FILE_DESCRIPTOR_NAME, DeleteAzureDataLakeStorage.FILE.getName()
+                );
+
+        assertEquals(expectedRenamed, propertyMigrationResult.getPropertiesRenamed());
+    }
+}

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestFetchAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestFetchAzureBlobStorage_v12.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import org.apache.nifi.processors.azure.AbstractAzureBlobProcessor_v12;
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.util.PropertyMigrationResult;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestFetchAzureBlobStorage_v12 {
+    @Test
+    void testMigration() {
+        TestRunner runner = TestRunners.newTestRunner(FetchAzureBlobStorage_v12.class);
+        final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
+        final Map<String, String> expectedRenamed =
+                Map.of(AbstractAzureBlobProcessor_v12.OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, FetchAzureBlobStorage_v12.BLOB_NAME.getName(),
+                        AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, FetchAzureBlobStorage_v12.CONTAINER.getName(),
+                        AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.getName(),
+                        "range-start", FetchAzureBlobStorage_v12.RANGE_START.getName(),
+                        "range-length", FetchAzureBlobStorage_v12.RANGE_LENGTH.getName());
+        assertEquals(expectedRenamed, propertyMigrationResult.getPropertiesRenamed());
+    }
+}

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestFetchAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestFetchAzureDataLakeStorage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.util.PropertyMigrationResult;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestFetchAzureDataLakeStorage {
+    @Test
+    void testMigration() {
+        TestRunner runner = TestRunners.newTestRunner(FetchAzureDataLakeStorage.class);
+        final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
+        final Map<String, String> expectedRenamed =
+                Map.of(AzureStorageUtils.OLD_ADLS_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.ADLS_CREDENTIALS_SERVICE.getName(),
+                        AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName(),
+                        AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, AzureStorageUtils.DIRECTORY.getName(),
+                        AzureStorageUtils.OLD_FILE_DESCRIPTOR_NAME, AzureStorageUtils.FILE.getName(),
+                        "number-of-retries", FetchAzureDataLakeStorage.NUM_RETRIES.getName(),
+                        "range-start", FetchAzureDataLakeStorage.RANGE_START.getName(),
+                        "range-length", FetchAzureDataLakeStorage.RANGE_LENGTH.getName()
+                );
+
+        assertEquals(expectedRenamed, propertyMigrationResult.getPropertiesRenamed());
+    }
+}

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestListAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestListAzureBlobStorage_v12.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.util.PropertyMigrationResult;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestListAzureBlobStorage_v12 {
+    @Test
+    void testMigration() {
+        TestRunner runner = TestRunners.newTestRunner(ListAzureBlobStorage_v12.class);
+        final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
+        final Map<String, String> expectedRenamed =
+                Map.of(AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, ListAzureBlobStorage_v12.CONTAINER.getName(),
+                        AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.getName(),
+                        "blob-name-prefix", ListAzureBlobStorage_v12.BLOB_NAME_PREFIX.getName());
+
+        assertEquals(expectedRenamed, propertyMigrationResult.getPropertiesRenamed());
+    }
+}

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestListAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestListAzureDataLakeStorage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.util.PropertyMigrationResult;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestListAzureDataLakeStorage {
+    @Test
+    void testMigration() {
+        TestRunner runner = TestRunners.newTestRunner(ListAzureDataLakeStorage.class);
+        final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
+        final Map<String, String> expectedRenamed = Map.of(
+                AzureStorageUtils.OLD_ADLS_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.ADLS_CREDENTIALS_SERVICE.getName(),
+                AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName(),
+                AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, AzureStorageUtils.DIRECTORY.getName(),
+                "recurse-subdirectories", ListAzureDataLakeStorage.RECURSE_SUBDIRECTORIES.getName(),
+                "file-filter", ListAzureDataLakeStorage.FILE_FILTER.getName(),
+                "path-filter", ListAzureDataLakeStorage.PATH_FILTER.getName(),
+                "include-temporary-files", ListAzureDataLakeStorage.INCLUDE_TEMPORARY_FILES.getName()
+        );
+
+        expectedRenamed.forEach((key, value) -> assertEquals(value, propertyMigrationResult.getPropertiesRenamed().get(key)));
+    }
+}

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestMoveAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestMoveAzureDataLakeStorage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.util.PropertyMigrationResult;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestMoveAzureDataLakeStorage {
+    @Test
+    void testMigration() {
+        TestRunner runner = TestRunners.newTestRunner(MoveAzureDataLakeStorage.class);
+        final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
+        final Map<String, String> expectedRenamed = Map.of(
+                AzureStorageUtils.OLD_ADLS_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.ADLS_CREDENTIALS_SERVICE.getName(),
+                AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, MoveAzureDataLakeStorage.DESTINATION_DIRECTORY.getName(),
+                AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, MoveAzureDataLakeStorage.DESTINATION_FILESYSTEM.getName(),
+                AzureStorageUtils.OLD_FILE_DESCRIPTOR_NAME, AzureStorageUtils.FILE.getName(),
+                "conflict-resolution-strategy", MoveAzureDataLakeStorage.CONFLICT_RESOLUTION.getName(),
+                "source-filesystem-name", MoveAzureDataLakeStorage.SOURCE_FILESYSTEM.getName(),
+                "source-directory-name", MoveAzureDataLakeStorage.SOURCE_DIRECTORY.getName()
+        );
+
+        assertEquals(expectedRenamed, propertyMigrationResult.getPropertiesRenamed());
+    }
+}

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestPutAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestPutAzureBlobStorage_v12.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage;
+
+import org.apache.nifi.processors.azure.AbstractAzureBlobProcessor_v12;
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
+import org.apache.nifi.util.PropertyMigrationResult;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestPutAzureBlobStorage_v12 {
+    @Test
+    void testMigration() {
+        TestRunner runner = TestRunners.newTestRunner(PutAzureBlobStorage_v12.class);
+        final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
+        final Map<String, String> expectedRenamed =
+                Map.ofEntries(Map.entry(AbstractAzureBlobProcessor_v12.OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, AbstractAzureBlobProcessor_v12.BLOB_NAME.getName()),
+                        Map.entry(AzureStorageUtils.OLD_CONFLICT_RESOLUTION_DESCRIPTOR_NAME, AzureStorageUtils.CONFLICT_RESOLUTION.getName()),
+                        Map.entry(AzureStorageUtils.OLD_CREATE_CONTAINER_DESCRIPTOR_NAME, AzureStorageUtils.CREATE_CONTAINER.getName()),
+                        Map.entry(AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, AzureStorageUtils.CONTAINER.getName()),
+                        Map.entry(AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.getName()));
+
+        assertEquals(expectedRenamed, propertyMigrationResult.getPropertiesRenamed());
+    }
+}

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/queue/TestGetAzureQueueStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/queue/TestGetAzureQueueStorage_v12.java
@@ -16,10 +16,16 @@
  */
 package org.apache.nifi.processors.azure.storage.queue;
 
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.PropertyMigrationResult;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestGetAzureQueueStorage_v12 extends AbstractTestAzureQueueStorage_v12 {
     @BeforeEach
@@ -75,5 +81,15 @@ public class TestGetAzureQueueStorage_v12 extends AbstractTestAzureQueueStorage_
         runner.setProperty(GetAzureQueueStorage_v12.REQUEST_TIMEOUT, "31 secs");
 
         runner.assertNotValid();
+    }
+
+    @Test
+    void testMigration() {
+        final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
+        final Map<String, String> expected = Map.of(
+                AzureStorageUtils.STORAGE_ENDPOINT_SUFFIX_PROPERTY_DESCRIPTOR_NAME, GetAzureQueueStorage_v12.ENDPOINT_SUFFIX.getName()
+        );
+
+        assertEquals(expected, propertyMigrationResult.getPropertiesRenamed());
     }
 }

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/queue/TestPutAzureQueueStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/queue/TestPutAzureQueueStorage_v12.java
@@ -16,10 +16,16 @@
  */
 package org.apache.nifi.processors.azure.storage.queue;
 
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.PropertyMigrationResult;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestPutAzureQueueStorage_v12 extends AbstractTestAzureQueueStorage_v12 {
     @BeforeEach
@@ -96,5 +102,15 @@ public class TestPutAzureQueueStorage_v12 extends AbstractTestAzureQueueStorage_
         runner.setProperty(PutAzureQueueStorage_v12.REQUEST_TIMEOUT, "31 secs");
 
         runner.assertNotValid();
+    }
+
+    @Test
+    void testMigration() {
+        final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
+        final Map<String, String> expected = Map.of(
+                AzureStorageUtils.STORAGE_ENDPOINT_SUFFIX_PROPERTY_DESCRIPTOR_NAME, GetAzureQueueStorage_v12.ENDPOINT_SUFFIX.getName()
+        );
+
+        assertEquals(expected, propertyMigrationResult.getPropertiesRenamed());
     }
 }

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AzureLogAnalyticsProvenanceReportingTask.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AzureLogAnalyticsProvenanceReportingTask.java
@@ -25,6 +25,7 @@ import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.status.ProcessGroupStatus;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
@@ -73,7 +74,7 @@ public class AzureLogAnalyticsProvenanceReportingTask extends AbstractAzureLogAn
                         "Start reading provenance Events from the end of the stream, ignoring old events");
 
         static final PropertyDescriptor FILTER_EVENT_TYPE = new PropertyDescriptor.Builder()
-                        .name("s2s-prov-task-event-filter").displayName("Event Type to Include")
+                        .name("Event Type to Include")
                         .description("Comma-separated list of event types that will be used to filter the provenance events sent by the reporting task. "
                                         + "Available event types are "
                                         + Arrays.deepToString(ProvenanceEventType.values())
@@ -83,7 +84,7 @@ public class AzureLogAnalyticsProvenanceReportingTask extends AbstractAzureLogAn
                         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
 
         static final PropertyDescriptor FILTER_EVENT_TYPE_EXCLUDE = new PropertyDescriptor.Builder()
-                        .name("s2s-prov-task-event-filter-exclude").displayName("Event Type to Exclude")
+                        .name("Event Type to Exclude")
                         .description("Comma-separated list of event types that will be used to exclude the provenance events sent by the reporting task. "
                                         + "Available event types are "
                                         + Arrays.deepToString(ProvenanceEventType.values())
@@ -94,14 +95,14 @@ public class AzureLogAnalyticsProvenanceReportingTask extends AbstractAzureLogAn
                         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
 
         static final PropertyDescriptor FILTER_COMPONENT_TYPE = new PropertyDescriptor.Builder()
-                        .name("s2s-prov-task-type-filter").displayName("Component Type to Include")
+                        .name("Component Type to Include")
                         .description("Regular expression to filter the provenance events based on the component type. Only the events matching the regular "
                                         + "expression will be sent. If no filter is set, all the events are sent. If multiple filters are set, the filters are cumulative.")
                         .required(false).expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
                         .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR).build();
 
         static final PropertyDescriptor FILTER_COMPONENT_TYPE_EXCLUDE = new PropertyDescriptor.Builder()
-                        .name("s2s-prov-task-type-filter-exclude").displayName("Component Type to Exclude")
+                        .name("Component Type to Exclude")
                         .description("Regular expression to exclude the provenance events based on the component type. The events matching the regular "
                                         + "expression will not be sent. If no filter is set, all the events are sent. If multiple filters are set, the filters are cumulative. "
                                         + "If a component type is included in Component Type to Include and excluded here, then the exclusion takes precedence and the event will not be sent.")
@@ -109,14 +110,14 @@ public class AzureLogAnalyticsProvenanceReportingTask extends AbstractAzureLogAn
                         .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR).build();
 
         static final PropertyDescriptor FILTER_COMPONENT_ID = new PropertyDescriptor.Builder()
-                        .name("s2s-prov-task-id-filter").displayName("Component ID to Include")
+                        .name("Component ID to Include")
                         .description("Comma-separated list of component UUID that will be used to filter the provenance events sent by the reporting task. If no "
                                         + "filter is set, all the events are sent. If multiple filters are set, the filters are cumulative.")
                         .required(false).expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
                         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
 
         static final PropertyDescriptor FILTER_COMPONENT_ID_EXCLUDE = new PropertyDescriptor.Builder()
-                        .name("s2s-prov-task-id-filter-exclude").displayName("Component ID to Exclude")
+                        .name("Component ID to Exclude")
                         .description("Comma-separated list of component UUID that will be used to exclude the provenance events sent by the reporting task. If no "
                                         + "filter is set, all the events are sent. If multiple filters are set, the filters are cumulative. If a component UUID is included in "
                                         + "Component ID to Include and excluded here, then the exclusion takes precedence and the event will not be sent.")
@@ -124,29 +125,29 @@ public class AzureLogAnalyticsProvenanceReportingTask extends AbstractAzureLogAn
                         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
 
         static final PropertyDescriptor FILTER_COMPONENT_NAME = new PropertyDescriptor.Builder()
-                        .name("s2s-prov-task-name-filter").displayName("Component Name to Include")
+                        .name("Component Name to Include")
                         .description("Regular expression to filter the provenance events based on the component name. Only the events matching the regular "
                                         + "expression will be sent. If no filter is set, all the events are sent. If multiple filters are set, the filters are cumulative.")
                         .required(false).expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
                         .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR).build();
 
         static final PropertyDescriptor FILTER_COMPONENT_NAME_EXCLUDE = new PropertyDescriptor.Builder()
-                        .name("s2s-prov-task-name-filter-exclude").displayName("Component Name to Exclude")
+                        .name("Component Name to Exclude")
                         .description("Regular expression to exclude the provenance events based on the component name. The events matching the regular "
                                         + "expression will not be sent. If no filter is set, all the events are sent. If multiple filters are set, the filters are cumulative. "
                                         + "If a component name is included in Component Name to Include and excluded here, then the exclusion takes precedence and the event will not be sent.")
                         .required(false).expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
                         .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR).build();
 
-        static final PropertyDescriptor START_POSITION = new PropertyDescriptor.Builder().name("start-position")
-                        .displayName("Start Position")
+        static final PropertyDescriptor START_POSITION = new PropertyDescriptor.Builder()
+                        .name("Start Position")
                         .description("If the Reporting Task has never been run, or if its state has been reset by a user, "
                                         + "specifies where in the stream of Provenance Events the Reporting Task should start")
                         .allowableValues(BEGINNING_OF_STREAM, END_OF_STREAM)
                         .defaultValue(BEGINNING_OF_STREAM).required(true).build();
 
-        static final PropertyDescriptor ALLOW_NULL_VALUES = new PropertyDescriptor.Builder().name("include-null-values")
-                        .displayName("Include Null Values")
+        static final PropertyDescriptor ALLOW_NULL_VALUES = new PropertyDescriptor.Builder()
+                        .name("Include Null Values")
                         .description("Indicate if null values should be included in records. Default will be false")
                         .required(true).allowableValues("true", "false").defaultValue("false").build();
 
@@ -276,6 +277,20 @@ public class AzureLogAnalyticsProvenanceReportingTask extends AbstractAzureLogAn
                 } catch (final Exception e) {
                         getLogger().error("Failed to publish metrics to Azure Log Analytics", e);
                 }
+        }
+
+        @Override
+        public void migrateProperties(PropertyConfiguration config) {
+                config.renameProperty("s2s-prov-task-event-filter", FILTER_EVENT_TYPE.getName());
+                config.renameProperty("s2s-prov-task-event-filter-exclude", FILTER_EVENT_TYPE_EXCLUDE.getName());
+                config.renameProperty("s2s-prov-task-type-filter", FILTER_COMPONENT_TYPE.getName());
+                config.renameProperty("s2s-prov-task-type-filter-exclude", FILTER_COMPONENT_TYPE_EXCLUDE.getName());
+                config.renameProperty("s2s-prov-task-id-filter", FILTER_COMPONENT_ID.getName());
+                config.renameProperty("s2s-prov-task-id-filter-exclude", FILTER_COMPONENT_ID_EXCLUDE.getName());
+                config.renameProperty("s2s-prov-task-name-filter", FILTER_COMPONENT_NAME.getName());
+                config.renameProperty("s2s-prov-task-name-filter-exclude", FILTER_COMPONENT_NAME_EXCLUDE.getName());
+                config.renameProperty("start-position", START_POSITION.getName());
+                config.renameProperty("include-null-values", ALLOW_NULL_VALUES.getName());
         }
 
         public void processProvenanceData(final ReportingContext context) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14951](https://issues.apache.org/jira/browse/NIFI-14951)
Please note the following for the properties listed below. Instead of using `fromDescriptor` on properties defined in `AzureStorageUtils`, the actual definitions were taken from there (i.e. the settings), as it was too hard otherwise to change the name.

In `CopyAzureBlobStorage_v12` properties `DESTINATION_STORAGE_CREDENTIALS_SERVICE`, `DESTINATION_CONTAINER_NAME` and `DESTINATION_BLOB_NAME`.

In `MoveAzureDataLakeStorage` properties `DESTINATION_FILESYSTEM` and `DESTINATION_DIRECTORY`.



# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
