### PR TITLE
NIFI-15698 - Fix Python bridge hang during startup with many Python processors

### DIFF
--- a/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/PythonProcess.java
+++ b/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/PythonProcess.java
@@ -74,6 +74,8 @@ public class PythonProcess {
     private final Map<String, Boolean> processorPrefersIsolation = new ConcurrentHashMap<>();
     private final Set<CreatedProcessor> createdProcessors = new CopyOnWriteArraySet<>();
     private volatile boolean shutdown = false;
+    private volatile boolean ready = false;
+    private volatile boolean startFailed = false;
     private volatile List<String> extensionDirs;
     private volatile String workDir;
     private Thread logReaderThread;
@@ -99,79 +101,132 @@ public class PythonProcess {
         return controller;
     }
 
+    /**
+     * Returns true if this process has completed start() successfully and is ready to create processors.
+     * Used by StandardPythonBridge so other threads can skip not-yet-ready processes or wait for them.
+     */
+    public boolean isReady() {
+        return ready;
+    }
+
+    /**
+     * Blocks until this process is ready (start() completed successfully) or the process is shut down.
+     * Callers must invoke this outside any bridge lock to avoid deadlock.
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     * @throws IOException if the process was shut down before becoming ready
+     */
+    public void waitUntilReady() throws InterruptedException, IOException {
+        synchronized (this) {
+            while (!ready && !shutdown && !startFailed) {
+                wait();
+            }
+            if (shutdown && !ready) {
+                throw new IOException("Python Process [%s] was shut down before becoming ready".formatted(componentId));
+            }
+            if (startFailed && !ready) {
+                throw new IOException("Python Process [%s] failed to start".formatted(componentId));
+            }
+        }
+    }
+
+    void markReadyAndNotify() {
+        synchronized (this) {
+            ready = true;
+            notifyAll();
+        }
+    }
+
+    private void notifyWaiters() {
+        synchronized (this) {
+            notifyAll();
+        }
+    }
+
     public synchronized void start() throws IOException {
-        final ServerSocketFactory serverSocketFactory = ServerSocketFactory.getDefault();
-        final SocketFactory socketFactory = SocketFactory.getDefault();
+        ready = false;
+        startFailed = false;
+        try {
+            final ServerSocketFactory serverSocketFactory = ServerSocketFactory.getDefault();
+            final SocketFactory socketFactory = SocketFactory.getDefault();
 
-        final int timeoutMillis = (int) processConfig.getCommsTimeout().toMillis();
-        final String authToken = generateAuthToken();
-        final CallbackClient callbackClient = new CallbackClient(GatewayServer.DEFAULT_PYTHON_PORT, GatewayServer.defaultAddress(), authToken,
-            50000L, TimeUnit.MILLISECONDS, socketFactory, false, timeoutMillis);
+            final int timeoutMillis = (int) processConfig.getCommsTimeout().toMillis();
+            final String authToken = generateAuthToken();
+            final CallbackClient callbackClient = new CallbackClient(GatewayServer.DEFAULT_PYTHON_PORT, GatewayServer.defaultAddress(), authToken,
+                50000L, TimeUnit.MILLISECONDS, socketFactory, false, timeoutMillis);
 
-        final JavaObjectBindings bindings = new JavaObjectBindings();
-        gateway = new NiFiPythonGateway(bindings, null, callbackClient);
-        gateway.startup();
+            final JavaObjectBindings bindings = new JavaObjectBindings();
+            gateway = new NiFiPythonGateway(bindings, null, callbackClient);
+            gateway.startup();
 
-        server = new NiFiGatewayServer(gateway,
-            0,
-            GatewayServer.defaultAddress(),
-            timeoutMillis,
-            timeoutMillis,
-            Collections.emptyList(),
-            serverSocketFactory,
-            authToken,
-            componentType,
-            componentId);
-        server.start();
+            server = new NiFiGatewayServer(gateway,
+                0,
+                GatewayServer.defaultAddress(),
+                timeoutMillis,
+                timeoutMillis,
+                Collections.emptyList(),
+                serverSocketFactory,
+                authToken,
+                componentType,
+                componentId);
+            server.start();
 
-        final int listeningPort = server.getListeningPort();
+            final int listeningPort = server.getListeningPort();
 
-        setupEnvironment();
-        this.process = launchPythonProcess(listeningPort, authToken);
-        this.process.onExit().thenAccept(this::handlePythonProcessDied);
+            setupEnvironment();
+            this.process = launchPythonProcess(listeningPort, authToken);
+            this.process.onExit().thenAccept(this::handlePythonProcessDied);
 
-        final String logReaderThreadName = LOG_READER_THREAD_NAME_FORMAT.formatted(process.pid());
-        final Runnable logReaderCommand = new PythonProcessLogReader(process.inputReader(StandardCharsets.UTF_8));
-        this.logReaderThread = Thread.ofVirtual().name(logReaderThreadName).start(logReaderCommand);
+            final String logReaderThreadName = LOG_READER_THREAD_NAME_FORMAT.formatted(process.pid());
+            final Runnable logReaderCommand = new PythonProcessLogReader(process.inputReader(StandardCharsets.UTF_8));
+            this.logReaderThread = Thread.ofVirtual().name(logReaderThreadName).start(logReaderCommand);
 
-        final StandardPythonClient pythonClient = new StandardPythonClient(gateway);
-        controller = pythonClient.getController();
+            final StandardPythonClient pythonClient = new StandardPythonClient(gateway);
+            controller = pythonClient.getController();
 
-        final long timeout = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60L);
-        Exception lastException = null;
-        boolean pingSuccessful = false;
-        while (System.currentTimeMillis() < timeout) {
-            try {
-                final String pingResponse = controller.ping();
-                pingSuccessful = "pong".equals(pingResponse);
+            final long timeout = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60L);
+            Exception lastException = null;
+            boolean pingSuccessful = false;
+            while (System.currentTimeMillis() < timeout) {
+                try {
+                    final String pingResponse = controller.ping();
+                    pingSuccessful = "pong".equals(pingResponse);
 
-                if (pingSuccessful) {
-                    break;
-                } else {
-                    logger.debug("Got unexpected response from Py4J Server during ping: {}", pingResponse);
+                    if (pingSuccessful) {
+                        break;
+                    } else {
+                        logger.debug("Got unexpected response from Py4J Server during ping: {}", pingResponse);
+                    }
+                } catch (final Exception e) {
+                    lastException = e;
+                    logger.debug("Failed to start Py4J Server", e);
                 }
-            } catch (final Exception e) {
-                lastException = e;
-                logger.debug("Failed to start Py4J Server", e);
+
+                try {
+                    Thread.sleep(50L);
+                } catch (final InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    startFailed = true;
+                    notifyWaiters();
+                    return;
+                }
             }
 
-            try {
-                Thread.sleep(50L);
-            } catch (final InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                return;
+            if (!pingSuccessful && lastException != null) {
+                throw new RuntimeException("Failed to start Python Bridge", lastException);
             }
+
+            logListenerId = Long.toString(process.pid());
+            StandardLogLevelChangeHandler.getHandler().addListener(logListenerId, new PythonProcessLogLevelChangeListener());
+
+            controller.setControllerServiceTypeLookup(controllerServiceTypeLookup);
+            logger.info("Successfully started and pinged Python Server. Python Process = {}", process);
+        } catch (final Throwable t) {
+            startFailed = true;
+            notifyWaiters();
+            throw t;
+        } finally {
+            notifyWaiters();
         }
-
-        if (!pingSuccessful && lastException != null) {
-            throw new RuntimeException("Failed to start Python Bridge", lastException);
-        }
-
-        logListenerId = Long.toString(process.pid());
-        StandardLogLevelChangeHandler.getHandler().addListener(logListenerId, new PythonProcessLogLevelChangeListener());
-
-        controller.setControllerServiceTypeLookup(controllerServiceTypeLookup);
-        logger.info("Successfully started and pinged Python Server. Python Process = {}", process);
     }
 
     private void handlePythonProcessDied(final Process process) {
@@ -198,6 +253,7 @@ public class PythonProcess {
                 // Ensure that we re-discover any extensions, as this is necessary in order to create Processors
                 if (extensionDirs != null && workDir != null) {
                     discoverExtensions(extensionDirs, workDir);
+                    markReadyAndNotify();
                     recreateProcessors();
                 }
 
@@ -423,6 +479,7 @@ public class PythonProcess {
 
     public void shutdown() {
         shutdown = true;
+        notifyWaiters();
         logger.info("Shutting down Python Process {}", process);
         killProcess();
     }

--- a/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/StandardPythonBridge.java
+++ b/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/StandardPythonBridge.java
@@ -85,6 +85,7 @@ public class StandardPythonBridge implements PythonBridge {
             final File envHome = new File(processConfig.getPythonWorkingDirectory(), "controller");
             controllerProcess = new PythonProcess(processConfig, serviceTypeLookup, envHome, true, "Controller", "Controller");
             controllerProcess.start();
+            controllerProcess.markReadyAndNotify();
             running = true;
         } catch (final Exception e) {
             shutdown();
@@ -118,18 +119,12 @@ public class StandardPythonBridge implements PythonBridge {
         controllerProcess.discoverExtensions(extensionsDirs, workDirPath);
     }
 
-    private PythonProcessorBridge createProcessorBridge(final String identifier, final String type, final String version, final boolean preferIsolatedProcess) {
+    private PythonProcessorBridge createProcessorBridge(final String identifier, final String type, final String version,
+                                                        final boolean preferIsolatedProcess, final PythonProcessorDetails processorDetails) {
         ensureStarted();
 
-        final Optional<ExtensionId> extensionIdFound = findExtensionId(type, version);
-        final ExtensionId extensionId = extensionIdFound.orElseThrow(() -> new IllegalArgumentException("Processor Type [%s] Version [%s] not found".formatted(type, version)));
+        final ExtensionId extensionId = new ExtensionId(processorDetails.getProcessorType(), processorDetails.getProcessorVersion());
         logger.debug("Creating Python Processor Type [{}] Version [{}]", extensionId.type(), extensionId.version());
-
-        final PythonProcessorDetails processorDetails = getProcessorTypes().stream()
-            .filter(details -> details.getProcessorType().equals(type))
-            .filter(details -> details.getProcessorVersion().equals(version))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("Could not find Processor Details for Python Processor type [%s] or version [%s]".formatted(type, version)));
 
         final String processorHome = processorDetails.getExtensionHome();
         final boolean bundledWithDependencies = processorDetails.isBundledWithDependencies();
@@ -138,7 +133,15 @@ public class StandardPythonBridge implements PythonBridge {
         // to avoid a deadlock between StandardPythonBridge and StandardExtensionDiscoveringManager locks
         final Set<String> narDirectories = getNarDirectories();
 
-        final PythonProcess pythonProcess = getProcessForNextComponent(extensionId, identifier, processorHome, preferIsolatedProcess, bundledWithDependencies, narDirectories);
+        final PythonProcess pythonProcess;
+        try {
+            pythonProcess = getProcessForNextComponent(extensionId, identifier, processorHome, preferIsolatedProcess, bundledWithDependencies, narDirectories);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while obtaining Python process for processor type [%s] version [%s]".formatted(type, version), e);
+        } catch (final IOException e) {
+            throw new RuntimeException("Failed to obtain Python process for processor type [%s] version [%s]".formatted(type, version), e);
+        }
 
         final String workDirPath = processConfig.getPythonWorkingDirectory().getAbsolutePath();
 
@@ -157,7 +160,7 @@ public class StandardPythonBridge implements PythonBridge {
             .orElseThrow(() -> new IllegalArgumentException("Unknown Python Processor type [%s] or version [%s]".formatted(type, version)));
 
         final String implementedInterface = processorDetails.getInterface();
-        final Supplier<PythonProcessorBridge> processorBridgeFactory = () -> createProcessorBridge(identifier, type, version, preferIsolatedProcess);
+        final Supplier<PythonProcessorBridge> processorBridgeFactory = () -> createProcessorBridge(identifier, type, version, preferIsolatedProcess, processorDetails);
 
         if (FlowFileTransform.class.getName().equals(implementedInterface)) {
             return new FlowFileTransformProxy(type, processorBridgeFactory, initialize);
@@ -229,28 +232,26 @@ public class StandardPythonBridge implements PythonBridge {
         return count;
     }
 
-    private synchronized PythonProcess getProcessForNextComponent(final ExtensionId extensionId, final String componentId, final String processorHome, final boolean preferIsolatedProcess,
-                final boolean packagedWithDependencies, final Set<String> narDirectories) {
+    private PythonProcess getProcessForNextComponent(final ExtensionId extensionId, final String componentId, final String processorHome, final boolean preferIsolatedProcess,
+                final boolean packagedWithDependencies, final Set<String> narDirectories) throws IOException, InterruptedException {
 
-        final int processorsOfThisType = processorCountByType.getOrDefault(extensionId, 0);
-        final int processIndex = processorsOfThisType % processConfig.getMaxPythonProcessesPerType();
+        PythonProcess processToStart = null;
+        PythonProcess processToWait = null;
 
-        // Check if we have any existing process that we can add the processor to.
-        // We can add the processor to an existing process if either the processor to be created doesn't prefer
-        // isolation (which is the case when Extension Manager creates a temp component), or if an existing process
-        // consists only of processors that don't prefer isolation. I.e., we don't want to collocate two Processors if
-        // they both prefer isolation.
-        final List<PythonProcess> processesForType = processesByProcessorType.computeIfAbsent(extensionId, key -> new CopyOnWriteArrayList<>());
-        for (final PythonProcess pythonProcess : processesForType) {
-            if (!preferIsolatedProcess || !pythonProcess.containsIsolatedProcessor()) {
-                logger.debug("Using {} to create Processor of type {}", pythonProcess, extensionId.type());
-                return pythonProcess;
+        synchronized (this) {
+            final int processorsOfThisType = processorCountByType.getOrDefault(extensionId, 0);
+            final int processIndex = processorsOfThisType % processConfig.getMaxPythonProcessesPerType();
+
+            final List<PythonProcess> processesForType = processesByProcessorType.computeIfAbsent(extensionId, key -> new CopyOnWriteArrayList<>());
+
+            for (final PythonProcess pythonProcess : processesForType) {
+                if (pythonProcess.isReady() && (!preferIsolatedProcess || !pythonProcess.containsIsolatedProcessor())) {
+                    logger.debug("Using {} to create Processor of type {}", pythonProcess, extensionId.type());
+                    return pythonProcess;
+                }
             }
-        }
 
-        if (processesForType.size() <= processIndex) {
-            try {
-                // Make sure that we don't have too many processes already launched.
+            if (processesForType.size() <= processIndex) {
                 final int totalProcessCount = getTotalProcessCount();
                 if (totalProcessCount >= processConfig.getMaxPythonProcesses()) {
                     throw new IllegalStateException("Cannot launch new Python Process because the maximum number of processes allowed, according to nifi.properties, is " +
@@ -260,8 +261,6 @@ public class StandardPythonBridge implements PythonBridge {
                 logger.info("In order to create Python Processor of type {}, launching a new Python Process because there are currently {} Python Processors of this type and {} Python Processes",
                     extensionId.type(), processorsOfThisType, processesByProcessorType.size());
 
-                // If the processor is packaged with its dependencies as a NAR, we can use the Processor Home as the Environment Home.
-                // Otherwise, we need to create a Virtual Environment for the Processor.
                 final File envHome;
                 if (packagedWithDependencies) {
                     envHome = new File(processorHome);
@@ -272,38 +271,48 @@ public class StandardPythonBridge implements PythonBridge {
                 }
 
                 final PythonProcess pythonProcess = new PythonProcess(processConfig, serviceTypeLookup, envHome, packagedWithDependencies, extensionId.type(), componentId);
-
-                // Add process to list before start() so removal requests during startup can find it
                 processesForType.add(pythonProcess);
-
-                try {
-                    pythonProcess.start();
-
-                    final List<String> extensionsDirs = processConfig.getPythonExtensionsDirectories().stream()
-                        .map(File::getAbsolutePath)
-                        .collect(Collectors.toCollection(ArrayList::new));
-                    extensionsDirs.addAll(narDirectories);
-
-                    final String workDirPath = processConfig.getPythonWorkingDirectory().getAbsolutePath();
-                    pythonProcess.discoverExtensions(extensionsDirs, workDirPath);
-                } catch (final IOException e) {
-                    processesForType.remove(pythonProcess);
-                    throw e;
+                processToStart = pythonProcess;
+            } else {
+                final PythonProcess pythonProcess = processesForType.get(processIndex);
+                if (pythonProcess.isReady()) {
+                    logger.warn("Using existing process {} to create Processor of type {} because configuration indicates that no more than {} processes " +
+                        "should be created for any Processor Type. This may result in slower performance for Processors of this type",
+                        pythonProcess, extensionId.type(), processConfig.getMaxPythonProcessesPerType());
+                    return pythonProcess;
                 }
-
-                return pythonProcess;
-            } catch (final IOException ioe) {
-                final String message = String.format("Failed to launch Process for Python Processor [%s] Version [%s]", extensionId.type(), extensionId.version());
-                throw new RuntimeException(message, ioe);
+                processToWait = pythonProcess;
             }
-        } else {
-            final PythonProcess pythonProcess = processesForType.get(processIndex);
-            logger.warn("Using existing process {} to create Processor of type {} because configuration indicates that no more than {} processes " +
-                "should be created for any Processor Type. This may result in slower performance for Processors of this type",
-                pythonProcess, extensionId.type(), processConfig.getMaxPythonProcessesPerType());
-
-            return pythonProcess;
         }
+
+        if (processToStart != null) {
+            try {
+                processToStart.start();
+                final List<String> extensionsDirs = processConfig.getPythonExtensionsDirectories().stream()
+                    .map(File::getAbsolutePath)
+                    .collect(Collectors.toCollection(ArrayList::new));
+                extensionsDirs.addAll(narDirectories);
+                final String workDirPath = processConfig.getPythonWorkingDirectory().getAbsolutePath();
+                processToStart.discoverExtensions(extensionsDirs, workDirPath);
+                processToStart.markReadyAndNotify();
+                return processToStart;
+            } catch (final IOException e) {
+                synchronized (this) {
+                    final List<PythonProcess> processesForType = processesByProcessorType.get(extensionId);
+                    if (processesForType != null) {
+                        processesForType.remove(processToStart);
+                    }
+                }
+                throw e;
+            }
+        }
+
+        if (processToWait != null) {
+            processToWait.waitUntilReady();
+            return processToWait;
+        }
+
+        throw new IllegalStateException("No process to start or wait for");
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/client/NiFiPythonGateway.java
+++ b/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/client/NiFiPythonGateway.java
@@ -35,6 +35,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * <p>
@@ -64,7 +66,9 @@ public class NiFiPythonGateway extends Gateway {
     private static final Logger logger = LoggerFactory.getLogger(NiFiPythonGateway.class);
     private final JavaObjectBindings objectBindings;
 
-    // Guarded by synchronized methods
+    // Guarded by invocationLock. Uses ReentrantLock instead of synchronized to avoid
+    // pinning virtual threads to their carrier threads (JDK 21 virtual thread limitation).
+    private final Lock invocationLock = new ReentrantLock();
     private final List<InvocationBindings> activeInvocations = new ArrayList<>();
 
     private static final ReturnObject END_OF_ITERATOR_OBJECT = ReturnObject.getErrorReturnObject(new NoSuchElementException());
@@ -132,23 +136,33 @@ public class NiFiPythonGateway extends Gateway {
     }
 
     @Override
-    public synchronized String putNewObject(final Object object) {
-        final String objectId = objectBindings.bind(object, activeInvocations.size() + 1);
+    public String putNewObject(final Object object) {
+        invocationLock.lock();
+        try {
+            final String objectId = objectBindings.bind(object, activeInvocations.size() + 1);
 
-        for (final InvocationBindings activeInvocation : activeInvocations) {
-            activeInvocation.add(objectId);
+            for (final InvocationBindings activeInvocation : activeInvocations) {
+                activeInvocation.add(objectId);
+            }
+
+            logger.debug("Binding {}: {} ({})", objectId, object, object == null ? "null" : object.getClass().getName());
+            return objectId;
+        } finally {
+            invocationLock.unlock();
         }
-
-        logger.debug("Binding {}: {} ({})", objectId, object, object == null ? "null" : object.getClass().getName());
-        return objectId;
     }
 
     @Override
-    public synchronized Object putObject(final String id, final Object object) {
-        objectBindings.bind(id, object, activeInvocations.size() + 1);
-        logger.debug("Binding {}: {} ({})", id, object, object == null ? "null" : object.getClass().getName());
+    public Object putObject(final String id, final Object object) {
+        invocationLock.lock();
+        try {
+            objectBindings.bind(id, object, activeInvocations.size() + 1);
+            logger.debug("Binding {}: {} ({})", id, object, object == null ? "null" : object.getClass().getName());
 
-        return super.putObject(id, object);
+            return super.putObject(id, object);
+        } finally {
+            invocationLock.unlock();
+        }
     }
 
     @Override
@@ -176,38 +190,48 @@ public class NiFiPythonGateway extends Gateway {
         };
     }
 
-    public synchronized InvocationBindings beginInvocation(final String objectId, final Method method, final Object[] args) {
+    public InvocationBindings beginInvocation(final String objectId, final Method method, final Object[] args) {
         final boolean unbind = isUnbind(method);
-
         final InvocationBindings bindings = new InvocationBindings(objectId, method, args, unbind);
 
-        // We don't want to keep track of invocations of the Ping method.
-        // The Ping method has no arguments or bound objects to free, and can occasionally
-        // even hang, if the timing is right because of the startup sequence of the Python side and how the
-        // communications are established.
-        if (!pingMethod.equals(method)) {
-            activeInvocations.add(bindings);
-        }
+        invocationLock.lock();
+        try {
+            // We don't want to keep track of invocations of the Ping method.
+            // The Ping method has no arguments or bound objects to free, and can occasionally
+            // even hang, if the timing is right because of the startup sequence of the Python side and how the
+            // communications are established.
+            if (!pingMethod.equals(method)) {
+                activeInvocations.add(bindings);
+            }
 
-        logger.debug("Beginning method invocation {}", bindings);
+            logger.debug("Beginning method invocation {}", bindings);
+        } finally {
+            invocationLock.unlock();
+        }
 
         return bindings;
     }
 
-    public synchronized void endInvocation(final InvocationBindings invocationBindings) {
-        final String methodName = invocationBindings.getMethod().getName();
-        logger.debug("Ending method invocation {}", invocationBindings);
+    public void endInvocation(final InvocationBindings invocationBindings) {
+        invocationLock.lock();
+        try {
+            final String methodName = invocationBindings.getMethod().getName();
+            logger.debug("Ending method invocation {}", invocationBindings);
 
-        final String objectId = invocationBindings.getTargetObjectId();
+            final String objectId = invocationBindings.getTargetObjectId();
 
-        activeInvocations.remove(invocationBindings);
-        invocationBindings.getObjectIds().forEach(id -> {
-            final Object unbound = objectBindings.unbind(id);
+            activeInvocations.remove(invocationBindings);
+            invocationBindings.getObjectIds().forEach(id -> {
+                final Object unbound = objectBindings.unbind(id);
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Unbinding {}: {} because invocation of {} on {} with args {} has completed", id, unbound, methodName, objectId, Arrays.toString(invocationBindings.getArgs()));
-            }
-        });
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Unbinding {}: {} because invocation of {} on {} with args {} has completed", id, unbound, methodName, objectId,
+                        Arrays.toString(invocationBindings.getArgs()));
+                }
+            });
+        } finally {
+            invocationLock.unlock();
+        }
     }
 
     protected boolean isUnbind(final Method method) {

--- a/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/PythonProcessTest.java
+++ b/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/PythonProcessTest.java
@@ -161,4 +161,34 @@ class PythonProcessTest {
         pythonProcess.shutdown();
         assertTrue(pythonProcess.isShutdown());
     }
+
+    @Test
+    void testIsReadyInitialState() {
+        assertFalse(pythonProcess.isReady());
+    }
+
+    @Test
+    void testWaitUntilReadyThrowsWhenShutdownBeforeReady() {
+        pythonProcess.shutdown();
+        final IOException thrown = assertThrows(IOException.class, () -> pythonProcess.waitUntilReady());
+        assertTrue(thrown.getMessage().contains("shut down before becoming ready"));
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void testWaitUntilReadyWakesUpWhenShutdown() throws InterruptedException {
+        final Thread waiter = new Thread(() -> {
+            try {
+                pythonProcess.waitUntilReady();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (IOException ignored) {
+            }
+        });
+        waiter.start();
+        Thread.sleep(100L);
+        pythonProcess.shutdown();
+        waiter.join(2000);
+        assertFalse(waiter.isAlive());
+    }
 }

--- a/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/client/TestNiFiPythonGateway.java
+++ b/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/client/TestNiFiPythonGateway.java
@@ -20,11 +20,15 @@ package org.apache.nifi.py4j.client;
 import org.apache.nifi.py4j.client.NiFiPythonGateway.InvocationBindings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import py4j.CallbackClient;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -145,6 +149,43 @@ public class TestNiFiPythonGateway {
 
         // When the final invocation completes, the object should be unbound
         assertNull(gateway.getObject(objectId));
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testConcurrentVirtualThreadsDoNotDeadlock() throws InterruptedException {
+        final int threadCount = 200;
+        final int iterationsPerThread = 50;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        final AtomicInteger completedCount = new AtomicInteger(0);
+        final AtomicInteger errorCount = new AtomicInteger(0);
+
+        for (int t = 0; t < threadCount; t++) {
+            Thread.ofVirtual().name("gateway-test-" + t).start(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < iterationsPerThread; i++) {
+                        final Object[] args = new Object[]{new Object()};
+                        final InvocationBindings invocationBindings = gateway.beginInvocation("o" + Thread.currentThread().getName(), NOP_METHOD, args);
+                        gateway.putNewObject(args[0]);
+                        gateway.endInvocation(invocationBindings);
+                    }
+                    completedCount.incrementAndGet();
+                } catch (final Exception e) {
+                    errorCount.incrementAndGet();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        final boolean allFinished = doneLatch.await(25, TimeUnit.SECONDS);
+
+        assertEquals(true, allFinished, "Not all virtual threads completed within the timeout, possible deadlock");
+        assertEquals(threadCount, completedCount.get());
+        assertEquals(0, errorCount.get());
     }
 
     public void nop(Object... args) {

--- a/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/client/TestNiFiPythonGateway.java
+++ b/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/client/TestNiFiPythonGateway.java
@@ -154,8 +154,8 @@ public class TestNiFiPythonGateway {
     @Test
     @Timeout(value = 30, unit = TimeUnit.SECONDS)
     public void testConcurrentVirtualThreadsDoNotDeadlock() throws InterruptedException {
-        final int threadCount = 200;
-        final int iterationsPerThread = 50;
+        final int threadCount = 50;
+        final int iterationsPerThread = 20;
         final CountDownLatch startLatch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(threadCount);
         final AtomicInteger completedCount = new AtomicInteger(0);

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/src/main/python/framework/ProcessorInspection.py
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/src/main/python/framework/ProcessorInspection.py
@@ -273,8 +273,16 @@ def get_imported_property_descriptors_from_ast(root_node: ast.AST, module_file: 
 
 
 def get_processor_class_nodes(module_file: str) -> list:
-    with open(module_file) as file:
-        root_node = ast.parse(file.read())
+    try:
+        with open(module_file) as file:
+            root_node = ast.parse(file.read())
+    except SystemError as e:
+        # Python 3.11+ AST bug (gh-95185): recursion depth counter not decremented on error path.
+        # Treat as non-processor so the file can still be loaded as a dependency.
+        if "recursion depth mismatch" in str(e):
+            logger.warning("AST parse failed for %s due to Python AST recursion depth bug; treating as non-processor: %s", module_file, e)
+            return []
+        raise
 
     processor_class_nodes = []
     class_nodes = get_class_nodes(root_node)


### PR DESCRIPTION
# Summary

NIFI-15698 - Fix Python bridge hang during startup with many Python processors

It has been challenging to work on this one and I was unable to come up with a system test systematically reproducing the issue. It was, however, very easy to reproduce the problem following the steps in the repository shared by the reporter: https://github.com/distroitt/nifi-bug

I was able to confirm the issue on latest release and was able to confirm that the fix is solving the problem by building the 2.9.0-SNAPSHOT Docker image and running the same tests.

When loading a flow with many Python processors, NiFi can hang during startup or restart and never reach "Started Application". The root cause is virtual thread pinning in `NiFiPythonGateway`. The four methods that guard the `activeInvocations` list (`beginInvocation`, `endInvocation`, `putNewObject`, `putObject`) use `synchronized`, which pins virtual threads to their carrier threads in JDK 21. During flow synchronization, the main thread and many processor-initialization virtual threads all contend for this single intrinsic lock. Because each waiting virtual thread pins its carrier, the ForkJoinPool carrier threads are quickly exhausted, and no thread can make progress - including the one holding the lock. This change replaces the `synchronized` methods with a `ReentrantLock`, which is virtual-thread-friendly: blocked virtual threads yield their carrier thread instead of pinning it.

The `PythonProcess` lifecycle has been updated so that a process is only handed out to callers after `discoverExtensions()` completes. New `isReady()`, `waitUntilReady()`, and `markReadyAndNotify()` methods prevent the main thread or initialization threads from calling into a Python process that is still loading extensions, which was another source of hangs on first start.

The `getProcessForNextComponent` method in `StandardPythonBridge` has been restructured to hold the bridge lock only for the decision phase (picking or creating a process), then release it before performing blocking operations like `start()` and `discoverExtensions()`. Previously the entire method was `synchronized`, blocking all other processor creation threads during these slow operations.

The `createProcessorBridge` method now receives the already-resolved `PythonProcessorDetails` from its caller instead of calling `getProcessorTypes()` again. This eliminates two redundant Python proxy round-trips per processor creation, reducing gateway lock contention during startup.

A workaround has been added in `ProcessorInspection.py` for a CPython 3.11+ bug (gh-95185) where `ast.parse()` can raise `SystemError: AST constructor recursion depth mismatch` under concurrent load. The error is caught and the file is treated as a non-processor module so that extension loading continues.

For reference, extract of thread dump when reproducing the issue:

````

"main" #1 [95] prio=5 os_prio=0 cpu=10197.37ms elapsed=247.51s tid=0x0000ffffa802b610 nid=95 waiting for monitor entry  [0x0000ffffaf3bb000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at org.apache.nifi.py4j.client.NiFiPythonGateway.endInvocation(NiFiPythonGateway.java:198)
	- waiting to lock <0x00000000d9907b40> (a org.apache.nifi.py4j.client.NiFiPythonGateway)
	at org.apache.nifi.py4j.client.PythonProxyInvocationHandler.invoke(PythonProxyInvocationHandler.java:103)
	at jdk.proxy8.$Proxy73.getProcessorTypes(jdk.proxy8/Unknown Source)
	at org.apache.nifi.py4j.StandardPythonBridge.getProcessorTypes(StandardPythonBridge.java:327)
	at org.apache.nifi.py4j.StandardPythonBridge.createProcessor(StandardPythonBridge.java:162)
	at org.apache.nifi.components.ClassLoaderAwarePythonBridge.createProcessor(ClassLoaderAwarePythonBridge.java:109)
	at org.apache.nifi.controller.ExtensionBuilder.createLoggablePythonProcessor(ExtensionBuilder.java:912)
	at org.apache.nifi.controller.ExtensionBuilder.createLoggableProcessor(ExtensionBuilder.java:792)
	at org.apache.nifi.controller.ExtensionBuilder.buildProcessor(ExtensionBuilder.java:261)
	at org.apache.nifi.controller.flow.StandardFlowManager.createProcessor(StandardFlowManager.java:369)
	at org.apache.nifi.controller.flow.AbstractFlowManager.createProcessor(AbstractFlowManager.java:430)
	at org.apache.nifi.flow.synchronization.StandardVersionedComponentSynchronizer.addProcessor(StandardVersionedComponentSynchronizer.java:2696)
	at org.apache.nifi.flow.synchronization.StandardVersionedComponentSynchronizer.synchronizeProcessors(StandardVersionedComponentSynchronizer.java:1197)
	at org.apache.nifi.flow.synchronization.StandardVersionedComponentSynchronizer.synchronize(StandardVersionedComponentSynchronizer.java:601)
	at org.apache.nifi.flow.synchronization.StandardVersionedComponentSynchronizer.addProcessGroup(StandardVersionedComponentSynchronizer.java:1387)
	at org.apache.nifi.flow.synchronization.StandardVersionedComponentSynchronizer.synchronizeChildGroups(StandardVersionedComponentSynchronizer.java:697)
	at org.apache.nifi.flow.synchronization.StandardVersionedComponentSynchronizer.synchronize(StandardVersionedComponentSynchronizer.java:595)
	at org.apache.nifi.flow.synchronization.StandardVersionedComponentSynchronizer.lambda$synchronize$10(StandardVersionedComponentSynchronizer.java:394)
	at org.apache.nifi.flow.synchronization.StandardVersionedComponentSynchronizer$$Lambda/0x0000000100b4cc78.run(Unknown Source)
	at org.apache.nifi.controller.flow.AbstractFlowManager.withParameterContextResolution(AbstractFlowManager.java:670)
	at org.apache.nifi.flow.synchronization.StandardVersionedComponentSynchronizer.synchronize(StandardVersionedComponentSynchronizer.java:389)
	at org.apache.nifi.groups.StandardProcessGroup.synchronizeFlow(StandardProcessGroup.java:3895)
	at org.apache.nifi.controller.serialization.VersionedFlowSynchronizer.synchronizeFlow(VersionedFlowSynchronizer.java:464)
	at org.apache.nifi.controller.serialization.VersionedFlowSynchronizer.sync(VersionedFlowSynchronizer.java:221)
	- locked <0x00000000d8a781d0> (a org.apache.nifi.controller.serialization.VersionedFlowSynchronizer)
	at org.apache.nifi.controller.FlowController.synchronize(FlowController.java:1840)
	at org.apache.nifi.persistence.StandardFlowConfigurationDAO.load(StandardFlowConfigurationDAO.java:92)
	- locked <0x00000000d8e388a8> (a org.apache.nifi.persistence.StandardFlowConfigurationDAO)
	at org.apache.nifi.controller.StandardFlowService.loadFromBytes(StandardFlowService.java:775)
	at org.apache.nifi.controller.StandardFlowService.load(StandardFlowService.java:497)
...
````

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [ ] Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
