### PR TITLE
NIFI-14949 - Display bulletin stack trace on bulletin board if it exi…

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/bulletins/ui/bulletin-board/bulletin-board-list/bulletin-board-list.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/bulletins/ui/bulletin-board/bulletin-board-list/bulletin-board-list.component.html
@@ -48,7 +48,7 @@
                     @if (isBulletin(item)) {
                         @if (asBulletin(item); as bulletin) {
                             @if (bulletin.canRead) {
-                                <li>
+                                <li class="w-full">
                                     <div class="inline-flex flex-wrap gap-x-1.5">
                                         <div>{{ bulletin.timestamp }}</div>
                                         <div class="font-bold {{ getSeverity(bulletin.bulletin.level) }}">
@@ -64,8 +64,23 @@
                                         @if (!!bulletin.nodeAddress) {
                                             <div>{{ bulletin.nodeAddress }}</div>
                                         }
-                                        <pre class="whitespace-pre-wrap">{{ bulletin.bulletin.message }}</pre>
+                                        <pre class="whitespace-pre-wrap" [copy]="getBulletinCopyMessage(bulletin)">{{
+                                            bulletin.bulletin.message
+                                        }}</pre>
                                     </div>
+                                    @if (bulletin.bulletin.stackTrace) {
+                                        <div class="w-full">
+                                            <a class="italic" (click)="toggleStackTrace(bulletin)">
+                                                {{ isExpanded(bulletin) ? 'Hide stack trace' : 'Show stack trace' }}
+                                            </a>
+                                            @if (isExpanded(bulletin)) {
+                                                <pre
+                                                    class="stack-trace mt-2 p-2 border whitespace-pre-wrap overflow-auto max-h-96"
+                                                    >{{ bulletin.bulletin.stackTrace }}</pre
+                                                >
+                                            }
+                                        </div>
+                                    }
                                 </li>
                             }
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/bulletins/ui/bulletin-board/bulletin-board-list/bulletin-board-list.component.scss
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/bulletins/ui/bulletin-board/bulletin-board-list/bulletin-board-list.component.scss
@@ -14,3 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+.stack-trace {
+    background-color: var(--mat-sys-surface-container);
+}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/bulletins/ui/bulletin-board/bulletin-board-list/bulletin-board-list.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/bulletins/ui/bulletin-board/bulletin-board-list/bulletin-board-list.component.spec.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { BulletinBoardList } from './bulletin-board-list.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -27,7 +28,7 @@ describe('BulletinBoardList', () => {
     beforeEach(() => {
         Element.prototype.scroll = jest.fn();
         TestBed.configureTestingModule({
-            imports: [BulletinBoardList, NoopAnimationsModule]
+            imports: [BulletinBoardList, NoopAnimationsModule, RouterTestingModule]
         });
         fixture = TestBed.createComponent(BulletinBoardList);
         component = fixture.componentInstance;
@@ -37,4 +38,234 @@ describe('BulletinBoardList', () => {
     it('should create', () => {
         expect(component).toBeTruthy();
     });
+
+    it('should emit filterChanged when applyFilter is called', () => {
+        const received: any[] = [];
+        component.filterChanged.subscribe((args) => received.push(args));
+        component.applyFilter('foo', 'message');
+        expect(received).toEqual([{ filterTerm: 'foo', filterColumn: 'message' }]);
+    });
+
+    it('should debounce filter term changes before emitting', fakeAsync(() => {
+        const received: any[] = [];
+        component.filterChanged.subscribe((args) => received.push(args));
+
+        component.filterForm.get('filterTerm')!.setValue('abc');
+        tick(499);
+        expect(received.length).toBe(0);
+        tick(1);
+        expect(received).toEqual([{ filterTerm: 'abc', filterColumn: 'message' }]);
+    }));
+
+    it('should emit immediately when filter column changes', () => {
+        const received: any[] = [];
+        component.filterChanged.subscribe((args) => received.push(args));
+        component.filterForm.get('filterColumn')!.setValue('name');
+        expect(received).toEqual([{ filterTerm: '', filterColumn: 'name' }]);
+    });
+
+    it('should return proper severity classes', () => {
+        expect(component.getSeverity('error')).toBe('bulletin-error error-color');
+        expect(component.getSeverity('warn')).toBe('bulletin-warn caution-color');
+        expect(component.getSeverity('warning')).toBe('bulletin-warn caution-color');
+        expect(component.getSeverity('info')).toBe('bulletin-normal success-color-default');
+    });
+
+    it('should determine bulletin vs event types correctly', () => {
+        const bulletin = {
+            canRead: true,
+            id: 1,
+            sourceId: 's1',
+            groupId: 'g1',
+            timestamp: 'now',
+            bulletin: {
+                id: 1,
+                sourceId: 's1',
+                groupId: 'g1',
+                category: 'cat',
+                level: 'INFO',
+                message: 'm',
+                sourceName: 'sn',
+                timestamp: 'now',
+                sourceType: 'PROCESSOR'
+            }
+        } as any;
+
+        const event = { type: 'filter', message: 'applied' } as any;
+
+        const bulletinItem = { item: bulletin } as any;
+        const eventItem = { item: event } as any;
+
+        expect(component.isBulletin(bulletinItem)).toBe(true);
+        expect(component.asBulletin(bulletinItem)).toBe(bulletin);
+        expect(component.asBulletinEvent(bulletinItem)).toBeNull();
+
+        expect(component.isBulletin(eventItem)).toBe(false);
+        expect(component.asBulletin(eventItem)).toBeNull();
+        expect(component.asBulletinEvent(eventItem)).toBe(event);
+    });
+
+    it('should build router links for known component types and contexts', () => {
+        const base = {
+            canRead: true,
+            id: 1,
+            sourceId: 'sid',
+            groupId: 'gid',
+            timestamp: 't'
+        } as any;
+
+        const generateBulletin = (sourceType: string, groupId: string | null = 'gid') =>
+            ({
+                ...base,
+                groupId: groupId ?? (undefined as any),
+                bulletin: {
+                    id: 1,
+                    sourceId: 'sid',
+                    groupId: groupId ?? undefined,
+                    category: 'c',
+                    level: 'INFO',
+                    message: 'm',
+                    sourceName: 'sn',
+                    timestamp: 't',
+                    sourceType
+                }
+            }) as any;
+
+        expect(component.getRouterLink(generateBulletin('CONTROLLER_SERVICE'))).toEqual([
+            '/process-groups',
+            'gid',
+            'controller-services',
+            'sid'
+        ]);
+        expect(component.getRouterLink(generateBulletin('CONTROLLER_SERVICE', null))).toEqual([
+            '/settings',
+            'management-controller-services',
+            'sid'
+        ]);
+        expect(component.getRouterLink(generateBulletin('REPORTING_TASK'))).toEqual([
+            '/settings',
+            'reporting-tasks',
+            'sid'
+        ]);
+        expect(component.getRouterLink(generateBulletin('FLOW_REGISTRY_CLIENT'))).toEqual([
+            '/settings',
+            'registry-clients',
+            'sid'
+        ]);
+        expect(component.getRouterLink(generateBulletin('FLOW_ANALYSIS_RULE'))).toEqual([
+            '/settings',
+            'flow-analysis-rules',
+            'sid'
+        ]);
+        expect(component.getRouterLink(generateBulletin('PARAMETER_PROVIDER'))).toEqual([
+            '/settings',
+            'parameter-providers',
+            'sid'
+        ]);
+        expect(component.getRouterLink(generateBulletin('PROCESSOR'))).toEqual([
+            '/process-groups',
+            'gid',
+            'Processor',
+            'sid'
+        ]);
+        expect(component.getRouterLink(generateBulletin('UNKNOWN'))).toBeNull();
+    });
+
+    it('should toggle stack trace expansion by bulletin id', () => {
+        const bulletin = {
+            canRead: true,
+            id: 1,
+            sourceId: 's1',
+            groupId: 'g1',
+            timestamp: 'now',
+            bulletin: {
+                id: 42,
+                sourceId: 's1',
+                groupId: 'g1',
+                category: 'cat',
+                level: 'ERROR',
+                message: 'm',
+                stackTrace: 'st',
+                sourceName: 'sn',
+                timestamp: 'now',
+                sourceType: 'PROCESSOR'
+            }
+        } as any;
+
+        expect(component.isExpanded(bulletin)).toBe(false);
+        component.toggleStackTrace(bulletin);
+        expect(component.isExpanded(bulletin)).toBe(true);
+        component.toggleStackTrace(bulletin);
+        expect(component.isExpanded(bulletin)).toBe(false);
+    });
+
+    it('should compose bulletin copy message with optional stack trace', () => {
+        const base = {
+            canRead: true,
+            id: 1,
+            sourceId: 's1',
+            groupId: 'g1',
+            timestamp: 'now'
+        } as any;
+        const withStack = {
+            ...base,
+            bulletin: {
+                id: 1,
+                sourceId: 's1',
+                groupId: 'g1',
+                category: 'c',
+                level: 'ERROR',
+                message: 'm',
+                stackTrace: 'st',
+                sourceName: 'sn',
+                timestamp: 'now',
+                sourceType: 'PROCESSOR'
+            }
+        } as any;
+        const withoutStack = {
+            ...base,
+            bulletin: {
+                id: 1,
+                sourceId: 's1',
+                groupId: 'g1',
+                category: 'c',
+                level: 'ERROR',
+                message: 'm',
+                sourceName: 'sn',
+                timestamp: 'now',
+                sourceType: 'PROCESSOR'
+            }
+        } as any;
+
+        expect(component.getBulletinCopyMessage(withStack)).toBe('m\n\nst');
+        expect(component.getBulletinCopyMessage(withoutStack)).toBe('m');
+    });
+
+    it('should auto-scroll when bulletins change', fakeAsync(() => {
+        const scrollSpy = jest.spyOn(Element.prototype as any, 'scroll');
+        scrollSpy.mockClear();
+        const bulletin = {
+            canRead: true,
+            id: 1,
+            sourceId: 's1',
+            groupId: 'g1',
+            timestamp: 'now',
+            bulletin: {
+                id: 1,
+                sourceId: 's1',
+                groupId: 'g1',
+                category: 'c',
+                level: 'INFO',
+                message: 'm',
+                sourceName: 'sn',
+                timestamp: 'now',
+                sourceType: 'PROCESSOR'
+            }
+        } as any;
+
+        component.bulletinBoardItems = [{ item: bulletin } as any];
+        fixture.detectChanges();
+        tick(11);
+        expect(scrollSpy).toHaveBeenCalledTimes(1);
+    }));
 });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/bulletins/ui/bulletin-board/bulletin-board-list/bulletin-board-list.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/bulletins/ui/bulletin-board/bulletin-board-list/bulletin-board-list.component.ts
@@ -32,7 +32,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatOptionModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { BulletinEntity, ComponentType, NiFiCommon } from '@nifi/shared';
+import { BulletinEntity, ComponentType, CopyDirective, NiFiCommon } from '@nifi/shared';
 import { BulletinBoardEvent, BulletinBoardFilterArgs, BulletinBoardItem } from '../../../state/bulletin-board';
 import { debounceTime, delay, Subject } from 'rxjs';
 import { RouterLink } from '@angular/router';
@@ -40,7 +40,16 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'bulletin-board-list',
-    imports: [MatFormFieldModule, MatInputModule, MatOptionModule, MatSelectModule, ReactiveFormsModule, RouterLink],
+    standalone: true,
+    imports: [
+        MatFormFieldModule,
+        MatInputModule,
+        MatOptionModule,
+        MatSelectModule,
+        ReactiveFormsModule,
+        RouterLink,
+        CopyDirective
+    ],
     templateUrl: './bulletin-board-list.component.html',
     styleUrls: ['./bulletin-board-list.component.scss']
 })
@@ -58,6 +67,8 @@ export class BulletinBoardList implements AfterViewInit, OnDestroy {
     private destroyRef: DestroyRef = inject(DestroyRef);
 
     @ViewChild('scrollContainer') private scroll!: ElementRef;
+
+    expandedBulletinIds: Set<number> = new Set<number>();
 
     @Input() set bulletinBoardItems(items: BulletinBoardItem[]) {
         this._items = items;
@@ -215,5 +226,24 @@ export class BulletinBoardList implements AfterViewInit, OnDestroy {
             default:
                 return null;
         }
+    }
+
+    isExpanded(bulletin: BulletinEntity): boolean {
+        return this.expandedBulletinIds.has(bulletin.bulletin.id);
+    }
+
+    toggleStackTrace(bulletin: BulletinEntity): void {
+        const id = bulletin.bulletin.id;
+        if (this.expandedBulletinIds.has(id)) {
+            this.expandedBulletinIds.delete(id);
+        } else {
+            this.expandedBulletinIds.add(id);
+        }
+    }
+    getBulletinCopyMessage(bulletin: BulletinEntity): string {
+        if (bulletin.bulletin.stackTrace) {
+            return bulletin.bulletin.message + '\n\n' + bulletin.bulletin.stackTrace;
+        }
+        return bulletin.bulletin.message;
     }
 }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/tooltips/bulletins-tip/bulletins-tip.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/tooltips/bulletins-tip/bulletins-tip.component.html
@@ -21,7 +21,7 @@
             @if (bulletinEntity.canRead) {
                 <li>
                     <div class="inline-flex flex-wrap gap-x-1.5">
-                        <div class="inline-flex flex-wrap gap-x-1.5" [copy]="bulletinEntity.bulletin.message">
+                        <div class="inline-flex flex-wrap gap-x-1.5">
                             <div>{{ bulletinEntity.bulletin.timestamp }}</div>
                             @if (bulletinEntity.nodeAddress) {
                                 <div>{{ bulletinEntity.nodeAddress }}</div>
@@ -30,7 +30,9 @@
                                 {{ bulletinEntity.bulletin.level }}
                             </div>
                         </div>
-                        <pre class="whitespace-pre-wrap">{{ bulletinEntity.bulletin.message }}</pre>
+                        <pre class="whitespace-pre-wrap" [copy]="getBulletinCopyMessage(bulletinEntity)">{{
+                            bulletinEntity.bulletin.message
+                        }}</pre>
                     </div>
                 </li>
             }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/tooltips/bulletins-tip/bulletins-tip.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/tooltips/bulletins-tip/bulletins-tip.component.spec.ts
@@ -35,4 +35,28 @@ describe('Bulletins', () => {
     it('should create', () => {
         expect(component).toBeTruthy();
     });
+
+    it('should return proper severity classes', () => {
+        expect(component.getSeverity('error')).toBe('bulletin-error error-color');
+        expect(component.getSeverity('warn')).toBe('bulletin-warn caution-color');
+        expect(component.getSeverity('warning')).toBe('bulletin-warn caution-color');
+        expect(component.getSeverity('info')).toBe('bulletin-normal success-color-default');
+    });
+
+    it('should compose bulletin copy message with optional stack trace', () => {
+        const withStack = {
+            bulletin: {
+                message: 'm',
+                stackTrace: 'st'
+            }
+        } as any;
+        const withoutStack = {
+            bulletin: {
+                message: 'm'
+            }
+        } as any;
+
+        expect(component.getBulletinCopyMessage(withStack)).toBe('m\n\nst');
+        expect(component.getBulletinCopyMessage(withoutStack)).toBe('m');
+    });
 });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/tooltips/bulletins-tip/bulletins-tip.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/tooltips/bulletins-tip/bulletins-tip.component.ts
@@ -17,7 +17,7 @@
 
 import { Component, Input } from '@angular/core';
 import { BulletinsTipInput } from '../../../../state/shared';
-import { CopyDirective } from '@nifi/shared';
+import { BulletinEntity, CopyDirective } from '@nifi/shared';
 
 @Component({
     selector: 'bulletins-tip',
@@ -38,5 +38,12 @@ export class BulletinsTip {
             default:
                 return 'bulletin-normal success-color-default';
         }
+    }
+
+    getBulletinCopyMessage(bulletin: BulletinEntity): string {
+        if (bulletin.bulletin.stackTrace) {
+            return bulletin.bulletin.message + '\n\n' + bulletin.bulletin.stackTrace;
+        }
+        return bulletin.bulletin.message;
     }
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/directives/copy/copy.directive.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/directives/copy/copy.directive.ts
@@ -18,7 +18,7 @@
  */
 
 import { Directive, ElementRef, HostListener, Input, NgZone, Renderer2, inject } from '@angular/core';
-import { fromEvent, Subscription, switchMap, take } from 'rxjs';
+import { fromEvent, Subscription, switchMap, take, tap } from 'rxjs';
 
 @Directive({
     selector: '[copy]',
@@ -49,8 +49,13 @@ export class CopyDirective {
 
                 // run outside the angular zone to prevent unnecessary change detection cycles
                 this.subscription = this.zone.runOutsideAngular(() => {
-                    return fromEvent(cb, 'click')
+                    return fromEvent<MouseEvent>(cb, 'click')
                         .pipe(
+                            tap((event: MouseEvent) => {
+                                // prevent copy click from triggering parent click handlers
+                                event.stopPropagation();
+                                event.preventDefault();
+                            }),
                             switchMap(() => navigator.clipboard.writeText(this.copy)),
                             take(1)
                         )

--- a/nifi-frontend/src/main/frontend/libs/shared/src/types/index.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/types/index.ts
@@ -181,6 +181,7 @@ export interface BulletinEntity {
         category: string;
         level: string;
         message: string;
+        stackTrace?: string;
         sourceName: string;
         timestamp: string;
         nodeAddress?: string;

--- a/nifi-frontend/src/main/frontend/package-lock.json
+++ b/nifi-frontend/src/main/frontend/package-lock.json
@@ -11617,28 +11617,28 @@
             }
         },
         "node_modules/@rspack/binding": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.5.6.tgz",
-            "integrity": "sha512-1I6VOr5pe4FeL6wUlrOmMUVXWcYTVJTpwBzprxGdiu9oYwltBTiTXd7F6x6NOId1CiPcmXZII+3aZr9X3JwoPA==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.5.7.tgz",
+            "integrity": "sha512-/fFrf4Yu8Tc0yXBw33g2++turdld1MDphLiLg05bx92fOVI1MafocwPvm35e3y1z7CtlQJ2Bmvzhi6APJShKxg==",
             "dev": true,
             "license": "MIT",
             "optionalDependencies": {
-                "@rspack/binding-darwin-arm64": "1.5.6",
-                "@rspack/binding-darwin-x64": "1.5.6",
-                "@rspack/binding-linux-arm64-gnu": "1.5.6",
-                "@rspack/binding-linux-arm64-musl": "1.5.6",
-                "@rspack/binding-linux-x64-gnu": "1.5.6",
-                "@rspack/binding-linux-x64-musl": "1.5.6",
-                "@rspack/binding-wasm32-wasi": "1.5.6",
-                "@rspack/binding-win32-arm64-msvc": "1.5.6",
-                "@rspack/binding-win32-ia32-msvc": "1.5.6",
-                "@rspack/binding-win32-x64-msvc": "1.5.6"
+                "@rspack/binding-darwin-arm64": "1.5.7",
+                "@rspack/binding-darwin-x64": "1.5.7",
+                "@rspack/binding-linux-arm64-gnu": "1.5.7",
+                "@rspack/binding-linux-arm64-musl": "1.5.7",
+                "@rspack/binding-linux-x64-gnu": "1.5.7",
+                "@rspack/binding-linux-x64-musl": "1.5.7",
+                "@rspack/binding-wasm32-wasi": "1.5.7",
+                "@rspack/binding-win32-arm64-msvc": "1.5.7",
+                "@rspack/binding-win32-ia32-msvc": "1.5.7",
+                "@rspack/binding-win32-x64-msvc": "1.5.7"
             }
         },
         "node_modules/@rspack/binding-darwin-arm64": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.5.6.tgz",
-            "integrity": "sha512-eRG8wbciBn09rdEGGijt3ZKYNgq1DGaiLaDb08HP1hZ/+SN4OdM9wxGo+abwkWl/Zv9ab/Ff8xc+Ry357UFvKA==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.5.7.tgz",
+            "integrity": "sha512-prQ/vgJxOPdlYiR4gVeOEKofTCEOu70JQIQApqFnw8lKM7rd9ag8ogDNqmc2L/GGXGHLAqds28oeKXRlzYf7+Q==",
             "cpu": [
                 "arm64"
             ],
@@ -11650,9 +11650,9 @@
             ]
         },
         "node_modules/@rspack/binding-darwin-x64": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.5.6.tgz",
-            "integrity": "sha512-+0ulwI2XNu1ArNP2UucKbePr1GAJiwaNL6Us5Ke0Qx/DRRzPGuA6X+R2iT30HjJRSLe6G9T9DxnBOnnqJOlysw==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.5.7.tgz",
+            "integrity": "sha512-FPqiWSbEEerqfJrGnYe68svvl6NyuQFAb3qqFe/Q0MqFhBYmAZwa0R2/ylugCdgFLZxmkFuWqpDgItpvJb/E3Q==",
             "cpu": [
                 "x64"
             ],
@@ -11664,9 +11664,9 @@
             ]
         },
         "node_modules/@rspack/binding-linux-arm64-gnu": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.5.6.tgz",
-            "integrity": "sha512-a7LxYdJzANj8xNjjlNJDCITQ9yAYGlc4Znz4DAYTX6vW0Q146rXCDif/UJLboYjQgrrbNbufpfRKEpPbYu2zGw==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.5.7.tgz",
+            "integrity": "sha512-fwy+NY+0CHrZqqzDrjPBlTuK53W4dG5EEg/QQFAE7KVM+okRqPk8tg45bJ5628rCNLe13GDmPIE107LmgspNqA==",
             "cpu": [
                 "arm64"
             ],
@@ -11678,9 +11678,9 @@
             ]
         },
         "node_modules/@rspack/binding-linux-arm64-musl": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.5.6.tgz",
-            "integrity": "sha512-Bi2Z8HhWH1ZikH2Ettowzej75Iy219KZYIl2W1RVwLkuAqm/DBRx099YsMmh+6esI8e3UgBQtWcHLz5lXaB+6g==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.5.7.tgz",
+            "integrity": "sha512-576u/0F4ZUzpHckFme4vQ0sSxjE+B/gVP4tNJ+P6bJaclXLFXV4icbjTUQwOIgmA1EQz/JFeKGGJZ4p6mowpBQ==",
             "cpu": [
                 "arm64"
             ],
@@ -11692,9 +11692,9 @@
             ]
         },
         "node_modules/@rspack/binding-linux-x64-gnu": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.5.6.tgz",
