### PR TITLE
NIFI-14995 - Improve Flow Differences Filter to account for renameProperty and createControllerService

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -3983,8 +3983,12 @@ public final class StandardProcessGroup implements ProcessGroup {
             final FlowComparator flowComparator = new StandardFlowComparator(snapshotFlow, currentFlow, getAncestorServiceIds(),
                 new EvolvingDifferenceDescriptor(), encryptor::decrypt, VersionedComponent::getIdentifier, FlowComparatorVersionedStrategy.SHALLOW);
             final FlowComparison comparison = flowComparator.compare();
-            final Set<FlowDifference> differences = comparison.getDifferences().stream()
-                .filter(difference -> !FlowDifferenceFilters.isEnvironmentalChange(difference, versionedGroup, flowManager))
+            final Collection<FlowDifference> comparisonDifferences = comparison.getDifferences();
+            final FlowDifferenceFilters.EnvironmentalChangeContext environmentalContext =
+                FlowDifferenceFilters.buildEnvironmentalChangeContext(comparisonDifferences, flowManager);
+
+            final Set<FlowDifference> differences = comparisonDifferences.stream()
+                .filter(difference -> !FlowDifferenceFilters.isEnvironmentalChange(difference, versionedGroup, flowManager, environmentalContext))
                 .collect(Collectors.toCollection(HashSet::new));
 
             LOG.debug("There are {} differences between this Local Flow and the Versioned Flow: {}", differences.size(), differences);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
@@ -27,12 +27,15 @@ import org.apache.nifi.controller.label.StandardLabel;
 import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.apache.nifi.flow.ComponentType;
 import org.apache.nifi.flow.VersionedComponent;
+import org.apache.nifi.flow.VersionedConfigurableComponent;
 import org.apache.nifi.flow.VersionedConnection;
+import org.apache.nifi.flow.VersionedControllerService;
 import org.apache.nifi.flow.VersionedFlowCoordinates;
 import org.apache.nifi.flow.VersionedLabel;
 import org.apache.nifi.flow.VersionedPort;
 import org.apache.nifi.flow.VersionedProcessGroup;
 import org.apache.nifi.flow.VersionedProcessor;
+import org.apache.nifi.flow.VersionedReportingTask;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.registry.flow.diff.DifferenceType;
 import org.apache.nifi.registry.flow.diff.FlowDifference;
@@ -40,14 +43,24 @@ import org.apache.nifi.registry.flow.mapping.InstantiatedVersionedComponent;
 import org.apache.nifi.registry.flow.mapping.InstantiatedVersionedControllerService;
 import org.apache.nifi.registry.flow.mapping.InstantiatedVersionedProcessor;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class FlowDifferenceFilters {
+
+    private static final Pattern PARAMETER_REFERENCE_PATTERN = Pattern.compile("#\\{[A-Za-z0-9\\-_. ]+}");
 
     /**
      * Determines whether or not the Flow Difference depicts an environmental change. I.e., a change that is expected to happen from environment to environment,
@@ -58,6 +71,12 @@ public class FlowDifferenceFilters {
      * @return <code>true</code> if the change is an environment-specific change, <code>false</code> otherwise
      */
     public static boolean isEnvironmentalChange(final FlowDifference difference, final VersionedProcessGroup localGroup, final FlowManager flowManager) {
+        return isEnvironmentalChange(difference, localGroup, flowManager, EnvironmentalChangeContext.empty());
+    }
+
+    public static boolean isEnvironmentalChange(final FlowDifference difference, final VersionedProcessGroup localGroup, final FlowManager flowManager,
+                                                final EnvironmentalChangeContext context) {
+        final EnvironmentalChangeContext evaluatedContext = context == null ? EnvironmentalChangeContext.empty() : context;
         return difference.getDifferenceType() == DifferenceType.BUNDLE_CHANGED
             || isSensitivePropertyDueToGhosting(difference, flowManager)
             || isRpgUrlChange(difference)
@@ -74,7 +93,9 @@ public class FlowDifferenceFilters {
             || isRegistryUrlChange(difference)
             || isParameterContextChange(difference)
             || isLogFileSuffixChange(difference)
-            || isStaticPropertyRemoved(difference, flowManager);
+            || isStaticPropertyRemoved(difference, flowManager)
+            || isControllerServiceCreatedForNewProperty(difference, evaluatedContext)
+            || isPropertyParameterizationRename(difference, evaluatedContext);
     }
 
     private static boolean isSensitivePropertyDueToGhosting(final FlowDifference difference, final FlowManager flowManager) {
@@ -110,6 +131,15 @@ public class FlowDifferenceFilters {
             default -> null;
         };
 
+    }
+
+    private static ComponentNode getComponent(final FlowManager flowManager, final VersionedComponent component) {
+        if (!(component instanceof InstantiatedVersionedComponent)) {
+            return null;
+        }
+
+        final InstantiatedVersionedComponent instantiatedComponent = (InstantiatedVersionedComponent) component;
+        return getComponent(flowManager, component.getComponentType(), instantiatedComponent.getInstanceIdentifier());
     }
 
     private static boolean supportsDynamicProperties(final ConfigurableComponent component) {
@@ -546,5 +576,303 @@ public class FlowDifferenceFilters {
 
     private static boolean isLogFileSuffixChange(final FlowDifference flowDifference) {
         return flowDifference.getDifferenceType() == DifferenceType.LOG_FILE_SUFFIX_CHANGED;
+    }
+
+    public static EnvironmentalChangeContext buildEnvironmentalChangeContext(final Collection<FlowDifference> differences, final FlowManager flowManager) {
+        if (differences == null || differences.isEmpty() || flowManager == null) {
+            return EnvironmentalChangeContext.empty();
+        }
+
+        final Set<String> serviceIdsReferencedByNewProperties = new HashSet<>();
+        final Map<String, List<PropertyDiffInfo>> parameterizedAddsByComponent = new HashMap<>();
+        final Map<String, List<PropertyDiffInfo>> parameterizationRemovalsByComponent = new HashMap<>();
+
+        for (final FlowDifference difference : differences) {
+            if (difference.getDifferenceType() == DifferenceType.PROPERTY_ADDED) {
+                final ComponentNode componentNode = Optional.ofNullable(getComponent(flowManager, difference.getComponentB()))
+                        .orElseGet(() -> getComponent(flowManager, difference.getComponentA()));
+                if (componentNode != null) {
+                    final Optional<String> fieldNameOptional = difference.getFieldName();
+                    if (fieldNameOptional.isPresent()) {
+                        final PropertyDescriptor propertyDescriptor = componentNode.getPropertyDescriptor(fieldNameOptional.get());
+                        if (propertyDescriptor != null && !propertyDescriptor.isDynamic() && propertyDescriptor.getControllerServiceDefinition() != null) {
+                            final Object valueB = difference.getValueB();
+                            if (valueB instanceof String) {
+                                serviceIdsReferencedByNewProperties.add((String) valueB);
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (difference.getDifferenceType() == DifferenceType.PROPERTY_PARAMETERIZED
+                    || difference.getDifferenceType() == DifferenceType.PROPERTY_PARAMETERIZATION_REMOVED) {
+
+                final Optional<String> propertyNameOptional = difference.getFieldName();
+                final Optional<String> componentIdOptional = getComponentInstanceIdentifier(difference);
+
+                if (!propertyNameOptional.isPresent() || !componentIdOptional.isPresent()) {
+                    continue;
+                }
+
+                final String componentId = componentIdOptional.get();
+                final Optional<String> propertyValue = difference.getDifferenceType() == DifferenceType.PROPERTY_PARAMETERIZED
+                        ? getParameterReferenceValue(difference, false)
+                        : getParameterReferenceValue(difference, true);
+
+                final PropertyDiffInfo diffInfo = new PropertyDiffInfo(propertyValue, difference);
+
+                if (difference.getDifferenceType() == DifferenceType.PROPERTY_PARAMETERIZED) {
+                    parameterizedAddsByComponent.computeIfAbsent(componentId, key -> new ArrayList<>()).add(diffInfo);
+                } else {
+                    parameterizationRemovalsByComponent.computeIfAbsent(componentId, key -> new ArrayList<>()).add(diffInfo);
+                }
+            }
+        }
+
+        Set<String> serviceIdsWithMatchingAdditions = Collections.emptySet();
+        if (!serviceIdsReferencedByNewProperties.isEmpty()) {
+            serviceIdsWithMatchingAdditions = differences.stream()
+                    .filter(diff -> diff.getDifferenceType() == DifferenceType.COMPONENT_ADDED)
+                    .map(FlowDifferenceFilters::extractControllerServiceIdentifier)
+                    .filter(Objects::nonNull)
+                    .filter(serviceIdsReferencedByNewProperties::contains)
+                    .collect(Collectors.toCollection(HashSet::new));
+        }
+
+        final Set<FlowDifference> parameterizedPropertyRenameDifferences = new HashSet<>();
+        for (final Map.Entry<String, List<PropertyDiffInfo>> entry : parameterizationRemovalsByComponent.entrySet()) {
+            final String componentId = entry.getKey();
+            final List<PropertyDiffInfo> removals = entry.getValue();
+            final List<PropertyDiffInfo> additions = new ArrayList<>(parameterizedAddsByComponent.getOrDefault(componentId, Collections.emptyList()));
+            if (additions.isEmpty()) {
+                continue;
+            }
+
+            for (final PropertyDiffInfo removalInfo : removals) {
+                final Optional<String> removalValue = removalInfo.propertyValue();
+                if (removalValue.isPresent() && !isParameterReference(removalValue.get())) {
+                    continue;
+                }
+
+                PropertyDiffInfo matchingAddition = null;
+                for (final Iterator<PropertyDiffInfo> iterator = additions.iterator(); iterator.hasNext();) {
+                    final PropertyDiffInfo additionInfo = iterator.next();
+                    final Optional<String> additionValue = additionInfo.propertyValue();
+                    if (additionValue.isPresent() && !isParameterReference(additionValue.get())) {
+                        continue;
+                    }
+
+                    if (valuesMatch(removalValue, additionValue)) {
+                        matchingAddition = additionInfo;
+                        iterator.remove();
+                        break;
+                    }
+                }
+
+                if (matchingAddition != null) {
+                    parameterizedPropertyRenameDifferences.add(removalInfo.difference());
+                    parameterizedPropertyRenameDifferences.add(matchingAddition.difference());
+                }
+            }
+        }
+
+        if (serviceIdsWithMatchingAdditions.isEmpty() && parameterizedPropertyRenameDifferences.isEmpty()) {
+            return EnvironmentalChangeContext.empty();
+        }
+
+        return new EnvironmentalChangeContext(serviceIdsWithMatchingAdditions, parameterizedPropertyRenameDifferences);
+    }
+
+    public static boolean isControllerServiceCreatedForNewProperty(final FlowDifference difference, final EnvironmentalChangeContext context) {
+        return isControllerServiceCreatedForNewPropertyInternal(difference, context == null ? EnvironmentalChangeContext.empty() : context);
+    }
+
+    private static boolean isControllerServiceCreatedForNewPropertyInternal(final FlowDifference difference, final EnvironmentalChangeContext context) {
+        if (context.serviceIdsCreatedForNewProperties().isEmpty()) {
+            return false;
+        }
+
+        if (difference.getDifferenceType() == DifferenceType.PROPERTY_ADDED) {
+            final Object valueB = difference.getValueB();
+            if (valueB instanceof String) {
+                return context.serviceIdsCreatedForNewProperties().contains(valueB);
+            }
+        }
+
+        if (difference.getDifferenceType() == DifferenceType.COMPONENT_ADDED) {
+            final String serviceIdentifier = extractControllerServiceIdentifier(difference);
+            return serviceIdentifier != null && context.serviceIdsCreatedForNewProperties().contains(serviceIdentifier);
+        }
+
+        return false;
+    }
+
+    private static String extractControllerServiceIdentifier(final FlowDifference difference) {
+        final String identifierFromComponentB = extractControllerServiceIdentifier(difference.getComponentB());
+        if (identifierFromComponentB != null) {
+            return identifierFromComponentB;
+        }
+
+        return extractControllerServiceIdentifier(difference.getComponentA());
+    }
+
+    private static String extractControllerServiceIdentifier(final VersionedComponent component) {
+        if (component instanceof InstantiatedVersionedControllerService) {
+            final InstantiatedVersionedControllerService instantiatedControllerService = (InstantiatedVersionedControllerService) component;
+            final String instanceIdentifier = instantiatedControllerService.getInstanceIdentifier();
+            if (instanceIdentifier != null) {
+                return instanceIdentifier;
+            }
+        }
+
+        if (component instanceof VersionedControllerService) {
+            return component.getIdentifier();
+        }
+
+        return null;
+    }
+
+    public static boolean isPropertyParameterizationRename(final FlowDifference difference, final EnvironmentalChangeContext context) {
+        return (context == null || context.parameterizedPropertyRenames().isEmpty()) ? false : context.parameterizedPropertyRenames().contains(difference);
+    }
+
+    private static Optional<String> getComponentInstanceIdentifier(final FlowDifference difference) {
+        final Optional<String> identifierB = getComponentInstanceIdentifier(difference.getComponentB());
+        if (identifierB.isPresent()) {
+            return identifierB;
+        }
+
+        return getComponentInstanceIdentifier(difference.getComponentA());
+    }
+
+    private static Optional<String> getComponentInstanceIdentifier(final VersionedComponent component) {
+        if (component == null) {
+            return Optional.empty();
+        }
+
+        if (component instanceof InstantiatedVersionedComponent) {
+            final String instanceId = ((InstantiatedVersionedComponent) component).getInstanceIdentifier();
+            if (instanceId != null) {
+                return Optional.of(instanceId);
+            }
+        }
+
+        return Optional.ofNullable(component.getIdentifier());
+    }
+
+    private static Optional<String> getParameterReferenceValue(final FlowDifference difference, final boolean fromComponentA) {
+        final VersionedComponent primaryComponent = fromComponentA ? difference.getComponentA() : difference.getComponentB();
+        final VersionedComponent secondaryComponent = fromComponentA ? difference.getComponentB() : difference.getComponentA();
+
+        final Map<String, String> primaryProperties = getProperties(primaryComponent);
+        if (primaryProperties.isEmpty()) {
+            return Optional.empty();
+        }
+
+        final Map<String, String> secondaryProperties = getProperties(secondaryComponent);
+
+        final Optional<String> fieldNameOptional = difference.getFieldName();
+        if (fieldNameOptional.isPresent()) {
+            final String fieldName = fieldNameOptional.get();
+            final String propertyValue = primaryProperties.get(fieldName);
+            if (propertyValue != null) {
+                return Optional.of(propertyValue);
+            }
+        }
+
+        // Fallback: find a property unique to the primary component whose value is a parameter reference.
+        for (Map.Entry<String, String> entry : primaryProperties.entrySet()) {
+            final String propertyName = entry.getKey();
+            final String propertyValue = entry.getValue();
+            if (!isParameterReference(propertyValue)) {
+                continue;
+            }
+
+            if (!secondaryProperties.containsKey(propertyName)) {
+                return Optional.of(propertyValue);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static Map<String, String> getProperties(final VersionedComponent component) {
+        if (component == null) {
+            return Collections.emptyMap();
+        }
+
+        if (component instanceof VersionedConfigurableComponent) {
+            final Map<String, String> properties = ((VersionedConfigurableComponent) component).getProperties();
+            return properties == null ? Collections.emptyMap() : properties;
+        }
+
+        if (component instanceof VersionedProcessor) {
+            final Map<String, String> properties = ((VersionedProcessor) component).getProperties();
+            return properties == null ? Collections.emptyMap() : properties;
+        }
+
+        if (component instanceof VersionedControllerService) {
+            final Map<String, String> properties = ((VersionedControllerService) component).getProperties();
+            return properties == null ? Collections.emptyMap() : properties;
+        }
+
+        if (component instanceof VersionedReportingTask) {
+            final Map<String, String> properties = ((VersionedReportingTask) component).getProperties();
+            return properties == null ? Collections.emptyMap() : properties;
+        }
+
+        return Collections.emptyMap();
+    }
+
+    private static boolean valuesMatch(final Optional<String> first, final Optional<String> second) {
+        return first.isPresent() && second.isPresent() && first.get().equals(second.get());
+    }
+
+    private static boolean isParameterReference(final String propertyValue) {
+        return propertyValue != null && PARAMETER_REFERENCE_PATTERN.matcher(propertyValue).matches();
+    }
+
+    private static final class PropertyDiffInfo {
+        private final Optional<String> propertyValue;
+        private final FlowDifference difference;
+
+        private PropertyDiffInfo(final Optional<String> propertyValue, final FlowDifference difference) {
+            this.propertyValue = propertyValue;
+            this.difference = difference;
+        }
+
+        Optional<String> propertyValue() {
+            return propertyValue;
+        }
+
+        FlowDifference difference() {
+            return difference;
+        }
+    }
+
+    public static final class EnvironmentalChangeContext {
+        private static final EnvironmentalChangeContext EMPTY = new EnvironmentalChangeContext(Collections.emptySet(), Collections.emptySet());
+
+        private final Set<String> serviceIdsCreatedForNewProperties;
+        private final Set<FlowDifference> parameterizedPropertyRenames;
+
+        private EnvironmentalChangeContext(final Set<String> serviceIdsCreatedForNewProperties,
+                                           final Set<FlowDifference> parameterizedPropertyRenames) {
+            this.serviceIdsCreatedForNewProperties = Collections.unmodifiableSet(new HashSet<>(serviceIdsCreatedForNewProperties));
+            this.parameterizedPropertyRenames = Collections.unmodifiableSet(new HashSet<>(parameterizedPropertyRenames));
+        }
+
+        static EnvironmentalChangeContext empty() {
+            return EMPTY;
+        }
+
+        Set<String> serviceIdsCreatedForNewProperties() {
+            return serviceIdsCreatedForNewProperties;
+        }
+
+        Set<FlowDifference> parameterizedPropertyRenames() {
+            return parameterizedPropertyRenames;
+        }
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -2803,9 +2803,13 @@ public final class DtoFactory {
 
        final Map<String, VersionedProcessGroup> versionedGroups = flattenProcessGroups(comparison.getFlowA().getContents());
 
-       for (final FlowDifference difference : comparison.getDifferences()) {
+       final Collection<FlowDifference> comparisonDifferences = comparison.getDifferences();
+       final FlowDifferenceFilters.EnvironmentalChangeContext environmentalContext =
+               FlowDifferenceFilters.buildEnvironmentalChangeContext(comparisonDifferences, flowManager);
+
+       for (final FlowDifference difference : comparisonDifferences) {
            // Ignore any environment-specific change
-           if (FlowDifferenceFilters.isEnvironmentalChange(difference, localGroup, flowManager)) {
+           if (FlowDifferenceFilters.isEnvironmentalChange(difference, localGroup, flowManager, environmentalContext)) {
                continue;
            }
 


### PR DESCRIPTION
# Summary

NIFI-14995 - Improve Flow Differences Filter to account for renameProperty and createControllerService

As we use more and more the `migrateProperties` capabilities, we see that we have some corner cases where the automated changes are showing as local changes which is confusing because a user is upgrading without making any changes to their versioned flows and the UI is showing that some local modifications have been made. Such scenarios should be better handled to not show local changes.

One scenario has been handled in [NIFI-14985](https://issues.apache.org/jira/browse/NIFI-14985) to better deal with removed properties.

This change is to handle two additional scenarios (this is combined in a single PR because of the approach taken that is introducing a concept of environmental context)

### Rename property with parameters

Let's consider a processor version N with

````java
    public static final PropertyDescriptor ACCESS_KEY_ID = new PropertyDescriptor.Builder()
        .name("Access Key")
        .displayName("Access Key ID")
        .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
        .required(false)
        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
        .sensitive(true)
        .build();
````

And then version N+1 with

````java
    public static final PropertyDescriptor ACCESS_KEY_ID = new PropertyDescriptor.Builder()
        .name("Access Key ID")
        .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
        .required(false)
        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
        .sensitive(true)
        .build();
...
    public void migrateProperties(PropertyConfiguration config) {
        config.renameProperty("Access Key", ACCESS_KEY_ID.getName());
    }
````

If the versioned flow is containing:

````json
       "groupIdentifier" : "flow-contents-group",
       "identifier" : "8de3b31b-0a70-3e01-a01c-4ed2fe3a4cbe",
       "name" : "AWS Credentials Provider",
       "properties" : {
         "Access Key" : "#{AWS Access Key ID}",
         "default-credentials" : "false",
         "Session Time" : "3600",
         "assume-role-sts-signer-override" : "Default Signature",
         "assume-role-sts-region" : "us-west-2",
         "Secret Key" : "#{AWS Secret Access Key}",
         "anonymous-credentials" : "false"
       }, 
````

Then we would show two local changes:
- Property Parameterization Removed - Property 'Access Key ID' is no longer a parameter reference
- Property Parameterized - Property 'Access Key ID' was parameterized

We should not be showing this as local changes.

### Create Controller Service

When using something like:

````java
     @Override
     public void migrateProperties(final PropertyConfiguration config) {
         if (!config.isPropertySet(ABC.getName())) {
             final String serviceId = config.createControllerService(
                     "org.apache.nifi.foo",
                     Map.of());
             config.setProperty(ABC, serviceId);
         }
         super.migrateProperties(config);
     } 
````

Then we would be showing two local changes:
- Property Added: the property ABC has been added
- Component Created: a controller service has been created

We should check that if the property being added is not a dynamic property, and is referencing the UUID of the created controller service, then both changes should not be showing as local changes.

### Approach

Introducing a richer `EnvironmentalChangeContext` that is reused across all comparisons. This is how we can link a couple of differences as related to the same change and decide to filter out the differences or not.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
