### PR TITLE
NIFI-15835 - Flaky test PollingKinesisClientTest.testExpiredIteratorRecoveryDoesNotDeliverSameShardOutOfOrder

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/test/java/org/apache/nifi/processors/aws/kinesis/PollingKinesisClientTest.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/test/java/org/apache/nifi/processors/aws/kinesis/PollingKinesisClientTest.java
@@ -194,6 +194,7 @@ class PollingKinesisClientTest {
     void testExpiredIteratorRecoveryDoesNotDeliverSameShardOutOfOrder() throws Exception {
         final AtomicInteger getRecordsCallCount = new AtomicInteger();
         final AtomicInteger getShardIteratorCallCount = new AtomicInteger();
+        final CountDownLatch firstResultPolled = new CountDownLatch(1);
 
         when(mockShardManager.readCheckpoint(anyString())).thenReturn("100");
         when(mockKinesisClient.getShardIterator(any(GetShardIteratorRequest.class))).thenAnswer(invocation -> {
@@ -211,11 +212,14 @@ class PollingKinesisClientTest {
                         .nextShardIterator("iter-1a")
                         .millisBehindLatest(0L)
                         .build();
-                case "iter-1a" -> GetRecordsResponse.builder()
-                        .records(record("300", "B"))
-                        .nextShardIterator("iter-1b")
-                        .millisBehindLatest(0L)
-                        .build();
+                case "iter-1a" -> {
+                    firstResultPolled.await(10, TimeUnit.SECONDS);
+                    yield GetRecordsResponse.builder()
+                            .records(record("300", "B"))
+                            .nextShardIterator("iter-1b")
+                            .millisBehindLatest(0L)
+                            .build();
+                }
                 case "iter-1b" -> throw ExpiredIteratorException.builder().message("expired").build();
                 case "iter-2" -> GetRecordsResponse.builder()
                         .records(record("200", "A-replay"))
@@ -236,11 +240,7 @@ class PollingKinesisClientTest {
         assertNotNull(firstResult, "Initial result must be available");
         assertEquals(new BigInteger("200"), firstResult.firstSequenceNumber());
 
-        final long newerQueuedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-        while (System.nanoTime() < newerQueuedDeadline && getRecordsCallCount.get() < 2) {
-            Thread.sleep(20);
-        }
-        Thread.sleep(50);
+        firstResultPolled.countDown();
 
         final long replayQueuedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
         while (System.nanoTime() < replayQueuedDeadline && (getShardIteratorCallCount.get() < 2 || getRecordsCallCount.get() < 4)) {


### PR DESCRIPTION
# Summary

NIFI-15835 - Flaky test PollingKinesisClientTest.testExpiredIteratorRecoveryDoesNotDeliverSameShardOutOfOrder

The fetch loop runs with 1-nanosecond backoffs, so on some thread schedules it could complete the entire cycle (fetch seq 200, fetch seq 300, hit `ExpiredIteratorException`, drain the shard queue, replay from checkpoint) before the test thread's first `pollAnyResult` call. The drain removed both batches (including the one the test expected to poll first), and the replay batch was consumed by the first poll, leaving nothing for the second poll -- which then returned null after 5 seconds.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
