### PR TITLE
NIFI-14959 fix consistent hash function for partition-by-attribute

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/CorrelationAttributePartitioner.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/CorrelationAttributePartitioner.java
@@ -72,8 +72,13 @@ public class CorrelationAttributePartitioner implements FlowFilePartitioner {
         return false;
     }
 
+    /*
+     * Method implementation based on Google Guava com.google.common.hash.Hashing.consistentHash()
+     *
+     * Assigns an index number in the range [0 - (partitions-1)] with a uniform distribution across partitions
+     * while minimizing redistribution if the number of partitions changes.
+     */
     private int findIndex(final long hash, final int partitions) {
-        // Method implementation based on Google Guava com.google.common.hash.Hashing.consistentHash()
         final LinearCongruentialGenerator generator = new LinearCongruentialGenerator(hash);
         int candidate = 0;
 
@@ -84,14 +89,7 @@ public class CorrelationAttributePartitioner implements FlowFilePartitioner {
             if (next >= 0 && next < partitions) {
                 candidate = next;
             } else {
-                final int index;
-                if (candidate == 0) {
-                    index = candidate;
-                } else {
-                    // Adjust index when handling more than one partition
-                    index = candidate - INDEX_OFFSET;
-                }
-                return index;
+                return candidate;
             }
         }
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/partition/CorrelationAttributePartitionerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/partition/CorrelationAttributePartitionerTest.java
@@ -34,9 +34,9 @@ import static org.mockito.Mockito.when;
 class CorrelationAttributePartitionerTest {
     private static final String PARTITIONING_ATTRIBUTE = "group";
 
-    private static final String FIRST_ATTRIBUTE = "1";
-
-    private static final String SECOND_ATTRIBUTE = "2";
+    private static final String FIRST_ATTRIBUTE = "4";  // value chosen so its hash places it in partition 1
+    private static final String SECOND_ATTRIBUTE = "1"; // value chosen so its hash places it in partition 2
+    private static final String THIRD_ATTRIBUTE = "2";  // value chosen so its hash places it in partition 3
 
     @Mock
     private FlowFileRecord flowFileRecord;
@@ -112,5 +112,11 @@ class CorrelationAttributePartitionerTest {
 
         final QueuePartition fourthSelected = partitioner.getPartition(flowFileRecord, partitions, localPartition);
         assertEquals(firstPartition, fourthSelected);
+
+        // Set Third Attribute for partitioning
+        when(flowFileRecord.getAttribute(eq(PARTITIONING_ATTRIBUTE))).thenReturn(THIRD_ATTRIBUTE);
+
+        final QueuePartition fifthSelected = partitioner.getPartition(flowFileRecord, partitions, localPartition);
+        assertEquals(thirdPartition, fifthSelected);
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-14959](https://issues.apache.org/jira/browse/NIFI-14959)

NIFI-14959 fix consistent hash function for partition-by-attribute load balance strategy.
If there are N partitions, the old function would return a range [0 - (N-2)]
and the index N-1 would never be returned.  The function should return a range [0 - (N-1)]

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