-            "integrity": "sha512-Ko4IbyaWA0B4e0EtXyfouVvkeIyh0bcgcESahir1tX/wRyXAV9aqOm0uRZ3eSIRaIvKxWQAmoi49/gFNgUMNJA==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.5.7.tgz",
+            "integrity": "sha512-brSHywXjjeuWkv0ywgxS4VgDgquarEb4XGr+eXhOaPcc8x2rNefyc4hErplrI7+oxPXVuGK5VE4ZH5bj3Yknvg==",
             "cpu": [
                 "x64"
             ],
@@ -11706,9 +11706,9 @@
             ]
         },
         "node_modules/@rspack/binding-linux-x64-musl": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.5.6.tgz",
-            "integrity": "sha512-Nyk2KoMiWruGe8GSGKlg0MU+EBWUiWJ+fV4/IEZw6tnAsod4YKIm4vD7f9jac0Mw07GIXggKQc0MaVhWTC8F7g==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.5.7.tgz",
+            "integrity": "sha512-HcS0DzbLlWCwVfYcWMbTgILh4GELD6m4CZoFEhIr4fJCJi0p8NgLYycy1QtDhaUjs8TKalmyMwHrJwGnD141JA==",
             "cpu": [
                 "x64"
             ],
@@ -11720,9 +11720,9 @@
             ]
         },
         "node_modules/@rspack/binding-wasm32-wasi": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.5.6.tgz",
