### PR TITLE
NIFI-11295 Expanded Mapping File property to also take the mapping file content.

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
@@ -23,10 +23,12 @@ import org.apache.nifi.annotation.behavior.SideEffectFree;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.resource.ResourceCardinality;
+import org.apache.nifi.components.resource.ResourceReference;
 import org.apache.nifi.components.resource.ResourceType;
 import org.apache.nifi.expression.AttributeValueDecorator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
@@ -45,7 +47,6 @@ import org.apache.nifi.util.StopWatch;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -68,8 +69,9 @@ import java.util.regex.Pattern;
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @Tags({"Text", "Regular Expression", "Update", "Change", "Replace", "Modify", "Regex", "Mapping"})
-@CapabilityDescription("Updates the content of a FlowFile by evaluating a Regular Expression against it and replacing the section of the content that "
-        + "matches the Regular Expression with some alternate value provided in a mapping file.")
+@CapabilityDescription("""
+        Updates the content of a FlowFile by evaluating a Regular Expression against it and replacing the section of the content that
+        matches the Regular Expression with some alternate value provided in a mapping file.""")
 public class ReplaceTextWithMapping extends AbstractProcessor {
 
     public static final PropertyDescriptor REGEX = new PropertyDescriptor.Builder()
@@ -90,13 +92,13 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
             .build();
     public static final PropertyDescriptor MAPPING_FILE = new PropertyDescriptor.Builder()
             .name("Mapping File")
-            .description("The name of the file (including the full path) containing the Mappings.")
-            .identifiesExternalResource(ResourceCardinality.SINGLE, ResourceType.FILE)
+            .description("The name of the file (including the full path) containing the Mappings or the actual mapping contents.")
+            .identifiesExternalResource(ResourceCardinality.SINGLE, ResourceType.FILE, ResourceType.TEXT)
             .required(true)
             .build();
     public static final PropertyDescriptor MAPPING_FILE_REFRESH_INTERVAL = new PropertyDescriptor.Builder()
             .name("Mapping File Refresh Interval")
-            .description("The polling interval to check for updates to the mapping file. The default is 60s.")
+            .description("The polling interval to check for updates to the mapping file only if the mapping file is a file on the filesystem. The default is 60s.")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .required(true)
             .defaultValue("60s")
@@ -176,6 +178,20 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
         return RELATIONSHIPS;
     }
 
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        final ResourceReference resourceReference = context.getProperty(MAPPING_FILE).asResource();
+        if (resourceReference.getResourceType() == ResourceType.TEXT) {
+            try {
+                getLogger().info("Reloading mapping file contents");
+                final InputStream inputStream = resourceReference.read();
+                setConfigurationState(inputStream);
+            } catch (IOException ioe) {
+                getLogger().error("Error reading mapping file", ioe);
+            }
+        }
+    }
+
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
         updateMapping(context);
@@ -214,7 +230,7 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
                 final StringBuilder sb = new StringBuilder(replacement.length() + 1);
                 final int groupStart = backRefMatcher.start(1) + replacementCount++;
 
-                sb.append(replacement.substring(0, groupStart - 1));
+                sb.append(replacement, 0, groupStart - 1);
                 sb.append("\\");
                 sb.append(replacement.substring(groupStart - 1));
                 replacement = sb.toString();
