### PR TITLE
NIFI-13672 - Add documentation for controller service referencing in Python processors

### DIFF
--- a/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
@@ -389,6 +389,25 @@ def getDynamicPropertyDescriptor(self, propertyname):
 If this method is not implemented and a user adds a property other than those that are explicitly supported, the Processor will become
 invalid. Of course, we might also specify explicit validators that can be used, etc.
 
+==== Referencing Controller Services
+
+Python processors can reference existing Java controller services using the same mechanism as Java processors. Set the
+`controller_service_definition` parameter on a `PropertyDescriptor` to the fully qualified class name of the controller service
+interface that should be exposed in the drop-down. For example:
+
+----
+self.lookup_service = PropertyDescriptor(
+    name='Lookup Service',
+    description='String lookup service used to enrich incoming records.',
+    required=True,
+    controller_service_definition='org.apache.nifi.lookup.StringLookupService'
+)
+----
+
+Within the processor implementation the configured service instance can be retrieved via the usual property accessors, for
+example `context.getProperty(self.lookup_service.name).asControllerService()`. NiFi ensures that only controller services
+implementing the referenced interface are eligible for selection. While simple class names work when type names are unique, using
+the fully qualified interface name avoids ambiguity when multiple controller services share the same simple name.
 
 
 [[relationships]]


### PR DESCRIPTION
# Summary

NIFI-13672 - Add documentation for controller service referencing in Python processors

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