-            "integrity": "sha512-Jj44lsdQWAaBZZwKk/x6UeQD/NFpH5uucHVXQUsC5BGF0PO3XbGSwhX7GSQ7+JuvFvEpIZDg6DuFXycB0Kv6iA==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.5.7.tgz",
+            "integrity": "sha512-uTRUEuK+TVlvUBSWXVoxD+6JTN+rvtRqVlO+A7I7VnOY7p9Rpvk1sXcHtEwg/XuDCq4DALnvlzbFLh7G3zILvw==",
             "cpu": [
                 "wasm32"
             ],
@@ -11734,9 +11734,9 @@
             }
         },
         "node_modules/@rspack/binding-win32-arm64-msvc": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.5.6.tgz",
-            "integrity": "sha512-zkAe6JRAUqHGYFO64GyGDQHk6jg5s+odFkZ66Z1jun7AvHXB99iDN5mX8+kNjaECXjIl4A9dT5oO8Ogc04vLkQ==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.5.7.tgz",
+            "integrity": "sha512-dFHrXRUmMTkxEn/Uw2RLbIckKfi0Zmn2NnEXwedWdyRgZW4Vhk7+VBxM22O/CHZmAGt12Ol25yTuVv58ANLEKA==",
             "cpu": [
                 "arm64"
             ],
