### PR TITLE
NIFI-15001 - Fix PutElasticsearchRecord with recursive reads

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractPutElasticsearch.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractPutElasticsearch.java
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public abstract class AbstractPutElasticsearch extends AbstractProcessor implements ElasticsearchRestProcessor {
-    static final Relationship REL_ORIGINAL = new Relationship.Builder()
+    public static final Relationship REL_ORIGINAL = new Relationship.Builder()
             .name("original")
             .description("All flowfiles that are sent to Elasticsearch without request failures go to this relationship.")
             .build();

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -108,7 +108,7 @@ language governing permissions and limitations under the License. -->
         <profile>
             <id>elasticsearch8</id>
             <properties>
-                <elasticsearch_docker_image>8.18.2</elasticsearch_docker_image>
+                <elasticsearch_docker_image>8.19.4</elasticsearch_docker_image>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
# Summary

NIFI-15001 - Fix `PutElasticsearchRecord` with recursive reads

When `PutElasticsearchRecord` processed FlowFiles with batch sizes smaller than the record count, it re-read the FlowFile to build error batches. With recursive reads disabled (the default), the second `session.read()` triggered `IllegalStateException: FlowFile … already in use`, so entire FlowFiles were routed to failure.

The change keeps processing single-pass: every record is cloned exactly once when read from the RecordReader. The mutated copy is used for the Elasticsearch `_bulk` request, while an untouched clone is retained for provenance and error routing. This eliminates the recursive read and keeps RecordPath mutations from leaking into error output.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
