### PR TITLE
NIFI-15810 Document missing RecordPath functions

### DIFF
--- a/nifi-docs/src/main/asciidoc/record-path-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/record-path-guide.adoc
@@ -446,6 +446,18 @@ and the replacement value. The replacement value may optionally use back-referen
 
 
 
+=== replaceNull
+
+Returns the value of the first argument when it is non-null. If the first argument evaluates to `null`, the function returns the replacement value.
+
+|==========================================================
+| RecordPath | Return value
+| `replaceNull( /details/vehicle, 'no vehicle' )` | no vehicle
+| `replaceNull( /name, 'default' )` | John Doe
+| `replaceNull( /details/vehicle, /name )` | John Doe
+|==========================================================
+
+
 === concat
 
 Concatenates all the arguments together.
@@ -1327,6 +1339,21 @@ Returns `true` if a String value contains the provided substring, `false` otherw
 | `/name[contains(., 'o')]` | John Doe
 | `/name[contains(., 'x')]` | <returns no results>
 | `/name[contains( ../workAddress/state, /details/preferredState )]` | John Doe
+|==============================================================================
+
+
+
+=== containsRegex
+
+Evaluates a Regular Expression against the contents of a String value and returns `true` if the String value contains a substring
+that matches the Regular Expression, `false` otherwise.
+This function requires 2 arguments: the String to run the regular expression against, and the regular expression to run.
+
+|==============================================================================
+| RecordPath | Return value
+| `/name[containsRegex(., 'o[gh]n')]` | John Doe
+| `/name[containsRegex(., 'John')]` | John Doe
+| `/name[containsRegex(., 'o[xy]n')]` | <returns no results>
 |==============================================================================
 
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15810](https://issues.apache.org/jira/browse/NIFI-15810)

~~In addition to the changes, there are some functions which are present in the repository docs, but are absent in the [public docs](https://nifi.apache.org/docs/nifi-docs/html/record-path-guide.html). E.g. Math Functions, like `toNumber`.~~ That's a reference to v1 docs.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files. Verified with 
```sh
./mvnw -q -pl nifi-docs package -DskipTests && open nifi-docs/target/generated-docs/record-path-guide.html
```
