### PR TITLE
NIFI-15811 Validate First Commit Message for Jira Issue Number

### DIFF
--- a/.github/scripts/build/validate-commit-messages.sh
+++ b/.github/scripts/build/validate-commit-messages.sh
@@ -16,19 +16,18 @@
 
 set -e
 
-INVALID=0
-COMMITS=$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}/commits" --jq '.[].commit.message | split("\n") | .[0]')
+COMMITS_JSON=$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}/commits")
+FIRST_LINE=$(echo "${COMMITS_JSON}" | jq -r 'if length > 0 then .[0].commit.message | split("\n") | .[0] else empty end')
 
-while IFS= read -r FIRST_LINE; do
-  if ! echo "${FIRST_LINE}" | grep -qP '^NIFI-[1-9][0-9]+'; then
-    echo "::error::Commit message does not start with Apache NiFi Jira issue number: ${FIRST_LINE}"
-    INVALID=1
-  fi
-done <<< "${COMMITS}"
-
-if [ "${INVALID}" -eq 1 ]; then
-  echo "::error::All commit messages must start with an Apache NiFi Jira issue number such as NIFI-00000"
+if [ -z "${FIRST_LINE}" ]; then
+  echo "::error::No commits found for pull request"
   exit 1
 fi
 
-echo "All commit messages start with a valid Apache NiFi Jira issue number"
+if ! echo "${FIRST_LINE}" | grep -qP '^NIFI-[1-9][0-9]+'; then
+  echo "::error::First commit message does not start with Apache NiFi Jira issue number: ${FIRST_LINE}"
+  echo "::error::The first commit message must start with an Apache NiFi Jira issue number such as NIFI-00000"
+  exit 1
+fi
+
+echo "The first commit message starts with a valid Apache NiFi Jira issue number"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     name: Validate Pull Request
-    if: github.event_name == 'pull_request' && github.repository == 'apache/nifi'
+    if: github.event_name == 'pull_request' && github.repository == 'apache/nifi' && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -107,12 +107,13 @@ jobs:
           COMMIT_COUNT: ${{ github.event.pull_request.commits }}
           GITHUB_EVENT_ACTION: ${{ github.event.action }}
         run: .github/scripts/build/validate-single-commit.sh
-      - name: Evaluate Validation Results
+      - name: Validation Results
         env:
           VALIDATION_FAILED: ${{ contains(steps.*.outcome, 'failure') }}
         run: |
           if [[ "${VALIDATION_FAILED}" == "true" ]]; then
-            echo "::error::Pull request validation failed"
+            RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "::error::Pull request validation failed. Review workflow run: ${RUN_URL}"
             exit 1
           fi
 


### PR DESCRIPTION
# Summary

[NIFI-15811](https://issues.apache.org/jira/browse/NIFI-15811) Adjusts the GitHub `build` workflow to validate only the first commit message on a pull request branch to start a project Jira issue number. This supports commit tracking and aligns with the standard merge process, which squashes intermediate commits when merging an approved branch.

Additional adjustments exclude GitHub `dependabot` pull requests from validation checking, and add a link to the workflow run when writing the summary message for validation failures.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