@@ -11748,9 +11748,9 @@
             ]
         },
         "node_modules/@rspack/binding-win32-ia32-msvc": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.5.6.tgz",
-            "integrity": "sha512-M7ghMl0eh/cD5oNCCd8OPsUdgCPEsI3BKJqrWZmKFIMbJci0mDTLivc2/NIMt7fgbfRBSeUKeIQKbVbey6yufg==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.5.7.tgz",
+            "integrity": "sha512-PNtnOIUzE9p/Fbl6l/1Zs7bhn8ccTlaHTgZgQq0sO/QxjLlbU0WPjRl+YLo27cAningSOAbANuYlN8vAcuimrw==",
             "cpu": [
                 "ia32"
             ],
@@ -11762,9 +11762,9 @@
             ]
         },
         "node_modules/@rspack/binding-win32-x64-msvc": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.5.6.tgz",
-            "integrity": "sha512-i8HiI1gErP+vQ8DYz+oDbpNHPRZ8BSRl8tt3GA02FINujanKvy0xWyOQyOssxSio4IwWTlZQRQf0TEAT1UraUg==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.5.7.tgz",
+            "integrity": "sha512-22gTaYkwaIUvyXRxf1RVnFTJPqF2hD1pgAQNBIz7kYybe6vvSZ6KInW4WyG4vjYKrJg/cbS4QvtlLn0lYXrdIw==",
             "cpu": [
                 "x64"
             ],
