### PR TITLE
NIFI-13402 - Multiple flowfiles as output for Python Processors

### DIFF
--- a/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
@@ -223,6 +223,12 @@ The constructor has a single required positional argument, the `relationship` to
 the FlowFile are to be updated, the FlowFile's new contents should be returned via the `contents` argument. Any FlowFile attributes that
 are to be added or modified may additionally provided using the `attributes` argument.
 
+The method may also return an iterable (for example, a list or generator) of `FlowFileTransformResult` instances. In this case the
+framework clones the original FlowFile once per result, applies the contents and attributes described by that result, and transfers each
+clone to the requested relationship. After the iterable has been processed the original FlowFile is routed to the `original`
+relationship (unless that relationship is auto-terminated). Returning the `failure` relationship is only supported when a single result
+is produced.
+
 
 
 [[record-transform]]
@@ -328,6 +334,10 @@ empty `FlowFileSourceResult`. When `create()` returns with `None`, the processor
 When there is nothing to return, it might be useful to yield the processor's resources and not schedule the processor
 to run for the period of time defined by the processor's Yield Duration. This can be achieved by calling
 `context.yield_resources()` from the processor's `create` method right before returning `None`.
+
+A source processor may also return an iterable of `FlowFileSourceResult` objects. Each entry in the iterable causes the framework to
+create a new FlowFile, apply the specified contents and attributes, and transfer it to the requested relationship. Returning `None` or
+an empty iterable results in no FlowFiles being created for that invocation.
 
 
 [[property-descriptors]]

--- a/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/python/processor/FlowFileSource.java
+++ b/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/python/processor/FlowFileSource.java
@@ -19,6 +19,6 @@ package org.apache.nifi.python.processor;
 
 public interface FlowFileSource extends PythonProcessor {
 
-    FlowFileSourceResult createFlowFile();
+    Object createFlowFile();
 
 }

--- a/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/python/processor/FlowFileTransform.java
+++ b/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/python/processor/FlowFileTransform.java
@@ -19,6 +19,6 @@ package org.apache.nifi.python.processor;
 
 public interface FlowFileTransform extends PythonProcessor {
 
-    FlowFileTransformResult transformFlowFile(InputFlowFile flowFile);
+    Object transformFlowFile(InputFlowFile flowFile);
 
 }

--- a/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-python-test-extensions/src/main/resources/extensions/GeneratePages.py
+++ b/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-python-test-extensions/src/main/resources/extensions/GeneratePages.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nifiapi.flowfilesource import FlowFileSource, FlowFileSourceResult
+
+
+class GeneratePages(FlowFileSource):
+    class Java:
+        implements = ['org.apache.nifi.python.processor.FlowFileSource']
+
+    class ProcessorDetails:
+        version = '0.0.1-SNAPSHOT'
+        description = 'Emits a FlowFile for each page encountered when paging through results.'
+        tags = ['pagination', 'test', 'python']
+
+    def __init__(self, **kwargs):
+        pass
+
+    def create(self, context):
+        results = []
+        for index in range(3):
+            attributes = {'page.index': str(index)}
+            contents = f'page-{index}'
+            results.append(FlowFileSourceResult(relationship='success', attributes=attributes, contents=contents))
+        return results

--- a/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-python-test-extensions/src/main/resources/extensions/SplitLines.py
+++ b/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-python-test-extensions/src/main/resources/extensions/SplitLines.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nifiapi.flowfiletransform import FlowFileTransform, FlowFileTransformResult
+
+
+class SplitLines(FlowFileTransform):
+    class Java:
+        implements = ['org.apache.nifi.python.processor.FlowFileTransform']
+
+    class ProcessorDetails:
+        version = '0.0.1-SNAPSHOT'
+        description = 'Splits the incoming FlowFile into one FlowFile per line of text.'
+        tags = ['split', 'line', 'test', 'python']
+
+    def __init__(self, **kwargs):
+        pass
+
+    def transform(self, context, flowFile):
+        contents = flowFile.getContentsAsBytes().decode('utf-8')
+        if not contents:
+            return []
+
+        results = []
+        for index, line in enumerate(contents.splitlines()):
+            attributes = {
+                'split.index': str(index),
+                'split.line.length': str(len(line))
+            }
+            results.append(FlowFileTransformResult(relationship='success', attributes=attributes, contents=line))
+        return results

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-extension-api/src/main/python/src/nifiapi/flowfilesource.py
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-extension-api/src/main/python/src/nifiapi/flowfilesource.py
@@ -30,11 +30,35 @@ class FlowFileSource(ABC):
         self.process_context = ProcessContext(context)
 
     def createFlowFile(self):
-        return self.create(self.process_context)
+        result = self.create(self.process_context)
+        return self.__normalize_results(result)
 
     @abstractmethod
     def create(self, context):
         pass
