### PR TITLE
NIFI-15834 Disable ZooKeeper Admin Server in Embedded Configuration

### DIFF
--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-zookeeper-state-provider/src/main/java/org/apache/nifi/controller/state/providers/zookeeper/server/ZooKeeperStateServer.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-zookeeper-state-provider/src/main/java/org/apache/nifi/controller/state/providers/zookeeper/server/ZooKeeperStateServer.java
@@ -50,6 +50,7 @@ public class ZooKeeperStateServer extends ZooKeeperServerMain {
     private static final String ZOOKEEPER_SSL_QUORUM = "sslQuorum";
     private static final String ZOOKEEPER_PORT_UNIFICATION = "portUnification";
     private static final String ZOOKEEPER_SERVER_CNXN_FACTORY = "serverCnxnFactory";
+    private static final String ZOOKEEPER_ADMIN_ENABLE_SERVER = "admin.enableServer";
     private final QuorumPeerConfig quorumPeerConfig;
     private volatile boolean started = false;
 
@@ -272,6 +273,9 @@ public class ZooKeeperStateServer extends ZooKeeperServerMain {
 
         // Port unification allows both secure and insecure connections - setting to false means only secure connections will be allowed.
         zkProperties.setProperty(ZOOKEEPER_PORT_UNIFICATION, Boolean.FALSE.toString());
+
+        // Disable ZooKeeper Admin Server to avoid resource consumption and dependency issues
+        zkProperties.setProperty(ZOOKEEPER_ADMIN_ENABLE_SERVER, Boolean.FALSE.toString());
 
         // Recreate and reload the adjusted properties to ensure they're still valid for ZK:
         peerConfig = new QuorumPeerConfig();

--- a/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/zookeeper.properties
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/zookeeper.properties
@@ -44,14 +44,6 @@ autopurge.snapRetainCount=30
 #
 # https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_configuration
 
-# Other common settings:
-#
-# client.portUnification=true
-# admin.enableServer=false
-
-# The server string has changed as of 3.5.5 and the client port is now specified at the end of the server string:
-# https://zookeeper.apache.org/doc/r3.5.5/zookeeperReconfig.html#sc_reconfig_clientport
-#
 # Specifies the servers that are part of this zookeeper ensemble. For
 # every NiFi instance running an embedded zookeeper, there needs to be
 # a server entry below. Client port is now specified at the end of the string


### PR DESCRIPTION
# Summary

[NIFI-15834](https://issues.apache.org/jira/browse/NIFI-15834) Disables the ZooKeeper Admin Server in the embedded configuration for the `ZooKeeperStateServer` implementation.

The ZooKeeper Admin Server provides non-essential monitoring information, which consumes additional resources and requires additional dependencies, such as specific versions of Jetty. Disabling the Admin Server in the standard configuration avoids potential ambiguity associated with configuring this property in the `zookeeper.properties` file, ensuring minimum resource consumption.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