@@ -11776,14 +11776,14 @@
             ]
         },
         "node_modules/@rspack/core": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.5.6.tgz",
-            "integrity": "sha512-lM+0m5P+YZdY1tMWX8qbEO3gywAS2lV7pUWFQRF2hqyF7mwWo9oN4erp99MIf5dq5A+vDrK3oPDNIuTWrWz5NA==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.5.7.tgz",
+            "integrity": "sha512-57ey3wafK/g+B9zLdCiIrX3eTK8rFEM3yvxBUb2ro3ZtAaCGm4y7xERcXZJNn4D01pjzzCJ/u1ezpQmsZYLP7A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@module-federation/runtime-tools": "0.18.0",
-                "@rspack/binding": "1.5.6",
+                "@rspack/binding": "1.5.7",
                 "@rspack/lite-tapable": "1.0.1"
             },
             "engines": {
@@ -14987,9 +14987,9 @@
             "license": "ISC"
         },
         "node_modules/cacache/node_modules/tar": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.0.tgz",
-            "integrity": "sha512-StRGMxeVwyozZpAmHLm2IfbwUlE21DbRXyZrYpGPFBVxM8cxALPongxFVMrs+HqCN7jQVVKyAgKOwGB1WbCp4A==",
+            "version": "7.5.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
+            "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -17460,9 +17460,9 @@
             }
         },
         "node_modules/detect-libc": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
-            "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+            "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
@@ -17777,9 +17777,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.222",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.222.tgz",
-            "integrity": "sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w==",
+            "version": "1.5.223",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.223.tgz",
+            "integrity": "sha512-qKm55ic6nbEmagFlTFczML33rF90aU+WtrJ9MdTCThrcvDNdUHN4p6QfVN78U06ZmguqXIyMPyYhw2TrbDUwPQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -20013,9 +20013,9 @@
             }
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
-            "version": "11.2.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
-            "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+            "version": "11.2.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+            "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -26555,9 +26555,9 @@
             }
         },
         "node_modules/node-gyp/node_modules/tar": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.0.tgz",
-            "integrity": "sha512-StRGMxeVwyozZpAmHLm2IfbwUlE21DbRXyZrYpGPFBVxM8cxALPongxFVMrs+HqCN7jQVVKyAgKOwGB1WbCp4A==",
+            "version": "7.5.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
+            "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -29784,9 +29784,9 @@
             }
         },
         "node_modules/sass-embedded": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.93.1.tgz",
