### PR TITLE
NIFI-15071 - Give enough space to add property dialog so it doesn't have scrollbars by default

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/new-property-dialog/new-property-dialog.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/new-property-dialog/new-property-dialog.component.html
@@ -27,7 +27,7 @@
                 }
             </mat-form-field>
         </div>
-        <div class="flex flex-col">
+        <div class="flex flex-col pb-1">
             <label>Sensitive Value</label>
             <mat-radio-group formControlName="sensitive">
                 <mat-radio-button [value]="true">Yes</mat-radio-button>


### PR DESCRIPTION
[NIFI-15071](https://issues.apache.org/jira/browse/NIFI-15071)

## Before
<img width="1033" height="632" alt="scroll bars on add property dialog" src="https://github.com/user-attachments/assets/6a98b2f8-1eb2-4691-90d1-b3a32dcb4c95" />


## After
<img width="1030" height="628" alt="Screenshot 2025-10-07 at 08 38 51" src="https://github.com/user-attachments/assets/7f8919bb-7474-4142-8f3f-137dcaeb2a5f" />

