### PR TITLE
NIFI-15758: Add fragment attribute support to UnpackContent and remov…

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
@@ -208,6 +208,9 @@ public class MergeContent extends BinFiles {
     public static final String FRAGMENT_COUNT_ATTRIBUTE = FragmentAttributes.FRAGMENT_COUNT.key();
     public static final String SEGMENT_ORIGINAL_FILENAME = FragmentAttributes.SEGMENT_ORIGINAL_FILENAME.key();
 
+    private static final Set<String> FRAGMENT_ATTRIBUTE_KEYS = Set.of(
+            FRAGMENT_ID_ATTRIBUTE, FRAGMENT_INDEX_ATTRIBUTE, FRAGMENT_COUNT_ATTRIBUTE, SEGMENT_ORIGINAL_FILENAME);
+
     public static final String TAR_PERMISSIONS_ATTRIBUTE = "tar.permissions";
     public static final String MERGE_COUNT_ATTRIBUTE = "merge.count";
     public static final String MERGE_BIN_AGE_ATTRIBUTE = "merge.bin.age";
@@ -469,15 +472,16 @@ public class MergeContent extends BinFiles {
     protected BinProcessingResult processBin(final Bin bin, final ProcessContext context) throws ProcessException {
         final BinProcessingResult binProcessingResult = new BinProcessingResult(true);
 
+        final boolean isDefragment = context.getProperty(MERGE_STRATEGY).asAllowableValue(MergeStrategy.class) == MergeStrategy.DEFRAGMENT;
         MergeBin merger = switch (context.getProperty(MERGE_FORMAT).asAllowableValue(MergeFormat.class)) {
             case TAR -> new TarMerge();
             case ZIP -> new ZipMerge(context.getProperty(COMPRESSION_LEVEL).asInteger());
             case FLOWFILE_STREAM_V3 ->
-                new FlowFileStreamMerger(new FlowFilePackagerV3(), StandardFlowFileMediaType.VERSION_3.getMediaType());
+                new FlowFileStreamMerger(new FlowFilePackagerV3(), StandardFlowFileMediaType.VERSION_3.getMediaType(), isDefragment);
             case FLOWFILE_STREAM_V2 ->
-                new FlowFileStreamMerger(new FlowFilePackagerV2(), StandardFlowFileMediaType.VERSION_2.getMediaType());
+                new FlowFileStreamMerger(new FlowFilePackagerV2(), StandardFlowFileMediaType.VERSION_2.getMediaType(), isDefragment);
             case FLOWFILE_TAR_V1 ->
-                new FlowFileStreamMerger(new FlowFilePackagerV1(), StandardFlowFileMediaType.VERSION_1.getMediaType());
+                new FlowFileStreamMerger(new FlowFilePackagerV1(), StandardFlowFileMediaType.VERSION_1.getMediaType(), isDefragment);
             case CONCAT -> new BinaryConcatenationMerge();
             case AVRO -> new AvroMerge();
         };
@@ -487,7 +491,7 @@ public class MergeContent extends BinFiles {
         final List<FlowFile> contents = bin.getContents();
         final ProcessSession binSession = bin.getSession();
 
-        if (context.getProperty(MERGE_STRATEGY).asAllowableValue(MergeStrategy.class) == MergeStrategy.DEFRAGMENT) {
+        if (isDefragment) {
             final String error = getDefragmentValidationError(bin.getContents());
 
             // Fail the FlowFiles and commit them
@@ -519,6 +523,11 @@ public class MergeContent extends BinFiles {
         bundleAttributes.put(REASON_FOR_MERGING, bin.getEvictionReason().name());
 
         bundle = binSession.putAllAttributes(bundle, bundleAttributes);
+
+        if (isDefragment) {
+            bundle = binSession.removeAllAttributes(bundle, Set.of(
+                    FRAGMENT_ID_ATTRIBUTE, FRAGMENT_INDEX_ATTRIBUTE, FRAGMENT_COUNT_ATTRIBUTE, SEGMENT_ORIGINAL_FILENAME));
+        }
 
         final String inputDescription = contents.size() < 10 ? contents.toString() : contents.size() + " FlowFiles";
 
@@ -1006,10 +1015,12 @@ public class MergeContent extends BinFiles {
 
         private final FlowFilePackager packager;
         private final String mimeType;
+        private final boolean removeFragmentAttributes;
 
-        public FlowFileStreamMerger(final FlowFilePackager packager, final String mimeType) {
+        public FlowFileStreamMerger(final FlowFilePackager packager, final String mimeType, final boolean removeFragmentAttributes) {
             this.packager = packager;
             this.mimeType = mimeType;
+            this.removeFragmentAttributes = removeFragmentAttributes;
         }
 
         @Override
@@ -1030,6 +1041,9 @@ public class MergeContent extends BinFiles {
                             bin.getSession().read(flowFile, rawIn -> {
                                 try (final InputStream in = new BufferedInputStream(rawIn)) {
                                     final Map<String, String> attributes = new HashMap<>(flowFile.getAttributes());
+                                    if (removeFragmentAttributes) {
+                                        FRAGMENT_ATTRIBUTE_KEYS.forEach(attributes::remove);
+                                    }
                                     packager.packageFlowFile(in, out, attributes, flowFile.getSize());
                                 }
                             });

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -40,6 +40,7 @@ import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.DescribedValue;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.flowfile.attributes.FragmentAttributes;
@@ -96,13 +97,20 @@ import java.util.regex.Pattern;
 @WritesAttributes({
     @WritesAttribute(attribute = "mime.type", description = "If the FlowFile is successfully unpacked, its MIME Type is no longer known, so the mime.type "
             + "attribute is set to application/octet-stream."),
-    @WritesAttribute(attribute = "fragment.identifier", description = "All unpacked FlowFiles produced from the same parent FlowFile will have the same randomly generated "
-            + "UUID added for this attribute"),
+    @WritesAttribute(attribute = "fragment.identifier", description = "All unpacked FlowFiles produced from the same parent FlowFile will have the same value for this "
+            + "attribute, determined by the Fragment Identifier Value property. For TAR and ZIP formats this attribute "
+            + "is always written. For FlowFile stream formats it is written when Add Fragment Attributes to FlowFile "
+            + "Streams is enabled."),
     @WritesAttribute(attribute = "fragment.index", description = "A one-up number that indicates the ordering of the unpacked FlowFiles that were created from a single "
-            + "parent FlowFile"),
-    @WritesAttribute(attribute = "fragment.count", description = "The number of unpacked FlowFiles generated from the parent FlowFile"),
+            + "parent FlowFile. For TAR and ZIP formats this attribute is always written. For FlowFile stream formats "
+            + "it is written when Add Fragment Attributes to FlowFile Streams is enabled."),
+    @WritesAttribute(attribute = "fragment.count", description = "The number of unpacked FlowFiles generated from the parent FlowFile. For TAR and ZIP formats this "
+            + "attribute is always written. For FlowFile stream formats it is written when Add Fragment Attributes to "
+            + "FlowFile Streams is enabled."),
     @WritesAttribute(attribute = "segment.original.filename ", description = "The filename of the parent FlowFile. Extensions of .tar, .zip or .pkg are removed because "
-            + "the MergeContent processor automatically adds those extensions if it is used to rebuild the original FlowFile"),
+            + "the MergeContent processor automatically adds those extensions if it is used to rebuild the original FlowFile. "
+            + "For TAR and ZIP formats this attribute is always written. For FlowFile stream formats it is written when "
+            + "Add Fragment Attributes to FlowFile Streams is enabled."),
     @WritesAttribute(attribute = UnpackContent.FILE_LAST_MODIFIED_TIME_ATTRIBUTE, description = "The date and time that the unpacked file was last modified (tar and zip only)."),
     @WritesAttribute(attribute = UnpackContent.FILE_CREATION_TIME_ATTRIBUTE, description = "The date and time that the file was created. For encrypted zip files this attribute" +
             " always holds the same value as " + UnpackContent.FILE_LAST_MODIFIED_TIME_ATTRIBUTE + ". For tar and unencrypted zip files if available it will be returned otherwise" +
@@ -200,10 +208,35 @@ public class UnpackContent extends AbstractProcessor {
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .build();
 
+    public static final PropertyDescriptor ADD_FRAGMENT_ATTRIBUTES = new PropertyDescriptor.Builder()
+            .name("Add Fragment Attributes to FlowFile Streams")
+            .description("When enabled, assigns fragment.identifier, fragment.index, fragment.count, and "
+                    + "segment.original.filename to FlowFiles unpacked from FlowFile stream formats. TAR and ZIP "
+                    + "formats always write these attributes. Enabling this allows FlowFile stream output to be "
+                    + "regrouped by MergeContent in Defragment mode.")
+            .required(true)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor FRAGMENT_IDENTIFIER_VALUE = new PropertyDescriptor.Builder()
+            .name("Fragment Identifier Value")
+            .description("Expression evaluated once against the incoming FlowFile to determine the value of "
+                    + "fragment.identifier on all unpacked children. The default ${UUID()} generates a unique "
+                    + "random identifier per parent FlowFile.")
+            .required(false)
+            .defaultValue("${UUID()}")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PACKAGING_FORMAT,
             ZIP_FILENAME_CHARSET,
             FILE_FILTER,
+            ADD_FRAGMENT_ATTRIBUTES,
+            FRAGMENT_IDENTIFIER_VALUE,
             PASSWORD,
             ALLOW_STORED_ENTRIES_WITH_DATA_DESCRIPTOR
     );
@@ -348,8 +381,10 @@ public class UnpackContent extends AbstractProcessor {
                 return;
             }
 
-            if (addFragmentAttrs) {
-                finishFragmentAttributes(session, flowFile, unpacked);
+            final boolean addFragmentAttrsEnabled = context.getProperty(ADD_FRAGMENT_ATTRIBUTES).asBoolean();
+            if (addFragmentAttrs || addFragmentAttrsEnabled) {
+                final String customFragmentId = getFragmentIdentifierValue(context, flowFile);
+                finishFragmentAttributesCustom(session, flowFile, unpacked, customFragmentId);
             }
             session.transfer(unpacked, REL_SUCCESS);
             final String fragmentId = !unpacked.isEmpty() ? unpacked.getFirst().getAttribute(FRAGMENT_ID) : null;
@@ -691,33 +726,40 @@ public class UnpackContent extends AbstractProcessor {
         }
     }
 
-    private void finishFragmentAttributes(final ProcessSession session, final FlowFile source, final List<FlowFile> unpacked) {
-        // first pass verifies all FlowFiles have the FRAGMENT_INDEX attribute and gets the total number of fragments
-        int fragmentCount = 0;
-        for (FlowFile ff : unpacked) {
-            String fragmentIndex = ff.getAttribute(FRAGMENT_INDEX);
-            if (fragmentIndex != null) {
-                fragmentCount++;
-            } else {
-                return;
-            }
-        }
-
-        String originalFilename = source.getAttribute(CoreAttributes.FILENAME.key());
-        if (originalFilename.endsWith(".tar") || originalFilename.endsWith(".zip") || originalFilename.endsWith(".pkg")) {
-            originalFilename = originalFilename.substring(0, originalFilename.length() - 4);
-        }
-
-        // second pass adds fragment attributes
-        List<FlowFile> newList = new ArrayList<>(unpacked);
+    private void finishFragmentAttributesCustom(final ProcessSession session, final FlowFile source,
+            final List<FlowFile> unpacked, final String fragmentId) {
+        final String originalFilename = stripArchiveExtension(source.getAttribute(CoreAttributes.FILENAME.key()));
+        final int fragmentCount = unpacked.size();
+        final List<FlowFile> newList = new ArrayList<>(unpacked);
         unpacked.clear();
-        for (FlowFile ff : newList) {
-            FlowFile newFF = session.putAllAttributes(ff, Map.of(
+        for (int i = 0; i < newList.size(); i++) {
+            final FlowFile newFF = session.putAllAttributes(newList.get(i), Map.of(
+                    FRAGMENT_ID, fragmentId,
+                    FRAGMENT_INDEX, String.valueOf(i + 1),
                     FRAGMENT_COUNT, String.valueOf(fragmentCount),
                     SEGMENT_ORIGINAL_FILENAME, originalFilename
             ));
             unpacked.add(newFF);
         }
+    }
+
+    private String getFragmentIdentifierValue(final ProcessContext context, final FlowFile source) {
+        final String fragmentId = context.getProperty(FRAGMENT_IDENTIFIER_VALUE)
+                .evaluateAttributeExpressions(source).getValue();
+        if (fragmentId == null || fragmentId.isBlank()) {
+            throw new ProcessException("Fragment Identifier Value must evaluate to a non-empty value");
+        }
+        return fragmentId;
+    }
+
+    private static String stripArchiveExtension(final String filename) {
+        if (filename == null) {
+            return "";
+        }
+        if (filename.endsWith(".tar") || filename.endsWith(".zip") || filename.endsWith(".pkg")) {
+            return filename.substring(0, filename.length() - 4);
+        }
+        return filename;
     }
 
     protected enum PackageFormat implements DescribedValue {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.MergeContent/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.MergeContent/additionalDetails.md
@@ -52,7 +52,10 @@ fragment.identifier" attribute. Each FlowFile with the same identifier must also
 fragment.index" attribute so that the FlowFiles can be ordered correctly. For a given "fragment.identifier", at least
 one FlowFile must have the "fragment.count" attribute (which indicates how many FlowFiles belong in the bin). Other
 FlowFiles with the same identifier must have the same value for the "fragment.count" attribute, or they can omit this
-attribute. **NOTE:** while there are valid use cases for breaking apart FlowFiles and later re-merging them, it is an
+attribute. Once defragmentation is complete, the fragment attributes (fragment.identifier, fragment.index, fragment.count,
+and segment.original.filename) are automatically removed from the merged output FlowFile. When the Merge Format is a
+FlowFile stream, these attributes are also removed from each inner FlowFile packaged within the stream, so that unpacking
+the result does not produce FlowFiles with stale fragment attributes. **NOTE:** while there are valid use cases for breaking apart FlowFiles and later re-merging them, it is an
 antipattern to take a larger FlowFile, break it into a million tiny FlowFiles, and then re-merge them. Doing so can
 result in using huge amounts of Java heap and can result in Out Of Memory Errors. Additionally, it adds large amounts of
 load to the NiFi framework. This can result in increased CPU and disk utilization and often times can be an order of

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestMergeContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestMergeContent.java
@@ -1480,6 +1480,75 @@ public class TestMergeContent {
     }
 
     @Test
+    public void testDefragmentRemoveFragmentAttributes() throws IOException {
+        runner.setProperty(MergeContent.MERGE_STRATEGY, MergeContent.MergeStrategy.DEFRAGMENT);
+        runner.setProperty(MergeContent.MAX_BIN_AGE, "1 min");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(MergeContent.FRAGMENT_ID_ATTRIBUTE, "1");
+        attributes.put(MergeContent.FRAGMENT_COUNT_ATTRIBUTE, "2");
+        attributes.put(MergeContent.FRAGMENT_INDEX_ATTRIBUTE, "1");
+        attributes.put(MergeContent.SEGMENT_ORIGINAL_FILENAME, "original");
+
+        runner.enqueue("Hello ".getBytes(StandardCharsets.UTF_8), attributes);
+        attributes.put(MergeContent.FRAGMENT_INDEX_ATTRIBUTE, "2");
+        runner.enqueue("World".getBytes(StandardCharsets.UTF_8), attributes);
+
+        runner.run();
+
+        runner.assertTransferCount(MergeContent.REL_MERGED, 1);
+        final MockFlowFile assembled = runner.getFlowFilesForRelationship(MergeContent.REL_MERGED).getFirst();
+        assembled.assertContentEquals("Hello World".getBytes(StandardCharsets.UTF_8));
+        assembled.assertAttributeNotExists(MergeContent.FRAGMENT_ID_ATTRIBUTE);
+        assembled.assertAttributeNotExists(MergeContent.FRAGMENT_INDEX_ATTRIBUTE);
+        assembled.assertAttributeNotExists(MergeContent.FRAGMENT_COUNT_ATTRIBUTE);
+        assembled.assertAttributeNotExists(MergeContent.SEGMENT_ORIGINAL_FILENAME);
+    }
+
+    @Test
+    public void testDefragmentRemoveFragmentAttributesFromFlowFileStream() throws IOException {
+        // Defragment two fragments into a FlowFile stream V3
+        runner.setProperty(MergeContent.MERGE_STRATEGY, MergeContent.MergeStrategy.DEFRAGMENT);
+        runner.setProperty(MergeContent.MERGE_FORMAT, MergeContent.MergeFormat.FLOWFILE_STREAM_V3);
+        runner.setProperty(MergeContent.MAX_BIN_AGE, "1 min");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(MergeContent.FRAGMENT_ID_ATTRIBUTE, "1");
+        attributes.put(MergeContent.FRAGMENT_COUNT_ATTRIBUTE, "2");
+        attributes.put(MergeContent.FRAGMENT_INDEX_ATTRIBUTE, "1");
+        attributes.put(MergeContent.SEGMENT_ORIGINAL_FILENAME, "original");
+
+        runner.enqueue("Hello ".getBytes(StandardCharsets.UTF_8), attributes);
+        attributes.put(MergeContent.FRAGMENT_INDEX_ATTRIBUTE, "2");
+        runner.enqueue("World".getBytes(StandardCharsets.UTF_8), attributes);
+
+        runner.run();
+
+        runner.assertTransferCount(MergeContent.REL_MERGED, 1);
+        final MockFlowFile merged = runner.getFlowFilesForRelationship(MergeContent.REL_MERGED).getFirst();
+
+        // Verify outer FlowFile has no fragment attributes
+        merged.assertAttributeNotExists(MergeContent.FRAGMENT_ID_ATTRIBUTE);
+        merged.assertAttributeNotExists(MergeContent.FRAGMENT_INDEX_ATTRIBUTE);
+        merged.assertAttributeNotExists(MergeContent.FRAGMENT_COUNT_ATTRIBUTE);
+        merged.assertAttributeNotExists(MergeContent.SEGMENT_ORIGINAL_FILENAME);
+
+        // Unpack the stream and verify inner FlowFiles also have no fragment attributes
+        final TestRunner unpackRunner = TestRunners.newTestRunner(new UnpackContent());
+        unpackRunner.setProperty(UnpackContent.PACKAGING_FORMAT, UnpackContent.PackageFormat.FLOWFILE_STREAM_FORMAT_V3);
+        unpackRunner.enqueue(merged);
+        unpackRunner.run();
+
+        unpackRunner.assertTransferCount(UnpackContent.REL_SUCCESS, 2);
+        for (final MockFlowFile inner : unpackRunner.getFlowFilesForRelationship(UnpackContent.REL_SUCCESS)) {
+            inner.assertAttributeNotExists(MergeContent.FRAGMENT_ID_ATTRIBUTE);
+            inner.assertAttributeNotExists(MergeContent.FRAGMENT_INDEX_ATTRIBUTE);
+            inner.assertAttributeNotExists(MergeContent.FRAGMENT_COUNT_ATTRIBUTE);
+            inner.assertAttributeNotExists(MergeContent.SEGMENT_ORIGINAL_FILENAME);
+        }
+    }
+
+    @Test
     void testMigrateProperties() {
         final Map<String, String> expectedRenamed = Map.ofEntries(
                 Map.entry("mergecontent-metadata-strategy", MergeContent.METADATA_STRATEGY.getName()),

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
@@ -45,6 +45,7 @@ import static org.apache.nifi.processors.standard.SplitContent.FRAGMENT_COUNT;
 import static org.apache.nifi.processors.standard.SplitContent.FRAGMENT_ID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestUnpackContent {
@@ -585,6 +586,82 @@ public class TestUnpackContent {
 
         final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
         assertEquals(expectedRenamed, propertyMigrationResult.getPropertiesRenamed());
+    }
+
+    @Test
+    public void testAddFragmentAttributes() throws IOException {
+        // ZIP: fragment attributes always written; identifier controlled by Fragment Identifier Value
+        runner.setProperty(UnpackContent.PACKAGING_FORMAT, UnpackContent.PackageFormat.ZIP_FORMAT);
+        runner.enqueue(dataPath.resolve("data.zip"));
+        runner.run();
+
+        runner.assertTransferCount(UnpackContent.REL_SUCCESS, 2);
+        runner.assertTransferCount(UnpackContent.REL_FAILURE, 0);
+        List<MockFlowFile> unpacked = runner.getFlowFilesForRelationship(UnpackContent.REL_SUCCESS);
+        String sharedId = unpacked.getFirst().getAttribute(UnpackContent.FRAGMENT_ID);
+        assertNotNull(sharedId);
+        for (final MockFlowFile ff : unpacked) {
+            ff.assertAttributeEquals(UnpackContent.FRAGMENT_ID, sharedId);
+            ff.assertAttributeEquals(UnpackContent.FRAGMENT_COUNT, "2");
+            ff.assertAttributeExists(UnpackContent.FRAGMENT_INDEX);
+            ff.assertAttributeEquals(UnpackContent.SEGMENT_ORIGINAL_FILENAME, "data");
+        }
+        assertEquals("1", unpacked.get(0).getAttribute(UnpackContent.FRAGMENT_INDEX));
+        assertEquals("2", unpacked.get(1).getAttribute(UnpackContent.FRAGMENT_INDEX));
+
+        // FlowFile stream: fragment attributes only written when Add Fragment Attributes to FlowFile Streams is enabled
+        runner.setProperty(UnpackContent.PACKAGING_FORMAT, UnpackContent.PackageFormat.FLOWFILE_STREAM_FORMAT_V3);
+        runner.setProperty(UnpackContent.ADD_FRAGMENT_ATTRIBUTES, "true");
+        runner.enqueue(dataPath.resolve("data.flowfilev3"));
+        runner.run();
+
+        runner.assertTransferCount(UnpackContent.REL_SUCCESS, 4);
+        runner.assertTransferCount(UnpackContent.REL_FAILURE, 0);
+        final List<MockFlowFile> all = runner.getFlowFilesForRelationship(UnpackContent.REL_SUCCESS);
+        unpacked = all.subList(all.size() - 2, all.size());
+        sharedId = unpacked.getFirst().getAttribute(UnpackContent.FRAGMENT_ID);
+        assertNotNull(sharedId);
+        for (final MockFlowFile ff : unpacked) {
+            ff.assertAttributeEquals(UnpackContent.FRAGMENT_ID, sharedId);
+            ff.assertAttributeEquals(UnpackContent.FRAGMENT_COUNT, "2");
+            ff.assertAttributeExists(UnpackContent.FRAGMENT_INDEX);
+            ff.assertAttributeEquals(UnpackContent.SEGMENT_ORIGINAL_FILENAME, "data.flowfilev3");
+        }
+        assertEquals("1", unpacked.get(0).getAttribute(UnpackContent.FRAGMENT_INDEX));
+        assertEquals("2", unpacked.get(1).getAttribute(UnpackContent.FRAGMENT_INDEX));
+    }
+
+    @Test
+    public void testFragmentIdentifierValue() throws IOException {
+        runner.setProperty(UnpackContent.PACKAGING_FORMAT, UnpackContent.PackageFormat.ZIP_FORMAT);
+        runner.setProperty(UnpackContent.FRAGMENT_IDENTIFIER_VALUE, "${filename}");
+        runner.enqueue(dataPath.resolve("data.zip"));
+        runner.run();
+
+        runner.assertTransferCount(UnpackContent.REL_SUCCESS, 2);
+        runner.assertTransferCount(UnpackContent.REL_FAILURE, 0);
+        final List<MockFlowFile> unpacked = runner.getFlowFilesForRelationship(UnpackContent.REL_SUCCESS);
+        for (final MockFlowFile ff : unpacked) {
+            ff.assertAttributeEquals(UnpackContent.FRAGMENT_ID, "data.zip");
+            ff.assertAttributeEquals(UnpackContent.FRAGMENT_COUNT, "2");
+            ff.assertAttributeExists(UnpackContent.FRAGMENT_INDEX);
+            ff.assertAttributeEquals(UnpackContent.SEGMENT_ORIGINAL_FILENAME, "data");
+        }
+        assertEquals("1", unpacked.get(0).getAttribute(UnpackContent.FRAGMENT_INDEX));
+        assertEquals("2", unpacked.get(1).getAttribute(UnpackContent.FRAGMENT_INDEX));
+    }
+
+    @Test
+    public void testFragmentIdentifierValueMustResolveToNonEmptyValue() throws IOException {
+        runner.setProperty(UnpackContent.PACKAGING_FORMAT, UnpackContent.PackageFormat.ZIP_FORMAT);
+        runner.setProperty(UnpackContent.FRAGMENT_IDENTIFIER_VALUE, "${missing.attribute}");
+        runner.enqueue(dataPath.resolve("data.zip"));
+
+        runner.run();
+
+        runner.assertTransferCount(UnpackContent.REL_SUCCESS, 0);
+        runner.assertTransferCount(UnpackContent.REL_ORIGINAL, 0);
+        runner.assertTransferCount(UnpackContent.REL_FAILURE, 1);
     }
 
     private void runZipEncryptionMethod(final EncryptionMethod encryptionMethod) throws IOException {


### PR DESCRIPTION
…e fragment attributes from MergeContent in Defragment mode

## Summary

This change adds optional fragment attribute support to `UnpackContent` so unpacked FlowFiles can be regrouped downstream using `MergeContent` in `Defragment` mode.

It also updates `MergeContent` to remove reassembly-related attributes from the merged FlowFile once defragmentation has completed successfully, including:

- `fragment.identifier`
- `fragment.index`
- `fragment.count`
- `segment.original.filename`

## Motivation

A common dataflow pattern is:

1. Data is packaged to optimise transport
2. `UnpackContent` extracts individual FlowFiles
3. Files are enriched or transformed independently
4. Files are regrouped and repackaged

This works well conceptually, but today `UnpackContent` does not provide a built-in way to assign the fragment attributes needed for downstream reassembly across formats such as ZIP, TAR, and FlowFile Package.

Without those attributes, users need custom logic to preserve grouping and ordering, which adds complexity and can lead to inconsistent behaviour.

This change makes that workflow easier by allowing `UnpackContent` to optionally generate fragment attributes, while ensuring `MergeContent` removes the temporary reassembly metadata once the final merged FlowFile has been produced.

## Changes Included

### UnpackContent

Added optional support for assigning fragment attributes to unpacked FlowFiles.

#### New Properties

**Add Fragment Attributes**
- When enabled, assigns:
  - `fragment.identifier`
  - `fragment.index`
  - `fragment.count`
  -  `segment.original.filename`

**Fragment Identifier Value**
- Specifies the value used for `fragment.identifier`
- Supports Expression Language evaluated against the incoming packed FlowFile
- Evaluated once per source FlowFile, with the resulting value applied to all unpacked FlowFiles derived from that source
- Default: `${UUID()}`

Examples:
- `${UUID()}` for a unique grouping per archive (default)
- `${filename}` for grouping based on the original filename
- `${archive.filename}` when an explicit archive attribute is available

#### Behaviour

When enabled:
- All FlowFiles produced from a single archive share the same `fragment.identifier`
- `fragment.index` is assigned based on entry order within the archive
- `fragment.count` is set to the total number of unpacked entries
- The identifier expression is evaluated once per parent FlowFile

When disabled:
- No change to current `UnpackContent` behaviour

### MergeContent

Updated `MergeContent` so that after a successful defragmentation, the merged FlowFile no longer retains temporary reassembly metadata.

When operating in `Defragment` mode, the merged FlowFile now removes:

- `fragment.identifier`
- `fragment.index`
- `fragment.count`
- `segment.original.filename`

This ensures the final merged output reflects the completed repackaged artifact rather than the intermediate fragmentation state used to drive regrouping.

## Compatibility

- Fully backward compatible
- Fragment attribute generation in `UnpackContent` is opt-in
- Existing flows are unchanged unless the new property is enabled
- The `MergeContent` cleanup only applies after successful defragmentation

## Example

Input:
- `archive.zip` containing 3 files

Unpack output when enabled with `${filename}` as the identifier:

| filename  | fragment.identifier | fragment.index | fragment.count |
|-----------|---------------------|----------------|----------------|
| file1.txt | archive.zip         | 0              | 3              |
| file2.txt | archive.zip         | 1              | 3              |
| file3.txt | archive.zip         | 2              | 3              |

After processing and successful defragmentation in `MergeContent`, the merged FlowFile no longer retains:

- `fragment.identifier`
- `fragment.index`
- `fragment.count`
- `segment.original.filename`


<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15758](https://issues.apache.org/jira/browse/NIFI-15758)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [x] Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