-            "integrity": "sha512-LgXSubbCngOUZ7sVhxtfREa/lHa+hkG0Pjul02I4gB4cb0PhsR+UTLH0GIMnEafoL4dhFM1x8tdtezB3Njv7ng==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.93.2.tgz",
+            "integrity": "sha512-FvQdkn2dZ8DGiLgi0Uf4zsj7r/BsiLImNa5QJ10eZalY6NfZyjrmWGFcuCN5jNwlDlXFJnftauv+UtvBKLvepQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -29806,30 +29806,30 @@
                 "node": ">=16.0.0"
             },
             "optionalDependencies": {
-                "sass-embedded-all-unknown": "1.93.1",
-                "sass-embedded-android-arm": "1.93.1",
-                "sass-embedded-android-arm64": "1.93.1",
-                "sass-embedded-android-riscv64": "1.93.1",
-                "sass-embedded-android-x64": "1.93.1",
-                "sass-embedded-darwin-arm64": "1.93.1",
-                "sass-embedded-darwin-x64": "1.93.1",
-                "sass-embedded-linux-arm": "1.93.1",
-                "sass-embedded-linux-arm64": "1.93.1",
-                "sass-embedded-linux-musl-arm": "1.93.1",
-                "sass-embedded-linux-musl-arm64": "1.93.1",
-                "sass-embedded-linux-musl-riscv64": "1.93.1",
-                "sass-embedded-linux-musl-x64": "1.93.1",
-                "sass-embedded-linux-riscv64": "1.93.1",
-                "sass-embedded-linux-x64": "1.93.1",
-                "sass-embedded-unknown-all": "1.93.1",
-                "sass-embedded-win32-arm64": "1.93.1",
-                "sass-embedded-win32-x64": "1.93.1"
+                "sass-embedded-all-unknown": "1.93.2",
+                "sass-embedded-android-arm": "1.93.2",
+                "sass-embedded-android-arm64": "1.93.2",
+                "sass-embedded-android-riscv64": "1.93.2",
+                "sass-embedded-android-x64": "1.93.2",
+                "sass-embedded-darwin-arm64": "1.93.2",
+                "sass-embedded-darwin-x64": "1.93.2",
+                "sass-embedded-linux-arm": "1.93.2",
+                "sass-embedded-linux-arm64": "1.93.2",
+                "sass-embedded-linux-musl-arm": "1.93.2",
+                "sass-embedded-linux-musl-arm64": "1.93.2",
+                "sass-embedded-linux-musl-riscv64": "1.93.2",
+                "sass-embedded-linux-musl-x64": "1.93.2",
+                "sass-embedded-linux-riscv64": "1.93.2",
+                "sass-embedded-linux-x64": "1.93.2",
+                "sass-embedded-unknown-all": "1.93.2",
+                "sass-embedded-win32-arm64": "1.93.2",
+                "sass-embedded-win32-x64": "1.93.2"
             }
         },
         "node_modules/sass-embedded-all-unknown": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.93.1.tgz",
-            "integrity": "sha512-APlGAJhk/Twv1i8K/jHfkruMwTVV03M5+RZ2yxalYWhn0pouC+MIQ8I/xkiOPk2sNmCQ4M3EewMb0FUVyS/LMQ==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.93.2.tgz",
+            "integrity": "sha512-GdEuPXIzmhRS5J7UKAwEvtk8YyHQuFZRcpnEnkA3rwRUI27kwjyXkNeIj38XjUQ3DzrfMe8HcKFaqWGHvblS7Q==",
             "cpu": [
                 "!arm",
                 "!arm64",
@@ -29840,13 +29840,13 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "sass": "1.93.1"
+                "sass": "1.93.2"
             }
         },
         "node_modules/sass-embedded-all-unknown/node_modules/sass": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.1.tgz",
-            "integrity": "sha512-wLAeLB7IksO2u+cCfhHqcy7/2ZUMPp/X2oV6+LjmweTqgjhOKrkaE/Q1wljxtco5EcOcupZ4c981X0gpk5Tiag==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
+            "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -29866,9 +29866,9 @@
             }
         },
         "node_modules/sass-embedded-android-arm": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.93.1.tgz",
-            "integrity": "sha512-ysejojGThRhsnyYRQtNyAstQqqOP+W+EsEbxnhKVZRLBp4WxeAza/W5x1/GBzLjhk6HUJ7N1MwNkkpvF0eqnuQ==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.93.2.tgz",
+            "integrity": "sha512-I8bpO8meZNo5FvFx5FIiE7DGPVOYft0WjuwcCCdeJ6duwfkl6tZdatex1GrSigvTsuz9L0m4ngDcX/Tj/8yMow==",
             "cpu": [
                 "arm"
             ],
@@ -29883,9 +29883,9 @@
             }
         },
         "node_modules/sass-embedded-android-arm64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.93.1.tgz",
-            "integrity": "sha512-kWvCvNXnHjPmjSS4uYGcSRLZo9am8cNDdg+jIY4mZy62Q3nmz0h0p9if1GszBHl4H3eIBXJIEJQiDY5E26amdQ==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.93.2.tgz",
+            "integrity": "sha512-346f4iVGAPGcNP6V6IOOFkN5qnArAoXNTPr5eA/rmNpeGwomdb7kJyQ717r9rbJXxOG8OAAUado6J0qLsjnjXQ==",
             "cpu": [
                 "arm64"
             ],
@@ -29900,9 +29900,9 @@
             }
         },
         "node_modules/sass-embedded-android-riscv64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.93.1.tgz",
-            "integrity": "sha512-EaNkWJ5IOMCZid3IZWl/Bvb3RkCFz0RBas6Ns05F7W3hls+ggaqiFB7RaVr4Wbr7Em8Ak6yYw5CuTgUiY58nDg==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.93.2.tgz",
+            "integrity": "sha512-hSMW1s4yJf5guT9mrdkumluqrwh7BjbZ4MbBW9tmi1DRDdlw1Wh9Oy1HnnmOG8x9XcI1qkojtPL6LUuEJmsiDg==",
             "cpu": [
                 "riscv64"
             ],
@@ -29917,9 +29917,9 @@
             }
         },
         "node_modules/sass-embedded-android-x64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.93.1.tgz",
-            "integrity": "sha512-kyGNIgFTAgWPa79LI+vkbOUNV1DzCywSAayAHsvuK6NgPcq560ET7qekp/OlbZ97wgTjVRlj68UAP0jVhq4k4A==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.93.2.tgz",
+            "integrity": "sha512-JqktiHZduvn+ldGBosE40ALgQ//tGCVNAObgcQ6UIZznEJbsHegqStqhRo8UW3x2cgOO2XYJcrInH6cc7wdKbw==",
             "cpu": [
                 "x64"
             ],
@@ -29934,9 +29934,9 @@
             }
         },
         "node_modules/sass-embedded-darwin-arm64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.93.1.tgz",
