### PR TITLE
NIFI-15015 - Bump Commons Lang3 to 3.19.0, H2 to 2.4.240, Datafaker to 2.5.1, and others

### DIFF
--- a/nifi-commons/nifi-xml-processing/pom.xml
+++ b/nifi-commons/nifi-xml-processing/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.9.5.0</version>
+                <version>4.9.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-nar/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.6.0</version>
+                <version>2.7.0</version>
                 <configuration>
                     <!--
                         mvn clean license:add-third-party license:download-licenses

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.eclipse.angus</groupId>
             <artifactId>angus-mail</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.integration</groupId>

--- a/nifi-extension-bundles/nifi-hadoop-libraries-bundle/nifi-hadoop-libraries-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-hadoop-libraries-bundle/nifi-hadoop-libraries-nar/pom.xml
@@ -17,6 +17,9 @@
     </parent>
     <artifactId>nifi-hadoop-libraries-nar</artifactId>
     <packaging>nar</packaging>
+    <properties>
+        <gcs.version>2.1.5</gcs.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -407,7 +407,7 @@
         <dependency>
             <groupId>net.datafaker</groupId>
             <artifactId>datafaker</artifactId>
-            <version>2.5.0</version>
+            <version>2.5.1</version>
             <exclusions>
                 <!-- Exclude snakeyaml with android qualifier -->
                 <exclusion>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -81,7 +81,7 @@
             <dependency>
                 <groupId>org.eclipse.angus</groupId>
                 <artifactId>angus-mail</artifactId>
-                <version>2.0.4</version>
+                <version>2.0.5</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.mail</groupId>

--- a/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/pom.xml
@@ -21,7 +21,7 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <jna.version>5.17.0</jna.version>
+        <jna.version>5.18.0</jna.version>
         <javassist.version>3.30.2-GA</javassist.version>
     </properties>
 

