### PR TITLE
NIFI-1501 - Allow users to only show controller services for the current process group (scope) in the listing

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi-registry/src/app/service/guard/base-guard.utils.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi-registry/src/app/service/guard/base-guard.utils.ts
@@ -16,7 +16,15 @@
  */
 
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivateFn, CanMatchFn, Router, RouterStateSnapshot, UrlSegment, UrlTree } from '@angular/router';
+import {
+    ActivatedRouteSnapshot,
+    CanActivateFn,
+    CanMatchFn,
+    Router,
+    RouterStateSnapshot,
+    UrlSegment,
+    UrlTree
+} from '@angular/router';
 import { Store } from '@ngrx/store';
 import { NiFiRegistryState } from '../../state';
 import { RegistryAuthService } from '../registry-auth.service';
@@ -47,7 +55,12 @@ export const showAccessDenied = (store: Store, router: Router): UrlTree => {
     return router.parseUrl(fallbackUrl);
 };
 
-const redirectToLogin = (store: Store, router: Router, authService: RegistryAuthService, requestedUrl: string): UrlTree => {
+const redirectToLogin = (
+    store: Store,
+    router: Router,
+    authService: RegistryAuthService,
+    requestedUrl: string
+): UrlTree => {
     authService.setRedirectUrl(requestedUrl || fallbackUrl);
     return router.parseUrl('/login');
 };
@@ -72,10 +85,7 @@ const evaluateAuthorization = (
     return showAccessDenied(store, router);
 };
 
-const authorize = (
-    requestedUrl: string,
-    authorizationCheck: AuthorizationCheck
-): Observable<boolean | UrlTree> => {
+const authorize = (requestedUrl: string, authorizationCheck: AuthorizationCheck): Observable<boolean | UrlTree> => {
     const store = inject(Store<NiFiRegistryState>);
     const router = inject(Router);
     const authService = inject(RegistryAuthService);
@@ -120,4 +130,5 @@ export const buildCanActivateGuard = (authorizationCheck: AuthorizationCheck): C
         authorize(computeRequestedUrlFromState(state), authorizationCheck);
 };
 
-export const buildGuard = (authorizationCheck: AuthorizationCheck): CanMatchFn => buildCanMatchGuard(authorizationCheck);
+export const buildGuard = (authorizationCheck: AuthorizationCheck): CanMatchFn =>
+    buildCanMatchGuard(authorizationCheck);

--- a/nifi-frontend/src/main/frontend/apps/nifi-registry/src/app/service/guard/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi-registry/src/app/service/guard/index.ts
@@ -19,4 +19,3 @@ export * from './resources.guard';
 export * from './admin-workflow.guard';
 export * from './admin-tenants.guard';
 export * from './login.guard';
-

--- a/nifi-frontend/src/main/frontend/apps/nifi-registry/src/app/service/guard/login.guard.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi-registry/src/app/service/guard/login.guard.ts
@@ -82,4 +82,3 @@ export const loginGuard: CanActivateFn = (_route, state: RouterStateSnapshot): O
         })
     );
 };
-

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.html
@@ -21,7 +21,7 @@
     </header>
     <div class="pb-5 px-5 flex-1 flex flex-col">
         <h3 class="primary-color">Controller Services</h3>