-            "integrity": "sha512-GOD2Nt+BZZdBmg+BM2CozkhAZFGzaU8IK1lI2KP5C6HTuhQP7mTPA9UZWNN3c7iHj6JrkenfWd1ec/vsCZVr+Q==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.93.2.tgz",
+            "integrity": "sha512-qI1X16qKNeBJp+M/5BNW7v/JHCDYWr1/mdoJ7+UMHmP0b5AVudIZtimtK0hnjrLnBECURifd6IkulybR+h+4UA==",
             "cpu": [
                 "arm64"
             ],
@@ -29951,9 +29951,9 @@
             }
         },
         "node_modules/sass-embedded-darwin-x64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.93.1.tgz",
-            "integrity": "sha512-79UlR88nNDbsGqa/87yxOdShPL9Bqz0KnFzv8ioh1NkxYwKYUM9XuKwohFEBTyGg8KDw6h31oTFAvrEFR2qBzg==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.93.2.tgz",
+            "integrity": "sha512-4KeAvlkQ0m0enKUnDGQJZwpovYw99iiMb8CTZRSsQm8Eh7halbJZVmx67f4heFY/zISgVOCcxNg19GrM5NTwtA==",
             "cpu": [
                 "x64"
             ],
@@ -29968,9 +29968,9 @@
             }
         },
         "node_modules/sass-embedded-linux-arm": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.93.1.tgz",
-            "integrity": "sha512-CdJXeZazBU1Ry1jG0T0ohZkoKHnUBIdniqw3o8ZzqHPzVY3A4svuQWj0WvGGM+YrZ+SV5HQ3nmzezS58dlandA==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.93.2.tgz",
+            "integrity": "sha512-N3+D/ToHtzwLDO+lSH05Wo6/KRxFBPnbjVHASOlHzqJnK+g5cqex7IFAp6ozzlRStySk61Rp6d+YGrqZ6/P0PA==",
             "cpu": [
                 "arm"
             ],
@@ -29985,9 +29985,9 @@
             }
         },
         "node_modules/sass-embedded-linux-arm64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.93.1.tgz",
-            "integrity": "sha512-F5ZHx1s5ce3NdjtwPAq6oTXpTC1bZUlHweFgqzbYH5rhVhdhkOemIdHHUG+3gl8YttYrqZ0KASVDtJKBrJMnSg==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.93.2.tgz",
+            "integrity": "sha512-9ftX6nd5CsShJqJ2WRg+ptaYvUW+spqZfJ88FbcKQBNFQm6L87luj3UI1rB6cP5EWrLwHA754OKxRJyzWiaN6g==",
             "cpu": [
                 "arm64"
             ],
@@ -30002,9 +30002,9 @@
             }
         },
         "node_modules/sass-embedded-linux-musl-arm": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.93.1.tgz",
-            "integrity": "sha512-gMxRky1OjjVh8HHw/blgMggkmIu5a9l8iLAODuBIi+AOOuF9v7v20JXyUfXh2jT2HvdXjKfc/EvIuhhELnBPpg==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.93.2.tgz",
+            "integrity": "sha512-XBTvx66yRenvEsp3VaJCb3HQSyqCsUh7R+pbxcN5TuzueybZi0LXvn9zneksdXcmjACMlMpIVXi6LyHPQkYc8A==",
             "cpu": [
                 "arm"
             ],
@@ -30019,9 +30019,9 @@
             }
         },
         "node_modules/sass-embedded-linux-musl-arm64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.93.1.tgz",
-            "integrity": "sha512-p7fxdQI+ev6KMkqRNgl1i7yG5PaUiPgudF4usfSE5NaQobORZYuFXt4m2XPd1h5xwP0ykYLyXjad1EMXTnGr7Q==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.93.2.tgz",
+            "integrity": "sha512-+3EHuDPkMiAX5kytsjEC1bKZCawB9J6pm2eBIzzLMPWbf5xdx++vO1DpT7hD4bm4ZGn0eVHgSOKIfP6CVz6tVg==",
             "cpu": [
                 "arm64"
             ],
@@ -30036,9 +30036,9 @@
             }
         },
         "node_modules/sass-embedded-linux-musl-riscv64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.93.1.tgz",
-            "integrity": "sha512-iVtkoiwXxVcIjbOD3ctX1CxgkXMPUzkw3A/1Iok55lmLLDRKB6t4nny8vT8qiejKrQ9DF4Oz2/+q7Cj0S3mN+Q==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.93.2.tgz",
+            "integrity": "sha512-0sB5kmVZDKTYzmCSlTUnjh6mzOhzmQiW/NNI5g8JS4JiHw2sDNTvt1dsFTuqFkUHyEOY3ESTsfHHBQV8Ip4bEA==",
             "cpu": [
                 "riscv64"
             ],
@@ -30053,9 +30053,9 @@
             }
         },
         "node_modules/sass-embedded-linux-musl-x64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.93.1.tgz",
-            "integrity": "sha512-UPtkoxgljB+Tz5TF8Pg/5EaMDlDRhqlqnA3cCOqj+bDoaAgTQcqYNpAz/6wJSXYTv7Jjs54kWjI+NDMSOPdh/Q==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.93.2.tgz",
+            "integrity": "sha512-t3ejQ+1LEVuHy7JHBI2tWHhoMfhedUNDjGJR2FKaLgrtJntGnyD1RyX0xb3nuqL/UXiEAtmTmZY+Uh3SLUe1Hg==",
             "cpu": [
                 "x64"
             ],
@@ -30070,9 +30070,9 @@
             }
         },
         "node_modules/sass-embedded-linux-riscv64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.93.1.tgz",
-            "integrity": "sha512-gTzxKGPK1vwqO8ZOYlQIVh1BFI2dBW1GyMHmyjqM4Mc/orAjOmTN3aJYGafJjxiMmH424JwlUmCN5vARRJQsJg==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.93.2.tgz",
+            "integrity": "sha512-e7AndEwAbFtXaLy6on4BfNGTr3wtGZQmypUgYpSNVcYDO+CWxatKVY4cxbehMPhxG9g5ru+eaMfynvhZt7fLaA==",
             "cpu": [
                 "riscv64"
             ],
