### PR TITLE
NIFI-14471 clear branch value when switching between registry clients…

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/import-from-registry/import-from-registry.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/import-from-registry/import-from-registry.component.ts
@@ -199,7 +199,6 @@ export class ImportFromRegistry extends CloseOnEscapeDialog implements OnInit {
         if (this.supportsBranching) {
             this.loadBranches(registryId);
         } else {
-            this.clearBuckets();
             this.loadBuckets(registryId);
         }
     }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/import-from-registry/import-from-registry.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/import-from-registry/import-from-registry.component.ts
@@ -195,8 +195,8 @@ export class ImportFromRegistry extends CloseOnEscapeDialog implements OnInit {
 
     registryChanged(registryId: string): void {
         this.supportsBranching = this.clientBranchingSupportMap.get(registryId) || false;
+        this.clearBranches();
         if (this.supportsBranching) {
-            this.clearBranches();
             this.loadBranches(registryId);
         } else {
             this.clearBuckets();


### PR DESCRIPTION
… in the import from registry form

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

NiFi can be configured with multiple Registry clients. When multiple clients have at least one that supports branching, e.g. GitHubFlowRegistryClient, and another which does not, e.g. NifiRegistryFlowRegistryClient, the client not supporting branching was being handed branch information. The information was a remnant from the branch-supporting client. Worse, if that branch name was not "main", an error was thrown.

On the "import from registry" form in the UI, the code was updated so that the branch details are wiped each time the registry selection is changed thereby preventing branches from being included in the API calls for non-supporting clients.

[NIFI-14471](https://issues.apache.org/jira/browse/NIFI-14471)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

See Jira issue for steps to reproduce - except where the error is reported in the issue, the import of a dataflow should succeed.

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
