### PR TITLE
NIFI-11362 Stabilize TestValidateRecord#testValidateJsonTimestamp by reordering scenarios and resetting reader properties

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateRecord.java
@@ -546,6 +546,8 @@ public class TestValidateRecord {
 
         runner.setProperty(ValidateRecord.STRICT_TYPE_CHECKING, "true");
         final Path timestampPath = Paths.get("src/test/resources/TestValidateRecord/timestamp.json");
+
+        // 1) Valid with explicit schema + slash format
         runner.enqueue(timestampPath);
         runner.run();
 
@@ -553,33 +555,36 @@ public class TestValidateRecord {
         final MockFlowFile validFlowFile = runner.getFlowFilesForRelationship(ValidateRecord.REL_VALID).getFirst();
         validFlowFile.assertContentEquals(new File("src/test/resources/TestValidateRecord/timestamp.json"));
 
-        // Test with a timestamp that has an invalid format.
+        // 2) Inferred schema — run this BEFORE the invalid-format scenario to avoid order-dependence
         runner.clearTransferState();
 
-        runner.disableControllerService(jsonReader);
-        runner.setProperty(jsonReader, DateTimeUtils.TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss");
-        runner.enqueue(timestampPath);
-        runner.enableControllerService(jsonReader);
-
-        runner.run();
-
-        runner.assertTransferCount(ValidateRecord.REL_INVALID, 1);
-        final MockFlowFile invalidFlowFile = runner.getFlowFilesForRelationship(ValidateRecord.REL_INVALID).getFirst();
-        invalidFlowFile.assertContentEquals(new File("src/test/resources/TestValidateRecord/timestamp.json"));
-
-        // Test with an Inferred Schema.
         runner.disableControllerService(jsonReader);
         runner.setProperty(jsonReader, ValidateRecord.SCHEMA_ACCESS_STRATEGY, SchemaInferenceUtil.INFER_SCHEMA.getValue());
         runner.setProperty(jsonReader, DateTimeUtils.TIMESTAMP_FORMAT, "yyyy/MM/dd HH:mm:ss");
         runner.enableControllerService(jsonReader);
 
-        runner.clearTransferState();
         runner.enqueue(timestampPath);
         runner.run();
 
         runner.assertTransferCount(ValidateRecord.REL_VALID, 1);
         final MockFlowFile validFlowFileInferredSchema = runner.getFlowFilesForRelationship(ValidateRecord.REL_VALID).getFirst();
         validFlowFileInferredSchema.assertContentEquals(new File("src/test/resources/TestValidateRecord/timestamp.json"));
+
+        // 3) Invalid timestamp format
+        runner.clearTransferState();
+
+        runner.disableControllerService(jsonReader);
+        // IMPORTANT: switch the READER back to schema-text strategy before changing the format
+        runner.setProperty(jsonReader, ValidateRecord.SCHEMA_ACCESS_STRATEGY, "schema-text-property");
+        runner.setProperty(jsonReader, SCHEMA_TEXT, validateSchema);
+        runner.setProperty(jsonReader, DateTimeUtils.TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss");
+        runner.enableControllerService(jsonReader);
+
+        runner.enqueue(timestampPath);
+        runner.run();
+        runner.assertTransferCount(ValidateRecord.REL_INVALID, 1);
+        final MockFlowFile invalidFlowFile = runner.getFlowFilesForRelationship(ValidateRecord.REL_INVALID).getFirst();
+        invalidFlowFile.assertContentEquals(new File("src/test/resources/TestValidateRecord/timestamp.json"));
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11362](https://issues.apache.org/jira/browse/NIFI-11362) 
This PR fixes a flaky test in `TestValidateRecord#testValidateJsonTimestamp` that fails under the NonDex plugin. The failure is caused by order‑dependent configuration in a single test method that reuses the same `JsonTreeReader` controller service across multiple scenarios. The change reorders the scenarios and explicitly resets the reader properties to remove hidden state coupling.

# Problem

Running the test normally passes:
```bash
mvn -pl nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors \
    test -Dtest=org.apache.nifi.processors.standard.TestValidateRecord#testValidateJsonTimestamp
```
…but running with NonDex reveals a failure:
```bash
mvn -pl nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors \
    edu.illinois:nondex-maven-plugin:2.2.1:nondex \
    -Dtest=org.apache.nifi.processors.standard.TestValidateRecord#testValidateJsonTimestamp
```
Failure excerpt:
```
org.opentest4j.AssertionFailedError: expected: <1> but was: <0>
    at org.apache.nifi.util.StandardProcessorTestRunner.assertTransferCount(StandardProcessorTestRunner.java:407)
    at org.apache.nifi.processors.standard.TestValidateRecord.testValidateJsonTimestamp(TestValidateRecord.java:580)
```

# Root Cause

`testValidateJsonTimestamp()` executes three scenarios by reconfiguring the same `JsonTreeReader` and rerunning:

1. Valid JSON with explicit schema and `yyyy/MM/dd HH:mm:ss`

2. JSON with an invalid timestamp format (`yyyy-MM-dd HH:mm:ss`)

3. Inferred schema with `yyyy/MM/dd HH:mm:ss`

Because the same controller service instance is reused and reconfigured in‑place, internal state/configuration can leak across scenarios. The final scenario sometimes observes residual configuration from the previous one, leading to unexpected routing (e.g., `REL_VALID` count is `0` instead of `1`).

# What this PR changes

* Reorder scenarios so that the Inferred Schema scenario runs before the Invalid Format scenario.

* Reset the reader configuration back to `schema-text-property` and restore `SCHEMA_TEXT` before running the Invalid Format scenario.

* Preserve `clearTransferState()` calls and the disable/enable cycle to apply configuration changes deterministically.

This keeps the test’s intent/coverage the same while avoiding state leakage that NonDex can expose. 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