@@ -30087,9 +30087,9 @@
             }
         },
         "node_modules/sass-embedded-linux-x64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.93.1.tgz",
-            "integrity": "sha512-x67rR5KmmjZrnqzKSqNFEEyQoybajFmWnsWvxt3Fn2BCewK40EThVjJAJwNdZtXKcc8y7CZrMF+kmxBDxFbv4g==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.93.2.tgz",
+            "integrity": "sha512-U3EIUZQL11DU0xDDHXexd4PYPHQaSQa2hzc4EzmhHqrAj+TyfYO94htjWOd+DdTPtSwmLp+9cTWwPZBODzC96w==",
             "cpu": [
                 "x64"
             ],
@@ -30104,9 +30104,9 @@
             }
         },
         "node_modules/sass-embedded-unknown-all": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.93.1.tgz",
-            "integrity": "sha512-noDOdIJWRTXAW77J2bkrKGyoPWNuJ5G+JnXVHH+zLll1AlVcwPjVCKag9dNk6+o4cXDb0hx8b8Sg4ojdCzK8VA==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.93.2.tgz",
+            "integrity": "sha512-7VnaOmyewcXohiuoFagJ3SK5ddP9yXpU0rzz+pZQmS1/+5O6vzyFCUoEt3HDRaLctH4GT3nUGoK1jg0ae62IfQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -30117,13 +30117,13 @@
                 "!win32"
             ],
             "dependencies": {
-                "sass": "1.93.1"
+                "sass": "1.93.2"
             }
         },
         "node_modules/sass-embedded-unknown-all/node_modules/sass": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.1.tgz",
-            "integrity": "sha512-wLAeLB7IksO2u+cCfhHqcy7/2ZUMPp/X2oV6+LjmweTqgjhOKrkaE/Q1wljxtco5EcOcupZ4c981X0gpk5Tiag==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
+            "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -30143,9 +30143,9 @@
             }
         },
         "node_modules/sass-embedded-win32-arm64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.93.1.tgz",
-            "integrity": "sha512-B6seb+gjZ9XV/rXO2STkBkFLpsRnlLS1Hs9tqJyWe723VhuaOy/cyI8LSuUjNDolYVbo4YKb4vbx3+BNFNRGBQ==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.93.2.tgz",
+            "integrity": "sha512-Y90DZDbQvtv4Bt0GTXKlcT9pn4pz8AObEjFF8eyul+/boXwyptPZ/A1EyziAeNaIEIfxyy87z78PUgCeGHsx3Q==",
             "cpu": [
                 "arm64"
             ],
@@ -30160,9 +30160,9 @@
             }
         },
         "node_modules/sass-embedded-win32-x64": {
-            "version": "1.93.1",
-            "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.93.1.tgz",
-            "integrity": "sha512-tt4OxnQN2b1PbTWHeZHVFxnQTTSbzOZlSIVeZZ8T9hQmSWrAfzjuV0B96V1/YzhKfhSKtbCo7KD/JIgADKugqg==",
+            "version": "1.93.2",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.93.2.tgz",
+            "integrity": "sha512-BbSucRP6PVRZGIwlEBkp+6VQl2GWdkWFMN+9EuOTPrLxCJZoq+yhzmbjspd3PeM8+7WJ7AdFu/uRYdO8tor1iQ==",
             "cpu": [
                 "x64"
             ],
@@ -32114,9 +32114,9 @@
             }
         },
         "node_modules/ts-checker-rspack-plugin/node_modules/memfs": {
-            "version": "4.43.0",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.43.0.tgz",
-            "integrity": "sha512-XCdhMy33sgxCwJ4JgjSasLGgOjFm9/i+IEhO03gPHroJeTBhM7ZQ1+v3j7di9nNKtcLGjVvKjHVOkTbVop/R/Q==",
+            "version": "4.46.0",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.46.0.tgz",
+            "integrity": "sha512-//IxqL9OO/WMpm2kE2aq+y7vO7/xS9xgVIbFM8RUIfW7TY7lowtnuS1j9MwLGm0OwcHUa4p8Bp+40W7f1BiWGQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -32126,9 +32126,6 @@
                 "thingies": "^2.5.0",
                 "tree-dump": "^1.0.3",
                 "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 4.0.0"
             },
             "funding": {
                 "type": "github",
@@ -33116,9 +33113,9 @@
             }
         },
         "node_modules/webpack-dev-middleware/node_modules/memfs": {
-            "version": "4.43.0",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.43.0.tgz",
-            "integrity": "sha512-XCdhMy33sgxCwJ4JgjSasLGgOjFm9/i+IEhO03gPHroJeTBhM7ZQ1+v3j7di9nNKtcLGjVvKjHVOkTbVop/R/Q==",
+            "version": "4.46.0",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.46.0.tgz",
+            "integrity": "sha512-//IxqL9OO/WMpm2kE2aq+y7vO7/xS9xgVIbFM8RUIfW7TY7lowtnuS1j9MwLGm0OwcHUa4p8Bp+40W7f1BiWGQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -33128,9 +33125,6 @@
                 "thingies": "^2.5.0",
                 "tree-dump": "^1.0.3",
                 "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 4.0.0"
             },
             "funding": {
                 "type": "github",


### PR DESCRIPTION
…sts. Add the stack trace to the copied content if available.

# Summary

[NIFI-14949](https://issues.apache.org/jira/browse/NIFI-14949)

* If a bulletin has a stack trace, it will be offered to view through an expandable link on the bulletin board.

* Changed the bulletin copy mechanism slightly: the copy icon was moved to the end of the bulletin description in both the bulletin board and the bulletin tool-tip component. In both cases, if a stack trace is present it will be copied to the clipboard as well, appended after the message.

<img width="1076" height="709" alt="Screenshot 2025-09-24 at 12 10 15" src="https://github.com/user-attachments/assets/bd6d08a3-3a95-406d-b972-7a938bd1d7de" />
<img width="1076" height="795" alt="Screenshot 2025-09-24 at 12 10 31" src="https://github.com/user-attachments/assets/086d000e-1b65-4f33-949e-0516b5e5c412" />
 
