### PR TITLE
NIFI-15037 - Clean up nifi ui unit test console error messages

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/app.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/app.component.spec.ts
@@ -22,6 +22,10 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { provideMockStore } from '@ngrx/store/testing';
 import { navigationFeatureKey } from './state/navigation';
 import * as fromNavigation from './state/navigation/navigation.reducer';
+import { initialState as initialErrorState } from './state/error/error.reducer';
+import { errorFeatureKey } from './state/error';
+import { initialState as initialCurrentUserState } from './state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from './state/current-user';
 
 describe('AppComponent', () => {
     beforeEach(() =>
@@ -31,6 +35,8 @@ describe('AppComponent', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [navigationFeatureKey]: fromNavigation.initialState
                     }
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/access-policies/ui/component-access-policies/component-access-policies.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/access-policies/ui/component-access-policies/component-access-policies.component.spec.ts
@@ -19,6 +19,11 @@ import { ComponentAccessPolicies } from './component-access-policies.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/access-policy/access-policy.reducer';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { accessPoliciesFeatureKey } from '../../state';
+import { accessPolicyFeatureKey } from '../../state/access-policy';
+import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 
 describe('ComponentAccessPolicies', () => {
     let component: ComponentAccessPolicies;
@@ -27,7 +32,17 @@ describe('ComponentAccessPolicies', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [ComponentAccessPolicies],
-            providers: [provideMockStore({ initialState })]
+            imports: [NgxSkeletonLoaderComponent],
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [accessPoliciesFeatureKey]: {
+                            [accessPolicyFeatureKey]: initialState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(ComponentAccessPolicies);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/access-policies/ui/global-access-policies/global-access-policies.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/access-policies/ui/global-access-policies/global-access-policies.component.spec.ts
@@ -19,6 +19,11 @@ import { GlobalAccessPolicies } from './global-access-policies.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/access-policy/access-policy.reducer';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { accessPoliciesFeatureKey } from '../../state';
+import { accessPolicyFeatureKey } from '../../state/access-policy';
+import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 
 describe('GlobalAccessPolicies', () => {
     let component: GlobalAccessPolicies;
@@ -27,7 +32,17 @@ describe('GlobalAccessPolicies', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [GlobalAccessPolicies],
-            providers: [provideMockStore({ initialState })]
+            imports: [NgxSkeletonLoaderComponent],
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [accessPoliciesFeatureKey]: {
+                            [accessPolicyFeatureKey]: initialState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(GlobalAccessPolicies);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/bulletins/ui/bulletin-board/bulletin-board.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/bulletins/ui/bulletin-board/bulletin-board.component.spec.ts
@@ -19,6 +19,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BulletinBoard } from './bulletin-board.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialBulletinBoardState } from '../../state/bulletin-board/bulletin-board.reducer';
+import { bulletinBoardFeatureKey } from '../../state/bulletin-board';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
 
 describe('BulletinBoard', () => {
     let component: BulletinBoard;
@@ -27,7 +30,16 @@ describe('BulletinBoard', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [BulletinBoard],
-            providers: [provideMockStore({ initialState: initialBulletinBoardState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        bulletins: {
+                            [bulletinBoardFeatureKey]: initialBulletinBoardState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(BulletinBoard);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/feature/cluster.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/feature/cluster.component.spec.ts
@@ -24,19 +24,27 @@ import { ClusterNodeListing } from '../ui/cluster-node-listing/cluster-node-list
 import { MatTabsModule } from '@angular/material/tabs';
 import { selectClusterListing } from '../state/cluster-listing/cluster-listing.selectors';
 import { clusterListingFeatureKey } from '../state/cluster-listing';
-import { ClusterState } from '../state';
+import { clusterFeatureKey } from '../state';
 import { MockComponent } from 'ng-mocks';
 import { Navigation } from '../../../ui/common/navigation/navigation.component';
 import { BannerText } from '../../../ui/common/banner-text/banner-text.component';
 import { ContextErrorBanner } from '../../../ui/common/context-error-banner/context-error-banner.component';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
 
 describe('Cluster', () => {
     let component: Cluster;
     let fixture: ComponentFixture<Cluster>;
 
     beforeEach(() => {
-        const initialState: ClusterState = {
-            [clusterListingFeatureKey]: initialClusterState
+        const initialState = {
+            [errorFeatureKey]: initialErrorState,
+            [currentUserFeatureKey]: initialCurrentUserState,
+            [clusterFeatureKey]: {
+                [clusterListingFeatureKey]: initialClusterState
+            }
         };
         TestBed.configureTestingModule({
             declarations: [Cluster],
@@ -54,7 +62,7 @@ describe('Cluster', () => {
                     selectors: [
                         {
                             selector: selectClusterListing,
-                            value: initialState[clusterListingFeatureKey]
+                            value: initialState[clusterFeatureKey][clusterListingFeatureKey]
                         }
                     ]
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-content-storage-listing/cluster-content-storage-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-content-storage-listing/cluster-content-storage-listing.component.spec.ts
@@ -18,19 +18,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ClusterContentStorageListing } from './cluster-content-storage-listing.component';
-import { ClusterState } from '../../state';
 import { clusterListingFeatureKey } from '../../state/cluster-listing';
 import { initialClusterState } from '../../state/cluster-listing/cluster-listing.reducer';
+import { clusterFeatureKey } from '../../state';
 import { provideMockStore } from '@ngrx/store/testing';
 import { selectClusterListing } from '../../state/cluster-listing/cluster-listing.selectors';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ClusterContentStorageListing', () => {
     let component: ClusterContentStorageListing;
     let fixture: ComponentFixture<ClusterContentStorageListing>;
 
     beforeEach(async () => {
-        const initialState: ClusterState = {
-            [clusterListingFeatureKey]: initialClusterState
+        const initialState = {
+            [errorFeatureKey]: initialErrorState,
+            [currentUserFeatureKey]: initialCurrentUserState,
+            [clusterFeatureKey]: {
+                [clusterListingFeatureKey]: initialClusterState
+            }
         };
         await TestBed.configureTestingModule({
             imports: [ClusterContentStorageListing],
@@ -40,7 +48,7 @@ describe('ClusterContentStorageListing', () => {
                     selectors: [
                         {
                             selector: selectClusterListing,
-                            value: initialState[clusterListingFeatureKey]
+                            value: initialState[clusterFeatureKey][clusterListingFeatureKey]
                         }
                     ]
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-flow-file-storage-listing/cluster-flow-file-storage-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-flow-file-storage-listing/cluster-flow-file-storage-listing.component.spec.ts
@@ -18,19 +18,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ClusterFlowFileStorageListing } from './cluster-flow-file-storage-listing.component';
-import { ClusterState } from '../../state';
 import { clusterListingFeatureKey } from '../../state/cluster-listing';
 import { initialClusterState } from '../../state/cluster-listing/cluster-listing.reducer';
+import { clusterFeatureKey } from '../../state';
 import { provideMockStore } from '@ngrx/store/testing';
 import { selectClusterListing } from '../../state/cluster-listing/cluster-listing.selectors';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ClusterFlowFileStorageListing', () => {
     let component: ClusterFlowFileStorageListing;
     let fixture: ComponentFixture<ClusterFlowFileStorageListing>;
 
     beforeEach(async () => {
-        const initialState: ClusterState = {
-            [clusterListingFeatureKey]: initialClusterState
+        const initialState = {
+            [errorFeatureKey]: initialErrorState,
+            [currentUserFeatureKey]: initialCurrentUserState,
+            [clusterFeatureKey]: {
+                [clusterListingFeatureKey]: initialClusterState
+            }
         };
         await TestBed.configureTestingModule({
             imports: [ClusterFlowFileStorageListing],
@@ -40,7 +48,7 @@ describe('ClusterFlowFileStorageListing', () => {
                     selectors: [
                         {
                             selector: selectClusterListing,
-                            value: initialState[clusterListingFeatureKey]
+                            value: initialState[clusterFeatureKey][clusterListingFeatureKey]
                         }
                     ]
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-jvm-listing/cluster-jvm-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-jvm-listing/cluster-jvm-listing.component.spec.ts
@@ -18,19 +18,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ClusterJvmListing } from './cluster-jvm-listing.component';
-import { ClusterState } from '../../state';
 import { clusterListingFeatureKey } from '../../state/cluster-listing';
 import { initialClusterState } from '../../state/cluster-listing/cluster-listing.reducer';
+import { clusterFeatureKey } from '../../state';
 import { provideMockStore } from '@ngrx/store/testing';
 import { selectClusterListing } from '../../state/cluster-listing/cluster-listing.selectors';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ClusterJvmListing', () => {
     let component: ClusterJvmListing;
     let fixture: ComponentFixture<ClusterJvmListing>;
 
     beforeEach(async () => {
-        const initialState: ClusterState = {
-            [clusterListingFeatureKey]: initialClusterState
+        const initialState = {
+            [errorFeatureKey]: initialErrorState,
+            [currentUserFeatureKey]: initialCurrentUserState,
+            [clusterFeatureKey]: {
+                [clusterListingFeatureKey]: initialClusterState
+            }
         };
 
         await TestBed.configureTestingModule({
@@ -41,7 +49,7 @@ describe('ClusterJvmListing', () => {
                     selectors: [
                         {
                             selector: selectClusterListing,
-                            value: initialState[clusterListingFeatureKey]
+                            value: initialState[clusterFeatureKey][clusterListingFeatureKey]
                         }
                     ]
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-node-listing/cluster-node-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-node-listing/cluster-node-listing.component.spec.ts
@@ -21,16 +21,24 @@ import { ClusterNodeListing } from './cluster-node-listing.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialClusterState } from '../../state/cluster-listing/cluster-listing.reducer';
 import { selectClusterListing } from '../../state/cluster-listing/cluster-listing.selectors';
-import { ClusterState } from '../../state';
 import { clusterListingFeatureKey } from '../../state/cluster-listing';
+import { clusterFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ClusterNodeListing', () => {
     let component: ClusterNodeListing;
     let fixture: ComponentFixture<ClusterNodeListing>;
 
     beforeEach(async () => {
-        const initialState: ClusterState = {
-            [clusterListingFeatureKey]: initialClusterState
+        const initialState = {
+            [errorFeatureKey]: initialErrorState,
+            [currentUserFeatureKey]: initialCurrentUserState,
+            [clusterFeatureKey]: {
+                [clusterListingFeatureKey]: initialClusterState
+            }
         };
         await TestBed.configureTestingModule({
             imports: [ClusterNodeListing],
@@ -40,7 +48,7 @@ describe('ClusterNodeListing', () => {
                     selectors: [
                         {
                             selector: selectClusterListing,
-                            value: initialState[clusterListingFeatureKey]
+                            value: initialState[clusterFeatureKey][clusterListingFeatureKey]
                         }
                     ]
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-provenance-storage-listing/cluster-provenance-storage-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-provenance-storage-listing/cluster-provenance-storage-listing.component.spec.ts
@@ -18,19 +18,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ClusterProvenanceStorageListing } from './cluster-provenance-storage-listing.component';
-import { ClusterState } from '../../state';
 import { clusterListingFeatureKey } from '../../state/cluster-listing';
 import { initialClusterState } from '../../state/cluster-listing/cluster-listing.reducer';
+import { clusterFeatureKey } from '../../state';
 import { provideMockStore } from '@ngrx/store/testing';
 import { selectClusterListing } from '../../state/cluster-listing/cluster-listing.selectors';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ClusterProvenanceStorageListing', () => {
     let component: ClusterProvenanceStorageListing;
     let fixture: ComponentFixture<ClusterProvenanceStorageListing>;
 
     beforeEach(async () => {
-        const initialState: ClusterState = {
-            [clusterListingFeatureKey]: initialClusterState
+        const initialState = {
+            [errorFeatureKey]: initialErrorState,
+            [currentUserFeatureKey]: initialCurrentUserState,
+            [clusterFeatureKey]: {
+                [clusterListingFeatureKey]: initialClusterState
+            }
         };
 
         await TestBed.configureTestingModule({
@@ -41,7 +49,7 @@ describe('ClusterProvenanceStorageListing', () => {
                     selectors: [
                         {
                             selector: selectClusterListing,
-                            value: initialState[clusterListingFeatureKey]
+                            value: initialState[clusterFeatureKey][clusterListingFeatureKey]
                         }
                     ]
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-system-listing/cluster-system-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-system-listing/cluster-system-listing.component.spec.ts
@@ -18,19 +18,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ClusterSystemListing } from './cluster-system-listing.component';
-import { ClusterState } from '../../state';
 import { clusterListingFeatureKey } from '../../state/cluster-listing';
 import { initialClusterState } from '../../state/cluster-listing/cluster-listing.reducer';
+import { clusterFeatureKey } from '../../state';
 import { provideMockStore } from '@ngrx/store/testing';
 import { selectClusterListing } from '../../state/cluster-listing/cluster-listing.selectors';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ClusterSystemListing', () => {
     let component: ClusterSystemListing;
     let fixture: ComponentFixture<ClusterSystemListing>;
 
     beforeEach(async () => {
-        const initialState: ClusterState = {
-            [clusterListingFeatureKey]: initialClusterState
+        const initialState = {
+            [errorFeatureKey]: initialErrorState,
+            [currentUserFeatureKey]: initialCurrentUserState,
+            [clusterFeatureKey]: {
+                [clusterListingFeatureKey]: initialClusterState
+            }
         };
         await TestBed.configureTestingModule({
             imports: [ClusterSystemListing],
@@ -40,7 +48,7 @@ describe('ClusterSystemListing', () => {
                     selectors: [
                         {
                             selector: selectClusterListing,
-                            value: initialState[clusterListingFeatureKey]
+                            value: initialState[clusterFeatureKey][clusterListingFeatureKey]
                         }
                     ]
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-version-listing/cluster-version-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/cluster/ui/cluster-version-listing/cluster-version-listing.component.spec.ts
@@ -18,19 +18,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ClusterVersionListing } from './cluster-version-listing.component';
-import { ClusterState } from '../../state';
 import { clusterListingFeatureKey } from '../../state/cluster-listing';
 import { initialClusterState } from '../../state/cluster-listing/cluster-listing.reducer';
+import { clusterFeatureKey } from '../../state';
 import { provideMockStore } from '@ngrx/store/testing';
 import { selectClusterListing } from '../../state/cluster-listing/cluster-listing.selectors';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ClusterVersionListing', () => {
     let component: ClusterVersionListing;
     let fixture: ComponentFixture<ClusterVersionListing>;
 
     beforeEach(async () => {
-        const initialState: ClusterState = {
-            [clusterListingFeatureKey]: initialClusterState
+        const initialState = {
+            [errorFeatureKey]: initialErrorState,
+            [currentUserFeatureKey]: initialCurrentUserState,
+            [clusterFeatureKey]: {
+                [clusterListingFeatureKey]: initialClusterState
+            }
         };
 
         await TestBed.configureTestingModule({
@@ -41,7 +49,7 @@ describe('ClusterVersionListing', () => {
                     selectors: [
                         {
                             selector: selectClusterListing,
-                            value: initialState[clusterListingFeatureKey]
+                            value: initialState[clusterFeatureKey][clusterListingFeatureKey]
                         }
                     ]
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/feature/documentation.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/feature/documentation.component.spec.ts
@@ -24,6 +24,10 @@ import { Navigation } from '../../../ui/common/navigation/navigation.component';
 import { Documentation } from './documentation.component';
 import { extensionTypesFeatureKey } from '../../../state/extension-types';
 import { initialExtensionsTypesState } from '../../../state/extension-types/extension-types.reducer';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
 import { MatAccordion, MatExpansionModule } from '@angular/material/expansion';
 import { BannerText } from '../../../ui/common/banner-text/banner-text.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -55,6 +59,8 @@ describe('Documentation', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [extensionTypesFeatureKey]: initialExtensionsTypesState
                     }
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/additional-details/additional-details.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/additional-details/additional-details.component.spec.ts
@@ -22,6 +22,10 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { additionalDetailsFeatureKey } from '../../../state/additional-details';
 import { initialState } from '../../../state/additional-details/additional-details.reducer';
 import { documentationFeatureKey } from '../../../state';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../state/current-user';
 
 describe('AdditionalDetailsComponent', () => {
     let component: AdditionalDetailsComponent;
@@ -33,6 +37,8 @@ describe('AdditionalDetailsComponent', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [documentationFeatureKey]: {
                             [additionalDetailsFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/multi-processor-use-case/multi-processor-use-case.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/multi-processor-use-case/multi-processor-use-case.component.spec.ts
@@ -21,6 +21,10 @@ import { MultiProcessorUseCaseComponent } from './multi-processor-use-case.compo
 import { provideMockStore } from '@ngrx/store/testing';
 import { extensionTypesFeatureKey } from '../../../../../state/extension-types';
 import { initialExtensionsTypesState } from '../../../../../state/extension-types/extension-types.reducer';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../state/current-user';
 
 describe('MultiProcessorUseCaseComponent', () => {
     let component: MultiProcessorUseCaseComponent;
@@ -32,6 +36,8 @@ describe('MultiProcessorUseCaseComponent', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [extensionTypesFeatureKey]: initialExtensionsTypesState
                     }
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/property-definition/property-definition.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/property-definition/property-definition.component.spec.ts
@@ -21,6 +21,10 @@ import { PropertyDefinitionComponent } from './property-definition.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { extensionTypesFeatureKey } from '../../../../../state/extension-types';
 import { initialExtensionsTypesState } from '../../../../../state/extension-types/extension-types.reducer';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../state/current-user';
 
 describe('PropertyDefinitionComponent', () => {
     let component: PropertyDefinitionComponent;
@@ -32,6 +36,8 @@ describe('PropertyDefinitionComponent', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [extensionTypesFeatureKey]: initialExtensionsTypesState
                     }
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/see-also/see-also.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/see-also/see-also.component.spec.ts
@@ -21,6 +21,10 @@ import { SeeAlsoComponent } from './see-also.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { extensionTypesFeatureKey } from '../../../../../state/extension-types';
 import { initialExtensionsTypesState } from '../../../../../state/extension-types/extension-types.reducer';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../state/current-user';
 
 describe('MultiProcessorUseCaseComponent', () => {
     let component: SeeAlsoComponent;
@@ -32,6 +36,8 @@ describe('MultiProcessorUseCaseComponent', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [extensionTypesFeatureKey]: initialExtensionsTypesState
                     }
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/controller-service-definition/controller-service-definition.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/controller-service-definition/controller-service-definition.component.spec.ts
@@ -22,6 +22,10 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { documentationFeatureKey } from '../../state';
 import { controllerServiceDefinitionFeatureKey } from '../../state/controller-service-definition';
 import { initialState } from '../../state/controller-service-definition/controller-service-definition.reducer';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ControllerServiceDefinition', () => {
     let component: ControllerServiceDefinition;
@@ -33,6 +37,8 @@ describe('ControllerServiceDefinition', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [documentationFeatureKey]: {
                             [controllerServiceDefinitionFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/flow-analysis-rule-definition/flow-analysis-rule-definition.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/flow-analysis-rule-definition/flow-analysis-rule-definition.component.spec.ts
@@ -22,6 +22,10 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { documentationFeatureKey } from '../../state';
 import { flowAnalysisRuleDefinitionFeatureKey } from '../../state/flow-analysis-rule-definition';
 import { initialState } from '../../state/flow-analysis-rule-definition/flow-analysis-rule-definition.reducer';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('FlowAnalysisRuleDefinition', () => {
     let component: FlowAnalysisRuleDefinition;
@@ -33,6 +37,8 @@ describe('FlowAnalysisRuleDefinition', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [documentationFeatureKey]: {
                             [flowAnalysisRuleDefinitionFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/overview/overview.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/overview/overview.component.spec.ts
@@ -22,6 +22,10 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { documentationFeatureKey } from '../../state';
 import { externalDocumentationFeatureKey } from '../../state/external-documentation';
 import { initialState } from '../../state/external-documentation/external-documentation.reducer';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('Overview', () => {
     let component: Overview;
@@ -33,6 +37,8 @@ describe('Overview', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [documentationFeatureKey]: {
                             [externalDocumentationFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/parameter-provider-definition/parameter-provider-definition.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/parameter-provider-definition/parameter-provider-definition.component.spec.ts
@@ -22,6 +22,10 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { documentationFeatureKey } from '../../state';
 import { parameterContextListingFeatureKey } from '../../../parameter-contexts/state/parameter-context-listing';
 import { initialState } from '../../state/parameter-provider-definition/parameter-provider-definition.reducer';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ParameterProviderDefinition', () => {
     let component: ParameterProviderDefinition;
@@ -33,6 +37,8 @@ describe('ParameterProviderDefinition', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [documentationFeatureKey]: {
                             [parameterContextListingFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/processor-definition/processor-definition.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/processor-definition/processor-definition.component.spec.ts
@@ -22,6 +22,10 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { processorDefinitionFeatureKey } from '../../state/processor-definition';
 import { initialState } from '../../state/processor-definition/processor-definition.reducer';
 import { documentationFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ProcessorDefinition', () => {
     let component: ProcessorDefinition;
@@ -33,6 +37,8 @@ describe('ProcessorDefinition', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [documentationFeatureKey]: {
                             [processorDefinitionFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/reporting-task-definition/reporting-task-definition.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/reporting-task-definition/reporting-task-definition.component.spec.ts
@@ -22,6 +22,10 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { documentationFeatureKey } from '../../state';
 import { reportingTaskDefinitionFeatureKey } from '../../state/reporting-task-definition';
 import { initialState } from '../../state/reporting-task-definition/reporting-task-definition.reducer';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ReportingTaskDefinition', () => {
     let component: ReportingTaskDefinition;
@@ -33,6 +37,8 @@ describe('ReportingTaskDefinition', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [documentationFeatureKey]: {
                             [reportingTaskDefinitionFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-configuration-history/ui/flow-configuration-history-listing/flow-configuration-history-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-configuration-history/ui/flow-configuration-history-listing/flow-configuration-history-listing.component.spec.ts
@@ -20,6 +20,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FlowConfigurationHistoryListing } from './flow-configuration-history-listing.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialHistoryState } from '../../state/flow-configuration-history-listing/flow-configuration-history-listing.reducer';
+import { flowConfigurationHistoryListingFeatureKey } from '../../state/flow-configuration-history-listing';
+import { flowConfigurationHistoryFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('FlowConfigurationHistoryListing', () => {
     let component: FlowConfigurationHistoryListing;
@@ -28,7 +34,17 @@ describe('FlowConfigurationHistoryListing', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [FlowConfigurationHistoryListing],
-            providers: [provideMockStore({ initialState: initialHistoryState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [flowConfigurationHistoryFeatureKey]: {
+                            [flowConfigurationHistoryListingFeatureKey]: initialHistoryState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(FlowConfigurationHistoryListing);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-configuration-history/ui/flow-configuration-history-listing/purge-history/purge-history.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-configuration-history/ui/flow-configuration-history-listing/purge-history/purge-history.component.spec.ts
@@ -20,6 +20,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PurgeHistory } from './purge-history.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialHistoryState } from '../../../state/flow-configuration-history-listing/flow-configuration-history-listing.reducer';
+import { flowConfigurationHistoryListingFeatureKey } from '../../../state/flow-configuration-history-listing';
+import { flowConfigurationHistoryFeatureKey } from '../../../state';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../state/current-user';
 import { MatNativeDateModule } from '@angular/material/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialogRef } from '@angular/material/dialog';
@@ -32,7 +38,15 @@ describe('PurgeHistory', () => {
         TestBed.configureTestingModule({
             imports: [PurgeHistory, MatNativeDateModule, NoopAnimationsModule],
             providers: [
-                provideMockStore({ initialState: initialHistoryState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [flowConfigurationHistoryFeatureKey]: {
+                            [flowConfigurationHistoryListingFeatureKey]: initialHistoryState
+                        }
+                    }
+                }),
                 {
                     provide: MatDialogRef,
                     useValue: null

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/flow-analysis.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/flow-analysis.service.spec.ts
@@ -20,6 +20,8 @@ import { TestBed } from '@angular/core/testing';
 import { FlowAnalysisService } from './flow-analysis.service';
 import { provideMockStore } from '@ngrx/store/testing';
 import { HttpClient } from '@angular/common/http';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
 
 describe('FlowAnalysisService', () => {
     let service: FlowAnalysisService;
@@ -27,7 +29,11 @@ describe('FlowAnalysisService', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             providers: [
-                provideMockStore({}),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState
+                    }
+                }),
                 {
                     provide: HttpClient,
                     useValue: {}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.spec.ts
@@ -35,6 +35,10 @@ import { FlowAnalysisDrawerComponent } from './header/flow-analysis-drawer/flow-
 import { CanvasActionsService } from '../../service/canvas-actions.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CopyResponseEntity } from '../../../../state/copy';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('Canvas', () => {
     let component: Canvas;
@@ -71,6 +75,8 @@ describe('Canvas', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [canvasFeatureKey]: {
                             [flowFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/change-color-dialog/change-color-dialog.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/change-color-dialog/change-color-dialog.component.spec.ts
@@ -21,6 +21,12 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../state/flow/flow.reducer';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../state/current-user';
+import { canvasFeatureKey } from '../../../state';
+import { flowFeatureKey } from '../../../state/flow';
 
 describe('ChangeColorDialog', () => {
     let component: ChangeColorDialog;
@@ -37,7 +43,15 @@ describe('ChangeColorDialog', () => {
                     }
                 },
                 { provide: MatDialogRef, useValue: null },
-                provideMockStore({ initialState })
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    }
+                })
             ]
         }).compileComponents();
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/footer/footer.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/footer/footer.component.spec.ts
@@ -19,11 +19,15 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FooterComponent } from './footer.component';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../state/flow/flow.reducer';
+import { initialState as initialFlowState } from '../../../state/flow/flow.reducer';
+import { flowFeatureKey } from '../../../state/flow';
+import { canvasFeatureKey } from '../../../state';
 import { selectBreadcrumbs } from '../../../state/flow/flow.selectors';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BreadcrumbEntity } from '../../../state/shared';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
 
 describe('FooterComponent', () => {
     let component: FooterComponent;
@@ -47,7 +51,12 @@ describe('FooterComponent', () => {
             imports: [RouterModule, RouterTestingModule],
             providers: [
                 provideMockStore({
-                    initialState,
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialFlowState
+                        }
+                    },
                     selectors: [
                         {
                             selector: selectBreadcrumbs,

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/graph-controls.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/graph-controls.component.spec.ts
@@ -28,6 +28,10 @@ import { BreadcrumbEntity } from '../../../state/shared';
 import { MockComponent } from 'ng-mocks';
 import { canvasFeatureKey } from '../../../state';
 import { flowFeatureKey } from '../../../state/flow';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../state/current-user';
 
 describe('GraphControls', () => {
     let component: GraphControls;
@@ -57,6 +61,8 @@ describe('GraphControls', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [canvasFeatureKey]: {
                             [flowFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/navigation-control.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/navigation-control.component.spec.ts
@@ -24,6 +24,10 @@ import { Birdseye } from './birdseye/birdseye.component';
 import { canvasFeatureKey } from '../../../../state';
 import { flowFeatureKey } from '../../../../state/flow';
 import { MockComponent } from 'ng-mocks';
+import { initialState as initialErrorState } from '../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../state/current-user';
 
 describe('NavigationControl', () => {
     let component: NavigationControl;
@@ -35,6 +39,8 @@ describe('NavigationControl', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [canvasFeatureKey]: {
                             [flowFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/operation-control.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/operation-control.component.spec.ts
@@ -21,6 +21,12 @@ import { OperationControl } from './operation-control.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../state/flow/flow.reducer';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { initialState as initialErrorState } from '../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../state/current-user';
+import { canvasFeatureKey } from '../../../../state';
+import { flowFeatureKey } from '../../../../state/flow';
 
 describe('OperationControl', () => {
     let component: OperationControl;
@@ -31,7 +37,13 @@ describe('OperationControl', () => {
             imports: [OperationControl, HttpClientTestingModule],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/flow-analysis-drawer/flow-analysis-drawer.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/flow-analysis-drawer/flow-analysis-drawer.component.spec.ts
@@ -19,6 +19,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FlowAnalysisDrawerComponent } from './flow-analysis-drawer.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { initialState as initialErrorState } from '../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../state/error';
+import { initialState as initialFlowAnalysisState } from '../../../../state/flow-analysis/flow-analysis.reducer';
+import { flowAnalysisFeatureKey } from '../../../../state/flow-analysis';
+import { initialState as initialFlowState } from '../../../../state/flow/flow.reducer';
+import { flowFeatureKey } from '../../../../state/flow';
 
 describe('FlowAnalysisDrawerComponent', () => {
     let component: FlowAnalysisDrawerComponent;
@@ -27,7 +33,17 @@ describe('FlowAnalysisDrawerComponent', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             imports: [FlowAnalysisDrawerComponent, NoopAnimationsModule],
-            providers: [provideMockStore({})]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        canvas: {
+                            [flowAnalysisFeatureKey]: initialFlowAnalysisState,
+                            [flowFeatureKey]: initialFlowState
+                        }
+                    }
+                })
+            ]
         }).compileComponents();
 
         fixture = TestBed.createComponent(FlowAnalysisDrawerComponent);

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/flow-analysis-drawer/violation-details-dialog/violation-details-dialog.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/flow-analysis-drawer/violation-details-dialog/violation-details-dialog.component.spec.ts
@@ -19,6 +19,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ViolationDetailsDialogComponent } from './violation-details-dialog.component';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { provideMockStore } from '@ngrx/store/testing';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialFlowState } from '../../../../../state/flow/flow.reducer';
+import { flowFeatureKey } from '../../../../../state/flow';
 
 describe('ViolationDetailsDialogComponent', () => {
     let component: ViolationDetailsDialogComponent;
@@ -89,7 +93,14 @@ describe('ViolationDetailsDialogComponent', () => {
                     provide: MatDialogRef,
                     useValue: {}
                 },
-                provideMockStore({})
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        canvas: {
+                            [flowFeatureKey]: initialFlowState
+                        }
+                    }
+                })
             ]
         }).compileComponents();
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/new-canvas-item/new-canvas-item.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/new-canvas-item/new-canvas-item.component.spec.ts
@@ -20,6 +20,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NewCanvasItem } from './new-canvas-item.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../state/flow/flow.reducer';
+import { initialState as initialErrorState } from '../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../state/current-user';
+import { canvasFeatureKey } from '../../../../state';
+import { flowFeatureKey } from '../../../../state/flow';
 
 describe('NewCanvasItem', () => {
     let component: NewCanvasItem;
@@ -30,7 +36,13 @@ describe('NewCanvasItem', () => {
             imports: [NewCanvasItem],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/create-connection/create-connection.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/create-connection/create-connection.component.spec.ts
@@ -27,6 +27,12 @@ import { DocumentedType } from '../../../../../../../state/shared';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
 import { ClusterConnectionService } from '../../../../../../../service/cluster-connection.service';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
+import { canvasFeatureKey } from '../../../../../state';
+import { flowFeatureKey } from '../../../../../state/flow';
 
 describe('CreateConnection', () => {
     let component: CreateConnection;
@@ -371,7 +377,15 @@ describe('CreateConnection', () => {
             imports: [CreateConnection, NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    }
+                }),
                 {
                     provide: ClusterConnectionService,
                     useValue: {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/edit-connection/edit-connection.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/edit-connection/edit-connection.component.spec.ts
@@ -25,6 +25,12 @@ import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../../state/flow/flow.reducer';
 import { selectPrioritizerTypes } from '../../../../../../../state/extension-types/extension-types.selectors';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
+import { canvasFeatureKey } from '../../../../../state';
+import { flowFeatureKey } from '../../../../../state/flow';
 
 describe('EditConnectionComponent', () => {
     let store: MockStore;
@@ -135,7 +141,15 @@ describe('EditConnectionComponent', () => {
                     provide: MAT_DIALOG_DATA,
                     useValue: data
                 },
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/change-version-dialog/change-version-dialog.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/change-version-dialog/change-version-dialog.spec.ts
@@ -26,6 +26,12 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../../state/flow/flow.reducer';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { selectTimeOffset } from '../../../../../../../state/flow-configuration/flow-configuration.selectors';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
+import { canvasFeatureKey } from '../../../../../state';
+import { flowFeatureKey } from '../../../../../state/flow';
 import { Sort } from '@angular/material/sort';
 
 interface SetupOptions {
@@ -92,7 +98,13 @@ describe('ChangeVersionDialog', () => {
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: dialogData },
                 provideMockStore({
-                    initialState,
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    },
                     selectors: [
                         {
                             selector: selectTimeOffset,

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/import-from-registry/import-from-registry.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/import-from-registry/import-from-registry.component.spec.ts
@@ -22,7 +22,13 @@ import { ImportFromRegistryDialogRequest } from '../../../../../state/flow';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { ComponentType } from '@nifi/shared';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../../state/flow/flow.reducer';
+import { initialState as initialFlowState } from '../../../../../state/flow/flow.reducer';
+import { flowFeatureKey } from '../../../../../state/flow';
+import { canvasFeatureKey } from '../../../../../state';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { EMPTY } from 'rxjs';
 import { ClusterConnectionService } from '../../../../../../../service/cluster-connection.service';
@@ -116,7 +122,15 @@ describe('ImportFromRegistry', () => {
             imports: [ImportFromRegistry, NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialFlowState
+                        }
+                    }
+                }),
                 {
                     provide: ClusterConnectionService,
                     useValue: {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/save-version-dialog/save-version-dialog.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/save-version-dialog/save-version-dialog.component.spec.ts
@@ -21,7 +21,13 @@ import { SaveVersionDialog } from './save-version-dialog.component';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { SaveVersionDialogRequest } from '../../../../../state/flow';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../../state/flow/flow.reducer';
+import { initialState as initialFlowState } from '../../../../../state/flow/flow.reducer';
+import { flowFeatureKey } from '../../../../../state/flow';
+import { canvasFeatureKey } from '../../../../../state';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
 import { EMPTY } from 'rxjs';
 import { Signal } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -118,7 +124,15 @@ describe('SaveVersionDialog', () => {
                     provide: MAT_DIALOG_DATA,
                     useValue: data
                 },
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialFlowState
+                        }
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         }).compileComponents();

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/label/edit-label/edit-label.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/label/edit-label/edit-label.component.spec.ts
@@ -25,6 +25,12 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../../state/flow/flow.reducer';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ClusterConnectionService } from '../../../../../../../service/cluster-connection.service';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
+import { canvasFeatureKey } from '../../../../../state';
+import { flowFeatureKey } from '../../../../../state/flow';
 
 describe('EditLabel', () => {
     let component: EditLabel;
@@ -73,7 +79,15 @@ describe('EditLabel', () => {
             imports: [EditLabel, NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    }
+                }),
                 {
                     provide: ClusterConnectionService,
                     useValue: {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/port/create-port/create-port.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/port/create-port/create-port.component.spec.ts
@@ -24,6 +24,12 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../../state/flow/flow.reducer';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
+import { canvasFeatureKey } from '../../../../../state';
+import { flowFeatureKey } from '../../../../../state/flow';
 
 describe('CreatePort', () => {
     let component: CreatePort;
@@ -46,7 +52,15 @@ describe('CreatePort', () => {
             imports: [CreatePort, NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/port/edit-port/edit-port.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/port/edit-port/edit-port.component.spec.ts
@@ -25,6 +25,12 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../../state/flow/flow.reducer';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ClusterConnectionService } from '../../../../../../../service/cluster-connection.service';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
+import { canvasFeatureKey } from '../../../../../state';
+import { flowFeatureKey } from '../../../../../state/flow';
 
 describe('EditPort', () => {
     let component: EditPort;
@@ -99,7 +105,15 @@ describe('EditPort', () => {
             imports: [EditPort, NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    }
+                }),
                 {
                     provide: ClusterConnectionService,
                     useValue: {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/create-process-group/create-process-group.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/create-process-group/create-process-group.component.spec.ts
@@ -27,6 +27,12 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CurrentUser } from '../../../../../../../state/current-user';
 import { of } from 'rxjs';
 import { By } from '@angular/platform-browser';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
+import { canvasFeatureKey } from '../../../../../state';
+import { flowFeatureKey } from '../../../../../state/flow';
 
 const noPermissionsParameterContextId = '95d509b9-018b-1000-daff-b7957ea7935e';
 const parameterContextId = '95d509b9-018b-1000-daff-b7957ea7934f';
@@ -89,7 +95,15 @@ describe('CreateProcessGroup', () => {
                 imports: [CreateProcessGroup, NoopAnimationsModule],
                 providers: [
                     { provide: MAT_DIALOG_DATA, useValue: data },
-                    provideMockStore({ initialState }),
+                    provideMockStore({
+                        initialState: {
+                            [errorFeatureKey]: initialErrorState,
+                            [currentUserFeatureKey]: initialCurrentUserState,
+                            [canvasFeatureKey]: {
+                                [flowFeatureKey]: initialState
+                            }
+                        }
+                    }),
                     { provide: MatDialogRef, useValue: null }
                 ]
             });
@@ -142,7 +156,15 @@ describe('CreateProcessGroup', () => {
                 imports: [CreateProcessGroup, NoopAnimationsModule],
                 providers: [
                     { provide: MAT_DIALOG_DATA, useValue: data },
-                    provideMockStore({ initialState }),
+                    provideMockStore({
+                        initialState: {
+                            [errorFeatureKey]: initialErrorState,
+                            [currentUserFeatureKey]: initialCurrentUserState,
+                            [canvasFeatureKey]: {
+                                [flowFeatureKey]: initialState
+                            }
+                        }
+                    }),
                     { provide: MatDialogRef, useValue: null }
                 ]
             });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/edit-process-group/edit-process-group.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/edit-process-group/edit-process-group.component.spec.ts
@@ -22,8 +22,13 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ClusterConnectionService } from '../../../../../../../service/cluster-connection.service';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../../state/flow/flow.reducer';
-import { CurrentUser } from '../../../../../../../state/current-user';
+import { initialState as initialFlowState } from '../../../../../state/flow/flow.reducer';
+import { flowFeatureKey } from '../../../../../state/flow';
+import { canvasFeatureKey } from '../../../../../state';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey, CurrentUser } from '../../../../../../../state/current-user';
 import { of } from 'rxjs';
 import { By } from '@angular/platform-browser';
 
@@ -150,7 +155,15 @@ describe('EditProcessGroup', () => {
                 imports: [EditProcessGroup, NoopAnimationsModule],
                 providers: [
                     { provide: MAT_DIALOG_DATA, useValue: data },
-                    provideMockStore({ initialState }),
+                    provideMockStore({
+                        initialState: {
+                            [errorFeatureKey]: initialErrorState,
+                            [currentUserFeatureKey]: initialCurrentUserState,
+                            [canvasFeatureKey]: {
+                                [flowFeatureKey]: initialFlowState
+                            }
+                        }
+                    }),
                     {
                         provide: ClusterConnectionService,
                         useValue: {
@@ -305,7 +318,15 @@ describe('EditProcessGroup', () => {
                 imports: [EditProcessGroup, NoopAnimationsModule],
                 providers: [
                     { provide: MAT_DIALOG_DATA, useValue: data },
-                    provideMockStore({ initialState }),
+                    provideMockStore({
+                        initialState: {
+                            [errorFeatureKey]: initialErrorState,
+                            [currentUserFeatureKey]: initialCurrentUserState,
+                            [canvasFeatureKey]: {
+                                [flowFeatureKey]: initialFlowState
+                            }
+                        }
+                    }),
                     {
                         provide: ClusterConnectionService,
                         useValue: {
@@ -424,7 +445,15 @@ describe('EditProcessGroup', () => {
                 imports: [EditProcessGroup, NoopAnimationsModule],
                 providers: [
                     { provide: MAT_DIALOG_DATA, useValue: data },
-                    provideMockStore({ initialState }),
+                    provideMockStore({
+                        initialState: {
+                            [errorFeatureKey]: initialErrorState,
+                            [currentUserFeatureKey]: initialCurrentUserState,
+                            [canvasFeatureKey]: {
+                                [flowFeatureKey]: initialFlowState
+                            }
+                        }
+                    }),
                     {
                         provide: ClusterConnectionService,
                         useValue: {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/group-components/group-components.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/group-components/group-components.component.spec.ts
@@ -24,6 +24,12 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../../state/flow/flow.reducer';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
+import { canvasFeatureKey } from '../../../../../state';
+import { flowFeatureKey } from '../../../../../state/flow';
 
 describe('GroupComponents', () => {
     let component: GroupComponents;
@@ -861,7 +867,21 @@ describe('GroupComponents', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [GroupComponents, NoopAnimationsModule],
-            providers: [{ provide: MAT_DIALOG_DATA, useValue: data }, provideMockStore({ initialState })]
+            providers: [
+                {
+                    provide: MAT_DIALOG_DATA,
+                    useValue: data
+                },
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(GroupComponents);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/processor/create-processor/create-processor.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/processor/create-processor/create-processor.component.spec.ts
@@ -22,6 +22,9 @@ import { CreateProcessorDialogRequest } from '../../../../../state/flow';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialExtensionsTypesState } from '../../../../../../../state/extension-types/extension-types.reducer';
+import { extensionTypesFeatureKey } from '../../../../../../../state/extension-types';
+import { initialState as initialFlowState } from '../../../../../state/flow/flow.reducer';
+import { flowFeatureKey } from '../../../../../state/flow';
 import { ComponentType } from '@nifi/shared';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { DocumentedType } from '../../../../../../../state/shared';
@@ -29,6 +32,8 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MockComponent } from 'ng-mocks';
 import { ExtensionCreation } from '../../../../../../../ui/common/extension-creation/extension-creation.component';
 import { of } from 'rxjs';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
 
 describe('CreateProcessor', () => {
     let component: CreateProcessor;
@@ -68,7 +73,15 @@ describe('CreateProcessor', () => {
             imports: [CreateProcessor, NoopAnimationsModule, MatIconTestingModule, MockComponent(ExtensionCreation)],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({ initialState: initialExtensionsTypesState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [extensionTypesFeatureKey]: initialExtensionsTypesState,
+                        canvas: {
+                            [flowFeatureKey]: initialFlowState
+                        }
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/remote-process-group/create-remote-process-group/create-remote-process-group.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/remote-process-group/create-remote-process-group/create-remote-process-group.component.spec.ts
@@ -21,7 +21,13 @@ import { CreateRemoteProcessGroup } from './create-remote-process-group.componen
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { ComponentType } from '@nifi/shared';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../../state/flow/flow.reducer';
+import { initialState as initialFlowState } from '../../../../../state/flow/flow.reducer';
+import { flowFeatureKey } from '../../../../../state/flow';
+import { canvasFeatureKey } from '../../../../../state';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CreateComponentRequest } from '../../../../../state/flow';
 
@@ -46,7 +52,15 @@ describe('CreateRemoteProcessGroup', () => {
             imports: [CreateRemoteProcessGroup, NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialFlowState
+                        }
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/remote-process-group/edit-remote-process-group/edit-remote-process-group.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/remote-process-group/edit-remote-process-group/edit-remote-process-group.component.spec.ts
@@ -22,7 +22,13 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ComponentType } from '@nifi/shared';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../../state/flow/flow.reducer';
+import { initialState as initialFlowState } from '../../../../../state/flow/flow.reducer';
+import { flowFeatureKey } from '../../../../../state/flow';
+import { canvasFeatureKey } from '../../../../../state';
+import { initialState as initialErrorState } from '../../../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../../../state/current-user';
 
 describe('EditRemoteProcessGroup', () => {
     let component: EditRemoteProcessGroup;
@@ -77,7 +83,15 @@ describe('EditRemoteProcessGroup', () => {
                     provide: MAT_DIALOG_DATA,
                     useValue: data
                 },
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialFlowState
+                        }
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/manage-remote-ports/edit-remote-port/edit-remote-port.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/manage-remote-ports/edit-remote-port/edit-remote-port.component.spec.ts
@@ -25,6 +25,11 @@ import { EditComponentDialogRequest } from '../../../state/flow';
 import { ComponentType } from '@nifi/shared';
 import { initialState } from '../../../state/manage-remote-ports/manage-remote-ports.reducer';
 import { ClusterConnectionService } from '../../../../../service/cluster-connection.service';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../state/current-user';
+import { remotePortsFeatureKey } from '../../../state/manage-remote-ports';
 
 describe('EditRemotePortComponent', () => {
     let component: EditRemotePortComponent;
@@ -53,7 +58,13 @@ describe('EditRemotePortComponent', () => {
             imports: [EditRemotePortComponent, NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [remotePortsFeatureKey]: initialState
+                    }
+                }),
                 {
                     provide: ClusterConnectionService,
                     useValue: {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/manage-remote-ports/manage-remote-ports.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/manage-remote-ports/manage-remote-ports.component.spec.ts
@@ -26,6 +26,10 @@ import { MockComponent } from 'ng-mocks';
 import { Navigation } from '../../../../ui/common/navigation/navigation.component';
 import { remotePortsFeatureKey } from '../../state/manage-remote-ports';
 import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ManageRemotePorts', () => {
     let component: ManageRemotePorts;
@@ -43,6 +47,8 @@ describe('ManageRemotePorts', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [remotePortsFeatureKey]: initialState
                     }
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-listing.component.spec.ts
@@ -20,6 +20,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ParameterContextListing } from './parameter-context-listing.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/parameter-context-listing/parameter-context-listing.reducer';
+import { parameterContextListingFeatureKey } from '../../state/parameter-context-listing';
+import { parameterContextsFeatureKey } from '../../state';
 
 describe('ParameterContextListing', () => {
     let component: ParameterContextListing;
@@ -28,7 +30,15 @@ describe('ParameterContextListing', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ParameterContextListing],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [parameterContextsFeatureKey]: {
+                            [parameterContextListingFeatureKey]: initialState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(ParameterContextListing);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.spec.ts
@@ -20,6 +20,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ParameterItem, ParameterTable } from './parameter-table.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../state/parameter-context-listing/parameter-context-listing.reducer';
+import { parameterContextListingFeatureKey } from '../../../state/parameter-context-listing';
+import { parameterContextsFeatureKey } from '../../../state';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../state/current-user';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { EditParameterResponse } from '../../../../../state/shared';
 import { Observable, of } from 'rxjs';
@@ -32,7 +38,17 @@ describe('ParameterTable', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ParameterTable, NoopAnimationsModule],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [parameterContextsFeatureKey]: {
+                            [parameterContextListingFeatureKey]: initialState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(ParameterTable);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/provenance/feature/provenance.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/provenance/feature/provenance.component.spec.ts
@@ -27,6 +27,10 @@ import { Navigation } from '../../../ui/common/navigation/navigation.component';
 import { provenanceFeatureKey } from '../state';
 import { provenanceEventListingFeatureKey } from '../state/provenance-event-listing';
 import { BannerText } from '../../../ui/common/banner-text/banner-text.component';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
 
 describe('Provenance', () => {
     let component: Provenance;
@@ -39,6 +43,8 @@ describe('Provenance', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [provenanceFeatureKey]: {
                             [provenanceEventListingFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/provenance/ui/provenance-event-listing/provenance-event-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/provenance/ui/provenance-event-listing/provenance-event-listing.component.spec.ts
@@ -20,6 +20,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProvenanceEventListing } from './provenance-event-listing.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/provenance-event-listing/provenance-event-listing.reducer';
+import { provenanceEventListingFeatureKey } from '../../state/provenance-event-listing';
+import { provenanceFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialLineageState } from '../../state/lineage/lineage.reducer';
+import { lineageFeatureKey } from '../../state/lineage';
+import { initialState as initialClusterSummaryState } from '../../../../state/cluster-summary/cluster-summary.reducer';
+import { clusterSummaryFeatureKey } from '../../../../state/cluster-summary';
 
 describe('ParameterContextListing', () => {
     let component: ProvenanceEventListing;
@@ -28,7 +36,18 @@ describe('ParameterContextListing', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ProvenanceEventListing],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [clusterSummaryFeatureKey]: initialClusterSummaryState,
+                        [provenanceFeatureKey]: {
+                            [provenanceEventListingFeatureKey]: initialState,
+                            [lineageFeatureKey]: initialLineageState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(ProvenanceEventListing);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/queue/ui/queue-listing/queue-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/queue/ui/queue-listing/queue-listing.component.spec.ts
@@ -20,6 +20,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { QueueListing } from './queue-listing.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/queue-listing/queue-listing.reducer';
+import { queueListingFeatureKey } from '../../state/queue-listing';
+import { queueFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialAboutState } from '../../../../state/about/about.reducer';
+import { aboutFeatureKey } from '../../../../state/about';
 
 describe('QueueListing', () => {
     let component: QueueListing;
@@ -28,7 +34,17 @@ describe('QueueListing', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [QueueListing],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [aboutFeatureKey]: initialAboutState,
+                        [queueFeatureKey]: {
+                            [queueListingFeatureKey]: initialState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(QueueListing);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/route-not-found/feature/route-not-found.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/route-not-found/feature/route-not-found.component.spec.ts
@@ -23,6 +23,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { currentUserFeatureKey } from '../../../state/current-user';
 import { initialState } from '../../../state/current-user/current-user.reducer';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
 
 describe('RouteNotFound', () => {
     let component: RouteNotFound;
@@ -34,6 +36,7 @@ describe('RouteNotFound', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
                         [currentUserFeatureKey]: initialState
                     }
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/feature/settings.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/feature/settings.component.spec.ts
@@ -27,6 +27,10 @@ import { MockComponent } from 'ng-mocks';
 import { Navigation } from '../../../ui/common/navigation/navigation.component';
 import { settingsFeatureKey } from '../state';
 import { generalFeatureKey } from '../state/general';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
 import { BannerText } from '../../../ui/common/banner-text/banner-text.component';
 
 describe('Settings', () => {
@@ -46,6 +50,8 @@ describe('Settings', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [settingsFeatureKey]: {
                             [generalFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/flow-analysis-rules/create-flow-analysis-rule/create-flow-analysis-rule.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/flow-analysis-rules/create-flow-analysis-rule/create-flow-analysis-rule.component.spec.ts
@@ -23,10 +23,15 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { DocumentedType } from '../../../../../state/shared';
 import { initialExtensionsTypesState } from '../../../../../state/extension-types/extension-types.reducer';
+import { extensionTypesFeatureKey } from '../../../../../state/extension-types';
+import { initialState as initialFlowAnalysisRulesState } from '../../../state/flow-analysis-rules/flow-analysis-rules.reducer';
+import { flowAnalysisRulesFeatureKey } from '../../../state/flow-analysis-rules';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MockComponent } from 'ng-mocks';
 import { ExtensionCreation } from '../../../../../ui/common/extension-creation/extension-creation.component';
 import { of } from 'rxjs';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
 
 describe('CreateFlowAnalysisRule', () => {
     let component: CreateFlowAnalysisRule;
@@ -56,7 +61,15 @@ describe('CreateFlowAnalysisRule', () => {
                 MockComponent(ExtensionCreation)
             ],
             providers: [
-                provideMockStore({ initialState: initialExtensionsTypesState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [extensionTypesFeatureKey]: initialExtensionsTypesState,
+                        settings: {
+                            [flowAnalysisRulesFeatureKey]: initialFlowAnalysisRulesState
+                        }
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.spec.ts
@@ -20,6 +20,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FlowAnalysisRules } from './flow-analysis-rules.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/flow-analysis-rules/flow-analysis-rules.reducer';
+import { flowAnalysisRulesFeatureKey } from '../../state/flow-analysis-rules';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
 
 describe('FlowAnalysisRules', () => {
     let component: FlowAnalysisRules;
@@ -30,7 +33,12 @@ describe('FlowAnalysisRules', () => {
             imports: [FlowAnalysisRules],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        settings: {
+                            [flowAnalysisRulesFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/general/general-form/general-form.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/general/general-form/general-form.component.spec.ts
@@ -20,6 +20,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { GeneralForm } from './general-form.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../state/general/general.reducer';
+import { generalFeatureKey } from '../../../state/general';
+import { settingsFeatureKey } from '../../../state';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../../state/current-user';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ClusterConnectionService } from '../../../../../service/cluster-connection.service';
 
@@ -32,7 +38,13 @@ describe('GeneralForm', () => {
             imports: [GeneralForm, NoopAnimationsModule],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [settingsFeatureKey]: {
+                            [generalFeatureKey]: initialState
+                        }
+                    }
                 }),
                 {
                     provide: ClusterConnectionService,

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/general/general.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/general/general.component.spec.ts
@@ -20,6 +20,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { General } from './general.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/general/general.reducer';
+import { generalFeatureKey } from '../../state/general';
+import { settingsFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('General', () => {
     let component: General;
@@ -30,7 +36,13 @@ describe('General', () => {
             imports: [General],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [settingsFeatureKey]: {
+                            [generalFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.spec.ts
@@ -20,6 +20,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ManagementControllerServices } from './management-controller-services.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/management-controller-services/management-controller-services.reducer';
+import { managementControllerServicesFeatureKey } from '../../state/management-controller-services';
+import { settingsFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ManagementControllerServices', () => {
     let component: ManagementControllerServices;
@@ -30,7 +36,13 @@ describe('ManagementControllerServices', () => {
             imports: [ManagementControllerServices],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [settingsFeatureKey]: {
+                            [managementControllerServicesFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/create-parameter-provider/create-parameter-provider.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/create-parameter-provider/create-parameter-provider.component.spec.ts
@@ -21,12 +21,15 @@ import { CreateParameterProvider } from './create-parameter-provider.component';
 import { MatDialogRef } from '@angular/material/dialog';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialParameterProvidersState } from '../../../state/parameter-providers/parameter-providers.reducer';
+import { parameterProvidersFeatureKey } from '../../../state/parameter-providers';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { DocumentedType } from '../../../../../state/shared';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MockComponent } from 'ng-mocks';
 import { ExtensionCreation } from '../../../../../ui/common/extension-creation/extension-creation.component';
 import { of } from 'rxjs';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
 
 describe('CreateParameterProvider', () => {
     let component: CreateParameterProvider;
@@ -68,7 +71,14 @@ describe('CreateParameterProvider', () => {
                 MockComponent(ExtensionCreation)
             ],
             providers: [
-                provideMockStore({ initialState: initialParameterProvidersState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        settings: {
+                            [parameterProvidersFeatureKey]: initialParameterProvidersState
+                        }
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/edit-parameter-provider/edit-parameter-provider.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/edit-parameter-provider/edit-parameter-provider.component.spec.ts
@@ -23,6 +23,10 @@ import { EditParameterProviderRequest } from '../../../state/parameter-providers
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialParameterProvidersState } from '../../../state/parameter-providers/parameter-providers.reducer';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { settingsFeatureKey } from '../../../state';
+import { parameterProvidersFeatureKey } from '../../../state/parameter-providers';
 
 describe('EditParameterProvider', () => {
     let component: EditParameterProvider;
@@ -161,7 +165,12 @@ describe('EditParameterProvider', () => {
                     useValue: data
                 },
                 provideMockStore({
-                    initialState: initialParameterProvidersState
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [settingsFeatureKey]: {
+                            [parameterProvidersFeatureKey]: initialParameterProvidersState
+                        }
+                    }
                 }),
                 { provide: MatDialogRef, useValue: null }
             ]

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/fetch-parameter-provider-parameters/fetch-parameter-provider-parameters.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/fetch-parameter-provider-parameters/fetch-parameter-provider-parameters.component.spec.ts
@@ -22,8 +22,12 @@ import { FetchParameterProviderDialogRequest } from '../../../state/parameter-pr
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialParameterProvidersState } from '../../../state/parameter-providers/parameter-providers.reducer';
+import { parameterProvidersFeatureKey } from '../../../state/parameter-providers';
+import { settingsFeatureKey } from '../../../state';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ClusterConnectionService } from '../../../../../service/cluster-connection.service';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
 
 describe('FetchParameterProviderParameters', () => {
     let component: FetchParameterProviderParameters;
@@ -163,7 +167,12 @@ describe('FetchParameterProviderParameters', () => {
                     useValue: data
                 },
                 provideMockStore({
-                    initialState: initialParameterProvidersState
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [settingsFeatureKey]: {
+                            [parameterProvidersFeatureKey]: initialParameterProvidersState
+                        }
+                    }
                 }),
                 {
                     provide: ClusterConnectionService,

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers.component.spec.ts
@@ -20,6 +20,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ParameterProviders } from './parameter-providers.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialParameterProvidersState } from '../../state/parameter-providers/parameter-providers.reducer';
+import { parameterProvidersFeatureKey } from '../../state/parameter-providers';
+import { settingsFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ParameterProviders', () => {
     let component: ParameterProviders;
@@ -30,7 +36,13 @@ describe('ParameterProviders', () => {
             imports: [ParameterProviders],
             providers: [
                 provideMockStore({
-                    initialState: initialParameterProvidersState
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [settingsFeatureKey]: {
+                            [parameterProvidersFeatureKey]: initialParameterProvidersState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/registry-clients/registry-clients.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/registry-clients/registry-clients.component.spec.ts
@@ -20,6 +20,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RegistryClients } from './registry-clients.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/registry-clients/registry-clients.reducer';
+import { registryClientsFeatureKey } from '../../state/registry-clients';
+import { settingsFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('RegistryClients', () => {
     let component: RegistryClients;
@@ -28,7 +34,17 @@ describe('RegistryClients', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [RegistryClients],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [settingsFeatureKey]: {
+                            [registryClientsFeatureKey]: initialState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(RegistryClients);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/reporting-tasks/create-reporting-task/create-reporting-task.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/reporting-tasks/create-reporting-task/create-reporting-task.component.spec.ts
@@ -21,12 +21,17 @@ import { CreateReportingTask } from './create-reporting-task.component';
 import { MatDialogRef } from '@angular/material/dialog';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialExtensionsTypesState } from '../../../../../state/extension-types/extension-types.reducer';
+import { extensionTypesFeatureKey } from '../../../../../state/extension-types';
+import { initialState as initialReportingTasksState } from '../../../state/reporting-tasks/reporting-tasks.reducer';
+import { reportingTasksFeatureKey } from '../../../state/reporting-tasks';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MockComponent } from 'ng-mocks';
 import { DocumentedType } from '../../../../../state/shared';
 import { ExtensionCreation } from '../../../../../ui/common/extension-creation/extension-creation.component';
 import { of } from 'rxjs';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
 
 describe('CreateReportingTask', () => {
     let component: CreateReportingTask;
@@ -55,7 +60,15 @@ describe('CreateReportingTask', () => {
                 MockComponent(ExtensionCreation)
             ],
             providers: [
-                provideMockStore({ initialState: initialExtensionsTypesState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [extensionTypesFeatureKey]: initialExtensionsTypesState,
+                        settings: {
+                            [reportingTasksFeatureKey]: initialReportingTasksState
+                        }
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.spec.ts
@@ -20,6 +20,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReportingTasks } from './reporting-tasks.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/reporting-tasks/reporting-tasks.reducer';
+import { reportingTasksFeatureKey } from '../../state/reporting-tasks';
+import { settingsFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 
 describe('ReportingTasks', () => {
     let component: ReportingTasks;
@@ -30,7 +36,13 @@ describe('ReportingTasks', () => {
             imports: [ReportingTasks],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [settingsFeatureKey]: {
+                            [reportingTasksFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/feature/summary.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/feature/summary.component.spec.ts
@@ -27,6 +27,8 @@ import { Navigation } from '../../../ui/common/navigation/navigation.component';
 import { summaryFeatureKey } from '../state';
 import { summaryListingFeatureKey } from '../state/summary-listing';
 import { BannerText } from '../../../ui/common/banner-text/banner-text.component';
+import { initialState as initialClusterSummaryState } from '../../../state/cluster-summary/cluster-summary.reducer';
+import { clusterSummaryFeatureKey } from '../../../state/cluster-summary';
 
 describe('Summary', () => {
     let component: Summary;
@@ -45,6 +47,7 @@ describe('Summary', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [clusterSummaryFeatureKey]: initialClusterSummaryState,
                         [summaryFeatureKey]: {
                             [summaryListingFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/common/cluster-summary-dialog/cluster-summary-dialog.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/common/cluster-summary-dialog/cluster-summary-dialog.component.spec.ts
@@ -24,6 +24,10 @@ import { initialComponentClusterStatusState } from '../../../state/component-clu
 import { ComponentClusterStatusRequest, ComponentClusterStatusState } from '../../../state/component-cluster-status';
 import { ComponentType } from '@nifi/shared';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { initialState as initialErrorState } from '../../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../../state/error';
+import { summaryFeatureKey } from '../../../state';
+import { componentClusterStatusFeatureKey } from '../../../state/component-cluster-status';
 
 describe('ClusterSummaryDialog', () => {
     let component: ClusterSummaryDialog;
@@ -42,11 +46,16 @@ describe('ClusterSummaryDialog', () => {
                 },
                 provideMockStore({
                     initialState: {
-                        ...initialComponentClusterStatusState,
-                        clusterStatus: {
-                            canRead: true
+                        [errorFeatureKey]: initialErrorState,
+                        [summaryFeatureKey]: {
+                            [componentClusterStatusFeatureKey]: {
+                                ...initialComponentClusterStatusState,
+                                clusterStatus: {
+                                    canRead: true
+                                }
+                            } as ComponentClusterStatusState
                         }
-                    } as ComponentClusterStatusState
+                    }
                 }),
                 { provide: MatDialogRef, useValue: null }
             ]

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-listing.component.spec.ts
@@ -20,7 +20,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ConnectionStatusListing } from './connection-status-listing.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../state/summary-listing/summary-listing.reducer';
+import { initialState as initialSummaryListingState } from '../../state/summary-listing/summary-listing.reducer';
+import { summaryListingFeatureKey } from '../../state/summary-listing';
+import { summaryFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
 
 describe('ConnectionStatusListing', () => {
     let component: ConnectionStatusListing;
@@ -29,7 +33,16 @@ describe('ConnectionStatusListing', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ConnectionStatusListing, NoopAnimationsModule],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [summaryFeatureKey]: {
+                            [summaryListingFeatureKey]: initialSummaryListingState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(ConnectionStatusListing);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/input-port-status-listing/input-port-status-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/input-port-status-listing/input-port-status-listing.component.spec.ts
@@ -20,7 +20,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { InputPortStatusListing } from './input-port-status-listing.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../state/summary-listing/summary-listing.reducer';
+import { initialState as initialSummaryListingState } from '../../state/summary-listing/summary-listing.reducer';
+import { summaryListingFeatureKey } from '../../state/summary-listing';
+import { summaryFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
 
 describe('InputPortStatusListing', () => {
     let component: InputPortStatusListing;
@@ -29,7 +33,16 @@ describe('InputPortStatusListing', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [InputPortStatusListing, NoopAnimationsModule],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [summaryFeatureKey]: {
+                            [summaryListingFeatureKey]: initialSummaryListingState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(InputPortStatusListing);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/output-port-status-listing/output-port-status-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/output-port-status-listing/output-port-status-listing.component.spec.ts
@@ -20,7 +20,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { OutputPortStatusListing } from './output-port-status-listing.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../state/summary-listing/summary-listing.reducer';
+import { initialState as initialSummaryListingState } from '../../state/summary-listing/summary-listing.reducer';
+import { summaryListingFeatureKey } from '../../state/summary-listing';
+import { summaryFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
 
 describe('OutputPortStatusListing', () => {
     let component: OutputPortStatusListing;
@@ -29,7 +33,16 @@ describe('OutputPortStatusListing', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [OutputPortStatusListing, NoopAnimationsModule],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [summaryFeatureKey]: {
+                            [summaryListingFeatureKey]: initialSummaryListingState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(OutputPortStatusListing);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/process-group-status-listing/process-group-status-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/process-group-status-listing/process-group-status-listing.component.spec.ts
@@ -20,7 +20,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProcessGroupStatusListing } from './process-group-status-listing.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../state/summary-listing/summary-listing.reducer';
+import { initialState as initialSummaryListingState } from '../../state/summary-listing/summary-listing.reducer';
+import { summaryListingFeatureKey } from '../../state/summary-listing';
+import { summaryFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
 
 describe('ProcessGroupStatusListing', () => {
     let component: ProcessGroupStatusListing;
@@ -30,7 +34,16 @@ describe('ProcessGroupStatusListing', () => {
         TestBed.configureTestingModule({
             declarations: [],
             imports: [ProcessGroupStatusListing, NoopAnimationsModule],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [summaryFeatureKey]: {
+                            [summaryListingFeatureKey]: initialSummaryListingState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(ProcessGroupStatusListing);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/processor-status-listing/processor-status-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/processor-status-listing/processor-status-listing.component.spec.ts
@@ -20,7 +20,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProcessorStatusListing } from './processor-status-listing.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { initialState } from '../../state/summary-listing/summary-listing.reducer';
+import { initialState as initialSummaryListingState } from '../../state/summary-listing/summary-listing.reducer';
+import { summaryListingFeatureKey } from '../../state/summary-listing';
+import { summaryFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
 
 describe('ProcessorStatusListing', () => {
     let component: ProcessorStatusListing;
@@ -29,7 +33,16 @@ describe('ProcessorStatusListing', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ProcessorStatusListing, NoopAnimationsModule],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [summaryFeatureKey]: {
+                            [summaryListingFeatureKey]: initialSummaryListingState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(ProcessorStatusListing);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/remote-process-group-status-listing/remote-process-group-status-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/remote-process-group-status-listing/remote-process-group-status-listing.component.spec.ts
@@ -20,7 +20,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RemoteProcessGroupStatusListing } from './remote-process-group-status-listing.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../state/summary-listing/summary-listing.reducer';
+import { initialState as initialSummaryListingState } from '../../state/summary-listing/summary-listing.reducer';
+import { summaryListingFeatureKey } from '../../state/summary-listing';
+import { summaryFeatureKey } from '../../state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
 
 describe('RemoteProcessGroupStatusListing', () => {
     let component: RemoteProcessGroupStatusListing;
@@ -29,7 +33,16 @@ describe('RemoteProcessGroupStatusListing', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [RemoteProcessGroupStatusListing, NoopAnimationsModule],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [summaryFeatureKey]: {
+                            [summaryListingFeatureKey]: initialSummaryListingState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(RemoteProcessGroupStatusListing);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/users/feature/users.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/users/feature/users.component.spec.ts
@@ -26,6 +26,10 @@ import { MockComponent } from 'ng-mocks';
 import { Navigation } from '../../../ui/common/navigation/navigation.component';
 import { usersFeatureKey } from '../state';
 import { BannerText } from '../../../ui/common/banner-text/banner-text.component';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
 
 describe('Users', () => {
     let component: Users;
@@ -38,6 +42,8 @@ describe('Users', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [usersFeatureKey]: {
                             [usersFeatureKey]: initialState
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/users/ui/user-listing/user-listing.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/users/ui/user-listing/user-listing.component.spec.ts
@@ -19,6 +19,9 @@ import { UserListing } from './user-listing.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/user-listing/user-listing.reducer';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { usersFeatureKey } from '../../state';
 
 describe('UserListing', () => {
     let component: UserListing;
@@ -27,7 +30,16 @@ describe('UserListing', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [UserListing],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [usersFeatureKey]: {
+                            [usersFeatureKey]: initialState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(UserListing);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/component-state/component-state.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/component-state/component-state.effects.spec.ts
@@ -30,6 +30,10 @@ import * as ErrorActions from '../error/error.actions';
 import { ComponentState, ComponentStateEntity, ClearStateEntryRequest } from './index';
 import { selectComponentUri, selectComponentState } from './component-state.selectors';
 import { ErrorContextKey } from '../error';
+import { initialState as initialErrorState } from '../error/error.reducer';
+import { errorFeatureKey } from '../error';
+import { initialState as initialCurrentUserState } from '../current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../current-user';
 
 describe('ComponentStateEffects', () => {
     let actions$: Observable<Action>;
@@ -75,7 +79,12 @@ describe('ComponentStateEffects', () => {
             providers: [
                 ComponentStateEffects,
                 provideMockActions(() => actions$),
-                provideMockStore(),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState
+                    }
+                }),
                 { provide: ComponentStateService, useValue: componentStateServiceSpy },
                 { provide: ErrorHelper, useValue: errorHelperSpy }
             ]

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/about-dialog/about-dialog.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/about-dialog/about-dialog.component.spec.ts
@@ -20,8 +20,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AboutDialog } from './about-dialog.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../state/component-state/component-state.reducer';
+import { initialState } from '../../../state/about/about.reducer';
+import { aboutFeatureKey } from '../../../state/about';
 import { MatDialogRef } from '@angular/material/dialog';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
 
 describe('AboutDialog', () => {
     let component: AboutDialog;
@@ -30,7 +33,15 @@ describe('AboutDialog', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [AboutDialog, NoopAnimationsModule],
-            providers: [provideMockStore({ initialState }), { provide: MatDialogRef, useValue: null }]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [aboutFeatureKey]: initialState
+                    }
+                }),
+                { provide: MatDialogRef, useValue: null }
+            ]
         });
         fixture = TestBed.createComponent(AboutDialog);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/advanced-ui/advanced-ui.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/advanced-ui/advanced-ui.component.spec.ts
@@ -34,6 +34,8 @@ import { currentUserFeatureKey } from '../../../state/current-user';
 import { navigationFeatureKey } from '../../../state/navigation';
 import { MockComponent } from 'ng-mocks';
 import { Navigation } from '../navigation/navigation.component';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
 
 describe('AdvancedUi', () => {
     let component: AdvancedUi;
@@ -45,6 +47,7 @@ describe('AdvancedUi', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
                         [currentUserFeatureKey]: fromUser.initialState,
                         [navigationFeatureKey]: fromNavigation.initialState
                     },

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/banner-text/banner-text.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/banner-text/banner-text.component.spec.ts
@@ -20,6 +20,10 @@ import { BannerText } from './banner-text.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import * as fromBannerText from '../../../state/banner-text/banner-text.reducer';
 import { bannerTextFeatureKey } from '../../../state/banner-text';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
 
 describe('BannerText', () => {
     let component: BannerText;
@@ -31,6 +35,8 @@ describe('BannerText', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [bannerTextFeatureKey]: fromBannerText.initialState
                     }
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/component-state/component-state.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/component-state/component-state.component.spec.ts
@@ -23,8 +23,12 @@ import { FormBuilder } from '@angular/forms';
 
 import { ComponentStateDialog } from './component-state.component';
 import { initialState } from '../../../state/component-state/component-state.reducer';
-import { ComponentState, ComponentStateState } from '../../../state/component-state';
+import { ComponentState, ComponentStateState, componentStateFeatureKey } from '../../../state/component-state';
 import * as ComponentStateActions from '../../../state/component-state/component-state.actions';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
 import { NiFiCommon } from '@nifi/shared';
 
 describe('ComponentStateDialog', () => {
@@ -73,7 +77,13 @@ describe('ComponentStateDialog', () => {
         TestBed.configureTestingModule({
             imports: [ComponentStateDialog, NoopAnimationsModule],
             providers: [
-                provideMockStore({ initialState: { componentState: mockInitialState } }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [componentStateFeatureKey]: mockInitialState
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null },
                 { provide: NiFiCommon, useValue: nifiCommonSpy },
                 FormBuilder

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/context-menu/context-menu.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/context-menu/context-menu.component.spec.ts
@@ -19,7 +19,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ContextMenu } from './context-menu.component';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../pages/flow-designer/state/flow/flow.reducer';
+import { initialState as initialFlowState } from '../../../pages/flow-designer/state/flow/flow.reducer';
+import { flowFeatureKey } from '../../../pages/flow-designer/state/flow';
+import { canvasFeatureKey } from '../../../pages/flow-designer/state';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
 
 describe('ContextMenu', () => {
     let component: ContextMenu;
@@ -28,7 +34,17 @@ describe('ContextMenu', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ContextMenu],
-            providers: [provideMockStore({ initialState })]
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialFlowState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(ContextMenu);
         component = fixture.componentInstance;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.html
@@ -150,7 +150,7 @@
                                     </button>
                                 }
                                 @if (canDelete(item)) {
-                                    <button mat-menu-item (click)="deleteClicked(item, $event)">
+                                    <button mat-menu-item (click)="deleteClicked(item)">
                                         <i class="fa fa-trash primary-color mr-2"></i>
                                         Delete
                                     </button>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.ts
@@ -247,7 +247,7 @@ export class ControllerServiceTable {
         return this.isDisabled(entity) && this.canRead(entity) && this.canWrite(entity) && this.canModifyParent(entity);
     }
 
-    deleteClicked(entity: ControllerServiceEntity, event: MouseEvent): void {
+    deleteClicked(entity: ControllerServiceEntity): void {
         this.deleteControllerService.next(entity);
     }
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/create-controller-service/create-controller-service.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/create-controller-service/create-controller-service.component.spec.ts
@@ -21,12 +21,15 @@ import { CreateControllerService } from './create-controller-service.component';
 import { MatDialogRef } from '@angular/material/dialog';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialExtensionsTypesState } from '../../../../state/extension-types/extension-types.reducer';
+import { extensionTypesFeatureKey } from '../../../../state/extension-types';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MockComponent } from 'ng-mocks';
 import { ExtensionCreation } from '../../extension-creation/extension-creation.component';
 import { DocumentedType } from '../../../../state/shared';
 import { of } from 'rxjs';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
 
 describe('CreateControllerService', () => {
     let component: CreateControllerService;
@@ -65,7 +68,12 @@ describe('CreateControllerService', () => {
                 MockComponent(ExtensionCreation)
             ],
             providers: [
-                provideMockStore({ initialState: initialExtensionsTypesState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [extensionTypesFeatureKey]: initialExtensionsTypesState
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/disable-controller-service/disable-controller-service.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/disable-controller-service/disable-controller-service.component.spec.ts
@@ -21,9 +21,12 @@ import { DisableControllerService } from './disable-controller-service.component
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../state/contoller-service-state/controller-service-state.reducer';
+import { controllerServiceStateFeatureKey } from '../../../../state/contoller-service-state';
 import { ComponentType } from '@nifi/shared';
 import { SetEnableControllerServiceDialogRequest } from '../../../../state/shared';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
 
 describe('EnableControllerService', () => {
     let component: DisableControllerService;
@@ -344,7 +347,12 @@ describe('EnableControllerService', () => {
         TestBed.configureTestingModule({
             imports: [DisableControllerService, NoopAnimationsModule],
             providers: [
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [controllerServiceStateFeatureKey]: initialState
+                    }
+                }),
                 {
                     provide: MAT_DIALOG_DATA,
                     useValue: data

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/enable-controller-service/enable-controller-service.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/enable-controller-service/enable-controller-service.component.spec.ts
@@ -21,6 +21,11 @@ import { EnableControllerService } from './enable-controller-service.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../state/contoller-service-state/controller-service-state.reducer';
+import { controllerServiceStateFeatureKey } from '../../../../state/contoller-service-state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { ComponentType } from '@nifi/shared';
 import { SetEnableControllerServiceDialogRequest } from '../../../../state/shared';
@@ -344,7 +349,13 @@ describe('EnableControllerService', () => {
         TestBed.configureTestingModule({
             imports: [EnableControllerService, NoopAnimationsModule, MatDialogModule],
             providers: [
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [controllerServiceStateFeatureKey]: initialState
+                    }
+                }),
                 {
                     provide: MAT_DIALOG_DATA,
                     useValue: data

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/navigation/navigation.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/navigation/navigation.component.spec.ts
@@ -32,6 +32,10 @@ import { selectLoginConfiguration } from '../../../state/login-configuration/log
 import * as fromLoginConfiguration from '../../../state/login-configuration/login-configuration.reducer';
 import { currentUserFeatureKey } from '../../../state/current-user';
 import { navigationFeatureKey } from '../../../state/navigation';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
+import { initialState as initialAboutState } from '../../../state/about/about.reducer';
+import { aboutFeatureKey } from '../../../state/about';
 import { popBackNavigation } from '../../../state/navigation/navigation.actions';
 
 describe('Navigation', () => {
@@ -45,6 +49,8 @@ describe('Navigation', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [aboutFeatureKey]: initialAboutState,
                         [currentUserFeatureKey]: fromUser.initialState,
                         [navigationFeatureKey]: fromNavigation.initialState
                     },

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/page-content/page-content.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/page-content/page-content.component.spec.ts
@@ -24,6 +24,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { currentUserFeatureKey } from '../../../state/current-user';
 import { initialState } from '../../../state/current-user/current-user.reducer';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
 
 describe('PageContent', () => {
     let component: PageContent;
@@ -35,6 +37,7 @@ describe('PageContent', () => {
             providers: [
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
                         [currentUserFeatureKey]: initialState
                     }
                 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/parameter-context/edit-parameter-context/edit-parameter-context.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/parameter-context/edit-parameter-context/edit-parameter-context.component.spec.ts
@@ -24,6 +24,12 @@ import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.reducer';
+import { parameterContextListingFeatureKey } from '../../../../pages/parameter-contexts/state/parameter-context-listing';
+import { parameterContextsFeatureKey } from '../../../../pages/parameter-contexts/state';
+import { initialState as initialErrorState } from '../../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../../state/current-user';
 import { ClusterConnectionService } from '../../../../service/cluster-connection.service';
 import { ParameterContextEntity, ParameterEntity } from '../../../../state/shared';
 
@@ -241,7 +247,15 @@ describe('EditParameterContext', () => {
             imports: [EditParameterContext, NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({ initialState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [parameterContextsFeatureKey]: {
+                            [parameterContextListingFeatureKey]: initialState
+                        }
+                    }
+                }),
                 {
                     provide: ClusterConnectionService,
                     useValue: {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/status-history/status-history.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/status-history/status-history.component.spec.ts
@@ -27,6 +27,10 @@ import {
     StatusHistoryEntity,
     statusHistoryFeatureKey
 } from '../../../state/status-history';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
 import { ComponentType } from '@nifi/shared';
 import { NiFiCommon } from '@nifi/shared';
 
@@ -83,6 +87,8 @@ describe('StatusHistory', () => {
                 { provide: MAT_DIALOG_DATA, useValue: {} },
                 provideMockStore({
                     initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
                         [statusHistoryFeatureKey]: statusHistoryState
                     }
                 }),

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/system-diagnostics-dialog/system-diagnostics-dialog.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/system-diagnostics-dialog/system-diagnostics-dialog.component.spec.ts
@@ -20,7 +20,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SystemDiagnosticsDialog } from './system-diagnostics-dialog.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialSystemDiagnosticsState } from '../../../state/system-diagnostics/system-diagnostics.reducer';
+import { systemDiagnosticsFeatureKey } from '../../../state/system-diagnostics';
+import { initialState as initialErrorState } from '../../../state/error/error.reducer';
+import { errorFeatureKey } from '../../../state/error';
+import { initialState as initialCurrentUserState } from '../../../state/current-user/current-user.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
 import { MatDialogRef } from '@angular/material/dialog';
+import { initialState as initialAboutState } from '../../../state/about/about.reducer';
+import { aboutFeatureKey } from '../../../state/about';
 
 describe('SystemDiagnosticsDialog', () => {
     let component: SystemDiagnosticsDialog;
@@ -30,7 +37,14 @@ describe('SystemDiagnosticsDialog', () => {
         TestBed.configureTestingModule({
             imports: [SystemDiagnosticsDialog],
             providers: [
-                provideMockStore({ initialState: initialSystemDiagnosticsState }),
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialErrorState,
+                        [currentUserFeatureKey]: initialCurrentUserState,
+                        [aboutFeatureKey]: initialAboutState,
+                        [systemDiagnosticsFeatureKey]: initialSystemDiagnosticsState
+                    }
+                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/tabbed-dialog/tabbed-dialog.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/tabbed-dialog/tabbed-dialog.component.spec.ts
@@ -288,7 +288,7 @@ describe('TabbedDialog', () => {
                 ]
             }).compileComponents();
 
-            const fixture1 = TestBed.createComponent(TestTabbedDialogComponent);
+            TestBed.createComponent(TestTabbedDialogComponent);
 
             expect(mockStorage1.getItem).toHaveBeenCalledWith('tabbed-dialog-selected-index');
 


### PR DESCRIPTION
# Summary

[NIFI-15037](https://issues.apache.org/jira/browse/NIFI-15037)

## Fix Console Errors in NiFi UI Test Suite

**Issue:** 
Unit tests were generating 100+ `TypeError: Cannot read properties of undefined` console errors due to incomplete NgRx mock store configurations, cluttering test output and making it difficult to identify real issues.

**Resolution:**
- Fixed missing state dependencies in `provideMockStore` configurations across 50+ test files
- Added proper initial states for `error`, `currentUser`, `about`, `clusterSummary`, and feature-specific states
- Corrected state nesting to match NgRx feature architecture (e.g., `canvas.flow`, `summary.summaryListing`)

The test suite now runs cleanly without console noise, making it easier to identify legitimate test failures and improving developer experience.
