### PR TITLE
NIFI-15053 Remove unused Netty 3 dependency management

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/pom.xml
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/pom.xml
@@ -32,14 +32,4 @@
         <module>nifi-schema-inference-utils</module>
         <module>nifi-yaml-record-utils</module>
     </modules>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
-                <version>${netty.3.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/nifi-extension-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -28,11 +28,6 @@
     </modules>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
-                <version>${netty.3.version}</version>
-            </dependency>
             <!-- Override nimbus-jose-jwt 9.8.1 from hadoop-auth -->
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-extension-bundles/nifi-parquet-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-parquet-bundle/pom.xml
@@ -30,11 +30,6 @@
     </modules>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
-                <version>${netty.3.version}</version>
-            </dependency>
             <!-- Override commons-beanutils -->
             <dependency>
                 <groupId>commons-beanutils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,6 @@
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
 
         <!-- Networking and transport -->
-        <netty.3.version>3.10.6.Final</netty.3.version>
         <netty.4.version>4.2.6.Final</netty.4.version>
         <okhttp.version>5.1.0</okhttp.version>
         <okio.version>3.16.0</okio.version>


### PR DESCRIPTION
# Summary

[NIFI-15053](https://issues.apache.org/jira/browse/NIFI-15053) Removes references to Netty 3 dependency management from Hadoop and Parquet modules. [Hadoop 3.4.0](https://issues.apache.org/jira/browse/HADOOP-11219) upgraded Netty dependencies to version 4, eliminating the need for managing a transitive version of Netty 3.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
