### PR TITLE
NIFI-15830 - Fix local change detection for versioned process groups when setting previously unset properties

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
@@ -943,12 +943,17 @@ public class FlowDifferenceFilters {
 
     /**
      * Determines whether a PROPERTY_ADDED difference is an environmental change because the added property is a
-     * non-dynamic property defined in the component code. Non-dynamic properties are declared through
-     * {@link ConfigurableComponent#getPropertyDescriptors()} and cannot be added by users. When a PROPERTY_ADDED
-     * diff exists for such a property, it means the component's code was updated (e.g., via NiFi upgrade or bundle
-     * version change) and migration added the property. This is an environmental change regardless of whether a
-     * corresponding BUNDLE_CHANGED diff is present, because the VCI baseline may already have resolved bundles
-     * (e.g., after {@code discoverCompatibleBundles} during import).
+     * non-dynamic property defined in the component code that did not exist in the versioned snapshot. Non-dynamic
+     * properties are declared through {@link ConfigurableComponent#getPropertyDescriptors()} and cannot be added by
+     * users. When a PROPERTY_ADDED diff exists for such a property and the snapshot did not already define it, it
+     * means the component's code was updated (e.g., via NiFi upgrade or bundle version change) and migration added
+     * the property. This is an environmental change regardless of whether a corresponding BUNDLE_CHANGED diff is
+     * present, because the VCI baseline may already have resolved bundles (e.g., after
+     * {@code discoverCompatibleBundles} during import).
+     *
+     * <p>If the snapshot (component A) already contains a property descriptor for the property in question, the
+     * property was part of the component definition when the flow was committed and the user has intentionally set
+     * a value. In that case, this method returns {@code false} so the change is treated as a local modification.</p>
      *
      * <p>Only Processors and Controller Services are considered because these are the component types that carry
      * properties within versioned process groups.</p>
@@ -967,6 +972,14 @@ public class FlowDifferenceFilters {
         final Optional<String> fieldName = difference.getFieldName();
         if (fieldName.isEmpty()) {
             return false;
+        }
+
+        final VersionedComponent componentA = difference.getComponentA();
+        if (componentA != null) {
+            final Map<String, VersionedPropertyDescriptor> descriptorsA = getPropertyDescriptors(componentA);
+            if (descriptorsA.containsKey(fieldName.get())) {
+                return false;
+            }
         }
 
         final VersionedComponent componentB = difference.getComponentB();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
@@ -741,6 +741,62 @@ public class TestFlowDifferenceFilters {
     }
 
     @Test
+    public void testPropertySetByUserOnProcessorIsNotEnvironmentalChange() {
+        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final ProcessorNode processorNode = Mockito.mock(ProcessorNode.class);
+        final ConfigurableComponent configurableComponent = Mockito.mock(ConfigurableComponent.class);
+
+        final String propertyName = "Table";
+        final String instanceId = "processor-instance";
+
+        Mockito.when(flowManager.getProcessorNode(instanceId)).thenReturn(processorNode);
+        Mockito.when(processorNode.getComponent()).thenReturn(configurableComponent);
+        Mockito.when(configurableComponent.getPropertyDescriptors()).thenReturn(List.of(
+                new PropertyDescriptor.Builder().name(propertyName).build()));
+
+        final VersionedPropertyDescriptor versionedDescriptor = new VersionedPropertyDescriptor();
+        versionedDescriptor.setName(propertyName);
+        versionedDescriptor.setDisplayName(propertyName);
+
+        final VersionedProcessor registryProcessor = new VersionedProcessor();
+        registryProcessor.setPropertyDescriptors(Map.of(propertyName, versionedDescriptor));
+
+        final InstantiatedVersionedProcessor localProcessor = new InstantiatedVersionedProcessor(instanceId, "group-id");
+        final FlowDifference difference = new StandardFlowDifference(
+                DifferenceType.PROPERTY_ADDED, registryProcessor, localProcessor, propertyName, null, "userValue", "Property set by user");
+
+        assertFalse(FlowDifferenceFilters.isEnvironmentalChange(difference, null, flowManager));
+    }
+
+    @Test
+    public void testPropertySetByUserOnControllerServiceIsNotEnvironmentalChange() {
+        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final ControllerServiceNode controllerServiceNode = Mockito.mock(ControllerServiceNode.class);
+        final ConfigurableComponent configurableComponent = Mockito.mock(ConfigurableComponent.class);
+
+        final String propertyName = "Service Property";
+        final String instanceId = "service-instance";
+
+        Mockito.when(flowManager.getControllerServiceNode(instanceId)).thenReturn(controllerServiceNode);
+        Mockito.when(controllerServiceNode.getComponent()).thenReturn(configurableComponent);
+        Mockito.when(configurableComponent.getPropertyDescriptors()).thenReturn(List.of(
+                new PropertyDescriptor.Builder().name(propertyName).build()));
+
+        final VersionedPropertyDescriptor versionedDescriptor = new VersionedPropertyDescriptor();
+        versionedDescriptor.setName(propertyName);
+        versionedDescriptor.setDisplayName(propertyName);
+
+        final VersionedControllerService registryService = new VersionedControllerService();
+        registryService.setPropertyDescriptors(Map.of(propertyName, versionedDescriptor));
+
+        final InstantiatedVersionedControllerService localService = new InstantiatedVersionedControllerService(instanceId, "group-id");
+        final FlowDifference difference = new StandardFlowDifference(
+                DifferenceType.PROPERTY_ADDED, registryService, localService, propertyName, null, "userValue", "Property set by user");
+
+        assertFalse(FlowDifferenceFilters.isEnvironmentalChange(difference, null, flowManager));
+    }
+
+    @Test
     public void testIsComponentUpdateRequiredForPositionChange() {
         final FlowManager flowManager = Mockito.mock(FlowManager.class);
         final VersionedProcessor processorA = new VersionedProcessor();


### PR DESCRIPTION
# Summary

NIFI-15830 - Fix local change detection for versioned process groups when setting previously unset properties

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