+
+    def __normalize_results(self, result):
+        if result is None:
+            return None
+
+        if isinstance(result, FlowFileSourceResult):
+            return result
+
+        if isinstance(result, (list, tuple)):
+            java_list = JvmHolder.jvm.java.util.ArrayList()
+            for entry in result:
+                if entry is not None:
+                    java_list.add(entry)
+            return java_list
+
+        if hasattr(result, '__iter__'):
+            java_list = JvmHolder.jvm.java.util.ArrayList()
+            for entry in result:
+                if entry is not None:
+                    java_list.add(entry)
+            return java_list
+
+        return result
 
 class FlowFileSourceResult:
     class Java:

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-extension-api/src/main/python/src/nifiapi/flowfiletransform.py
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-extension-api/src/main/python/src/nifiapi/flowfiletransform.py
@@ -30,11 +30,35 @@ class FlowFileTransform(ABC):
         self.process_context = ProcessContext(context)
 
     def transformFlowFile(self, flowfile):
-        return self.transform(self.process_context, flowfile)
+        result = self.transform(self.process_context, flowfile)
+        return self.__normalize_results(result)
 
     @abstractmethod
     def transform(self, context, flowFile):
         pass
+
+    def __normalize_results(self, result):
+        if result is None:
+            return None
+
+        if isinstance(result, FlowFileTransformResult):
+            return result
+
+        if isinstance(result, (list, tuple)):
+            java_list = JvmHolder.jvm.java.util.ArrayList()
+            for entry in result:
+                if entry is not None:
+                    java_list.add(entry)
+            return java_list
+
+        if hasattr(result, '__iter__'):
+            java_list = JvmHolder.jvm.java.util.ArrayList()
+            for entry in result:
+                if entry is not None:
+                    java_list.add(entry)
+            return java_list
+
+        return result
 
 
 class FlowFileTransformResult:


### PR DESCRIPTION
# Summary

NIFI-13402 - Multiple flowfiles as output for Python Processors

### Context

The current Python bridge allows each invocation of a Python Processor to return exactly one `FlowFileSourceResult` or `FlowFileTransformResult`. This works for simple use-cases but prevents Python processors from emitting multiple FlowFiles in a single trigger, which can be common for some use cases (pagination, splitting, etc).

The taken approach in this PR is to have the minimal changes needed across the Java bridge and the Python helper library to support multiple results while preserving backward compatibility.

### Goals

- Allow Python source processors to emit zero, one, or many FlowFiles per invocation without additional Java code
- Allow Python transform processors to emit zero, one, or many FlowFiles derived from the incoming FlowFile in a single `onTrigger` call
- Preserve existing processor behavior and API surface for implementations that continue to return a single result object
- Provide predictable handling of the original FlowFile when multiple results are returned

### Non-Goals

- Supporting Java-side streaming of arbitrarily large result sequences (iterables will be materialised into memory per call)
- Changing RecordTransform behavior

### Python Return Contract

Processors may return either:

- a single `FlowFile*Result` instance (current behaviour), or
- any iterable (list, tuple, generator) containing `FlowFile*Result` instances

Returning `None` continues to mean "no output".

Python helper classes (`FlowFileTransform` and `FlowFileSource`) will normalise generators into lists before returning to Py4J to ensure predictable conversion.

### FlowFileSourceProxy Changes

- Detect when the bridge returns a `Collection` or `Iterator` and iterate over each element, creating and transferring a FlowFile per result
- Maintain the current fast-path for single results to avoid overhead
- Continue to honour the implicit `success` relationship while allowing per-result relationship names
- `FlowFileSourceResult.free()` is invoked for every element to avoid leaking proxies

### FlowFileTransformProxy Changes

- Fan-out the incoming FlowFile when multiple results are returned by the Python side
- Default behaviour when more than one result is provided:
  - clone the original FlowFile once per result
  - apply the same attribute/content updates that are currently performed
  - transfer each clone to its requested relationship
- Single-result behaviour remains unchanged: mutate the original FlowFile in-place and transfer to the requested relationship, cloning only if the `original` relationship is expected (matching existing logic)
- The original FlowFile will be routed to `REL_ORIGINAL` when that relationship is not auto-terminated and at least one result was processed. If the relationship is auto-terminated we remove the clone as currently implemented
- Any result that requests the `failure` relationship causes the original FlowFile to be routed to failure once, mirroring today's semantics. Additional `failure` results on the same trigger is ignored with a warning to avoid double-transfer attempts
- Invalid result types (for example, returning plain strings) will trigger a `ProcessException` with a detailed message

### Backward Compatibility

- Existing processors that return a single `FlowFile*Result` continue to work without modification
- Processors that currently return a single result wrapped in a list will behave the same after this change
- The default cloning behaviour for multi-result transforms mirrors NiFi’s Java processors like `SplitText`

### Error Handling

- Null or empty iterables result in no FlowFiles being transferred
- Mixed results where some are `None` will be skipped with a warning and without failing the entire batch
- Any exception raised while handling a specific result (for example, write failure) will roll back the session and rethrow a `ProcessException`

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
