### PR TITLE
NIFI-15588 - Improve date, time, and timestamp type compatibility with ISO 8601 default formatters

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -57,6 +57,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1143,7 +1144,29 @@ public class DataTypeUtils {
         return new Date(zdtUTC.toInstant().toEpochMilli());
     }
 
+    private static final DateTimeFormatter[] DEFAULT_DATE_FORMATTERS = new DateTimeFormatter[]{
+            DateTimeFormatter.ISO_LOCAL_DATE.withResolverStyle(ResolverStyle.STRICT),
+            DateTimeFormatter.ISO_OFFSET_DATE.withResolverStyle(ResolverStyle.STRICT),
+            DateTimeFormatter.ISO_DATE.withResolverStyle(ResolverStyle.STRICT)
+    };
+
+    private static final DateTimeFormatter[] DEFAULT_TIME_FORMATTERS = new DateTimeFormatter[]{
+            DateTimeFormatter.ISO_LOCAL_TIME.withResolverStyle(ResolverStyle.STRICT),
+            DateTimeFormatter.ISO_OFFSET_TIME.withResolverStyle(ResolverStyle.STRICT),
+            DateTimeFormatter.ISO_TIME.withResolverStyle(ResolverStyle.STRICT)
+    };
+
+    private static final DateTimeFormatter[] DEFAULT_DATETIME_FORMATTERS = new DateTimeFormatter[]{
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME.withResolverStyle(ResolverStyle.STRICT),
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME.withResolverStyle(ResolverStyle.STRICT),
+            DateTimeFormatter.ISO_INSTANT.withResolverStyle(ResolverStyle.STRICT)
+    };
+
     public static boolean isDateTypeCompatible(final Object value, final String format) {
+        return isDateTypeCompatible(value, format, true);
+    }
+
+    public static boolean isDateTypeCompatible(final Object value, final String format, final boolean allowDefaultFormats) {
         if (value == null) {
             return false;
         }
@@ -1152,17 +1175,87 @@ public class DataTypeUtils {
             return true;
         }
 
-        if (value instanceof String) {
-            if (format == null) {
-                return isInteger((String) value);
-            }
-
-            try {
-                DateTimeFormatter.ofPattern(format).parse(value.toString());
-                return true;
-            } catch (final DateTimeParseException e) {
+        if (value instanceof String stringValue) {
+            final String trimmed = stringValue.trim();
+            if (trimmed.isEmpty()) {
                 return false;
             }
+
+            if (format != null && !format.isBlank()) {
+                return isParsable(trimmed, DateTimeFormatter.ofPattern(format).withResolverStyle(ResolverStyle.STRICT));
+            }
+
+            if (!allowDefaultFormats) {
+                return isInteger(trimmed);
+            }
+
+            return isParsable(trimmed, DEFAULT_DATE_FORMATTERS);
+        }
+
+        return false;
+    }
+
+    public static boolean isTimeTypeCompatible(final Object value, final String format) {
+        return isTimeTypeCompatible(value, format, true);
+    }
+
+    public static boolean isTimeTypeCompatible(final Object value, final String format, final boolean allowDefaultFormats) {
+        if (value == null) {
+            return false;
+        }
+
+        if (value instanceof java.util.Date || value instanceof Number) {
+            return true;
+        }
+
+        if (value instanceof String stringValue) {
+            final String trimmed = stringValue.trim();
+            if (trimmed.isEmpty()) {
+                return false;
+            }
+
+            if (format != null && !format.isBlank()) {
+                return isParsable(trimmed, DateTimeFormatter.ofPattern(format).withResolverStyle(ResolverStyle.STRICT));
+            }
+
+            if (!allowDefaultFormats) {
+                return isInteger(trimmed);
+            }
+
+            return isParsable(trimmed, DEFAULT_TIME_FORMATTERS);
+        }
+
+        return false;
+    }
+
+    public static boolean isTimestampTypeCompatible(final Object value, final String format) {
+        return isTimestampTypeCompatible(value, format, true);
+    }
+
+    public static boolean isTimestampTypeCompatible(final Object value, final String format, final boolean allowDefaultFormats) {
+        if (value == null) {
+            return false;
+        }
+
+        if (value instanceof java.util.Date || value instanceof Number) {
+            return true;
+        }
+
+        if (value instanceof String stringValue) {
+            final String trimmed = stringValue.trim();
+            if (trimmed.isEmpty()) {
+                return false;
+            }
+
+            if (format != null && !format.isBlank()) {
+                return isParsable(trimmed, DateTimeFormatter.ofPattern(format).withResolverStyle(ResolverStyle.STRICT));
+            }
+
+            if (!allowDefaultFormats) {
+                return isInteger(trimmed);
+            }
+
+            return isParsable(trimmed, DEFAULT_DATETIME_FORMATTERS);
         }
 
         return false;
@@ -1182,12 +1275,16 @@ public class DataTypeUtils {
         return true;
     }
 
-    public static boolean isTimeTypeCompatible(final Object value, final String format) {
-        return isDateTypeCompatible(value, format);
-    }
-
-    public static boolean isTimestampTypeCompatible(final Object value, final String format) {
-        return isDateTypeCompatible(value, format);
+    private static boolean isParsable(final String value, final DateTimeFormatter... formatters) {
+        for (final DateTimeFormatter formatter : formatters) {
+            try {
+                formatter.parse(value);
+                return true;
+            } catch (final DateTimeParseException e) {
+                continue;
+            }
+        }
+        return false;
     }
 
     public static BigInteger toBigInt(final Object value, final String fieldName) {

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
@@ -1223,4 +1223,70 @@ public class TestDataTypeUtils {
         assertNull(DataTypeUtils.toLong("", fieldName));
         assertNull(DataTypeUtils.toShort("", fieldName));
     }
+
+    @Test
+    void testIsoDateCompatibilityWithoutExplicitFormat() {
+        assertTrue(DataTypeUtils.isDateTypeCompatible("2024-01-15", null));
+        assertTrue(DataTypeUtils.isDateTypeCompatible(" 2024-01-15 ", null));
+        assertTrue(DataTypeUtils.isDateTypeCompatible("2024-01-15Z", null));
+
+        assertFalse(DataTypeUtils.isDateTypeCompatible("15/01/2024", null));
+        assertFalse(DataTypeUtils.isDateTypeCompatible("", null));
+    }
+
+    @Test
+    void testIsoTimeCompatibilityWithoutExplicitFormat() {
+        assertTrue(DataTypeUtils.isTimeTypeCompatible("13:45:00", null));
+        assertTrue(DataTypeUtils.isTimeTypeCompatible("13:45:00Z", null));
+        assertTrue(DataTypeUtils.isTimeTypeCompatible(" 13:45:00.123 ", null));
+
+        assertFalse(DataTypeUtils.isTimeTypeCompatible("25:61", null));
+        assertFalse(DataTypeUtils.isTimeTypeCompatible("", null));
+    }
+
+    @Test
+    void testIsoTimestampCompatibilityWithoutExplicitFormat() {
+        assertTrue(DataTypeUtils.isTimestampTypeCompatible("2024-01-15T13:45:00Z", null));
+        assertTrue(DataTypeUtils.isTimestampTypeCompatible("2024-01-15T13:45:00", null));
+        assertTrue(DataTypeUtils.isTimestampTypeCompatible(" 2024-01-15T13:45:00+01:00 ", null));
+
+        assertFalse(DataTypeUtils.isTimestampTypeCompatible("not-a-timestamp", null));
+        assertFalse(DataTypeUtils.isTimestampTypeCompatible("", null));
+    }
+
+    @Test
+    void testLegacyEpochCompatibilityWhenDefaultFormatsDisabled() {
+        // The three-argument overload keeps AbstractCSVRecordReader's non-coerce path aligned with legacy behaviour (see
+        // nifi-extension-bundles/.../csv/AbstractCSVRecordReader.java:122) by rejecting ISO strings when no explicit format
+        // is provided while still allowing epoch-based values.
+        assertFalse(DataTypeUtils.isDateTypeCompatible("2024-01-15", null, false));
+        assertFalse(DataTypeUtils.isTimeTypeCompatible("01:02:03", null, false));
+        assertFalse(DataTypeUtils.isTimestampTypeCompatible("2024-01-15T01:02:03Z", null, false));
+
+        assertTrue(DataTypeUtils.isDateTypeCompatible(String.valueOf(1700000000000L), null, false));
+        assertTrue(DataTypeUtils.isTimeTypeCompatible(String.valueOf(1700000000000L), null, false));
+        assertTrue(DataTypeUtils.isTimestampTypeCompatible(String.valueOf(1700000000000L), null, false));
+    }
+
+    @Test
+    void testDefaultIsoFormattersRejectInvalidDates() {
+        assertFalse(DataTypeUtils.isDateTypeCompatible("2024-02-30", null));
+        assertFalse(DataTypeUtils.isDateTypeCompatible("2024-13-01", null));
+        assertFalse(DataTypeUtils.isTimestampTypeCompatible("2024-02-30T10:00:00", null));
+
+        assertTrue(DataTypeUtils.isDateTypeCompatible("2024-02-29", null));
+        assertTrue(DataTypeUtils.isTimestampTypeCompatible("2024-02-29T10:00:00", null));
+    }
+
+    @Test
+    void testExplicitFormatWithYearOfEraPatternDoesNotRejectInvalidDates() {
+        // The yyyy pattern represents "year-of-era" which cannot fully resolve without an era under STRICT mode.
+        // As a result, formatter.parse() succeeds without validating day-of-month, unlike the default ISO formatters
+        // (tested in testDefaultIsoFormattersRejectInvalidDates) which use proleptic year (uuuu) and do reject invalid dates.
+        assertTrue(DataTypeUtils.isDateTypeCompatible("2024-02-30", "yyyy-MM-dd"));
+        assertTrue(DataTypeUtils.isTimestampTypeCompatible("2024-02-30 10:00:00", "yyyy-MM-dd HH:mm:ss"));
+
+        assertTrue(DataTypeUtils.isDateTypeCompatible("2024-02-29", "yyyy-MM-dd"));
+        assertTrue(DataTypeUtils.isTimestampTypeCompatible("2024-02-29 10:00:00", "yyyy-MM-dd HH:mm:ss"));
+    }
 }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateFieldConverter.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateFieldConverter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.serialization.record.field;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestObjectLocalDateFieldConverter {
+    private static final ObjectLocalDateFieldConverter CONVERTER = new ObjectLocalDateFieldConverter();
+
+    @Test
+    void testIsoLocalDateParsedWithoutPattern() {
+        final LocalDate result = CONVERTER.convertField("2024-01-15", Optional.empty(), "date");
+        assertEquals(LocalDate.of(2024, 1, 15), result);
+    }
+
+    @Test
+    void testIsoOffsetDateParsedWithoutPattern() {
+        final LocalDate result = CONVERTER.convertField("2024-06-15+02:00", Optional.empty(), "date");
+        assertEquals(LocalDate.of(2024, 6, 15), result);
+    }
+
+    @Test
+    void testInvalidStringFallsBackToNumericThenThrows() {
+        assertThrows(FieldConversionException.class,
+                () -> CONVERTER.convertField("not-a-date", Optional.empty(), "date"));
+    }
+}

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
@@ -26,6 +26,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestObjectLocalDateTimeFieldConverter {
     private static final String FIELD_NAME = "test";
@@ -99,5 +100,24 @@ public class TestObjectLocalDateTimeFieldConverter {
     public void testWithDateFormatMicrosecondPrecision() {
         final LocalDateTime result = converter.convertField(MICROS_TIMESTAMP_LONG, Optional.of("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"), FIELD_NAME);
         assertEquals(LOCAL_DATE_TIME_MICROS_PRECISION, result);
+    }
+
+    @Test
+    public void testIsoLocalDateTimeParsedWithoutPattern() {
+        final LocalDateTime result = converter.convertField("2024-01-15T13:45:30", Optional.empty(), FIELD_NAME);
+        assertEquals(LocalDateTime.of(2024, 1, 15, 13, 45, 30), result);
+    }
+
+    @Test
+    public void testIsoOffsetDateTimeConvertedToSystemZone() {
+        final LocalDateTime result = converter.convertField("2024-01-15T13:45:30Z", Optional.empty(), FIELD_NAME);
+        final LocalDateTime expected = LocalDateTime.ofInstant(Instant.parse("2024-01-15T13:45:30Z"), ZoneId.systemDefault());
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testInvalidStringFallsBackToNumericThenThrows() {
+        assertThrows(FieldConversionException.class,
+                () -> converter.convertField("not-a-timestamp", Optional.empty(), FIELD_NAME));
     }
 }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalTimeFieldConverter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.serialization.record.field;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestObjectLocalTimeFieldConverter {
+    private static final ObjectLocalTimeFieldConverter CONVERTER = new ObjectLocalTimeFieldConverter();
+
+    @Test
+    void testIsoLocalTimeParsedWithoutPattern() {
+        final LocalTime result = CONVERTER.convertField("13:45:30", Optional.empty(), "time");
+        assertEquals(LocalTime.of(13, 45, 30), result);
+    }
+
+    @Test
+    void testIsoLocalTimeWithMillisParsedWithoutPattern() {
+        final LocalTime result = CONVERTER.convertField("13:45:30.123", Optional.empty(), "time");
+        assertEquals(LocalTime.of(13, 45, 30, 123_000_000), result);
+    }
+
+    @Test
+    void testInvalidStringFallsBackToNumericThenThrows() {
+        assertThrows(FieldConversionException.class,
+                () -> CONVERTER.convertField("not-a-time", Optional.empty(), "time"));
+    }
+}

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
@@ -192,17 +192,20 @@ public class ExcelRecordReader implements RecordReader {
                 }
                 break;
             case DATE:
-                if (DataTypeUtils.isDateTypeCompatible(value, dateFormat)) {
+                final boolean allowDefaultDateFormats = dateFormat != null && !dateFormat.isBlank();
+                if (DataTypeUtils.isDateTypeCompatible(value, dateFormat, allowDefaultDateFormats)) {
                     return DataTypeUtils.convertType(value, dataType, Optional.ofNullable(dateFormat), Optional.ofNullable(timeFormat), Optional.ofNullable(timestampFormat), fieldName);
                 }
                 break;
             case TIME:
-                if (DataTypeUtils.isTimeTypeCompatible(value, timeFormat)) {
+                final boolean allowDefaultTimeFormats = timeFormat != null && !timeFormat.isBlank();
+                if (DataTypeUtils.isTimeTypeCompatible(value, timeFormat, allowDefaultTimeFormats)) {
                     return DataTypeUtils.convertType(value, dataType, Optional.ofNullable(dateFormat), Optional.ofNullable(timeFormat), Optional.ofNullable(timestampFormat), fieldName);
                 }
                 break;
             case TIMESTAMP:
-                if (DataTypeUtils.isTimestampTypeCompatible(value, timestampFormat)) {
+                final boolean allowDefaultTimestampFormats = timestampFormat != null && !timestampFormat.isBlank();
+                if (DataTypeUtils.isTimestampTypeCompatible(value, timestampFormat, allowDefaultTimestampFormats)) {
                     return DataTypeUtils.convertType(value, dataType, Optional.ofNullable(dateFormat), Optional.ofNullable(timeFormat), Optional.ofNullable(timestampFormat), fieldName);
                 }
                 break;

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/csv/AbstractCSVRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/csv/AbstractCSVRecordReader.java
@@ -121,17 +121,20 @@ public abstract class AbstractCSVRecordReader implements RecordReader {
                 }
                 break;
             case DATE:
-                if (DataTypeUtils.isDateTypeCompatible(trimmed, dateFormat)) {
+                final boolean allowDefaultDateFormats = dateFormat != null && !dateFormat.isBlank();
+                if (DataTypeUtils.isDateTypeCompatible(trimmed, dateFormat, allowDefaultDateFormats)) {
                     return DataTypeUtils.convertType(trimmed, dataType, Optional.ofNullable(dateFormat), Optional.ofNullable(timeFormat), Optional.ofNullable(timestampFormat), fieldName);
                 }
                 break;
             case TIME:
-                if (DataTypeUtils.isTimeTypeCompatible(trimmed, timeFormat)) {
+                final boolean allowDefaultTimeFormats = timeFormat != null && !timeFormat.isBlank();
+                if (DataTypeUtils.isTimeTypeCompatible(trimmed, timeFormat, allowDefaultTimeFormats)) {
                     return DataTypeUtils.convertType(trimmed, dataType, Optional.ofNullable(dateFormat), Optional.ofNullable(timeFormat), Optional.ofNullable(timestampFormat), fieldName);
                 }
                 break;
             case TIMESTAMP:
-                if (DataTypeUtils.isTimestampTypeCompatible(trimmed, timestampFormat)) {
+                final boolean allowDefaultTimestampFormats = timestampFormat != null && !timestampFormat.isBlank();
+                if (DataTypeUtils.isTimestampTypeCompatible(trimmed, timestampFormat, allowDefaultTimestampFormats)) {
                     return DataTypeUtils.convertType(trimmed, dataType, Optional.ofNullable(dateFormat), Optional.ofNullable(timeFormat), Optional.ofNullable(timestampFormat), fieldName);
                 }
                 break;


### PR DESCRIPTION
# Summary

NIFI-15588 - Improve date, time, and timestamp type compatibility with ISO 8601 default formatters

## Summary

- Add default ISO 8601 formatter fallback to temporal compatibility checks (`isDateTypeCompatible`, `isTimeTypeCompatible`, `isTimestampTypeCompatible`) and to the field converters (`ObjectLocalDateFieldConverter`, `ObjectLocalTimeFieldConverter`, `ObjectLocalDateTimeFieldConverter`), allowing ISO-formatted strings to be recognized and converted without requiring an explicit format pattern.
- Introduce a three-argument overload for each compatibility method with an `allowDefaultFormats` parameter, enabling callers to opt out of the new ISO fallback and retain the legacy epoch-only behavior.
- Apply `ResolverStyle.STRICT` to both the default ISO formatters and the explicit format path in compatibility checks, improving date validation strictness.

## Motivation

Prior to this change, the temporal compatibility methods (`isDateTypeCompatible`, `isTimeTypeCompatible`, `isTimestampTypeCompatible`) only accepted numeric (epoch) strings when no explicit format pattern was provided. ISO 8601 strings such as `"2024-01-15"` or `"13:45:00"` were rejected, even though they are the most common standard date/time representations. Similarly, the field converters would throw a `FieldConversionException` for ISO strings when no pattern was supplied, falling through directly to the epoch-millis numeric parse.

Additionally, `isTimeTypeCompatible` and `isTimestampTypeCompatible` simply delegated to `isDateTypeCompatible`, meaning all three types shared the same set of accepted formats. This made it impossible to use type-specific default formatters.

## Important notes

### `AbstractCSVRecordReader`

Updated `convertSimpleIfPossible` to use the three-argument overloads with `allowDefaultFormats` set to `true` only when the corresponding format (`dateFormat`, `timeFormat`, `timestampFormat`) is non-null and non-blank. This preserves existing CSV reader behavior: without an explicit format configured, only epoch-like numeric strings are coerced.

### `ExcelRecordReader`

Applied the same guarding pattern as `AbstractCSVRecordReader` to `convertSimpleIfPossible`, preventing the new ISO fallback from changing behavior for the Excel reader when no explicit temporal format is configured.

## Behavior Changes

| Scenario | Before | After |
|---|---|---|
| `isDateTypeCompatible("2024-01-15", null)` | `false` (epoch-only) | `true` (ISO fallback) |
| `isTimeTypeCompatible("13:45:00", null)` | `false` (delegated to date check) | `true` (ISO fallback) |
| `isTimestampTypeCompatible("2024-01-15T13:45:00Z", null)` | `false` (delegated to date check) | `true` (ISO fallback) |
| `isDateTypeCompatible("2024-02-30", null)` | `false` | `false` (ISO STRICT rejects) |
| `isDateTypeCompatible("2024-01-15", null, false)` | N/A (new overload) | `false` (epoch-only) |
| CSV/Excel reader with no explicit format | epoch-only coercion | epoch-only coercion (unchanged) |
| Converter with no pattern, ISO string input | `FieldConversionException` | Parsed via ISO formatters |
| Blank format string `" "` passed to compatibility check | `IllegalArgumentException` | Treated as absent format |

**Callers unaffected by the two-argument overload change:**
- `isCompatibleDataType(value, dataType)` — always passes non-null default formats (`"yyyy-MM-dd"`, `"HH:mm:ss"`, `"yyyy-MM-dd HH:mm:ss"`), so the null-format ISO fallback path is never reached.
- `CEFRecordReader` — always passes non-null format constants.
- `AbstractCSVRecordReader` and `ExcelRecordReader` — explicitly use the three-argument overload to opt out.


# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [x] Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
