### PR TITLE
NIFI-14985 - Fix logic to check for dynamic properties for properties being removed showing as environmental changes

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
@@ -112,12 +112,7 @@ public class FlowDifferenceFilters {
 
     }
 
-    private static boolean supportsDynamicProperties(final ConfigurableComponent component, final String propertyName) {
-        final PropertyDescriptor descriptor = component.getPropertyDescriptor(propertyName);
-        if (descriptor != null && descriptor.isDynamic()) {
-            return true;
-        }
-
+    private static boolean supportsDynamicProperties(final ConfigurableComponent component) {
         final Class<?> componentClass = component.getClass();
         return componentClass.isAnnotationPresent(DynamicProperty.class) || componentClass.isAnnotationPresent(DynamicProperties.class);
     }
@@ -474,7 +469,7 @@ public class FlowDifferenceFilters {
             return false;
         }
 
-        if (supportsDynamicProperties(configurableComponent, propertyName)) {
+        if (supportsDynamicProperties(configurableComponent)) {
             return false;
         }
 


### PR DESCRIPTION
# Summary

NIFI-14985 - Fix logic to check for dynamic properties for properties being removed showing as environmental changes

This is a follow-up for the change in #10317 where the implemented logic was not correct.

The implemented logic is not correct when it comes to checking if we may be in the case of a dynamic property being removed. Checking the property descriptor is not the right solution because it will always be showing as dynamic: this is the default behavior of NiFi when a property is removed, NiFi will keep the property and convert it as a dynamic one by default. We should only rely on the annotations on the component to check if we're indeed facing a change where the property being removed was a static property and its removal should be ignored and not showing as a local change.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