@@ -227,49 +243,56 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
     }
 
     private void updateMapping(final ProcessContext context) {
-        if (processorLock.tryLock()) {
-            final ComponentLog logger = getLogger();
-            try {
-                // if not queried mapping file lastUpdate time in
-                // mapppingRefreshPeriodSecs, do so.
-                long currentTimeSecs = System.currentTimeMillis() / 1000;
-                long mappingRefreshPeriodSecs = context.getProperty(MAPPING_FILE_REFRESH_INTERVAL).asTimePeriod(TimeUnit.SECONDS);
+        final ResourceReference resourceReference = context.getProperty(MAPPING_FILE).asResource();
 
-                boolean retry = (currentTimeSecs > (mappingTestTime.get() + mappingRefreshPeriodSecs));
-                if (retry) {
-                    mappingTestTime.set(System.currentTimeMillis() / 1000);
-                    // see if the mapping file needs to be reloaded
-                    final String fileName = context.getProperty(MAPPING_FILE).getValue();
-                    final File file = new File(fileName);
-                    if (file.exists() && file.isFile() && file.canRead()) {
-                        if (file.lastModified() > lastModified.get()) {
-                            lastModified.getAndSet(file.lastModified());
-                            try (FileInputStream is = new FileInputStream(file)) {
-                                logger.info("Reloading mapping file: {}", fileName);
+        if (resourceReference.getResourceType() == ResourceType.FILE) {
+            if (processorLock.tryLock()) {
+                final ComponentLog logger = getLogger();
+                try {
+                    // if not queried mapping file lastUpdate time in
+                    // mappingRefreshPeriodSecs, do so.
+                    long currentTimeSecs = System.currentTimeMillis() / 1000;
+                    long mappingRefreshPeriodSecs = context.getProperty(MAPPING_FILE_REFRESH_INTERVAL).asTimePeriod(TimeUnit.SECONDS);
 
-                                final Map<String, String> mapping = loadMappingFile(is);
-                                final ConfigurationState newState = new ConfigurationState(mapping);
-                                configurationStateRef.set(newState);
-                            } catch (IOException e) {
-                                logger.error("Error reading mapping file", e);
+                    boolean retry = (currentTimeSecs > (mappingTestTime.get() + mappingRefreshPeriodSecs));
+                    if (retry) {
+                        mappingTestTime.set(System.currentTimeMillis() / 1000);
+                        // see if the mapping file needs to be reloaded
+                        final File file = resourceReference.asFile();
+                        final String fileName = file.getName();
+                        if (file.exists() && file.isFile() && file.canRead()) {
+                            if (file.lastModified() > lastModified.get()) {
+                                lastModified.getAndSet(file.lastModified());
+                                try (InputStream is = resourceReference.read()) {
+                                    logger.info("Reloading mapping file: {}", fileName);
+                                    setConfigurationState(is);
+                                } catch (IOException e) {
+                                    logger.error("Error reading mapping file", e);
+                                }
                             }
+                        } else {
+                            logger.error("Mapping file does not exist or is not readable: {}", fileName);
                         }
-                    } else {
-                        logger.error("Mapping file does not exist or is not readable: {}", fileName);
                     }
+                } catch (Exception e) {
+                    logger.error("Error loading mapping file", e);
+                } finally {
+                    processorLock.unlock();
                 }
-            } catch (Exception e) {
-                logger.error("Error loading mapping file", e);
-            } finally {
-                processorLock.unlock();
             }
         }
+    }
+
+    private void setConfigurationState(InputStream inputStream) throws IOException {
+        final Map<String, String> mapping = loadMappingFile(inputStream);
+        final ConfigurationState newState = new ConfigurationState(mapping);
+        configurationStateRef.set(newState);
     }
 
     protected Map<String, String> loadMappingFile(InputStream is) throws IOException {
         Map<String, String> mapping = new HashMap<>();
         BufferedReader reader = new BufferedReader(new InputStreamReader(is));
-        String line = null;
+        String line;
         while ((line = reader.readLine()) != null) {
             final String[] splits = StringUtils.split(line, "\t ", 2);
             if (splits.length == 1) {
@@ -311,14 +334,8 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
         private final int numCapturingGroups;
         private final int groupToMatch;
 
-        private final AttributeValueDecorator quotedAttributeDecorator = new AttributeValueDecorator() {
-            @Override
-            public String decorate(final String attributeValue) {
-                return Pattern.quote(attributeValue);
-            }
-        };
-
         private ReplaceTextCallback(ProcessContext context, FlowFile flowFile, int maxBufferSize) {
+            AttributeValueDecorator quotedAttributeDecorator = Pattern::quote;
             this.regex = context.getProperty(REGEX).evaluateAttributeExpressions(flowFile, quotedAttributeDecorator).getValue();
             this.flowFile = flowFile;
 
@@ -348,7 +365,7 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
             matcher.reset();
             boolean result = matcher.find();
             if (result) {
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 do {
                     String matched = matcher.group(groupToMatch);
                     String rv = mapping.get(matched);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
@@ -182,9 +182,8 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
     public void onScheduled(final ProcessContext context) {
         final ResourceReference resourceReference = context.getProperty(MAPPING_FILE).asResource();
         if (resourceReference.getResourceType() == ResourceType.TEXT) {
-            try {
-                getLogger().info("Reloading mapping file contents");
-                final InputStream inputStream = resourceReference.read();
+            getLogger().info("Loading mapping content");
+            try (final InputStream inputStream = resourceReference.read()) {
                 setConfigurationState(inputStream);
             } catch (IOException ioe) {
                 getLogger().error("Error reading mapping file", ioe);
@@ -251,10 +250,10 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
                 try {
                     // if not queried mapping file lastUpdate time in
                     // mappingRefreshPeriodSecs, do so.
-                    long currentTimeSecs = System.currentTimeMillis() / 1000;
-                    long mappingRefreshPeriodSecs = context.getProperty(MAPPING_FILE_REFRESH_INTERVAL).asTimePeriod(TimeUnit.SECONDS);
+                    final long currentTimeSecs = System.currentTimeMillis() / 1000;
+                    final long mappingRefreshPeriodSecs = context.getProperty(MAPPING_FILE_REFRESH_INTERVAL).asTimePeriod(TimeUnit.SECONDS);
 
-                    boolean retry = (currentTimeSecs > (mappingTestTime.get() + mappingRefreshPeriodSecs));
+                    final boolean retry = (currentTimeSecs > (mappingTestTime.get() + mappingRefreshPeriodSecs));
                     if (retry) {
                         mappingTestTime.set(System.currentTimeMillis() / 1000);
                         // see if the mapping file needs to be reloaded

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
@@ -186,7 +186,7 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
             try (final InputStream inputStream = resourceReference.read()) {
                 setConfigurationState(inputStream);
             } catch (IOException ioe) {
-                getLogger().error("Error reading mapping file", ioe);
+                getLogger().error("Error reading mapping content", ioe);
             }
         }
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestReplaceTextWithMapping.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestReplaceTextWithMapping.java
@@ -19,7 +19,11 @@ package org.apache.nifi.processors.standard;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -27,14 +31,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestReplaceTextWithMapping {
+    private TestRunner runner;
 
-    public TestRunner getRunner() {
-        TestRunner runner = TestRunners.newTestRunner(ReplaceTextWithMapping.class);
+    @BeforeEach
+    public void setUp() {
+        runner = TestRunners.newTestRunner(ReplaceTextWithMapping.class);
 
         /*
          * we have to disable validation of expression language because the processor will
@@ -42,32 +49,37 @@ public class TestReplaceTextWithMapping {
          * the test will throw an error about the evaluation scope
          */
         runner.setValidateExpressionUsage(false);
-
-        return runner;
     }
 
-    @Test
-    public void testSimple() throws IOException {
-        final TestRunner runner = getRunner();
-        final String mappingFile = Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-mapping.txt").toFile().getAbsolutePath();
+    @ParameterizedTest
+    @MethodSource("simpleTestArgs")
+    public void testSimple(String mappingFile) throws IOException {
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, mappingFile);
 
         runner.enqueue(Paths.get("src/test/resources/TestReplaceTextWithMapping/colors-without-dashes.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "roses are apple\n"
-                + "violets are blueberry\n"
-                + "something else is grape\n"
-                + "I'm not good at writing poems";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        final String expected = """
+                roses are apple
+                violets are blueberry
+                something else is grape
+                I'm not good at writing poems""";
         assertEquals(expected, outputString);
     }
 
+    private static Stream<Arguments> simpleTestArgs() throws IOException {
+        final Path mappingFile = Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-mapping.txt");
+        return Stream.of(
+                Arguments.argumentSet("File path", mappingFile.toFile().getAbsolutePath()),
+                Arguments.argumentSet("File contents", Files.readString(mappingFile))
+        );
+    }
+
     @Test
-    public void testExpressionLanguageInText() throws IOException {
-        final TestRunner runner = getRunner();
+    public void testExpressionLanguageInText() {
         final String mappingFile = Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-mapping.txt").toFile().getAbsolutePath();
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, mappingFile);
 
@@ -77,15 +89,14 @@ public class TestReplaceTextWithMapping {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "${foo} apple ${baz}";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        final String expected = "${foo} apple ${baz}";
         assertEquals(expected, outputString);
     }
 
     @Test
-    public void testExpressionLanguageInText2() throws IOException {
-        final TestRunner runner = getRunner();
+    public void testExpressionLanguageInText2() {
         final String mappingFile = Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-mapping.txt").toFile().getAbsolutePath();
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, mappingFile);
         runner.setProperty(ReplaceTextWithMapping.REGEX, "\\|(.*?)\\|");
@@ -97,15 +108,14 @@ public class TestReplaceTextWithMapping {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "${foo}|apple|${baz}";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        final String expected = "${foo}|apple|${baz}";
         assertEquals(expected, outputString);
     }
 
     @Test
-    public void testExpressionLanguageInText3() throws IOException {
-        final TestRunner runner = getRunner();
+    public void testExpressionLanguageInText3() {
         final String mappingFile = Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-mapping.txt").toFile().getAbsolutePath();
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, mappingFile);
         runner.setProperty(ReplaceTextWithMapping.REGEX, ".*\\|(.*?)\\|.*");
@@ -117,15 +127,14 @@ public class TestReplaceTextWithMapping {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "${foo}|apple|${baz}";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        final String expected = "${foo}|apple|${baz}";
         assertEquals(expected, outputString);
     }
 
     @Test
     public void testWithMatchingGroupAndContext() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.REGEX, "-(.*?)-");
         runner.setProperty(ReplaceTextWithMapping.MATCHING_GROUP_FOR_LOOKUP_KEY, "1");
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-mapping.txt").toFile().getAbsolutePath());
@@ -134,18 +143,18 @@ public class TestReplaceTextWithMapping {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "-roses- are -apple-\n"
-                + "violets are -blueberry-\n"
-                + "something else is -grape-\n"
-                + "I'm not good at writing poems";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        final String expected = """
+                -roses- are -apple-
+                violets are -blueberry-
+                something else is -grape-
+                I'm not good at writing poems""";
         assertEquals(expected, outputString);
     }
 
     @Test
     public void testBackReference() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.REGEX, "(\\S+)");
         runner.setProperty(ReplaceTextWithMapping.MATCHING_GROUP_FOR_LOOKUP_KEY, "1");
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-backreference-mapping.txt").toFile().getAbsolutePath());
@@ -154,25 +163,25 @@ public class TestReplaceTextWithMapping {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "roses are red apple\n"
-                + "violets are blue blueberry\n"
-                + "something else is green grape\n"
-                + "I'm not good at writing poems";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        final String expected = """
+                roses are red apple
+                violets are blue blueberry
+                something else is green grape
+                I'm not good at writing poems""";
         assertEquals(expected, outputString);
     }
 
     @Test
     public void testRoutesToFailureIfTooLarge() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.REGEX, "[123]");
         runner.setProperty(ReplaceTextWithMapping.MAX_BUFFER_SIZE, "1 b");
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-mapping.txt").toFile().getAbsolutePath());
 
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("abc", "Good");
-        runner.enqueue(Paths.get("src/test/resources/TestReplaceTextWithMapping/colors.txt"));
+        runner.enqueue(Paths.get("src/test/resources/TestReplaceTextWithMapping/colors.txt"), attributes);
 
         runner.run();
 
@@ -181,7 +190,6 @@ public class TestReplaceTextWithMapping {
 
     @Test
     public void testBackReferenceWithTooLargeOfIndexIsEscaped() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.REGEX, "-(.*?)-");
         runner.setProperty(ReplaceTextWithMapping.MATCHING_GROUP_FOR_LOOKUP_KEY, "1");
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-excessive-backreference-mapping.txt").toFile().getAbsolutePath());
@@ -190,18 +198,18 @@ public class TestReplaceTextWithMapping {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "-roses- are -red$2 apple-\n"
-                + "violets are -blue$2 blueberry-\n"
-                + "something else is -green$2 grape-\n"
-                + "I'm not good at writing poems";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        final String expected = """
+                -roses- are -red$2 apple-
+                violets are -blue$2 blueberry-
+                something else is -green$2 grape-
+                I'm not good at writing poems""";
         assertEquals(expected, outputString);
     }
 
     @Test
     public void testBackReferenceWithTooLargeOfIndexIsEscapedSimple() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE,
                 Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-excessive-backreference-mapping-simple.txt").toFile().getAbsolutePath());
 
@@ -209,18 +217,18 @@ public class TestReplaceTextWithMapping {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "roses are red$1 apple\n"
-                + "violets are blue$1 blueberry\n"
-                + "something else is green$1 grape\n"
-                + "I'm not good at writing poems";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        final String expected = """
+                roses are red$1 apple
+                violets are blue$1 blueberry
+                something else is green$1 grape
+                I'm not good at writing poems""";
         assertEquals(expected, outputString);
     }
 
     @Test
     public void testBackReferenceWithInvalidReferenceIsEscaped() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.REGEX, "(\\S+)");
         runner.setProperty(ReplaceTextWithMapping.MATCHING_GROUP_FOR_LOOKUP_KEY, "1");
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-invalid-backreference-mapping.txt").toFile().getAbsolutePath());
@@ -229,18 +237,18 @@ public class TestReplaceTextWithMapping {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "roses are red$d apple\n"
-                + "violets are blue$d blueberry\n"
-                + "something else is green$d grape\n"
-                + "I'm not good at writing poems";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        String expected = """
+                roses are red$d apple
+                violets are blue$d blueberry
+                something else is green$d grape
+                I'm not good at writing poems""";
         assertEquals(expected, outputString);
     }
 
     @Test
     public void testEscapingDollarSign() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.REGEX, "-(.*?)-");
         runner.setProperty(ReplaceTextWithMapping.MATCHING_GROUP_FOR_LOOKUP_KEY, "1");
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-escaped-dollar-mapping.txt").toFile().getAbsolutePath());
@@ -249,72 +257,72 @@ public class TestReplaceTextWithMapping {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "-roses- are -$1 apple-\n"
-                + "violets are -$1 blueberry-\n"
-                + "something else is -$1 grape-\n"
-                + "I'm not good at writing poems";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        final String expected = """
+                -roses- are -$1 apple-
+                violets are -$1 blueberry-
+                something else is -$1 grape-
+                I'm not good at writing poems""";
         assertEquals(expected, outputString);
     }
 
     @Test
     public void testEscapingDollarSignSimple() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-escaped-dollar-mapping.txt").toFile().getAbsolutePath());
 
         runner.enqueue(Paths.get("src/test/resources/TestReplaceTextWithMapping/colors-without-dashes.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "roses are $1 apple\n"
-                + "violets are $1 blueberry\n"
-                + "something else is $1 grape\n"
-                + "I'm not good at writing poems";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        final String expected = """
+                roses are $1 apple
+                violets are $1 blueberry
+                something else is $1 grape
+                I'm not good at writing poems""";
         assertEquals(expected, outputString);
     }
 
     @Test
     public void testReplaceWithEmptyString() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-blank-mapping.txt").toFile().getAbsolutePath());
 
         runner.enqueue(Paths.get("src/test/resources/TestReplaceTextWithMapping/colors-without-dashes.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "roses are \n"
-                + "violets are \n"
-                + "something else is \n"
-                + "I'm not good at writing poems";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        String expected = """
+                roses are\s
+                violets are\s
+                something else is\s
+                I'm not good at writing poems""";
         assertEquals(expected, outputString);
     }
 
     @Test
     public void testReplaceWithSpaceInString() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-space-mapping.txt").toFile().getAbsolutePath());
 
         runner.enqueue(Paths.get("src/test/resources/TestReplaceTextWithMapping/colors-without-dashes.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = "roses are really red\n"
-                + "violets are super blue\n"
-                + "something else is ultra green\n"
-                + "I'm not good at writing poems";
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        String expected = """
+                roses are really red
+                violets are super blue
+                something else is ultra green
+                I'm not good at writing poems""";
         assertEquals(expected, outputString);
     }
 
     @Test
     public void testWithNoMatch() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.REGEX, "-(.*?)-");
         runner.setProperty(ReplaceTextWithMapping.MATCHING_GROUP_FOR_LOOKUP_KEY, "1");
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, Paths.get("src/test/resources/TestReplaceTextWithMapping/color-fruit-no-match-mapping.txt").toFile().getAbsolutePath());
@@ -324,24 +332,20 @@ public class TestReplaceTextWithMapping {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
-        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).get(0);
-        String outputString = new String(out.toByteArray());
-        String expected = new String(Files.readAllBytes(path));
+        final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
+        final String outputString = out.getContent();
+        final String expected = Files.readString(path);
         assertEquals(expected, outputString);
     }
 
     @Test
     public void testMatchingGroupForLookupKeyTooLarge() throws IOException {
-        final TestRunner runner = getRunner();
         runner.setProperty(ReplaceTextWithMapping.REGEX, "-(.*?)-");
         runner.setProperty(ReplaceTextWithMapping.MATCHING_GROUP_FOR_LOOKUP_KEY, "2");
         runner.setProperty(ReplaceTextWithMapping.MAPPING_FILE, Paths.get("src/test/resources/TestReplaceTextWithMapping/color-mapping.txt").toFile().getAbsolutePath());
 
         final Path path = Paths.get("src/test/resources/TestReplaceTextWithMapping/colors.txt");
         runner.enqueue(path);
-        assertThrows(AssertionError.class, () -> {
-            runner.run();
-        });
+        assertThrows(AssertionError.class, runner::run);
     }
-
 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestReplaceTextWithMapping.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestReplaceTextWithMapping.java
@@ -239,7 +239,7 @@ public class TestReplaceTextWithMapping {
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
         final String outputString = out.getContent();
-        String expected = """
+        final String expected = """
                 roses are red$d apple
                 violets are blue$d blueberry
                 something else is green$d grape
@@ -295,7 +295,7 @@ public class TestReplaceTextWithMapping {
         runner.assertAllFlowFilesTransferred(ReplaceTextWithMapping.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceTextWithMapping.REL_SUCCESS).getFirst();
         final String outputString = out.getContent();
-        String expected = """
+        final String expected = """
                 roses are\s
                 violets are\s
                 something else is\s


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11295](https://issues.apache.org/jira/browse/NIFI-11295)
In addition to expanding the Mapping File property to take the mapping file content, refactored the `TestReplaceTextWithMapping` to have a `setUp` method annotated with the JUnit5 `BeforeEach` annotation and changed from using the `MockFlowFile` `toByteArray` method to using the `getContent` method.


# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [x] Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
