### PR TITLE
NIFI-14993 - Bump Spring Security to 6.5.5, Spring Boot to 3.5.6, Elasticsearch to 9.1.4, and others

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>9.1.3</elasticsearch.client.version>
+        <elasticsearch.client.version>9.1.4</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
-            <version>2.1.3</version>
+            <version>2.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20250829-2.0.0</version>
+            <version>v3-rev20250910-2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.tdunning</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -35,8 +35,8 @@
         <module>nifi-registry-docker-maven</module>
     </modules>
     <properties>
-        <spring.boot.version>3.5.5</spring.boot.version>
-        <flyway.version>11.13.0</flyway.version>
+        <spring.boot.version>3.5.6</spring.boot.version>
+        <flyway.version>11.13.1</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.3.0.202506031305-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.791</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.33.11</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.33.12</software.amazon.awssdk.version>
         <gson.version>2.13.2</gson.version>
         <io.fabric8.kubernetes.client.version>7.4.0</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.20</kotlin.version>
@@ -161,7 +161,7 @@
         <netty.4.version>4.2.6.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.version>6.2.11</spring.version>
-        <spring.security.version>6.5.4</spring.security.version>
+        <spring.security.version>6.5.5</spring.security.version>
         <swagger.annotations.version>2.2.37</swagger.annotations.version>
         <caffeine.version>3.2.2</caffeine.version>
         <hapi.version>2.6.0</hapi.version>


### PR DESCRIPTION
# Summary

NIFI-14993 - Bump Spring Security to 6.5.5, Spring Boot to 3.5.6, Elasticsearch to 9.1.4, and others

- Elasticsearch from 9.1.3 to 9.1.4 - https://github.com/elastic/elasticsearch-java/releases/tag/v9.1.4
- Jakarta Activation API from 2.1.3 to 2.1.4 - https://github.com/jakartaee/jaf-api/releases/tag/2.1.4
- Google Drive from v3-rev20250829-2.0.0 to v3-rev20250910-2.0.0 - https://github.com/googleapis/google-api-java-client-services/blob/main/clients/google-api-services-drive/v3/2.0.0/README.md
- Spring Boot from 3.5.5 to 3.5.6 - https://github.com/spring-projects/spring-boot/releases/tag/v3.5.6
- FlywayDB from 11.13.0 to 11.13.1 - https://github.com/flyway/flyway/releases/tag/flyway-11.13.1
- AWS SDK v2 from 2.33.11 to 2.33.12 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Spring Security from 6.5.4 to 6.5.5 - https://github.com/spring-projects/spring-security/releases/tag/6.5.5

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
