### PR TITLE
NIFI-15054 - Bump Azure SDK to 1.3.0, AWS v1 SDK to 1.12.792, AWS v2 SDK to 2.35.0, and others

### DIFF
--- a/nifi-extension-bundles/nifi-asana-bundle/nifi-asana-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-asana-bundle/nifi-asana-processors/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client</artifactId>
-            <version>1.36.0</version>
+            <version>1.47.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -28,8 +28,8 @@
 
     <properties>
         <!-- when changing the Azure SDK version, also update msal4j to the version that is required by azure-identity -->
-        <azure.sdk.bom.version>1.2.38</azure.sdk.bom.version>
-        <msal4j.version>1.22.0</msal4j.version>
+        <azure.sdk.bom.version>1.3.0</azure.sdk.bom.version>
+        <msal4j.version>1.23.1</msal4j.version>
         <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.box</groupId>
                 <artifactId>box-java-sdk</artifactId>
-                <version>4.16.3</version>
+                <version>4.16.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/pom.xml
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <neo4j.driver.version>6.0.0</neo4j.driver.version>
+        <neo4j.driver.version>6.0.1</neo4j.driver.version>
         <neo4j.docker.version>2025.09</neo4j.docker.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/pom.xml
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>software.amazon.msk</groupId>
             <artifactId>aws-msk-iam-auth</artifactId>
-            <version>2.3.2</version>
+            <version>2.3.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.questdb</groupId>
             <artifactId>questdb</artifactId>
-            <version>9.0.3</version>
+            <version>9.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,8 +120,8 @@
         <nifi.nar.maven.plugin.version>2.1.0</nifi.nar.maven.plugin.version>
 
         <!-- AWS SDK -->
-        <com.amazonaws.version>1.12.791</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.34.8</software.amazon.awssdk.version>
+        <com.amazonaws.version>1.12.792</com.amazonaws.version>
+        <software.amazon.awssdk.version>2.35.0</software.amazon.awssdk.version>
 
         <!-- Apache Commons -->
         <org.apache.commons.cli.version>1.10.0</org.apache.commons.cli.version>
@@ -148,7 +148,7 @@
 
         <!-- Data formats and serialization -->
         <avro.version>1.12.0</avro.version>
-        <com.github.luben.zstd-jni.version>1.5.7-4</com.github.luben.zstd-jni.version>
+        <com.github.luben.zstd-jni.version>1.5.7-5</com.github.luben.zstd-jni.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <gson.version>2.13.2</gson.version>
         <jackson.annotations.version>2.20</jackson.annotations.version>


### PR DESCRIPTION
# Summary

NIFI-15054 - Bump Azure SDK to 1.3.0, AWS v1 SDK to 1.12.792, AWS v2 SDK to 2.35.0, and others

- Google HTTP Client (Asana Bundle) from 1.36.0 to 1.47.1 - https://github.com/googleapis/google-http-java-client/releases/tag/v1.47.1
- Azure SDK BOM from 1.2.38 to 1.3.0 - https://github.com/Azure/azure-sdk-for-java/releases/tag/azure-sdk-bom_1.3.0
- MSAL4J from 1.22.0 to 1.23.1 - https://github.com/AzureAD/microsoft-authentication-library-for-java/releases/tag/v1.23.1
- Box Java SDK from 4.16.3 to 4.16.4 - https://github.com/box/box-java-sdk/releases/tag/v4.16.4
- Neo4J Driver from 6.0.0 to 6.0.1 - https://github.com/neo4j/neo4j-java-driver/releases/tag/6.0.1
- AWS MSK IAM Auth from 2.3.2 to 2.3.4 - https://github.com/aws/aws-msk-iam-auth/releases/tag/v2.3.4
- QuestDB from 9.0.3 to 9.1.0 - https://github.com/questdb/questdb/releases/tag/9.1.0
- AWS SDK v1 from 1.12.791 to 1.12.792 - https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md
- AWS SDK v2 from 2.34.8 to 2.35.0 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- ZSTD JNI from 1.5.7-4 to 1.5.7-5 - https://github.com/luben/zstd-jni/releases/tag/v1.5.7-5

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