--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -105,7 +105,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>oauth2-oidc-sdk</artifactId>
-                <version>11.28</version>
+                <version>${nimbus-oauth2-oidc.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>oauth2-oidc-sdk</artifactId>
-                <version>11.28</version>
+                <version>${nimbus-oauth2-oidc.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -40,7 +40,7 @@
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.3.0.202506031305-r</jgit.version>
-        <h2.version>2.3.232</h2.version>
+        <h2.version>2.4.240</h2.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -91,85 +91,120 @@
         <url>https://issues.apache.org/jira/browse/NIFI</url>
     </issueManagement>
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
-        <!-- Set minimum Java version for maven-enforcer-plugin from parent POM -->
-        <minimalJavaBuildVersion>21</minimalJavaBuildVersion>
-        <maven.surefire.arguments />
-        <!-- Disable maven-site-plugin from parent POM -->
-        <maven.site.skip>true</maven.site.skip>
-        <docker.jdk.image.name>bellsoft/liberica-openjdk-debian</docker.jdk.image.name>
-        <docker.jre.image.name>bellsoft/liberica-openjre-debian</docker.jre.image.name>
-        <docker.image.tag>21</docker.image.tag>
-        <node.version>v22.19.0</node.version>
-        <frontend.mvn.plugin.version>1.15.1</frontend.mvn.plugin.version>
-        <nifi.nar.maven.plugin.version>2.1.0</nifi.nar.maven.plugin.version>
-        <nifi-api.version>2.3.0</nifi-api.version>
+        <!-- Project metadata -->
+        <inceptionYear>2014</inceptionYear>
         <project.build.outputTimestamp>1758480119</project.build.outputTimestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <inceptionYear>2014</inceptionYear>
+        <!-- Build configuration -->
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
+        <!-- Disable maven-site-plugin from parent POM -->
+        <maven.site.skip>true</maven.site.skip>
+        <maven.surefire.arguments />
+        <!-- Set minimum Java version for maven-enforcer-plugin from parent POM -->
+        <minimalJavaBuildVersion>21</minimalJavaBuildVersion>
+        <surefire.version>3.5.1</surefire.version>
+
+        <!-- Container images -->
+        <docker.image.tag>21</docker.image.tag>
+        <docker.jdk.image.name>bellsoft/liberica-openjdk-debian</docker.jdk.image.name>
+        <docker.jre.image.name>bellsoft/liberica-openjre-debian</docker.jre.image.name>
+
+        <!-- Frontend tooling -->
+        <frontend.mvn.plugin.version>1.15.1</frontend.mvn.plugin.version>
+        <node.version>v22.19.0</node.version>
+
+        <!-- NiFi build -->
+        <nifi-api.version>2.3.0</nifi-api.version>
+        <nifi.nar.maven.plugin.version>2.1.0</nifi.nar.maven.plugin.version>
+
+        <!-- AWS SDK -->
         <com.amazonaws.version>1.12.791</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.34.0</software.amazon.awssdk.version>
-        <gson.version>2.13.2</gson.version>
-        <io.fabric8.kubernetes.client.version>7.4.0</io.fabric8.kubernetes.client.version>
-        <kotlin.version>2.2.20</kotlin.version>
-        <okhttp.version>5.1.0</okhttp.version>
-        <okio.version>3.16.0</okio.version>
+        <software.amazon.awssdk.version>2.34.3</software.amazon.awssdk.version>
+
+        <!-- Apache Commons -->
         <org.apache.commons.cli.version>1.10.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.19.0</org.apache.commons.codec.version>
         <org.apache.commons.collections4.version>4.5.0</org.apache.commons.collections4.version>
         <org.apache.commons.compress.version>1.28.0</org.apache.commons.compress.version>
-        <com.github.luben.zstd-jni.version>1.5.7-4</com.github.luben.zstd-jni.version>
         <org.apache.commons.configuration.version>2.12.0</org.apache.commons.configuration.version>
-        <org.apache.commons.lang3.version>3.18.0</org.apache.commons.lang3.version>
-        <org.apache.commons.net.version>3.12.0</org.apache.commons.net.version>
-        <org.apache.commons.io.version>2.20.0</org.apache.commons.io.version>
-        <org.apache.commons.text.version>1.14.0</org.apache.commons.text.version>
         <org.apache.commons.csv.version>1.14.1</org.apache.commons.csv.version>
+        <org.apache.commons.io.version>2.20.0</org.apache.commons.io.version>
+        <org.apache.commons.lang3.version>3.19.0</org.apache.commons.lang3.version>
+        <org.apache.commons.net.version>3.12.0</org.apache.commons.net.version>
+        <org.apache.commons.text.version>1.14.0</org.apache.commons.text.version>
+
+        <!-- Big data platforms -->
+        <hadoop.version>3.4.2</hadoop.version>
+        <ozone.version>1.4.1</ozone.version>
+
+        <!-- Kubernetes -->
+        <io.fabric8.kubernetes.client.version>7.4.0</io.fabric8.kubernetes.client.version>
+
+        <!-- Data access -->
+        <commons.dbcp2.version>2.13.0</commons.dbcp2.version>
+        <derby.version>10.17.1.0</derby.version>
+
+        <!-- Data formats and serialization -->
+        <avro.version>1.12.0</avro.version>
+        <com.github.luben.zstd-jni.version>1.5.7-4</com.github.luben.zstd-jni.version>
+        <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
+        <gson.version>2.13.2</gson.version>
+        <jackson.annotations.version>2.20</jackson.annotations.version>
+        <jackson.bom.version>2.20.0</jackson.bom.version>
+        <json.smart.version>2.6.0</json.smart.version>
+        <snakeyaml.version>2.5</snakeyaml.version>
+
+        <!-- JVM languages and bytecode -->
+        <aspectj.version>1.9.24</aspectj.version>
+        <groovy.version>5.0.1</groovy.version>
+        <kotlin.version>2.2.20</kotlin.version>
+
+        <!-- Logging and observability -->
+        <log4j2.version>2.25.2</log4j2.version>
+        <logback.version>1.5.18</logback.version>
+        <org.slf4j.version>2.0.17</org.slf4j.version>
+        <prometheus.version>0.16.0</prometheus.version>
+        <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
+
+        <!-- Networking and transport -->
+        <netty.3.version>3.10.6.Final</netty.3.version>
+        <netty.4.version>4.2.6.Final</netty.4.version>
+        <okhttp.version>5.1.0</okhttp.version>
+        <okio.version>3.16.0</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
         <org.apache.sshd.version>2.16.0</org.apache.sshd.version>
-        <org.bouncycastle.version>1.82</org.bouncycastle.version>
-        <pmd.version>7.17.0</pmd.version>
-        <testcontainers.version>1.21.3</testcontainers.version>
-        <org.slf4j.version>2.0.17</org.slf4j.version>
-        <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
-        <derby.version>10.17.1.0</derby.version>
-        <jetty.version>12.0.27</jetty.version>
-        <jackson.bom.version>2.20.0</jackson.bom.version>
-        <jackson.annotations.version>2.20</jackson.annotations.version>
-        <avro.version>1.12.0</avro.version>
-        <jaxb.runtime.version>4.0.5</jaxb.runtime.version>
-        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-        <jakarta.xml.bind-api.version>4.0.4</jakarta.xml.bind-api.version>
-        <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
-        <json.smart.version>2.6.0</json.smart.version>
-        <groovy.version>5.0.1</groovy.version>
-        <surefire.version>3.5.1</surefire.version>
-        <hadoop.version>3.4.2</hadoop.version>
-        <ozone.version>1.4.1</ozone.version>
-        <gcs.version>2.1.5</gcs.version>
-        <aspectj.version>1.9.24</aspectj.version>
-        <jersey.bom.version>3.1.11</jersey.bom.version>
-        <log4j2.version>2.25.2</log4j2.version>
-        <logback.version>1.5.18</logback.version>
-        <mockito.version>5.20.0</mockito.version>
-        <junit.version>5.13.4</junit.version>
-        <netty.3.version>3.10.6.Final</netty.3.version>
-        <snakeyaml.version>2.5</snakeyaml.version>
-        <netty.4.version>4.2.6.Final</netty.4.version>
-        <servlet-api.version>6.1.0</servlet-api.version>
-        <spring.version>6.2.11</spring.version>
-        <spring.security.version>6.5.5</spring.security.version>
-        <swagger.annotations.version>2.2.37</swagger.annotations.version>
-        <caffeine.version>3.2.2</caffeine.version>
-        <hapi.version>2.6.0</hapi.version>
-        <commons.dbcp2.version>2.13.0</commons.dbcp2.version>
-        <prometheus.version>0.16.0</prometheus.version>
-        <velocity-engine-core.version>2.4.1</velocity-engine-core.version>
-        <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
+
+        <!-- Security -->
         <nimbus-jose-jwt.version>10.5</nimbus-jose-jwt.version>
+        <nimbus-oauth2-oidc.version>11.29.1</nimbus-oauth2-oidc.version>
+        <org.bouncycastle.version>1.82</org.bouncycastle.version>
+
+        <!-- Utilities -->
+        <caffeine.version>3.2.2</caffeine.version>
+        <velocity-engine-core.version>2.4.1</velocity-engine-core.version>
+
+        <!-- Web and API frameworks -->
+        <hapi.version>2.6.0</hapi.version>
+        <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
+        <jakarta.xml.bind-api.version>4.0.4</jakarta.xml.bind-api.version>
+        <jaxb.runtime.version>4.0.6</jaxb.runtime.version>
+        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+        <jersey.bom.version>3.1.11</jersey.bom.version>
+        <jetty.version>12.0.27</jetty.version>
+        <servlet-api.version>6.1.0</servlet-api.version>
+        <spring.security.version>6.5.5</spring.security.version>
+        <spring.version>6.2.11</spring.version>
+        <swagger.annotations.version>2.2.37</swagger.annotations.version>
+
+        <!-- Testing and quality -->
+        <junit.version>5.13.4</junit.version>
+        <mockito.version>5.20.0</mockito.version>
+        <pmd.version>7.17.0</pmd.version>
+        <checkstyle.version>11.0.1</checkstyle.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -757,7 +792,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>11.0.1</version>
+                            <version>${checkstyle.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -768,7 +803,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.19.0</version>
+                    <version>2.19.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.rat</groupId>


### PR DESCRIPTION
# Summary

NIFI-15015 - Bump Commons Lang3 to 3.19.0, H2 to 2.4.240, Datafaker to 2.5.1, and others

- Spotbugs Maven Plugin from 4.9.5.0 to 4.9.6.0 - https://github.com/spotbugs/spotbugs-maven-plugin/releases/tag/spotbugs-maven-plugin-4.9.6.0
- License Maven Plugin from 2.6.0 to 2.7.0 - https://github.com/mojohaus/license-maven-plugin/releases/tag/2.7.0
- Version Maven Plugin from 2.19.0 to 2.19.1 - https://github.com/mojohaus/versions/releases/tag/2.19.1
- Angus Mail from 2.0.4 to 2.0.5 - https://github.com/eclipse-ee4j/angus-mail/releases/tag/2.0.5
- Datafaker from 2.5.0 to 2.5.1 - https://github.com/datafaker-net/datafaker/releases/tag/2.5.1
- JNA from 5.17.0 to 5.18.0 - https://github.com/java-native-access/jna/releases/tag/5.18.0
- Nimbus OAuth2 OIDC from 11.28 to 11.29.1 - https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/master/CHANGELOG.txt
- H2 Database from 2.3.232 to 2.4.240 - https://www.h2database.com/html/changelog.html
- Apache Commons Lang3 from 3.18.0 to 3.19.0 - https://commons.apache.org/proper/commons-lang/changes.html#a3.19.0
- AWS SDK v2 from 2.34.0 to 2.34.3 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