-        @if (serviceState$ | async; as serviceState) {
+        @if (serviceState(); as serviceState) {
             @if (isInitialLoading(serviceState)) {
                 <div>
                     <ngx-skeleton-loader count="3"></ngx-skeleton-loader>
@@ -34,20 +34,42 @@
                                 [entity]="serviceState.breadcrumb"
                                 [currentProcessGroupId]="serviceState.processGroupId"></breadcrumbs>
                         </div>
-                        @if (serviceState.breadcrumb.permissions.canWrite) {
-                            <button
-                                mat-icon-button
-                                class="primary-icon-button shrink-0"
-                                (click)="openNewControllerServiceDialog()">
-                                <i class="fa fa-plus"></i>
-                            </button>
-                        }
+                        <div class="flex items-center gap-x-3 shrink-0">
+                            @if (shouldShowFilter()) {
+                                <div class="flex items-center justify-between gap-x-2 current-scope-only">
+                                    <mat-checkbox [(ngModel)]="showCurrentScopeOnly" data-qa="current-scope-filter">
+                                    </mat-checkbox>
+                                    <div class="flex items-center justify-between gap-x-1">
+                                        <label
+                                            class="cursor-pointer select-none whitespace-nowrap nifi-body"
+                                            (click)="toggleFilter()"
+                                            data-qa="current-scope-label">
+                                            Show current scope only
+                                        </label>
+                                        <i
+                                            class="fa fa-info-circle"
+                                            nifiTooltip
+                                            [tooltipComponentType]="TextTip"
+                                            [tooltipInputData]="getFilterTooltip(serviceState.breadcrumb)"
+                                            data-qa="current-scope-help"></i>
+                                    </div>
+                                </div>
+                            }
+                            @if (serviceState.breadcrumb.permissions.canWrite) {
+                                <button
+                                    mat-icon-button
+                                    class="primary-icon-button"
+                                    (click)="openNewControllerServiceDialog()">
+                                    <i class="fa fa-plus"></i>
+                                </button>
+                            }
+                        </div>
                     </div>
                     @if (flowConfiguration$ | async; as flowConfiguration) {
                         <div class="flex-1">
                             <controller-service-table
                                 [selectedServiceId]="selectedServiceId$ | async"
-                                [controllerServices]="serviceState.controllerServices"
+                                [controllerServices]="filteredControllerServices()"
                                 [formatScope]="formatScope(serviceState.breadcrumb)"
                                 [definedByCurrentGroup]="definedByCurrentGroup(serviceState.breadcrumb)"
                                 [currentUser]="(currentUser$ | async)!"

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.scss
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.scss
@@ -14,3 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+.current-scope-only {
+    .fa-question-circle {
+        font-size: 14px;
+    }
+}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.spec.ts
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { ControllerServices } from './controller-services.component';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../state/controller-services/controller-services.reducer';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MockComponent } from 'ng-mocks';
@@ -27,36 +27,416 @@ import { Navigation } from '../../../../ui/common/navigation/navigation.componen
 import { canvasFeatureKey } from '../../state';
 import { controllerServicesFeatureKey } from '../../state/controller-services';
 import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
+import { ControllerServiceEntity } from '../../../../state/shared';
+import { BreadcrumbEntity } from '../../state/shared';
+import { FormsModule } from '@angular/forms';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { ControllerServicesState } from '../../state/controller-services';
+import { Breadcrumbs } from '../common/breadcrumbs/breadcrumbs.component';
+import { ControllerServiceTable } from '../../../../ui/common/controller-service/controller-service-table/controller-service-table.component';
 
 describe('ControllerServices', () => {
-    let component: ControllerServices;
-    let fixture: ComponentFixture<ControllerServices>;
+    // Mock data factories
+    function createMockBreadcrumb(
+        options: {
+            id?: string;
+            name?: string;
+            canRead?: boolean;
+            canWrite?: boolean;
+            hasParent?: boolean;
+        } = {}
+    ): BreadcrumbEntity {
+        const {
+            id = 'current-pg-id',
+            name = 'Current Process Group',
+            canRead = true,
+            canWrite = true,
+            hasParent = true
+        } = options;
 
-    beforeEach(() => {
-        TestBed.configureTestingModule({
+        const breadcrumb: BreadcrumbEntity = {
+            id,
+            permissions: {
+                canRead,
+                canWrite
+            },
+            versionedFlowState: '',
+            breadcrumb: {
+                id,
+                name
+            }
+        };
+
+        if (hasParent) {
+            breadcrumb.parentBreadcrumb = {
+                id: 'parent-pg-id',
+                permissions: {
+                    canRead: true,
+                    canWrite: true
+                },
+                versionedFlowState: '',
+                breadcrumb: {
+                    id: 'parent-pg-id',
+                    name: 'Parent Process Group'
+                }
+            };
+        }
+
+        return breadcrumb;
+    }
+
+    function createMockControllerService(
+        options: {
+            id?: string;
+            name?: string;
+            parentGroupId?: string;
+            canRead?: boolean;
+            canWrite?: boolean;
+        } = {}
+    ): ControllerServiceEntity {
+        const {
+            id = 'service-1',
+            name = 'Test Service',
+            parentGroupId = 'current-pg-id',
+            canRead = true,
+            canWrite = true
+        } = options;
+
+        return {
+            id,
+            parentGroupId,
+            permissions: { canRead, canWrite },
+            uri: `nifi-api/controller-services/${id}`,
+            revision: {
+                version: 0
+            },
+            component: {
+                id,
+                name,
+                type: 'TestService',
+                bundle: { group: 'test', artifact: 'test', version: '1.0' },
+                state: 'DISABLED',
+                persistsState: false,
+                restricted: false,
+                deprecated: false,
+                multipleVersionsAvailable: false,
+                properties: {},
+                descriptors: {},
+                referencingComponents: [],
+                validationErrors: []
+            }
+        } as ControllerServiceEntity;
+    }
+
+    function createMockControllerServices(): ControllerServiceEntity[] {
+        return [
+            createMockControllerService({ id: 'service-1', name: 'Service 1', parentGroupId: 'current-pg-id' }),
+            createMockControllerService({ id: 'service-2', name: 'Service 2', parentGroupId: 'parent-pg-id' }),
+            createMockControllerService({ id: 'service-3', name: 'Service 3', parentGroupId: 'current-pg-id' })
+        ];
+    }
+
+    function createMockState(
+        options: {
+            breadcrumb?: BreadcrumbEntity;
+            controllerServices?: ControllerServiceEntity[];
+            processGroupId?: string;
+        } = {}
+    ): ControllerServicesState {
+        const {
+            breadcrumb = createMockBreadcrumb(),
+            controllerServices = createMockControllerServices(),
+            processGroupId = 'current-pg-id'
+        } = options;
+
+        return {
+            processGroupId,
+            breadcrumb,
+            controllerServices,
+            parameterContext: null,
+            saving: false,
+            loadedTimestamp: '2024-01-01T00:00:00Z',
+            status: 'success'
+        };
+    }
+
+    // Setup function for component configuration
+    interface SetupOptions {
+        controllerServicesState?: ControllerServicesState;
+        mockStore?: any;
+    }
+
+    async function setup(options: SetupOptions = {}) {
+        const { controllerServicesState = createMockState(), mockStore = {} } = options;
+
+        const initialState = {
+            [canvasFeatureKey]: {
+                [controllerServicesFeatureKey]: controllerServicesState
+            },
+            flowConfiguration: {
+                flowConfiguration: {
+                    supportsManagedAuthorizer: false,
+                    supportsConfigurableAuthorizer: false,
+                    supportsConfigurableUsersAndGroups: false,
+                    supportsRestrictedComponents: false,
+                    supportsVersioning: false
+                }
+            },
+            currentUser: {
+                user: {
+                    identity: 'test-user',
+                    anonymous: false
+                }
+            },
+            extensionTypes: {
+                controllerServiceTypes: []
+            },
+            error: {
+                bannerErrors: {}
+            },
+            ...mockStore
+        };
+
+        await TestBed.configureTestingModule({
             declarations: [ControllerServices],
             imports: [
                 RouterTestingModule,
-                MockComponent(Navigation),
                 HttpClientTestingModule,
-                MockComponent(NgxSkeletonLoaderComponent)
+                FormsModule,
+                MatCheckboxModule,
+                MockComponent(Navigation),
+                MockComponent(NgxSkeletonLoaderComponent),
+                MockComponent(Breadcrumbs),
+                MockComponent(ControllerServiceTable)
             ],
-            providers: [
-                provideMockStore({
-                    initialState: {
-                        [canvasFeatureKey]: {
-                            [controllerServicesFeatureKey]: initialState
-                        }
-                    }
-                })
-            ]
-        });
-        fixture = TestBed.createComponent(ControllerServices);
-        component = fixture.componentInstance;
+            providers: [provideMockStore({ initialState })],
+            schemas: [NO_ERRORS_SCHEMA]
+        }).compileComponents();
+
+        const fixture = TestBed.createComponent(ControllerServices);
+        const component = fixture.componentInstance;
+        const store = TestBed.inject(MockStore);
+
         fixture.detectChanges();
+
+        return { component, fixture, store };
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks();
     });
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
+    describe('Component initialization', () => {
+        it('should create', async () => {
+            const { component } = await setup();
+            expect(component).toBeTruthy();
+        });
+    });
+
+    describe('Filtering functionality', () => {
+        it('should initialize with filter unchecked', async () => {
+            const { component } = await setup();
+            expect(component.showCurrentScopeOnly()).toBe(false);
+        });
+
+        it('should return all services when filter is disabled', async () => {
+            const { component } = await setup();
+            component.showCurrentScopeOnly.set(false);
+
+            const filtered = component.filteredControllerServices();
+            expect(filtered.length).toBe(3);
+            expect(filtered.map((s) => s.id)).toEqual(['service-1', 'service-2', 'service-3']);
+        });
+
+        it('should return only current scope services when filter is enabled', async () => {
+            const { component } = await setup();
+            component.showCurrentScopeOnly.set(true);
+
+            const filtered = component.filteredControllerServices();
+            expect(filtered.length).toBe(2);
+            expect(filtered.every((service) => service.parentGroupId === 'current-pg-id')).toBe(true);
+            expect(filtered.map((s) => s.id)).toEqual(['service-1', 'service-3']);
+        });
+
+        it('should return empty array when no service state is available', async () => {
+            const { component, store } = await setup();
+
+            // Manually set the store state to undefined for controller services
+            store.setState({
+                [canvasFeatureKey]: {
+                    [controllerServicesFeatureKey]: undefined
+                },
+                flowConfiguration: {
+                    flowConfiguration: {
+                        supportsManagedAuthorizer: false,
+                        supportsConfigurableAuthorizer: false,
+                        supportsConfigurableUsersAndGroups: false,
+                        supportsRestrictedComponents: false,
+                        supportsVersioning: false
+                    }
+                },
+                currentUser: {
+                    user: {
+                        identity: 'test-user',
+                        anonymous: false
+                    }
+                },
+                extensionTypes: {
+                    controllerServiceTypes: []
+                },
+                error: {
+                    bannerErrors: {}
+                }
+            });
+
+            const filtered = component.filteredControllerServices();
+            expect(filtered).toEqual([]);
+        });
+
+        it('should toggle filter state when toggleFilter is called', async () => {
+            const { component } = await setup();
+            expect(component.showCurrentScopeOnly()).toBe(false);
+
+            component.toggleFilter();
+            expect(component.showCurrentScopeOnly()).toBe(true);
+
+            component.toggleFilter();
+            expect(component.showCurrentScopeOnly()).toBe(false);
+        });
+
+        it('should generate correct tooltip text with readable process group name', async () => {
+            const breadcrumb = createMockBreadcrumb({ name: 'Test Process Group' });
+            const { component } = await setup({
+                controllerServicesState: createMockState({ breadcrumb })
+            });
+
+            const tooltip = component.getFilterTooltip(breadcrumb);
+            expect(tooltip).toBe(
+                "Only show the Controller Services defined in the current Process Group: 'Test Process Group'"
+            );
+        });
+
+        it('should generate tooltip with ID when process group name is not readable', async () => {
+            const breadcrumb = createMockBreadcrumb({
+                id: 'test-pg-id',
+                name: 'Test Process Group',
+                canRead: false
+            });
+            const { component } = await setup({
+                controllerServicesState: createMockState({ breadcrumb })
+            });
+
+            const tooltip = component.getFilterTooltip(breadcrumb);
+            expect(tooltip).toBe(
+                "Only show the Controller Services defined in the current Process Group: 'test-pg-id'"
+            );
+        });
+    });
+
+    describe('shouldShowFilter computed property', () => {
+        it('should return true when breadcrumb has parent (not root)', async () => {
+            const { component } = await setup();
+            expect(component.shouldShowFilter()).toBe(true);
+        });
+
+        it('should return false when breadcrumb has no parent (root process group)', async () => {
+            const rootBreadcrumb = createMockBreadcrumb({
+                id: 'root-pg-id',
+                name: 'Root Process Group',
+                hasParent: false
+            });
+            const { component } = await setup({
+                controllerServicesState: createMockState({ breadcrumb: rootBreadcrumb })
+            });
+
+            expect(component.shouldShowFilter()).toBe(false);
+        });
+
+        it('should return false when no service state is available', async () => {
+            const { component, store } = await setup();
+
+            // Manually set the store state to undefined for controller services
+            store.setState({
+                [canvasFeatureKey]: {
+                    [controllerServicesFeatureKey]: undefined
+                },
+                flowConfiguration: {
+                    flowConfiguration: {
+                        supportsManagedAuthorizer: false,
+                        supportsConfigurableAuthorizer: false,
+                        supportsConfigurableUsersAndGroups: false,
+                        supportsRestrictedComponents: false,
+                        supportsVersioning: false
+                    }
+                },
+                currentUser: {
+                    user: {
+                        identity: 'test-user',
+                        anonymous: false
+                    }
+                },
+                extensionTypes: {
+                    controllerServiceTypes: []
+                },
+                error: {
+                    bannerErrors: {}
+                }
+            });
+
+            expect(component.shouldShowFilter()).toBe(false);
+        });
+    });
+
+    describe('Template integration', () => {
+        it('should render checkbox with correct initial state', async () => {
+            const { fixture } = await setup();
+
+            const checkbox = fixture.nativeElement.querySelector('[data-qa="current-scope-filter"]');
+            expect(checkbox).toBeTruthy();
+        });
+
+        it('should render label with correct text', async () => {
+            const { fixture } = await setup();
+
+            const label = fixture.nativeElement.querySelector('[data-qa="current-scope-label"]');
+            expect(label).toBeTruthy();
+            expect(label.textContent.trim()).toBe('Show current scope only');
+        });
+
+        it('should render help icon with tooltip', async () => {
+            const { fixture } = await setup();
+
+            const helpIcon = fixture.nativeElement.querySelector('[data-qa="current-scope-help"]');
+            expect(helpIcon).toBeTruthy();
+        });
+
+        it('should toggle filter when label is clicked', async () => {
+            const { component, fixture } = await setup();
+
+            const label = fixture.nativeElement.querySelector('[data-qa="current-scope-label"]');
+            expect(component.showCurrentScopeOnly()).toBe(false);
+
+            label.click();
+            expect(component.showCurrentScopeOnly()).toBe(true);
+        });
+
+        it('should not render filter elements when at root process group', async () => {
+            const rootBreadcrumb = createMockBreadcrumb({
+                id: 'root-pg-id',
+                name: 'Root Process Group',
+                hasParent: false
+            });
+            const { fixture } = await setup({
+                controllerServicesState: createMockState({ breadcrumb: rootBreadcrumb })
+            });
+
+            const checkbox = fixture.nativeElement.querySelector('[data-qa="current-scope-filter"]');
+            const label = fixture.nativeElement.querySelector('[data-qa="current-scope-label"]');
+            const helpIcon = fixture.nativeElement.querySelector('[data-qa="current-scope-help"]');
+
+            expect(checkbox).toBeFalsy();
+            expect(label).toBeFalsy();
+            expect(helpIcon).toBeFalsy();
+        });
     });
 });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.module.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.module.ts
@@ -17,6 +17,7 @@
 
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { ControllerServices } from './controller-services.component';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { ControllerServiceTable } from '../../../../ui/common/controller-service/controller-service-table/controller-service-table.component';
@@ -24,18 +25,23 @@ import { ControllerServicesRoutingModule } from './controller-services-routing.m
 import { Breadcrumbs } from '../common/breadcrumbs/breadcrumbs.component';
 import { Navigation } from '../../../../ui/common/navigation/navigation.component';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { NifiTooltipDirective } from '@nifi/shared';
 
 @NgModule({
     declarations: [ControllerServices],
     exports: [ControllerServices],
     imports: [
         CommonModule,
+        FormsModule,
         NgxSkeletonLoaderModule,
         ControllerServicesRoutingModule,
         ControllerServiceTable,
         Breadcrumbs,
         Navigation,
-        MatButtonModule
+        MatButtonModule,
+        MatCheckboxModule,
+        NifiTooltipDirective
     ]
 })
 export class ControllerServicesModule {}


### PR DESCRIPTION
# Summary

[NIFI-15051](https://issues.apache.org/jira/browse/NIFI-15051)

## Add Filter to Show Current Scope Controller Services Only

This PR introduces a filtering feature to the Controller Services listing page that allows users to view only the controller services defined in the current process group, filtering out inherited services from parent process groups.

### Changes

**User-Facing Features:**
- Added a "Show current scope only" checkbox filter with help tooltip on the Controller Services page
- Filter only appears when viewing non-root process groups (hidden at root level)
- Tooltip displays the current process group name (or ID if not readable)
- Filter state defaults to unchecked, showing all services (current + inherited)

**Technical Implementation:**
- Converted `serviceState$` observable to signal-based state management using `selectSignal()`
- Added `showCurrentScopeOnly` signal to track filter state
- Implemented `filteredControllerServices` computed property for reactive filtering
- Added `shouldShowFilter` computed property to conditionally display filter based on hierarchy
- Updated module imports to include `FormsModule`, `MatCheckboxModule`, and `NifiTooltipDirective`

**Testing:**
- Added comprehensive test suite with 16 tests covering:
  - Component initialization
  - Filter functionality (enabled/disabled states, edge cases)
  - Computed property behavior
  - Template integration and user interactions
  - Root process group handling
- All tests passing ✅

### Why This Change?

Users working in nested process groups often inherit many controller services from parent groups, making it difficult to identify which services are defined at the current scope. This filter provides a quick way to focus on locally-defined services while still allowing visibility into inherited services when needed.
