### PR TITLE
NIFI-15226 Allow ConsumeKafka to use static partition mapping

### DIFF
--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/pom.xml
@@ -63,12 +63,6 @@
             <artifactId>nifi-mock-record-utils</artifactId>
             <scope>test</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.apache.nifi</groupId>-->
-<!--            <artifactId>nifi-framework-nar-utils</artifactId>-->
-<!--            <version>2.7.0-SNAPSHOT</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-record-serialization-services</artifactId>

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/pom.xml
@@ -63,12 +63,12 @@
             <artifactId>nifi-mock-record-utils</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-framework-nar-utils</artifactId>
-            <version>2.7.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.apache.nifi</groupId>-->
+<!--            <artifactId>nifi-framework-nar-utils</artifactId>-->
+<!--            <version>2.7.0-SNAPSHOT</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-record-serialization-services</artifactId>

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/pom.xml
@@ -65,6 +65,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-framework-nar-utils</artifactId>
+            <version>2.7.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-record-serialization-services</artifactId>
             <version>2.8.0-SNAPSHOT</version>
             <scope>test</scope>

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
@@ -446,7 +446,8 @@ public class ConsumeKafka extends AbstractProcessor implements VerifiableProcess
 
                 throw new ProcessException(
                         String.format(
-                                "Illegal Partition Assignment: There are %d partition%s statically assigned using the %s.* property names, but the Kafka topic(s) have %d partition%s",
+                                "Illegal Partition Assignment: There %s %d partition%s statically assigned using the %s.* property names, but the Kafka topic(s) have %d partition%s",
+                                numAssignedPartitions == 1 ? "is" : "are",
                                 numAssignedPartitions,
                                 numAssignedPartitions == 1 ? "" : "s",
                                 PARTITIONS_PROPERTY_PREFIX,
@@ -686,14 +687,14 @@ public class ConsumeKafka extends AbstractProcessor implements VerifiableProcess
                 final String thisTopic = topicAndPartitionStates.getKey();
                 final int partitionsThisTopic = topicAndPartitionStates.getValue().size();
                 if (partitionsEachTopic != 0 && partitionsThisTopic != partitionsEachTopic) {
-                    String.format(
+                    throw new IllegalStateException(String.format(
                             "The topics do not have the same number of partitions. Topic '%s' has %d partition%s, while others have %d partition%s",
                             thisTopic,
                             partitionsThisTopic,
                             partitionsThisTopic == 1 ? "" : "s",
                             partitionsEachTopic,
                             partitionsEachTopic == 1 ? "" : "s"
-                    );
+                    ));
                 }
 
                 partitionsEachTopic = partitionsThisTopic;

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
@@ -499,9 +499,9 @@ public class ConsumeKafka extends AbstractProcessor implements VerifiableProcess
 
         final PollingContext partitionedPollingContext = consumerServiceToPartitionedPollingContext.get(consumerService);
 
-        final PollingContext pollingContext = partitionedPollingContext == null ?
-                this.pollingContext :
-                partitionedPollingContext;
+        final PollingContext pollingContext = partitionedPollingContext == null
+                ? this.pollingContext
+                : partitionedPollingContext;
 
         final long maxUncommittedMillis = context.getProperty(MAX_UNCOMMITTED_TIME).asTimePeriod(TimeUnit.MILLISECONDS);
         final long stopTime = System.currentTimeMillis() + maxUncommittedMillis;

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
@@ -604,13 +604,13 @@ public class ConsumeKafka extends AbstractProcessor implements VerifiableProcess
         try {
             consumerService.close();
             activeConsumerCount.decrementAndGet();
-
+        } catch (final IOException ioe) {
+            getLogger().warn("Failed to close Kafka Consumer Service", ioe);
+        } finally {
             final PollingContext partitionedPollingContext = consumerServiceToPartitionedPollingContext.remove(consumerService);
             if (partitionedPollingContext != null) {
                 availablePartitionedPollingContexts.add(partitionedPollingContext);
             }
-        } catch (final IOException ioe) {
-            getLogger().warn("Failed to close Kafka Consumer Service", ioe);
         }
     }
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
@@ -568,11 +568,11 @@ public class ConsumeKafka extends AbstractProcessor implements VerifiableProcess
     public List<ConfigVerificationResult> verify(final ProcessContext context, final ComponentLog verificationLogger, final Map<String, String> attributes) {
         final List<ConfigVerificationResult> verificationResults = new ArrayList<>();
 
-        final Collection<String> topics = pollingContext.getTopics();
+        final KafkaConnectionService connectionService = context.getProperty(CONNECTION_SERVICE).asControllerService(KafkaConnectionService.class);
+        final PollingContext pollingContext = createPollingContext(context);
 
+        final Collection<String> topics = pollingContext.getTopics();
         if (!topics.isEmpty()) {
-            final KafkaConnectionService connectionService = context.getProperty(CONNECTION_SERVICE).asControllerService(KafkaConnectionService.class);
-            final PollingContext pollingContext = createPollingContext(context);
             try (final KafkaConsumerService consumerService = connectionService.getConsumerService(pollingContext)) {
                 final ConfigVerificationResult.Builder verificationPartitions = new ConfigVerificationResult.Builder()
                         .verificationStepName("Verify Topic Partitions");

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
@@ -676,7 +676,7 @@ public class ConsumeKafka extends AbstractProcessor implements VerifiableProcess
         }
     }
 
-    public int getPartitionCount(final KafkaConnectionService connectionService) {
+    private int getPartitionCount(final KafkaConnectionService connectionService) {
         Collection<String> topics = this.pollingContext.getTopics();
 
         if (topics.isEmpty()) {

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/ConsumerPartitionsUtil.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/ConsumerPartitionsUtil.java
@@ -103,7 +103,7 @@ public class ConsumerPartitionsUtil {
         final String[] splits = propertyValue.split(",");
         final List<Integer> partitionList = new ArrayList<>();
         for (final String split : splits) {
-            if (split.trim().isEmpty()) {
+            if (split.isBlank()) {
                 continue;
             }
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/ConsumerPartitionsUtil.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/ConsumerPartitionsUtil.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.kafka.processors.consumer;
+
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.logging.ComponentLog;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ConsumerPartitionsUtil {
+    public static final String PARTITION_PROPERTY_NAME_PREFIX = "partitions.";
+
+    public static int[] getPartitionsForHost(final Map<String, String> properties, final ComponentLog logger) throws UnknownHostException {
+        final Map<String, String> hostnameToPartitionString = mapHostnamesToPartitionStrings(properties);
+        final Map<String, int[]> partitionsByHost = mapPartitionValueToIntArrays(hostnameToPartitionString);
+
+        if (partitionsByHost.isEmpty()) {
+            // Explicit partitioning is not enabled.
+            logger.debug("No explicit Consumer Partitions have been declared.");
+            return null;
+        }
+
+        logger.info("Found the following mapping of hosts to partitions: {}", hostnameToPartitionString);
+
+        // Determine the partitions based on hostname/IP.
+        int[] partitionsForThisHost = getPartitionsForThisHost(partitionsByHost);
+        if (partitionsForThisHost == null) {
+            throw new IllegalArgumentException("Could not find a partition mapping for host " + InetAddress.getLocalHost().getCanonicalHostName());
+        }
+
+        return partitionsForThisHost;
+    }
+
+    private static Map<String, int[]> mapPartitionValueToIntArrays(final Map<String, String> partitionValues) {
+        final Map<String, int[]> partitionsByHost = new HashMap<>();
+        for (final Map.Entry<String, String> entry : partitionValues.entrySet()) {
+            final String host = entry.getKey();
+            final int[] partitions = parsePartitions(host, entry.getValue());
+            partitionsByHost.put(host, partitions);
+        }
+
+        return partitionsByHost;
+    }
+
+    private static int[] getPartitionsForThisHost(final Map<String, int[]> partitionsByHost) throws UnknownHostException {
+        // Determine the partitions based on hostname/IP.
+        final InetAddress localhost = InetAddress.getLocalHost();
+        int[] partitionsForThisHost = partitionsByHost.get(localhost.getCanonicalHostName());
+        if (partitionsForThisHost != null) {
+            return partitionsForThisHost;
+        }
+
+        partitionsForThisHost = partitionsByHost.get(localhost.getHostName());
+        if (partitionsForThisHost != null) {
+            return partitionsForThisHost;
+        }
+
+        return partitionsByHost.get(localhost.getHostAddress());
+    }
+
+    private static Map<String, String> mapHostnamesToPartitionStrings(final Map<String, String> properties) {
+        final Map<String, String> hostnameToPartitionString = new HashMap<>();
+        for (final Map.Entry<String, String> entry : properties.entrySet()) {
+            final String propertyName = entry.getKey();
+            if (!propertyName.startsWith(PARTITION_PROPERTY_NAME_PREFIX)) {
+                continue;
+            }
+
+            if (propertyName.length() <= PARTITION_PROPERTY_NAME_PREFIX.length()) {
+                continue;
+            }
+
+            final String propertyNameAfterPrefix = propertyName.substring(PARTITION_PROPERTY_NAME_PREFIX.length());
+            hostnameToPartitionString.put(propertyNameAfterPrefix, entry.getValue());
+        }
+
+        return hostnameToPartitionString;
+    }
+
+    private static int[] parsePartitions(final String hostname, final String propertyValue) {
+        final String[] splits = propertyValue.split(",");
+        final List<Integer> partitionList = new ArrayList<>();
+        for (final String split : splits) {
+            if (split.trim().isEmpty()) {
+                continue;
+            }
+
+            try {
+                final int partition = Integer.parseInt(split.trim());
+                if (partition < 0) {
+                    throw new IllegalArgumentException("Found invalid value for the partitions for hostname " + hostname + ": " + split + " is negative");
+                }
+
+                partitionList.add(partition);
+            } catch (final NumberFormatException nfe) {
+                throw new IllegalArgumentException("Found invalid value for the partitions for hostname " + hostname + ": " + split + " is not an integer");
+            }
+        }
+
+        // Map out List<Integer> to int[]
+        return partitionList.stream().mapToInt(Integer::intValue).toArray();
+    }
+
+    public static ValidationResult validateConsumePartitions(final Map<String, String> properties) {
+        final Map<String, String> hostnameToPartitionMapping = mapHostnamesToPartitionStrings(properties);
+        if (hostnameToPartitionMapping.isEmpty()) {
+            // Partitions are not being explicitly assigned.
+            return new ValidationResult.Builder().valid(true).build();
+        }
+
+        final Set<Integer> partitionsClaimed = new HashSet<>();
+        final Set<Integer> duplicatePartitions = new HashSet<>();
+        for (final Map.Entry<String, String> entry : hostnameToPartitionMapping.entrySet()) {
+            final int[] partitions = parsePartitions(entry.getKey(), entry.getValue());
+            for (final int partition : partitions) {
+                final boolean added = partitionsClaimed.add(partition);
+                if (!added) {
+                    duplicatePartitions.add(partition);
+                }
+            }
+        }
+
+        final List<Integer> partitionsMissing = new ArrayList<>();
+        for (int i = 0; i < partitionsClaimed.size(); i++) {
+            if (!partitionsClaimed.contains(i)) {
+                partitionsMissing.add(i);
+            }
+        }
+
+        if (!partitionsMissing.isEmpty()) {
+            return new ValidationResult.Builder()
+                .subject("Partitions")
+                .input(partitionsClaimed.toString())
+                .valid(false)
+                .explanation("The following partitions were not mapped to any node: " + partitionsMissing.toString())
+                .build();
+        }
+
+        if (!duplicatePartitions.isEmpty()) {
+            return new ValidationResult.Builder()
+                .subject("Partitions")
+                .input(partitionsClaimed.toString())
+                .valid(false)
+                .explanation("The following partitions were mapped to multiple nodes: " + duplicatePartitions.toString())
+                .build();
+        }
+
+        final Map<String, int[]> partitionsByHost = mapPartitionValueToIntArrays(hostnameToPartitionMapping);
+        final int[] partitionsForThisHost;
+        try {
+            partitionsForThisHost = getPartitionsForThisHost(partitionsByHost);
+        } catch (UnknownHostException e) {
+            return new ValidationResult.Builder()
+                .valid(false)
+                .subject("Partition Assignment")
+                .explanation("Unable to determine hostname of localhost")
+                .build();
+        }
+
+        if (partitionsForThisHost == null) {
+            return new ValidationResult.Builder()
+                .subject("Partition Assignment")
+                .valid(false)
+                .explanation("No assignment was given for this host")
+                .build();
+        }
+
+        return new ValidationResult.Builder().valid(true).build();
+    }
+
+    public static boolean isPartitionAssignmentExplicit(final Map<String, String> properties) {
+        final Map<String, String> hostnameToPartitionMapping = mapHostnamesToPartitionStrings(properties);
+        return !hostnameToPartitionMapping.isEmpty();
+    }
+
+    public static int getPartitionAssignmentCount(final Map<String, String> properties) {
+        final Map<String, String> hostnameToPartitionMapping = mapHostnamesToPartitionStrings(properties);
+        final Map<String, int[]> partitions = mapPartitionValueToIntArrays(hostnameToPartitionMapping);
+
+        int count = 0;
+        for (final int[] partitionArray : partitions.values()) {
+            count += partitionArray.length;
+        }
+
+        return count;
+    }
+}

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/OffsetTracker.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/OffsetTracker.java
@@ -60,7 +60,7 @@ public class OffsetTracker {
                     pollingContext.getAutoOffsetReset(), offsets);
         } else {
             pollingSummary = new PollingSummary(pollingContext.getGroupId(), pollingContext.getTopics(),
-                    pollingContext.getAutoOffsetReset(), offsets);
+                    pollingContext.getAutoOffsetReset(), pollingContext.getPartition(), offsets);
         }
         return pollingSummary;
     }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/resources/docs/org.apache.nifi.kafka.processors.ConsumeKafka/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/resources/docs/org.apache.nifi.kafka.processors.ConsumeKafka/additionalDetails.md
@@ -175,3 +175,45 @@ Here is an example of FlowFile content that is emitted by JsonRecordSetWriter wh
   }
 ]
 ```
+
+### Consumer Partition Assignment
+
+By default, this processor will subscribe to one or more Kafka topics in such a way that the topics to consume from are randomly
+assigned to the nodes in the NiFi cluster. Consider a scenario where a single Kafka topic has 8 partitions and the consuming
+NiFi cluster has 3 nodes. In this scenario, Node 1 may be assigned partitions 0, 1, and 2. Node 2 may be assigned partitions 3, 4, and 5.
+Node 3 will then be assigned partitions 6 and 7.
+
+In this scenario, if Node 3 somehow fails or stops pulling data from Kafka, partitions 6 and 7 may then be reassigned to the other two nodes.
+For most use cases, this is desirable. It provides fault tolerance and allows the remaining nodes to pick up the slack. However, there are cases
+where this is undesirable.
+
+One such case is when using NiFi to consume Change Data Capture (CDC) data from Kafka. Consider again the above scenario. Consider that Node 3
+has pulled 1,000 messages from Kafka but has not yet delivered them to their final destination. NiFi is then stopped and restarted, and that takes
+15 minutes to complete. In the meantime, Partitions 6 and 7 have been reassigned to the other nodes. Those nodes then proceeded to pull data from
+Kafka and deliver it to the desired destination. After 15 minutes, Node 3 rejoins the cluster and then continues to deliver its 1,000 messages that
+it has already pulled from Kafka to the destination system. Now, those records have been delivered out of order.
+
+The solution for this, then, is to assign partitions statically instead of dynamically. In this way, we can assign Partitions 6 and 7 to Node 3 specifically.
+Then, if Node 3 is restarted, the other nodes will not pull data from Partitions 6 and 7. The data will remain queued in Kafka until Node 3 is restarted. By
+using this approach, we can ensure that the data that already was pulled can be processed (assuming First In First Out Prioritizers are used) before newer messages
+are handled.
+
+In order to provide a static mapping of node to Kafka partition(s), one or more user-defined properties must be added using the naming scheme
+<code>partitions.&lt;hostname&gt;</code> with the value being a comma-separated list of Kafka partitions to use. For example,
+<code>partitions.nifi-01=0, 3, 6, 9</code>, <code>partitions.nifi-02=1, 4, 7, 10</code>, and <code>partitions.nifi-03=2, 5, 8, 11</code>.
+The hostname that is used can be the fully qualified hostname, the "simple" hostname, or the IP address. There must be an entry for each node in
+the cluster, or the Processor will become invalid. If it is desirable for a node to not have any partitions assigned to it, a Property may be
+added for the hostname with an empty string as the value.
+
+NiFi cannot readily validate that all Partitions have been assigned before the Processor is scheduled to run. However, it can validate that no
+partitions have been skipped. As such, if partitions 0, 1, and 3 are assigned but not partition 2, the Processor will not be valid. However,
+if partitions 0, 1, and 2 are assigned, the Processor will become valid, even if there are 4 partitions on the Topic. When the Processor is
+started, the Processor will immediately start to fail, logging errors, and avoid pulling any data until the Processor is updated to account
+for all partitions. Once running, if the number of partitions is changed, the Processor will continue to run but not pull data from the newly
+added partitions. Once stopped, it will begin to error until all partitions have been assigned. Additionally, if partitions that are assigned
+do not exist (e.g., partitions 0, 1, 2, 3, 4, 5, 6, and 7 are assigned, but the Topic has only 4 partitions), then the Processor will begin
+to log errors on startup and will not pull data.
+
+In order to use a static mapping of Kafka partitions, the "Topic Name Format" must be set to "names" rather than "pattern." Additionally, all
+Topics that are to be consumed must have the same number of partitions. If multiple Topics are to be consumed and have a different number of
+partitions, multiple Processors must be used so that each Processor consumes only from Topics with the same number of partitions.

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/ConsumeKafkaTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/ConsumeKafkaTest.java
@@ -31,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.nifi.kafka.processors.ConsumeKafka.CONNECTION_SERVICE;
 import static org.apache.nifi.kafka.processors.ConsumeKafka.GROUP_ID;
@@ -88,7 +89,7 @@ class ConsumeKafkaTest {
     public void testVerifySuccessful() throws InitializationException {
         final PartitionState firstPartitionState = new PartitionState(TEST_TOPIC_NAME, FIRST_PARTITION);
         final List<PartitionState> partitionStates = Collections.singletonList(firstPartitionState);
-        when(kafkaConsumerService.getPartitionStates()).thenReturn(partitionStates);
+        when(kafkaConsumerService.getPartitionStatesByTopic()).thenReturn(Map.of(TEST_TOPIC_NAME, partitionStates));
         setConnectionService();
         when(kafkaConnectionService.getConsumerService(any())).thenReturn(kafkaConsumerService);
 
@@ -105,7 +106,7 @@ class ConsumeKafkaTest {
 
     @Test
     public void testVerifyFailed() throws InitializationException {
-        when(kafkaConsumerService.getPartitionStates()).thenThrow(new IllegalStateException());
+        when(kafkaConsumerService.getPartitionStatesByTopic()).thenThrow(new IllegalStateException());
         when(kafkaConnectionService.getConsumerService(any())).thenReturn(kafkaConsumerService);
         setConnectionService();
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/TestConsumerPartitionsUtil.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/TestConsumerPartitionsUtil.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/TestConsumerPartitionsUtil.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/TestConsumerPartitionsUtil.java
@@ -36,24 +36,24 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class TestConsumerPartitionsUtil {
+class TestConsumerPartitionsUtil {
     private final ComponentLog logger = mock();
     private String hostname;
 
     @BeforeEach
-    public void setup() throws UnknownHostException {
+    void setup() throws UnknownHostException {
         hostname = InetAddress.getLocalHost().getHostName();
     }
 
     @Test
-    public void testNoPartitionAssignments() throws UnknownHostException {
-        final Map<String, String> properties = Collections.singletonMap("key", "value");
+    void testNoPartitionAssignments() throws UnknownHostException {
+        final Map<String, String> properties = Map.of("key", "value");
         final int[] partitions = ConsumerPartitionsUtil.getPartitionsForHost(properties, logger);
         assertNull(partitions);
     }
 
     @Test
-    public void testAllPartitionsAssignedToOneHost() throws UnknownHostException {
+    void testAllPartitionsAssignedToOneHost() throws UnknownHostException {
         final Map<String, String> properties = new HashMap<>();
         properties.put("key", "value");
         properties.put("partitions." + hostname, "0, 1, 2, 3");
@@ -64,7 +64,7 @@ public class TestConsumerPartitionsUtil {
     }
 
     @Test
-    public void testSomePartitionsSkipped() {
+    void testSomePartitionsSkipped() {
         final Map<String, String> properties = new HashMap<>();
         properties.put("key", "value");
         properties.put("partitions." + hostname, "0, 1, 2, 3, 5");
@@ -79,7 +79,7 @@ public class TestConsumerPartitionsUtil {
     }
 
     @Test
-    public void testCurrentNodeNotSpecified() {
+    void testCurrentNodeNotSpecified() {
         final Map<String, String> properties = new HashMap<>();
         properties.put("key", "value");
         properties.put("partitions.other-host", "0, 1, 2, 3");
@@ -90,7 +90,7 @@ public class TestConsumerPartitionsUtil {
     }
 
     @Test
-    public void testPartitionListedTwice() {
+    void testPartitionListedTwice() {
         final Map<String, String> properties = new HashMap<>();
         properties.put("key", "value");
         properties.put("partitions." + hostname, "2");
@@ -102,7 +102,7 @@ public class TestConsumerPartitionsUtil {
     }
 
     @Test
-    public void testNodeWithNoAssignment() throws UnknownHostException {
+    void testNodeWithNoAssignment() throws UnknownHostException {
         final Map<String, String> properties = new HashMap<>();
         properties.put("key", "value");
         properties.put("partitions." + hostname, "");

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/TestConsumerPartitionsUtil.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/TestConsumerPartitionsUtil.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.kafka.processors.consumer;
+
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.mock.MockComponentLogger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestConsumerPartitionsUtil {
+    private final ComponentLog logger = new MockComponentLogger();
+    private String hostname;
+
+    @BeforeEach
+    public void setup() throws UnknownHostException {
+        hostname = InetAddress.getLocalHost().getHostName();;
+    }
+
+    @Test
+    public void testNoPartitionAssignments() throws UnknownHostException {
+        final Map<String, String> properties = Collections.singletonMap("key", "value");
+        final int[] partitions = ConsumerPartitionsUtil.getPartitionsForHost(properties, logger);
+        assertNull(partitions);
+    }
+
+    @Test
+    public void testAllPartitionsAssignedToOneHost() throws UnknownHostException {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("key", "value");
+        properties.put("partitions." + hostname, "0, 1, 2, 3");
+        final int[] partitions = ConsumerPartitionsUtil.getPartitionsForHost(properties, logger);
+        assertNotNull(partitions);
+
+        assertArrayEquals(new int[] {0, 1, 2, 3}, partitions);
+    }
+
+    @Test
+    public void testSomePartitionsSkipped() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("key", "value");
+        properties.put("partitions." + hostname, "0, 1, 2, 3, 5");
+        final ValidationResult invalidResult = ConsumerPartitionsUtil.validateConsumePartitions(properties);
+        assertNotNull(invalidResult);
+        assertFalse(invalidResult.isValid());
+
+        properties.put("partitions." + hostname, "0, 1,2,3,4, 5");
+        final ValidationResult validResult = ConsumerPartitionsUtil.validateConsumePartitions(properties);
+        assertNotNull(validResult);
+        assertTrue(validResult.isValid());
+    }
+
+    @Test
+    public void testCurrentNodeNotSpecified() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("key", "value");
+        properties.put("partitions.other-host", "0, 1, 2, 3");
+
+        final ValidationResult invalidResult = ConsumerPartitionsUtil.validateConsumePartitions(properties);
+        assertNotNull(invalidResult);
+        assertFalse(invalidResult.isValid());
+    }
+
+    @Test
+    public void testPartitionListedTwice() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("key", "value");
+        properties.put("partitions." + hostname, "2");
+        properties.put("partitions.other-host", "0, 1, 2, 3");
+
+        final ValidationResult invalidResult = ConsumerPartitionsUtil.validateConsumePartitions(properties);
+        assertNotNull(invalidResult);
+        assertFalse(invalidResult.isValid());
+    }
+
+    @Test
+    public void testNodeWithNoAssignment() throws UnknownHostException {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("key", "value");
+        properties.put("partitions." + hostname, "");
+        properties.put("partitions.other-host", "0, 1, 2, 3");
+
+        final ValidationResult invalidResult = ConsumerPartitionsUtil.validateConsumePartitions(properties);
+        assertNotNull(invalidResult);
+        assertTrue(invalidResult.isValid());
+
+        final int[] partitions = ConsumerPartitionsUtil.getPartitionsForHost(properties, logger);
+        assertNotNull(partitions);
+        assertEquals(0, partitions.length);
+    }
+
+}

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/TestConsumerPartitionsUtil.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/TestConsumerPartitionsUtil.java
@@ -19,7 +19,6 @@ package org.apache.nifi.kafka.processors.consumer;
 
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.logging.ComponentLog;
-import org.apache.nifi.mock.MockComponentLogger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,14 +34,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class TestConsumerPartitionsUtil {
-    private final ComponentLog logger = new MockComponentLogger();
+    private final ComponentLog logger = mock();
     private String hostname;
 
     @BeforeEach
     public void setup() throws UnknownHostException {
-        hostname = InetAddress.getLocalHost().getHostName();;
+        hostname = InetAddress.getLocalHost().getHostName();
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-api/src/main/java/org/apache/nifi/kafka/service/api/consumer/KafkaConsumerService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-api/src/main/java/org/apache/nifi/kafka/service/api/consumer/KafkaConsumerService.java
@@ -22,6 +22,8 @@ import org.apache.nifi.kafka.service.api.record.ByteRecord;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Kafka Consumer Service must be closed to avoid leaking connection resources
@@ -57,4 +59,15 @@ public interface KafkaConsumerService extends Closeable {
      * @return List of Partition State information
      */
     List<PartitionState> getPartitionStates();
+
+    /**
+     *
+     * @return Map with the subscribed topics as keys and a list of PartitionState for a given topic as values
+     */
+    default Map<String, List<PartitionState>> getPartitionStatesByTopic() {
+        List<PartitionState> partitionStates = getPartitionStates();
+        Map<String, List<PartitionState>> topicToPartitionStates = partitionStates.stream().collect(Collectors.groupingBy(PartitionState::getTopic));
+
+        return topicToPartitionStates;
+    }
 }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-api/src/main/java/org/apache/nifi/kafka/service/api/consumer/PollingContext.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-api/src/main/java/org/apache/nifi/kafka/service/api/consumer/PollingContext.java
@@ -31,13 +31,15 @@ public class PollingContext {
     private final Collection<String> topics;
     private final Pattern topicPattern;
     private final AutoOffsetReset autoOffsetReset;
+    private final Integer partition;
 
     public PollingContext(final String groupId, final Collection<String> topics,
-            final AutoOffsetReset autoOffsetReset) {
+            final AutoOffsetReset autoOffsetReset, final Integer partition) {
         this.groupId = Objects.requireNonNull(groupId, "Group ID required");
         this.topics = Collections.unmodifiableCollection(Objects.requireNonNull(topics, "Topics required"));
         this.topicPattern = null;
         this.autoOffsetReset = Objects.requireNonNull(autoOffsetReset, "Auto Offset Reset required");
+        this.partition = partition;
     }
 
     public PollingContext(final String groupId, final Pattern topicPattern,
@@ -46,6 +48,7 @@ public class PollingContext {
         this.topics = Collections.emptyList();
         this.topicPattern = Objects.requireNonNull(topicPattern, "Topic Patten required");
         this.autoOffsetReset = Objects.requireNonNull(autoOffsetReset, "Auto Offset Reset required");
+        this.partition = null;
     }
 
     public String getGroupId() {
@@ -64,9 +67,13 @@ public class PollingContext {
         return autoOffsetReset;
     }
 
+    public Integer getPartition() {
+        return partition;
+    }
+
     @Override
     public String toString() {
-        return String.format("Group ID [%s] Topics %s Topic Pattern [%s] Auto Offset Reset [%s]",
-                groupId, topics, topicPattern, autoOffsetReset);
+        return String.format("Group ID [%s] Topics %s Topic Pattern [%s] Auto Offset Reset [%s] Partition [%d]",
+                groupId, topics, topicPattern, autoOffsetReset, partition);
     }
 }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-api/src/main/java/org/apache/nifi/kafka/service/api/consumer/PollingSummary.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-api/src/main/java/org/apache/nifi/kafka/service/api/consumer/PollingSummary.java
@@ -31,9 +31,10 @@ public class PollingSummary extends PollingContext {
             final String groupId,
             final Collection<String> topics,
             final AutoOffsetReset autoOffsetReset,
+            final Integer partition,
             final Map<TopicPartitionSummary, OffsetSummary> offsets
     ) {
-        super(groupId, topics, autoOffsetReset);
+        super(groupId, topics, autoOffsetReset, partition);
         this.offsets = Objects.requireNonNull(offsets, "Offsets required");
     }
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/Kafka3ConnectionService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/Kafka3ConnectionService.java
@@ -258,14 +258,6 @@ public class Kafka3ConnectionService extends AbstractControllerService implement
         final ByteArrayDeserializer deserializer = new ByteArrayDeserializer();
         final Consumer<byte[], byte[]> consumer = new KafkaConsumer<>(properties, deserializer, deserializer);
 
-        Integer partition = pollingContext.getPartition();
-        if (partition != null) {
-            List<TopicPartition> topicPartitions = pollingContext.getTopics().stream()
-                    .map(topic -> new TopicPartition(topic, partition))
-                    .collect(Collectors.toList());
-            consumer.assign(topicPartitions);
-        }
-
         return new Kafka3ConsumerService(getLogger(), consumer, subscription);
     }
 
@@ -276,7 +268,7 @@ public class Kafka3ConnectionService extends AbstractControllerService implement
 
         return topicPatternFound
             .map(pattern -> new Subscription(groupId, pattern, autoOffsetReset))
-            .orElseGet(() -> new Subscription(groupId, pollingContext.getTopics(), autoOffsetReset));
+            .orElseGet(() -> new Subscription(groupId, pollingContext.getPartition(), pollingContext.getTopics(), autoOffsetReset));
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/Kafka3ConnectionService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/Kafka3ConnectionService.java
@@ -25,7 +25,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.KafkaFuture;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
@@ -73,7 +72,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static org.apache.nifi.components.ConfigVerificationResult.Outcome.FAILED;
 import static org.apache.nifi.components.ConfigVerificationResult.Outcome.SUCCESSFUL;
@@ -268,7 +266,7 @@ public class Kafka3ConnectionService extends AbstractControllerService implement
 
         return topicPatternFound
             .map(pattern -> new Subscription(groupId, pattern, autoOffsetReset))
-            .orElseGet(() -> new Subscription(groupId, pollingContext.getPartition(), pollingContext.getTopics(), autoOffsetReset));
+            .orElseGet(() -> new Subscription(groupId, pollingContext.getTopics(), pollingContext.getPartition(), autoOffsetReset));
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/consumer/Kafka3ConsumerService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/consumer/Kafka3ConsumerService.java
@@ -62,7 +62,8 @@ public class Kafka3ConsumerService implements KafkaConsumerService, Closeable, C
         this.consumer = consumer;
         this.subscription = subscription;
 
-        if (consumer.assignment().isEmpty()) {
+        final Integer partition = subscription.getPartition();
+        if (partition == null) {
             final Optional<Pattern> topicPatternFound = subscription.getTopicPattern();
             if (topicPatternFound.isPresent()) {
                 final Pattern topicPattern = topicPatternFound.get();
@@ -71,6 +72,11 @@ public class Kafka3ConsumerService implements KafkaConsumerService, Closeable, C
                 final Collection<String> topics = subscription.getTopics();
                 consumer.subscribe(topics, this);
             }
+        } else {
+            List<TopicPartition> topicPartitions = subscription.getTopics().stream()
+                    .map(topic -> new TopicPartition(topic, partition))
+                    .collect(Collectors.toList());
+            consumer.assign(topicPartitions);
         }
     }
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/consumer/Subscription.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/consumer/Subscription.java
@@ -35,7 +35,7 @@ public class Subscription {
     private final Pattern topicPattern;
     private final AutoOffsetReset autoOffsetReset;
 
-    public Subscription(final String groupId, final Integer partition, final Collection<String> topics, final AutoOffsetReset autoOffsetReset) {
+    public Subscription(final String groupId, final Collection<String> topics, final Integer partition, final AutoOffsetReset autoOffsetReset) {
         this.groupId = Objects.requireNonNull(groupId, "Group ID required");
         this.topics = Collections.unmodifiableCollection(Objects.requireNonNull(topics, "Topics required"));
         this.partition = partition;

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/consumer/Subscription.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/consumer/Subscription.java
@@ -31,12 +31,14 @@ public class Subscription {
 
     private final String groupId;
     private final Collection<String> topics;
+    private final Integer partition;
     private final Pattern topicPattern;
     private final AutoOffsetReset autoOffsetReset;
 
-    public Subscription(final String groupId, final Collection<String> topics, final AutoOffsetReset autoOffsetReset) {
+    public Subscription(final String groupId, final Integer partition, final Collection<String> topics, final AutoOffsetReset autoOffsetReset) {
         this.groupId = Objects.requireNonNull(groupId, "Group ID required");
         this.topics = Collections.unmodifiableCollection(Objects.requireNonNull(topics, "Topics required"));
+        this.partition = partition;
         this.topicPattern = null;
         this.autoOffsetReset = Objects.requireNonNull(autoOffsetReset, "Auto Offset Reset required");
     }
@@ -44,6 +46,7 @@ public class Subscription {
     public Subscription(final String groupId, final Pattern topicPattern, final AutoOffsetReset autoOffsetReset) {
         this.groupId = Objects.requireNonNull(groupId, "Group ID required");
         this.topics = Collections.emptyList();
+        this.partition = null;
         this.topicPattern = Objects.requireNonNull(topicPattern, "Topic Pattern required");
         this.autoOffsetReset = Objects.requireNonNull(autoOffsetReset, "Auto Offset Reset required");
     }
@@ -54,6 +57,10 @@ public class Subscription {
 
     public Collection<String> getTopics() {
         return topics;
+    }
+
+    public Integer getPartition() {
+        return partition;
     }
 
     public Optional<Pattern> getTopicPattern() {
@@ -94,7 +101,11 @@ public class Subscription {
     }
 
     private boolean isTopicSubscriptionMatched(final Subscription subscription) {
-        if (topics.size() == subscription.topics.size() && topics.containsAll(subscription.topics)) {
+        if (
+                topics.size() == subscription.topics.size()
+                        && topics.containsAll(subscription.topics)
+                        && Objects.equals(this.partition, subscription.partition)
+        ) {
             final String regexLeft = (topicPattern == null ? null : topicPattern.pattern());
             final String regexRight = (subscription.topicPattern == null ? null : subscription.topicPattern.pattern());
             return Objects.equals(regexLeft, regexRight);

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/test/java/org/apache/nifi/kafka/service/Kafka3ConnectionServiceBaseIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/test/java/org/apache/nifi/kafka/service/Kafka3ConnectionServiceBaseIT.java
@@ -265,7 +265,7 @@ public class Kafka3ConnectionServiceBaseIT {
         final RecordSummary summary = producerService.complete();
         assertNotNull(summary);
 
-        final PollingContext pollingContext = new PollingContext(GROUP_ID, Set.of(TOPIC), AutoOffsetReset.EARLIEST);
+        final PollingContext pollingContext = new PollingContext(GROUP_ID, Set.of(TOPIC), AutoOffsetReset.EARLIEST, null);
         final KafkaConsumerService consumerService = service.getConsumerService(pollingContext);
         final Iterator<ByteRecord> consumerRecords = poll(consumerService);
 
@@ -330,7 +330,7 @@ public class Kafka3ConnectionServiceBaseIT {
 
     @Test
     void testGetConsumerService() {
-        final PollingContext pollingContext = new PollingContext(GROUP_ID, Set.of(TOPIC), AutoOffsetReset.EARLIEST);
+        final PollingContext pollingContext = new PollingContext(GROUP_ID, Set.of(TOPIC), AutoOffsetReset.EARLIEST, null);
         final KafkaConsumerService consumerService = service.getConsumerService(pollingContext);
         final List<PartitionState> partitionStates = consumerService.getPartitionStates();
         assertPartitionStatesFound(partitionStates);

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/DynamicPropertyValidator.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/DynamicPropertyValidator.java
@@ -31,8 +31,6 @@ import static org.apache.nifi.kafka.shared.util.SaslExtensionUtil.SASL_EXTENSION
  * Validator for dynamic Kafka properties
  */
 public class DynamicPropertyValidator implements Validator {
-    private static final String PARTITIONS_PROPERTY_PREFIX = "partitions";
-
     private final Set<String> clientPropertyNames;
 
     public DynamicPropertyValidator(final Class<?>... kafkaClientClasses) {
@@ -48,9 +46,7 @@ public class DynamicPropertyValidator implements Validator {
         final ValidationResult.Builder builder = new ValidationResult.Builder();
         builder.subject(subject);
 
-        if (subject.startsWith(PARTITIONS_PROPERTY_PREFIX)) {
-            builder.valid(true);
-        } else if (subject.startsWith(SASL_EXTENSION_PROPERTY_PREFIX)) {
+        if (subject.startsWith(SASL_EXTENSION_PROPERTY_PREFIX)) {
             builder.valid(true);
         } else {
             final boolean valid = clientPropertyNames.contains(subject);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15226](https://issues.apache.org/jira/browse/NIFI-15226)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
