### PR TITLE
NIFI-14999: Adding support to stop a starting processor.

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
@@ -49,6 +49,7 @@ public class ProcessorDTO extends ComponentDTO {
     private Boolean executionNodeRestricted;
     private Boolean multipleVersionsAvailable;
     private String inputRequirement;
+    private String physicalState;
 
     private ProcessorConfigDTO config;
 
@@ -230,6 +231,21 @@ public class ProcessorDTO extends ComponentDTO {
     public void setInputRequirement(String inputRequirement) {
         this.inputRequirement = inputRequirement;
     }
+
+    /**
+     * @return The physical state of this processor, including transition states such as STARTING and STOPPING
+     */
+    @Schema(description = "The physical state of the processor, including transition states",
+            allowableValues = {"RUNNING", "STOPPED", "DISABLED", "STARTING", "STOPPING", "RUN_ONCE"}
+    )
+    public String getPhysicalState() {
+        return physicalState;
+    }
+
+    public void setPhysicalState(String physicalState) {
+        this.physicalState = physicalState;
+    }
+
 
     /**
      * @return whether this processor supports batching

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessorEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessorEntity.java
@@ -31,6 +31,7 @@ public class ProcessorEntity extends ComponentEntity implements Permissible<Proc
 
     private ProcessorDTO component;
     private String inputRequirement;
+    private String physicalState;
     private ProcessorStatusDTO status;
     private PermissionsDTO operatePermissions;
 
@@ -74,6 +75,20 @@ public class ProcessorEntity extends ComponentEntity implements Permissible<Proc
     public void setInputRequirement(String inputRequirement) {
         this.inputRequirement = inputRequirement;
     }
+
+    /**
+     * @return the physical state of this processor
+     */
+    @Schema(description = "The physical state of the processor, including transition states",
+            allowableValues = {"RUNNING", "STOPPED", "DISABLED", "STARTING", "STOPPING", "RUN_ONCE"})
+    public String getPhysicalState() {
+        return physicalState;
+    }
+
+    public void setPhysicalState(String physicalState) {
+        this.physicalState = physicalState;
+    }
+
 
     /**
      * @return The permissions for this component operations

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ProcessorEntityMergerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/manager/ProcessorEntityMergerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.cluster.manager;
+
+import org.apache.nifi.cluster.protocol.NodeIdentifier;
+import org.apache.nifi.components.validation.ValidationStatus;
+import org.apache.nifi.controller.ScheduledState;
+import org.apache.nifi.controller.status.RunStatus;
+import org.apache.nifi.web.api.dto.PermissionsDTO;
+import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
+import org.apache.nifi.web.api.dto.ProcessorDTO;
+import org.apache.nifi.web.api.dto.RevisionDTO;
+import org.apache.nifi.web.api.dto.status.ProcessorStatusDTO;
+import org.apache.nifi.web.api.entity.ProcessorEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProcessorEntityMergerTest {
+
+    @Test
+    void testMergePhysicalState_StoppingTakePrecedence() {
+        // Test that STOPPING state takes precedence over stable states
+        final ProcessorEntity clientEntity = createProcessorEntity("client", "STOPPED");
+        final ProcessorEntity nodeEntity1 = createProcessorEntity("node1", "STOPPED");
+        final ProcessorEntity nodeEntity2 = createProcessorEntity("node2", "STOPPING");
+        final ProcessorEntity nodeEntity3 = createProcessorEntity("node3", "STOPPED");
+
+        final Map<NodeIdentifier, ProcessorEntity> entityMap = new HashMap<>();
+        entityMap.put(getNodeIdentifier("client", 8000), clientEntity);
+        entityMap.put(getNodeIdentifier("node1", 8001), nodeEntity1);
+        entityMap.put(getNodeIdentifier("node2", 8002), nodeEntity2);
+        entityMap.put(getNodeIdentifier("node3", 8003), nodeEntity3);
+
+        ProcessorEntityMerger merger = new ProcessorEntityMerger();
+        merger.merge(clientEntity, entityMap);
+
+        assertEquals("STOPPING", clientEntity.getPhysicalState());
+    }
+
+    @Test
+    void testMergePhysicalState_StartingTakePrecedence() {
+        // Test that STARTING state takes precedence over stable states
+        final ProcessorEntity clientEntity = createProcessorEntity("client", "RUNNING");
+        final ProcessorEntity nodeEntity1 = createProcessorEntity("node1", "RUNNING");
+        final ProcessorEntity nodeEntity2 = createProcessorEntity("node2", "STARTING");
+        final ProcessorEntity nodeEntity3 = createProcessorEntity("node3", "RUNNING");
+
+        final Map<NodeIdentifier, ProcessorEntity> entityMap = new HashMap<>();
+        entityMap.put(getNodeIdentifier("client", 8000), clientEntity);
+        entityMap.put(getNodeIdentifier("node1", 8001), nodeEntity1);
+        entityMap.put(getNodeIdentifier("node2", 8002), nodeEntity2);
+        entityMap.put(getNodeIdentifier("node3", 8003), nodeEntity3);
+
+        ProcessorEntityMerger merger = new ProcessorEntityMerger();
+        merger.merge(clientEntity, entityMap);
+
+        assertEquals("STARTING", clientEntity.getPhysicalState());
+    }
+
+    @Test
+    void testMergePhysicalState_NullPhysicalStates() {
+        // Test that null physical states are handled gracefully
+        final ProcessorEntity clientEntity = createProcessorEntity("client", null);
+        final ProcessorEntity nodeEntity1 = createProcessorEntity("node1", null);
+        final ProcessorEntity nodeEntity2 = createProcessorEntity("node2", "RUNNING");
+
+        final Map<NodeIdentifier, ProcessorEntity> entityMap = new HashMap<>();
+        entityMap.put(getNodeIdentifier("client", 8000), clientEntity);
+        entityMap.put(getNodeIdentifier("node1", 8001), nodeEntity1);
+        entityMap.put(getNodeIdentifier("node2", 8002), nodeEntity2);
+
+        ProcessorEntityMerger merger = new ProcessorEntityMerger();
+        merger.merge(clientEntity, entityMap);
+
+        assertEquals("RUNNING", clientEntity.getPhysicalState());
+    }
+
+    private NodeIdentifier getNodeIdentifier(final String id, final int port) {
+        return new NodeIdentifier(id, "localhost", port, "localhost", port + 1, "localhost", port + 2, port + 3, true);
+    }
+
+    private ProcessorEntity createProcessorEntity(final String id, final String physicalState) {
+        final ProcessorDTO dto = new ProcessorDTO();
+        dto.setId(id);
+        dto.setState(ScheduledState.STOPPED.name());
+        dto.setPhysicalState(physicalState);
+        dto.setValidationStatus(ValidationStatus.VALID.name());
+
+        // Add ProcessorConfigDTO to avoid NPE during merging
+        final ProcessorConfigDTO configDto = new ProcessorConfigDTO();
+        configDto.setDescriptors(new HashMap<>());
+        dto.setConfig(configDto);
+
+        final ProcessorStatusDTO statusDto = new ProcessorStatusDTO();
+        statusDto.setRunStatus(RunStatus.Stopped.name());
+
+        final PermissionsDTO permissions = new PermissionsDTO();
+        permissions.setCanRead(true);
+        permissions.setCanWrite(true);
+
+        final ProcessorEntity entity = new ProcessorEntity();
+        entity.setComponent(dto);
+        entity.setRevision(createNewRevision());
+        entity.setPermissions(permissions);
+        entity.setStatus(statusDto);
+        entity.setPhysicalState(physicalState);
+
+        return entity;
+    }
+
+    public RevisionDTO createNewRevision() {
+        final RevisionDTO revisionDto = new RevisionDTO();
+        revisionDto.setClientId(getClass().getName());
+        revisionDto.setVersion(0L);
+        return revisionDto;
+    }
+
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -1330,8 +1330,11 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
 
     @Override
     public void verifyCanStop() {
-        if (getScheduledState() != ScheduledState.RUNNING) {
-            throw new IllegalStateException(this + " cannot be stopped because is not scheduled to run");
+        final ScheduledState logicalState = getScheduledState();
+        final ScheduledState physicalState = getPhysicalScheduledState();
+
+        if (logicalState != ScheduledState.RUNNING && physicalState != ScheduledState.STARTING) {
+            throw new IllegalStateException(this + " cannot be stopped because is not scheduled to run and is not starting");
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -3379,6 +3379,7 @@ public final class DtoFactory {
        dto.setBundle(createBundleDto(bundleCoordinate));
        dto.setName(node.getName());
        dto.setState(node.getScheduledState().toString());
+       dto.setPhysicalState(node.getPhysicalScheduledState().toString());
 
        // build the relationship dtos
        final List<RelationshipDTO> relationships = new ArrayList<>();

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/EntityFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/EntityFactory.java
@@ -238,6 +238,7 @@ public final class EntityFactory {
             entity.setStatus(status);
             entity.setId(dto.getId());
             entity.setInputRequirement(dto.getInputRequirement());
+            entity.setPhysicalState(dto.getPhysicalState());
             entity.setPosition(dto.getPosition());
             if (permissions != null && permissions.getCanRead()) {
                 entity.setComponent(dto);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
@@ -559,19 +559,15 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
                     throw new NiFiCoreException(ise.getMessage(), ise);
                 } catch (RejectedExecutionException ree) {
                     throw new NiFiCoreException("Unable to schedule all tasks for the specified processor.", ree);
-                } catch (NullPointerException npe) {
-                    throw new NiFiCoreException("Unable to update processor run state.", npe);
                 } catch (Exception e) {
-                    throw new NiFiCoreException("Unable to update processor run state: " + e, e);
+                    throw new NiFiCoreException("Unable to update processor [%s] run state: %s".formatted(processor, e), e);
                 }
             } else if  (purposedScheduledState == ScheduledState.STOPPED && processor.getPhysicalScheduledState() == ScheduledState.STARTING) {
                 // Handle special case: allow stopping a processor that's physically starting
                 try {
                     parentGroup.stopProcessor(processor);
-                } catch (NullPointerException npe) {
-                    throw new NiFiCoreException("Unable to stop starting processor.", npe);
                 } catch (Exception e) {
-                    throw new NiFiCoreException("Unable to stop starting processor: " + e, e);
+                    throw new NiFiCoreException("Unable to stop starting processor [%s]: %s".formatted(processor, e), e);
                 }
             }
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/StandardProcessorDAOTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/StandardProcessorDAOTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.dao.impl;
+
+import org.apache.nifi.controller.FlowController;
+import org.apache.nifi.controller.ProcessorNode;
+import org.apache.nifi.controller.ScheduledState;
+import org.apache.nifi.groups.ProcessGroup;
+import org.apache.nifi.web.ResourceNotFoundException;
+import org.apache.nifi.web.api.dto.ProcessorDTO;
+import org.apache.nifi.web.dao.ComponentStateDAO;
+import org.apache.nifi.controller.flow.FlowManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StandardProcessorDAOTest {
+
+    @Mock
+    private FlowController flowController;
+
+    @Mock
+    private ComponentStateDAO componentStateDAO;
+
+    @Mock
+    private ProcessorNode processorNode;
+
+    @Mock
+    private ProcessGroup processGroup;
+
+    @Mock
+    private FlowManager flowManager;
+
+    private StandardProcessorDAO dao;
+
+    @BeforeEach
+    void setUp() {
+        dao = new StandardProcessorDAO();
+        dao.setFlowController(flowController);
+        dao.setComponentStateDAO(componentStateDAO);
+
+        // Set up lenient mocks for common interactions
+        lenient().when(flowController.getFlowManager()).thenReturn(flowManager);
+        lenient().when(flowManager.getRootGroup()).thenReturn(processGroup);
+        lenient().when(processGroup.findProcessor(anyString())).thenReturn(processorNode);
+        lenient().when(processorNode.getProcessGroup()).thenReturn(processGroup);
+        lenient().when(processorNode.getIdentifier()).thenReturn("test-processor-id");
+    }
+
+    @Test
+    void testVerifyUpdate_NormalStateChange() {
+        // Processor in STOPPED state, trying to change to RUNNING
+        ProcessorDTO processorDTO = new ProcessorDTO();
+        processorDTO.setId("test-processor-id");
+        processorDTO.setState("RUNNING");
+
+        when(processorNode.getScheduledState()).thenReturn(ScheduledState.STOPPED);
+
+        // Should not throw exception
+        assertDoesNotThrow(() -> dao.verifyUpdate(processorDTO));
+    }
+
+    @Test
+    void testVerifyUpdate_StopStartingProcessor() {
+        // Processor in STOPPED logical state but STARTING physical state
+        ProcessorDTO processorDTO = new ProcessorDTO();
+        processorDTO.setId("test-processor-id");
+        processorDTO.setState("STOPPED");
+
+        when(processorNode.getScheduledState()).thenReturn(ScheduledState.STOPPED);
+        when(processorNode.getPhysicalScheduledState()).thenReturn(ScheduledState.STARTING);
+
+        // Should not throw exception and should verify stop permissions
+        assertDoesNotThrow(() -> dao.verifyUpdate(processorDTO));
+        verify(processorNode).verifyCanStop();
+    }
+
+    @Test
+    void testVerifyUpdate_StopStartingProcessor_NoPermission() {
+        // Processor in STARTING physical state but no permission to stop
+        ProcessorDTO processorDTO = new ProcessorDTO();
+        processorDTO.setId("test-processor-id");
+        processorDTO.setState("STOPPED");
+
+        when(processorNode.getScheduledState()).thenReturn(ScheduledState.STOPPED);
+        when(processorNode.getPhysicalScheduledState()).thenReturn(ScheduledState.STARTING);
+        doThrow(new IllegalStateException("Cannot stop")).when(processorNode).verifyCanStop();
+
+        // Should throw exception
+        assertThrows(IllegalStateException.class, () -> dao.verifyUpdate(processorDTO));
+    }
+
+    @Test
+    void testVerifyUpdate_NoSpecialCaseForDisabled() {
+        // Processor in DISABLED physical state (not STARTING)
+        ProcessorDTO processorDTO = new ProcessorDTO();
+        processorDTO.setId("test-processor-id");
+        processorDTO.setState("STOPPED");
+
+        when(processorNode.getScheduledState()).thenReturn(ScheduledState.DISABLED);
+
+        // Should not call special case verification
+        assertDoesNotThrow(() -> dao.verifyUpdate(processorDTO));
+        verify(processorNode, never()).verifyCanStop();
+    }
+
+    @Test
+    void testVerifyUpdate_TransitionStatesNotAllowed() {
+        // User trying to set state to STARTING (internal transition state)
+        ProcessorDTO processorDTO = new ProcessorDTO();
+        processorDTO.setId("test-processor-id");
+        processorDTO.setState("STARTING");
+
+        // Should throw IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> dao.verifyUpdate(processorDTO));
+    }
+
+    @Test
+    void testVerifyUpdate_StoppingStateNotAllowed() {
+        // User trying to set state to STOPPING (internal transition state)
+        ProcessorDTO processorDTO = new ProcessorDTO();
+        processorDTO.setId("test-processor-id");
+        processorDTO.setState("STOPPING");
+
+        // Should throw IllegalArgumentException
+        assertThrows(IllegalArgumentException.class, () -> dao.verifyUpdate(processorDTO));
+    }
+
+    @Test
+    void testVerifyUpdate_ProcessorNotFound() {
+        // ProcessorDTO with ID that doesn't exist
+        ProcessorDTO processorDTO = new ProcessorDTO();
+        processorDTO.setId("non-existent-id");
+        processorDTO.setState("RUNNING");
+
+        when(processGroup.findProcessor("non-existent-id")).thenReturn(null);
+
+        // Should throw ResourceNotFoundException
+        assertThrows(ResourceNotFoundException.class, () -> dao.verifyUpdate(processorDTO));
+    }
+}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
@@ -1955,7 +1955,15 @@ export class CanvasUtils {
         let stoppable = false;
         const selectionData = selection.datum();
         if (this.isProcessor(selection) || this.isInputPort(selection) || this.isOutputPort(selection)) {
-            stoppable = selectionData.status.aggregateSnapshot.runStatus === 'Running';
+            const runStatus = selectionData.status.aggregateSnapshot.runStatus;
+
+            // For processors, also check if physical state is Starting when runStatus is Invalid
+            if (this.isProcessor(selection) && runStatus === 'Invalid') {
+                const physicalState = selectionData.physicalState;
+                stoppable = physicalState === 'STARTING';
+            } else {
+                stoppable = runStatus === 'Running';
+            }
         }
         return stoppable;
     }


### PR DESCRIPTION
## Summary
This PR adds support for exposing the **physical state** of processors in the NiFi API, enabling the UI to allow stopping processors that are in the `STARTING` physical state.

## Problem Statement
Previously, when a processor was starting up (executing `@OnScheduled` methods), its logical state was `STOPPED` but the physical state was `STARTING`. The UI had no visibility into this physical state. Users couldn't stop processors that were stuck in the `STARTING` state, requiring process group-level stops as a workaround

## Solution Overview
Added `physicalState` field to processor DTOs and entities, with full support for:
- API exposure with proper schema documentation
- Cluster response merging with transition state prioritization  
- Backend validation allowing stops of `STARTING` processors
- Frontend updates to allow the user to stop a STARTING processor