### PR TITLE
NIFI-15014 allow advanced UpdateAttribute Rules to be searched even i…

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/update-attribute/src/app/pages/update-attribute/ui/rule-listing/rule-listing.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/update-attribute/src/app/pages/update-attribute/ui/rule-listing/rule-listing.component.ts
@@ -163,7 +163,7 @@ export class RuleListing {
         return (
             rule.id.toLowerCase().includes(filterText) ||
             rule.name.toLowerCase().includes(filterText) ||
-            rule.comments.toLowerCase().includes(filterText) ||
+            (rule.comments ?? '').toLowerCase().includes(filterText) ||
             rule.conditions.some((condition) => this.conditionMatches(condition, filterText)) ||
             rule.actions.some((action) => this.actionMatches(action, filterText))
         );


### PR DESCRIPTION
…f missing Comments field such as when a processor was upgraded from prior to Comments being available

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

In certain cases, the Search feature of Rules in the advanced UpdateAttribute does not work. The cause was determined to be a missing Comments field; not an empty field with no value, but <comments> were missing from the definition in the flow.json.gz. Likely, this occurs only when the processor has been upgraded from a version prior to when Rule Comments were available. 

The fix ensures the Comments field is present before attempting to search in its value. Arguably, the check could be performed on other fields being searched. But in reality all other fields have always been present and should never be missing. Based on review/feedback, I would not be opposed to addressing additional fields if it was deemed appropriate.

[NIFI-15014](https://issues.apache.org/jira/browse/NIFI-15014)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

A thorough verification would mean editing a flow definition or flow.json.gz to remove the <comments> field entirely from an UpdateAttribute processor. The search should still function even after doing so. 

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
