### PR TITLE
NIFI-15045 - Prevent empty tooltip in help docs for property definition allowable values

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/property-definition/property-definition.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/property-definition/property-definition.component.html
@@ -43,12 +43,14 @@
                         @for (allowableValue of descriptor.allowableValues; track allowableValue.value) {
                             <li>
                                 {{ allowableValue.displayName }}
-                                <i
-                                    class="fa fa-info-circle primary-color"
-                                    nifiTooltip
-                                    [tooltipComponentType]="TextTip"
-                                    [tooltipInputData]="allowableValue.description"
-                                    [delayClose]="false"></i>
+                                @if (allowableValue.description) {
+                                    <i
+                                        class="fa fa-info-circle primary-color"
+                                        nifiTooltip
+                                        [tooltipComponentType]="TextTip"
+                                        [tooltipInputData]="allowableValue.description"
+                                        [delayClose]="false"></i>
+                                }
                             </li>
                         }
                     </ul>


### PR DESCRIPTION
# Summary

[NIFI-15045](https://issues.apache.org/jira/browse/NIFI-15045)

If there is no description for an allowable value, the UI would still show an info icon with an empty tooltip. This PR just removes the icon so they can't see the empty tooltip if there is no description.

One example can be found in the docs for `org.apache.nifi.controller.MonitorMemory`, in particular the Memory Pool allowable values:

This is what it looked like before:
<img width="460" height="212" alt="image" src="https://github.com/user-attachments/assets/66f5b426-acfb-4247-bf26-59df7dada356" />
