### PR TITLE
NIFI-15818: Implementing route-backed component selection so selecting a processor/connection/etc on the canvas updates the URL, and vice versa.

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.actions.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.actions.ts
@@ -16,8 +16,24 @@
  */
 
 import { createAction, props } from '@ngrx/store';
+import { ComponentType } from '@nifi/shared';
 import { BreadcrumbEntity } from '../../../flow-designer/state/shared';
 import { ErrorContext } from '../../../../state/error';
+
+/**
+ * Selected component for route-based selection
+ */
+export interface SelectedComponent {
+    id: string;
+    componentType: ComponentType;
+}
+
+/**
+ * Request for selecting components
+ */
+export interface SelectComponentsRequest {
+    components: SelectedComponent[];
+}
 
 export const loadConnectorFlow = createAction(
     '[Connector Canvas] Load Connector Flow',
@@ -56,6 +72,31 @@ export const enterProcessGroup = createAction(
 
 export const leaveProcessGroup = createAction('[Connector Canvas] Leave Process Group');
 
+/**
+ * Selection actions (trigger route updates)
+ */
+export const selectComponents = createAction(
+    '[Connector Canvas] Select Components',
+    props<{ request: SelectComponentsRequest }>()
+);
+
+export const deselectAllComponents = createAction('[Connector Canvas] Deselect All Components');
+
+/**
+ * Navigation action (internal - updates router)
+ */
+export const navigateWithoutTransform = createAction(
+    '[Connector Canvas] Navigate Without Transform',
+    props<{ url: string[] }>()
+);
+
+/**
+ * skipTransform is used when handling URL events for component selection. Since the
+ * URL is the source of truth, we set skipTransform when the URL changes due to user
+ * selection on the canvas. However, we do not want the transform skipped when using
+ * a deep link or leaving a process group -- in those cases the viewport should center
+ * on the selected component(s).
+ */
 export const setSkipTransform = createAction(
     '[Connector Canvas] Set Skip Transform',
     props<{ skipTransform: boolean }>()

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.spec.ts
@@ -307,7 +307,7 @@ describe('ConnectorCanvasEffects', () => {
             });
             actions$(of(leaveProcessGroup()));
 
-            await firstValueFrom(effects.leaveProcessGroup$.pipe(() => of(undefined)));
+            await expect(firstValueFrom(effects.leaveProcessGroup$)).rejects.toThrow();
             expect(mockRouter.navigate).not.toHaveBeenCalled();
         });
 
@@ -319,7 +319,7 @@ describe('ConnectorCanvasEffects', () => {
             });
             actions$(of(leaveProcessGroup()));
 
-            await firstValueFrom(effects.leaveProcessGroup$.pipe(() => of(undefined)));
+            await expect(firstValueFrom(effects.leaveProcessGroup$)).rejects.toThrow();
             expect(mockRouter.navigate).not.toHaveBeenCalled();
         });
     });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.spec.ts
@@ -19,7 +19,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { Router } from '@angular/router';
-import { Observable, of, Subject, throwError } from 'rxjs';
+import { firstValueFrom, Observable, of, Subject, throwError } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ComponentType } from '@nifi/shared';
 import { ConnectorCanvasEffects } from './connector-canvas.effects';
@@ -118,355 +118,307 @@ describe('ConnectorCanvasEffects', () => {
     });
 
     describe('loadConnectorFlow$', () => {
-        it('should call getConnectorFlow and dispatch loadConnectorFlowSuccess', () =>
-            new Promise<void>((resolve) => {
-                setup().then(({ effects, actions$, mockConnectorService }) => {
-                    const flowResponse = {
-                        processGroupFlow: {
-                            id: 'pg-123',
-                            parentGroupId: 'parent-456',
-                            breadcrumb: null,
-                            flow: {
-                                labels: [{ id: 'l1' }],
-                                funnels: [],
-                                inputPorts: [],
-                                outputPorts: [],
-                                remoteProcessGroups: [],
-                                processGroups: [],
-                                processors: [],
-                                connections: []
-                            }
-                        }
-                    };
-                    (mockConnectorService.getConnectorFlow as Mock).mockReturnValue(of(flowResponse));
-                    actions$(
-                        of(
-                            loadConnectorFlow({
-                                connectorId: 'conn-a',
-                                processGroupId: 'pg-in'
-                            })
-                        )
-                    );
+        it('should call getConnectorFlow and dispatch loadConnectorFlowSuccess', async () => {
+            const { effects, actions$, mockConnectorService } = await setup();
+            const flowResponse = {
+                processGroupFlow: {
+                    id: 'pg-123',
+                    parentGroupId: 'parent-456',
+                    breadcrumb: null,
+                    flow: {
+                        labels: [{ id: 'l1' }],
+                        funnels: [],
+                        inputPorts: [],
+                        outputPorts: [],
+                        remoteProcessGroups: [],
+                        processGroups: [],
+                        processors: [],
+                        connections: []
+                    }
+                }
+            };
+            (mockConnectorService.getConnectorFlow as Mock).mockReturnValue(of(flowResponse));
+            actions$(
+                of(
+                    loadConnectorFlow({
+                        connectorId: 'conn-a',
+                        processGroupId: 'pg-in'
+                    })
+                )
+            );
 
-                    effects.loadConnectorFlow$.subscribe((action) => {
-                        expect(mockConnectorService.getConnectorFlow).toHaveBeenCalledWith('conn-a', 'pg-in');
-                        expect(action).toEqual(
-                            loadConnectorFlowSuccess({
-                                connectorId: 'conn-a',
-                                processGroupId: 'pg-123',
-                                parentProcessGroupId: 'parent-456',
-                                breadcrumb: null,
-                                labels: [{ id: 'l1' }],
-                                funnels: [],
-                                inputPorts: [],
-                                outputPorts: [],
-                                remoteProcessGroups: [],
-                                processGroups: [],
-                                processors: [],
-                                connections: []
-                            })
-                        );
-                        resolve();
-                    });
-                });
-            }));
+            const action = await firstValueFrom(effects.loadConnectorFlow$);
+            expect(mockConnectorService.getConnectorFlow).toHaveBeenCalledWith('conn-a', 'pg-in');
+            expect(action).toEqual(
+                loadConnectorFlowSuccess({
+                    connectorId: 'conn-a',
+                    processGroupId: 'pg-123',
+                    parentProcessGroupId: 'parent-456',
+                    breadcrumb: null,
+                    labels: [{ id: 'l1' }],
+                    funnels: [],
+                    inputPorts: [],
+                    outputPorts: [],
+                    remoteProcessGroups: [],
+                    processGroups: [],
+                    processors: [],
+                    connections: []
+                })
+            );
+        });
 
-        it('should default flow collections when processGroupFlow.flow is missing', () =>
-            new Promise<void>((resolve) => {
-                setup().then(({ effects, actions$, mockConnectorService }) => {
-                    const flowResponse = {
-                        processGroupFlow: {
-                            id: 'pg-123',
-                            parentGroupId: null,
-                            breadcrumb: null
-                        }
-                    };
-                    (mockConnectorService.getConnectorFlow as Mock).mockReturnValue(of(flowResponse));
-                    actions$(
-                        of(
-                            loadConnectorFlow({
-                                connectorId: 'conn-a',
-                                processGroupId: 'pg-in'
-                            })
-                        )
-                    );
+        it('should default flow collections when processGroupFlow.flow is missing', async () => {
+            const { effects, actions$, mockConnectorService } = await setup();
+            const flowResponse = {
+                processGroupFlow: {
+                    id: 'pg-123',
+                    parentGroupId: null,
+                    breadcrumb: null
+                }
+            };
+            (mockConnectorService.getConnectorFlow as Mock).mockReturnValue(of(flowResponse));
+            actions$(
+                of(
+                    loadConnectorFlow({
+                        connectorId: 'conn-a',
+                        processGroupId: 'pg-in'
+                    })
+                )
+            );
 
-                    effects.loadConnectorFlow$.subscribe((action) => {
-                        expect(action).toEqual(
-                            loadConnectorFlowSuccess({
-                                connectorId: 'conn-a',
-                                processGroupId: 'pg-123',
-                                parentProcessGroupId: null,
-                                breadcrumb: null,
-                                labels: [],
-                                funnels: [],
-                                inputPorts: [],
-                                outputPorts: [],
-                                remoteProcessGroups: [],
-                                processGroups: [],
-                                processors: [],
-                                connections: []
-                            })
-                        );
-                        resolve();
-                    });
-                });
-            }));
+            const action = await firstValueFrom(effects.loadConnectorFlow$);
+            expect(action).toEqual(
+                loadConnectorFlowSuccess({
+                    connectorId: 'conn-a',
+                    processGroupId: 'pg-123',
+                    parentProcessGroupId: null,
+                    breadcrumb: null,
+                    labels: [],
+                    funnels: [],
+                    inputPorts: [],
+                    outputPorts: [],
+                    remoteProcessGroups: [],
+                    processGroups: [],
+                    processors: [],
+                    connections: []
+                })
+            );
+        });
 
-        it('should dispatch loadConnectorFlowFailure when getConnectorFlow errors', () =>
-            new Promise<void>((resolve) => {
-                setup().then(({ effects, actions$, mockConnectorService, mockErrorHelper }) => {
-                    const errorResponse = new HttpErrorResponse({ error: 'Failed', status: 500, statusText: 'ISE' });
-                    (mockConnectorService.getConnectorFlow as Mock).mockReturnValue(throwError(() => errorResponse));
-                    actions$(
-                        of(
-                            loadConnectorFlow({
-                                connectorId: 'conn-a',
-                                processGroupId: 'pg-in'
-                            })
-                        )
-                    );
+        it('should dispatch loadConnectorFlowFailure when getConnectorFlow errors', async () => {
+            const { effects, actions$, mockConnectorService, mockErrorHelper } = await setup();
+            const errorResponse = new HttpErrorResponse({ error: 'Failed', status: 500, statusText: 'ISE' });
+            (mockConnectorService.getConnectorFlow as Mock).mockReturnValue(throwError(() => errorResponse));
+            actions$(
+                of(
+                    loadConnectorFlow({
+                        connectorId: 'conn-a',
+                        processGroupId: 'pg-in'
+                    })
+                )
+            );
 
-                    effects.loadConnectorFlow$.subscribe((action) => {
-                        expect(mockErrorHelper.getErrorString).toHaveBeenCalledWith(errorResponse);
-                        expect(action).toEqual(
-                            loadConnectorFlowFailure({
-                                errorContext: {
-                                    errors: ['Error message'],
-                                    context: ErrorContextKey.CONNECTORS
-                                }
-                            })
-                        );
-                        resolve();
-                    });
-                });
-            }));
+            const action = await firstValueFrom(effects.loadConnectorFlow$);
+            expect(mockErrorHelper.getErrorString).toHaveBeenCalledWith(errorResponse);
+            expect(action).toEqual(
+                loadConnectorFlowFailure({
+                    errorContext: {
+                        errors: ['Error message'],
+                        context: ErrorContextKey.CONNECTORS
+                    }
+                })
+            );
+        });
     });
 
     describe('loadConnectorFlowComplete$', () => {
-        it('should dispatch loadConnectorFlowComplete on loadConnectorFlowSuccess', () =>
-            new Promise<void>((resolve) => {
-                setup().then(({ effects, actions$ }) => {
-                    actions$(
-                        of(
-                            loadConnectorFlowSuccess({
-                                connectorId: 'c1',
-                                processGroupId: 'pg1',
-                                parentProcessGroupId: null,
-                                breadcrumb: null,
-                                labels: [],
-                                funnels: [],
-                                inputPorts: [],
-                                outputPorts: [],
-                                remoteProcessGroups: [],
-                                processGroups: [],
-                                processors: [],
-                                connections: []
-                            })
-                        )
-                    );
+        it('should dispatch loadConnectorFlowComplete on loadConnectorFlowSuccess', async () => {
+            const { effects, actions$ } = await setup();
+            actions$(
+                of(
+                    loadConnectorFlowSuccess({
+                        connectorId: 'c1',
+                        processGroupId: 'pg1',
+                        parentProcessGroupId: null,
+                        breadcrumb: null,
+                        labels: [],
+                        funnels: [],
+                        inputPorts: [],
+                        outputPorts: [],
+                        remoteProcessGroups: [],
+                        processGroups: [],
+                        processors: [],
+                        connections: []
+                    })
+                )
+            );
 
-                    effects.loadConnectorFlowComplete$.subscribe((action) => {
-                        expect(action).toEqual(loadConnectorFlowComplete());
-                        resolve();
-                    });
-                });
-            }));
+            const action = await firstValueFrom(effects.loadConnectorFlowComplete$);
+            expect(action).toEqual(loadConnectorFlowComplete());
+        });
     });
 
     describe('enterProcessGroup$', () => {
-        it('should navigate to the child process group canvas URL', () =>
-            new Promise<void>((resolve) => {
-                setup({ connectorId: 'my-connector' }).then(({ effects, actions$, mockRouter }) => {
-                    actions$(
-                        of(
-                            enterProcessGroup({
-                                request: { id: 'child-pg-99' }
-                            })
-                        )
-                    );
+        it('should navigate to the child process group canvas URL', async () => {
+            const { effects, actions$, mockRouter } = await setup({ connectorId: 'my-connector' });
+            actions$(
+                of(
+                    enterProcessGroup({
+                        request: { id: 'child-pg-99' }
+                    })
+                )
+            );
 
-                    effects.enterProcessGroup$.subscribe(() => {
-                        expect(mockRouter.navigate).toHaveBeenCalledWith([
-                            '/connectors',
-                            'my-connector',
-                            'canvas',
-                            'child-pg-99'
-                        ]);
-                        resolve();
-                    });
-                });
-            }));
+            await firstValueFrom(effects.enterProcessGroup$);
+            expect(mockRouter.navigate).toHaveBeenCalledWith(['/connectors', 'my-connector', 'canvas', 'child-pg-99']);
+        });
     });
 
     describe('leaveProcessGroup$', () => {
-        it('should navigate to parent, then after loadConnectorFlowComplete dispatch navigateWithoutTransform', () =>
-            new Promise<void>((resolve) => {
-                setup({
-                    connectorId: 'conn-x',
-                    parentProcessGroupId: 'parent-pg',
-                    processGroupId: 'child-pg'
-                }).then(({ effects, actions$, mockRouter }) => {
-                    const actionSubject = new Subject<Action>();
-                    actions$(actionSubject.asObservable());
+        it('should navigate to parent, then after loadConnectorFlowComplete dispatch navigateWithoutTransform', async () => {
+            const { effects, actions$, mockRouter } = await setup({
+                connectorId: 'conn-x',
+                parentProcessGroupId: 'parent-pg',
+                processGroupId: 'child-pg'
+            });
+            const actionSubject = new Subject<Action>();
+            actions$(actionSubject.asObservable());
 
-                    effects.leaveProcessGroup$.subscribe((action) => {
-                        expect(mockRouter.navigate).toHaveBeenCalledWith([
-                            '/connectors',
-                            'conn-x',
-                            'canvas',
-                            'parent-pg'
-                        ]);
-                        expect(action).toEqual(
-                            navigateWithoutTransform({
-                                url: [
-                                    '/connectors',
-                                    'conn-x',
-                                    'canvas',
-                                    'parent-pg',
-                                    ComponentType.ProcessGroup,
-                                    'child-pg'
-                                ]
-                            })
-                        );
-                        resolve();
-                    });
+            const resultPromise = firstValueFrom(effects.leaveProcessGroup$);
 
-                    actionSubject.next(leaveProcessGroup());
-                    actionSubject.next(loadConnectorFlowComplete());
-                    actionSubject.complete();
-                });
-            }));
+            actionSubject.next(leaveProcessGroup());
+            actionSubject.next(loadConnectorFlowComplete());
+            actionSubject.complete();
 
-        it('should not navigate when parent process group id is null', () =>
-            new Promise<void>((resolve) => {
-                setup({
-                    connectorId: 'conn-x',
-                    parentProcessGroupId: null,
-                    processGroupId: 'child-pg'
-                }).then(({ effects, actions$, mockRouter }) => {
-                    actions$(of(leaveProcessGroup()));
+            const action = await resultPromise;
+            expect(mockRouter.navigate).toHaveBeenCalledWith(['/connectors', 'conn-x', 'canvas', 'parent-pg']);
+            expect(action).toEqual(
+                navigateWithoutTransform({
+                    url: ['/connectors', 'conn-x', 'canvas', 'parent-pg', ComponentType.ProcessGroup, 'child-pg']
+                })
+            );
+        });
 
-                    effects.leaveProcessGroup$.subscribe({
-                        complete: () => {
-                            expect(mockRouter.navigate).not.toHaveBeenCalled();
-                            resolve();
-                        }
-                    });
-                });
-            }));
+        it('should not navigate when parent process group id is null', async () => {
+            const { effects, actions$, mockRouter } = await setup({
+                connectorId: 'conn-x',
+                parentProcessGroupId: null,
+                processGroupId: 'child-pg'
+            });
+            actions$(of(leaveProcessGroup()));
 
-        it('should not navigate when current process group id is null', () =>
-            new Promise<void>((resolve) => {
-                setup({
-                    connectorId: 'conn-x',
-                    parentProcessGroupId: 'parent-pg',
-                    processGroupId: null
-                }).then(({ effects, actions$, mockRouter }) => {
-                    actions$(of(leaveProcessGroup()));
+            await firstValueFrom(effects.leaveProcessGroup$.pipe(() => of(undefined)));
+            expect(mockRouter.navigate).not.toHaveBeenCalled();
+        });
 
-                    effects.leaveProcessGroup$.subscribe({
-                        complete: () => {
-                            expect(mockRouter.navigate).not.toHaveBeenCalled();
-                            resolve();
-                        }
-                    });
-                });
-            }));
+        it('should not navigate when current process group id is null', async () => {
+            const { effects, actions$, mockRouter } = await setup({
+                connectorId: 'conn-x',
+                parentProcessGroupId: 'parent-pg',
+                processGroupId: null
+            });
+            actions$(of(leaveProcessGroup()));
+
+            await firstValueFrom(effects.leaveProcessGroup$.pipe(() => of(undefined)));
+            expect(mockRouter.navigate).not.toHaveBeenCalled();
+        });
     });
 
     describe('selectComponents$', () => {
-        it('should dispatch navigateWithoutTransform with single component URL', () =>
-            new Promise<void>((resolve) => {
-                setup({
-                    connectorId: 'conn-1',
-                    processGroupIdFromRoute: 'pg-root'
-                }).then(({ effects, actions$ }) => {
-                    actions$(
-                        of(
-                            selectComponents({
-                                request: {
-                                    components: [{ id: 'proc-1', componentType: ComponentType.Processor }]
-                                }
-                            })
-                        )
-                    );
+        it('should dispatch deselectAllComponents when components array is empty', async () => {
+            const { effects, actions$ } = await setup({
+                connectorId: 'conn-1',
+                processGroupIdFromRoute: 'pg-root'
+            });
+            actions$(
+                of(
+                    selectComponents({
+                        request: {
+                            components: []
+                        }
+                    })
+                )
+            );
 
-                    effects.selectComponents$.subscribe((action) => {
-                        expect(action).toEqual(
-                            navigateWithoutTransform({
-                                url: ['/connectors', 'conn-1', 'canvas', 'pg-root', ComponentType.Processor, 'proc-1']
-                            })
-                        );
-                        resolve();
-                    });
-                });
-            }));
+            const action = await firstValueFrom(effects.selectComponents$);
+            expect(action).toEqual(deselectAllComponents());
+        });
 
-        it('should dispatch navigateWithoutTransform with bulk URL for multiple components', () =>
-            new Promise<void>((resolve) => {
-                setup({
-                    connectorId: 'conn-1',
-                    processGroupIdFromRoute: 'pg-root'
-                }).then(({ effects, actions$ }) => {
-                    actions$(
-                        of(
-                            selectComponents({
-                                request: {
-                                    components: [
-                                        { id: 'proc-1', componentType: ComponentType.Processor },
-                                        { id: 'conn-2', componentType: ComponentType.Connection }
-                                    ]
-                                }
-                            })
-                        )
-                    );
+        it('should dispatch navigateWithoutTransform with single component URL', async () => {
+            const { effects, actions$ } = await setup({
+                connectorId: 'conn-1',
+                processGroupIdFromRoute: 'pg-root'
+            });
+            actions$(
+                of(
+                    selectComponents({
+                        request: {
+                            components: [{ id: 'proc-1', componentType: ComponentType.Processor }]
+                        }
+                    })
+                )
+            );
 
-                    effects.selectComponents$.subscribe((action) => {
-                        expect(action).toEqual(
-                            navigateWithoutTransform({
-                                url: ['/connectors', 'conn-1', 'canvas', 'pg-root', 'bulk', 'proc-1,conn-2']
-                            })
-                        );
-                        resolve();
-                    });
-                });
-            }));
+            const action = await firstValueFrom(effects.selectComponents$);
+            expect(action).toEqual(
+                navigateWithoutTransform({
+                    url: ['/connectors', 'conn-1', 'canvas', 'pg-root', ComponentType.Processor, 'proc-1']
+                })
+            );
+        });
+
+        it('should dispatch navigateWithoutTransform with bulk URL for multiple components', async () => {
+            const { effects, actions$ } = await setup({
+                connectorId: 'conn-1',
+                processGroupIdFromRoute: 'pg-root'
+            });
+            actions$(
+                of(
+                    selectComponents({
+                        request: {
+                            components: [
+                                { id: 'proc-1', componentType: ComponentType.Processor },
+                                { id: 'conn-2', componentType: ComponentType.Connection }
+                            ]
+                        }
+                    })
+                )
+            );
+
+            const action = await firstValueFrom(effects.selectComponents$);
+            expect(action).toEqual(
+                navigateWithoutTransform({
+                    url: ['/connectors', 'conn-1', 'canvas', 'pg-root', 'bulk', 'proc-1,conn-2']
+                })
+            );
+        });
     });
 
     describe('deselectAllComponents$', () => {
-        it('should dispatch navigateWithoutTransform with base canvas URL', () =>
-            new Promise<void>((resolve) => {
-                setup({
-                    connectorId: 'conn-1',
-                    processGroupIdFromRoute: 'pg-root'
-                }).then(({ effects, actions$ }) => {
-                    actions$(of(deselectAllComponents()));
+        it('should dispatch navigateWithoutTransform with base canvas URL', async () => {
+            const { effects, actions$ } = await setup({
+                connectorId: 'conn-1',
+                processGroupIdFromRoute: 'pg-root'
+            });
+            actions$(of(deselectAllComponents()));
 
-                    effects.deselectAllComponents$.subscribe((action) => {
-                        expect(action).toEqual(
-                            navigateWithoutTransform({
-                                url: ['/connectors', 'conn-1', 'canvas', 'pg-root']
-                            })
-                        );
-                        resolve();
-                    });
-                });
-            }));
+            const action = await firstValueFrom(effects.deselectAllComponents$);
+            expect(action).toEqual(
+                navigateWithoutTransform({
+                    url: ['/connectors', 'conn-1', 'canvas', 'pg-root']
+                })
+            );
+        });
     });
 
     describe('navigateWithoutTransform$', () => {
-        it('should call router.navigate with replaceUrl', () =>
-            new Promise<void>((resolve) => {
-                setup().then(({ effects, actions$, mockRouter }) => {
-                    const url = ['/connectors', 'conn-1', 'canvas', 'pg-root', 'Processor', 'proc-1'];
-                    actions$(of(navigateWithoutTransform({ url })));
+        it('should call router.navigate with replaceUrl', async () => {
+            const { effects, actions$, mockRouter } = await setup();
+            const url = ['/connectors', 'conn-1', 'canvas', 'pg-root', 'Processor', 'proc-1'];
+            actions$(of(navigateWithoutTransform({ url })));
 
-                    effects.navigateWithoutTransform$.subscribe(() => {
-                        expect(mockRouter.navigate).toHaveBeenCalledWith(url, { replaceUrl: true });
-                        resolve();
-                    });
-                });
-            }));
+            await firstValueFrom(effects.navigateWithoutTransform$);
+            expect(mockRouter.navigate).toHaveBeenCalledWith(url, { replaceUrl: true });
+        });
     });
 });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.spec.ts
@@ -28,18 +28,21 @@ import { ErrorHelper } from '../../../../service/error-helper.service';
 import { ErrorContextKey } from '../../../../state/error';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
 import {
+    deselectAllComponents,
     enterProcessGroup,
     leaveProcessGroup,
     loadConnectorFlow,
     loadConnectorFlowComplete,
     loadConnectorFlowFailure,
     loadConnectorFlowSuccess,
-    setSkipTransform
+    navigateWithoutTransform,
+    selectComponents
 } from './connector-canvas.actions';
 import {
     selectConnectorIdFromRoute,
     selectParentProcessGroupId,
-    selectProcessGroupId
+    selectProcessGroupId,
+    selectProcessGroupIdFromRoute
 } from './connector-canvas.selectors';
 import type { Mock } from 'vitest';
 
@@ -50,6 +53,7 @@ describe('ConnectorCanvasEffects', () => {
             connectorId?: string | null;
             parentProcessGroupId?: string | null;
             processGroupId?: string | null;
+            processGroupIdFromRoute?: string | null;
         } = {}
     ) {
         let actions$: Observable<Action>;
@@ -58,6 +62,8 @@ describe('ConnectorCanvasEffects', () => {
         const parentProcessGroupId =
             options.parentProcessGroupId !== undefined ? options.parentProcessGroupId : 'parent-pg';
         const processGroupId = options.processGroupId !== undefined ? options.processGroupId : 'child-pg';
+        const processGroupIdFromRoute =
+            options.processGroupIdFromRoute !== undefined ? options.processGroupIdFromRoute : processGroupId;
 
         // Mock services
         const mockConnectorService = {
@@ -82,7 +88,8 @@ describe('ConnectorCanvasEffects', () => {
                     selectors: [
                         { selector: selectConnectorIdFromRoute, value: connectorId },
                         { selector: selectParentProcessGroupId, value: parentProcessGroupId },
-                        { selector: selectProcessGroupId, value: processGroupId }
+                        { selector: selectProcessGroupId, value: processGroupId },
+                        { selector: selectProcessGroupIdFromRoute, value: processGroupIdFromRoute }
                     ]
                 }),
                 { provide: ConnectorService, useValue: mockConnectorService },
@@ -293,40 +300,36 @@ describe('ConnectorCanvasEffects', () => {
     });
 
     describe('leaveProcessGroup$', () => {
-        it('should navigate to parent, then after loadConnectorFlowComplete dispatch setSkipTransform and replaceUrl navigate', () =>
+        it('should navigate to parent, then after loadConnectorFlowComplete dispatch navigateWithoutTransform', () =>
             new Promise<void>((resolve) => {
                 setup({
                     connectorId: 'conn-x',
                     parentProcessGroupId: 'parent-pg',
                     processGroupId: 'child-pg'
-                }).then(({ effects, actions$, mockRouter, store }) => {
-                    const dispatchSpy = vi.spyOn(store, 'dispatch');
+                }).then(({ effects, actions$, mockRouter }) => {
                     const actionSubject = new Subject<Action>();
                     actions$(actionSubject.asObservable());
 
-                    effects.leaveProcessGroup$.subscribe({
-                        complete: () => {
-                            expect(mockRouter.navigate).toHaveBeenNthCalledWith(1, [
-                                '/connectors',
-                                'conn-x',
-                                'canvas',
-                                'parent-pg'
-                            ]);
-                            expect(dispatchSpy).toHaveBeenCalledWith(setSkipTransform({ skipTransform: true }));
-                            expect(mockRouter.navigate).toHaveBeenNthCalledWith(
-                                2,
-                                [
+                    effects.leaveProcessGroup$.subscribe((action) => {
+                        expect(mockRouter.navigate).toHaveBeenCalledWith([
+                            '/connectors',
+                            'conn-x',
+                            'canvas',
+                            'parent-pg'
+                        ]);
+                        expect(action).toEqual(
+                            navigateWithoutTransform({
+                                url: [
                                     '/connectors',
                                     'conn-x',
                                     'canvas',
                                     'parent-pg',
                                     ComponentType.ProcessGroup,
                                     'child-pg'
-                                ],
-                                { replaceUrl: true }
-                            );
-                            resolve();
-                        }
+                                ]
+                            })
+                        );
+                        resolve();
                     });
 
                     actionSubject.next(leaveProcessGroup());
@@ -367,6 +370,101 @@ describe('ConnectorCanvasEffects', () => {
                             expect(mockRouter.navigate).not.toHaveBeenCalled();
                             resolve();
                         }
+                    });
+                });
+            }));
+    });
+
+    describe('selectComponents$', () => {
+        it('should dispatch navigateWithoutTransform with single component URL', () =>
+            new Promise<void>((resolve) => {
+                setup({
+                    connectorId: 'conn-1',
+                    processGroupIdFromRoute: 'pg-root'
+                }).then(({ effects, actions$ }) => {
+                    actions$(
+                        of(
+                            selectComponents({
+                                request: {
+                                    components: [{ id: 'proc-1', componentType: ComponentType.Processor }]
+                                }
+                            })
+                        )
+                    );
+
+                    effects.selectComponents$.subscribe((action) => {
+                        expect(action).toEqual(
+                            navigateWithoutTransform({
+                                url: ['/connectors', 'conn-1', 'canvas', 'pg-root', ComponentType.Processor, 'proc-1']
+                            })
+                        );
+                        resolve();
+                    });
+                });
+            }));
+
+        it('should dispatch navigateWithoutTransform with bulk URL for multiple components', () =>
+            new Promise<void>((resolve) => {
+                setup({
+                    connectorId: 'conn-1',
+                    processGroupIdFromRoute: 'pg-root'
+                }).then(({ effects, actions$ }) => {
+                    actions$(
+                        of(
+                            selectComponents({
+                                request: {
+                                    components: [
+                                        { id: 'proc-1', componentType: ComponentType.Processor },
+                                        { id: 'conn-2', componentType: ComponentType.Connection }
+                                    ]
+                                }
+                            })
+                        )
+                    );
+
+                    effects.selectComponents$.subscribe((action) => {
+                        expect(action).toEqual(
+                            navigateWithoutTransform({
+                                url: ['/connectors', 'conn-1', 'canvas', 'pg-root', 'bulk', 'proc-1,conn-2']
+                            })
+                        );
+                        resolve();
+                    });
+                });
+            }));
+    });
+
+    describe('deselectAllComponents$', () => {
+        it('should dispatch navigateWithoutTransform with base canvas URL', () =>
+            new Promise<void>((resolve) => {
+                setup({
+                    connectorId: 'conn-1',
+                    processGroupIdFromRoute: 'pg-root'
+                }).then(({ effects, actions$ }) => {
+                    actions$(of(deselectAllComponents()));
+
+                    effects.deselectAllComponents$.subscribe((action) => {
+                        expect(action).toEqual(
+                            navigateWithoutTransform({
+                                url: ['/connectors', 'conn-1', 'canvas', 'pg-root']
+                            })
+                        );
+                        resolve();
+                    });
+                });
+            }));
+    });
+
+    describe('navigateWithoutTransform$', () => {
+        it('should call router.navigate with replaceUrl', () =>
+            new Promise<void>((resolve) => {
+                setup().then(({ effects, actions$, mockRouter }) => {
+                    const url = ['/connectors', 'conn-1', 'canvas', 'pg-root', 'Processor', 'proc-1'];
+                    actions$(of(navigateWithoutTransform({ url })));
+
+                    effects.navigateWithoutTransform$.subscribe(() => {
+                        expect(mockRouter.navigate).toHaveBeenCalledWith(url, { replaceUrl: true });
+                        resolve();
                     });
                 });
             }));

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.ts
@@ -27,10 +27,12 @@ import { ConnectorService } from '../../service/connector.service';
 import { ErrorHelper } from '../../../../service/error-helper.service';
 import { ErrorContextKey } from '../../../../state/error';
 import * as ConnectorCanvasActions from './connector-canvas.actions';
+import { SelectedComponent } from './connector-canvas.actions';
 import {
     selectConnectorIdFromRoute,
     selectParentProcessGroupId,
-    selectProcessGroupId
+    selectProcessGroupId,
+    selectProcessGroupIdFromRoute
 } from './connector-canvas.selectors';
 
 @Injectable()
@@ -102,6 +104,76 @@ export class ConnectorCanvasEffects {
         )
     );
 
+    /**
+     * Select components - updates route with selection
+     * Routes to /connectors/:id/canvas/:processGroupId/:type/:componentId
+     */
+    selectComponents$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(ConnectorCanvasActions.selectComponents),
+            map((action) => action.request),
+            concatLatestFrom(() => [
+                this.store.select(selectConnectorIdFromRoute),
+                this.store.select(selectProcessGroupIdFromRoute)
+            ]),
+            switchMap(([request, connectorId, processGroupId]) => {
+                let commands: string[] = [];
+                if (request.components.length === 1) {
+                    commands = [
+                        '/connectors',
+                        connectorId,
+                        'canvas',
+                        processGroupId,
+                        request.components[0].componentType,
+                        request.components[0].id
+                    ];
+                } else if (request.components.length > 1) {
+                    const ids: string[] = request.components.map(
+                        (selectedComponent: SelectedComponent) => selectedComponent.id
+                    );
+                    commands = ['/connectors', connectorId, 'canvas', processGroupId, 'bulk', ids.join(',')];
+                }
+                return of(ConnectorCanvasActions.navigateWithoutTransform({ url: commands }));
+            })
+        )
+    );
+
+    /**
+     * Deselect all components - returns to base canvas route
+     */
+    deselectAllComponents$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(ConnectorCanvasActions.deselectAllComponents),
+            concatLatestFrom(() => [
+                this.store.select(selectConnectorIdFromRoute),
+                this.store.select(selectProcessGroupIdFromRoute)
+            ]),
+            switchMap(([, connectorId, processGroupId]) => {
+                return of(
+                    ConnectorCanvasActions.navigateWithoutTransform({
+                        url: ['/connectors', connectorId, 'canvas', processGroupId]
+                    })
+                );
+            })
+        )
+    );
+
+    /**
+     * Navigate without transform - updates router
+     */
+    navigateWithoutTransform$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ConnectorCanvasActions.navigateWithoutTransform),
+                tap((action) => {
+                    this.router.navigate(action.url, {
+                        replaceUrl: true
+                    });
+                })
+            ),
+        { dispatch: false }
+    );
+
     enterProcessGroup$ = createEffect(
         () =>
             this.actions$.pipe(
@@ -115,41 +187,38 @@ export class ConnectorCanvasEffects {
         { dispatch: false }
     );
 
-    leaveProcessGroup$ = createEffect(
-        () =>
-            this.actions$.pipe(
-                ofType(ConnectorCanvasActions.leaveProcessGroup),
-                concatLatestFrom(() => [
-                    this.store.select(selectConnectorIdFromRoute),
-                    this.store.select(selectParentProcessGroupId),
-                    this.store.select(selectProcessGroupId)
-                ]),
-                filter(
-                    ([, , parentProcessGroupId, currentProcessGroupId]) =>
-                        parentProcessGroupId != null && currentProcessGroupId != null
-                ),
-                switchMap(([, connectorId, parentProcessGroupId, childProcessGroupId]) => {
-                    this.router.navigate(['/connectors', connectorId, 'canvas', parentProcessGroupId]);
-                    return this.actions$.pipe(
-                        ofType(ConnectorCanvasActions.loadConnectorFlowComplete),
-                        take(1),
-                        tap(() => {
-                            this.store.dispatch(ConnectorCanvasActions.setSkipTransform({ skipTransform: true }));
-                            this.router.navigate(
-                                [
-                                    '/connectors',
-                                    connectorId!,
-                                    'canvas',
-                                    parentProcessGroupId!,
-                                    ComponentType.ProcessGroup,
-                                    childProcessGroupId!
-                                ],
-                                { replaceUrl: true }
-                            );
-                        })
-                    );
-                })
+    leaveProcessGroup$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(ConnectorCanvasActions.leaveProcessGroup),
+            concatLatestFrom(() => [
+                this.store.select(selectConnectorIdFromRoute),
+                this.store.select(selectParentProcessGroupId),
+                this.store.select(selectProcessGroupId)
+            ]),
+            filter(
+                ([, , parentProcessGroupId, currentProcessGroupId]) =>
+                    parentProcessGroupId != null && currentProcessGroupId != null
             ),
-        { dispatch: false }
+            switchMap(([, connectorId, parentProcessGroupId, childProcessGroupId]) => {
+                this.router.navigate(['/connectors', connectorId, 'canvas', parentProcessGroupId]);
+
+                return this.actions$.pipe(
+                    ofType(ConnectorCanvasActions.loadConnectorFlowComplete),
+                    take(1),
+                    map(() =>
+                        ConnectorCanvasActions.navigateWithoutTransform({
+                            url: [
+                                '/connectors',
+                                connectorId,
+                                'canvas',
+                                parentProcessGroupId!,
+                                ComponentType.ProcessGroup,
+                                childProcessGroupId!
+                            ]
+                        })
+                    )
+                );
+            })
+        )
     );
 }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.ts
@@ -117,7 +117,11 @@ export class ConnectorCanvasEffects {
                 this.store.select(selectProcessGroupIdFromRoute)
             ]),
             switchMap(([request, connectorId, processGroupId]) => {
-                let commands: string[] = [];
+                if (request.components.length === 0) {
+                    return of(ConnectorCanvasActions.deselectAllComponents());
+                }
+
+                let commands: string[];
                 if (request.components.length === 1) {
                     commands = [
                         '/connectors',
@@ -127,7 +131,7 @@ export class ConnectorCanvasEffects {
                         request.components[0].componentType,
                         request.components[0].id
                     ];
-                } else if (request.components.length > 1) {
+                } else {
                     const ids: string[] = request.components.map(
                         (selectedComponent: SelectedComponent) => selectedComponent.id
                     );

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.reducer.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.reducer.spec.ts
@@ -163,6 +163,21 @@ describe('connectorCanvasReducer', () => {
         });
     });
 
+    describe('navigateWithoutTransform', () => {
+        it('should set skipTransform to true', () => {
+            const previousState = createPopulatedState({ skipTransform: false });
+
+            const result = connectorCanvasReducer(
+                previousState,
+                ConnectorCanvasActions.navigateWithoutTransform({
+                    url: ['/connectors', 'conn-1', 'canvas', 'pg-1', 'Processor', 'proc-1']
+                })
+            );
+
+            expect(result.skipTransform).toBe(true);
+        });
+    });
+
     describe('setSkipTransform', () => {
         it('should set skipTransform to the provided value', () => {
             const previousState = createPopulatedState({ skipTransform: true });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.reducer.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.reducer.ts
@@ -88,6 +88,11 @@ export const connectorCanvasReducer = createReducer(
         error: errorContext.errors.join(', ')
     })),
 
+    on(ConnectorCanvasActions.navigateWithoutTransform, (state) => ({
+        ...state,
+        skipTransform: true
+    })),
+
     on(ConnectorCanvasActions.setSkipTransform, (state, { skipTransform }) => ({
         ...state,
         skipTransform

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.selectors.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.selectors.ts
@@ -16,10 +16,8 @@
  */
 
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { getRouterSelectors } from '@ngrx/router-store';
+import { selectRouteParams } from '@nifi/shared';
 import { ConnectorCanvasState, connectorCanvasFeatureKey } from './index';
-
-export const { selectRouteParams } = getRouterSelectors();
 
 export const selectConnectorCanvasState = createFeatureSelector<ConnectorCanvasState>(connectorCanvasFeatureKey);
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.selectors.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.selectors.ts
@@ -19,7 +19,7 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { getRouterSelectors } from '@ngrx/router-store';
 import { ConnectorCanvasState, connectorCanvasFeatureKey } from './index';
 
-const { selectRouteParams } = getRouterSelectors();
+export const { selectRouteParams } = getRouterSelectors();
 
 export const selectConnectorCanvasState = createFeatureSelector<ConnectorCanvasState>(connectorCanvasFeatureKey);
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.html
@@ -33,7 +33,10 @@
                 [processGroupId]="currentProcessGroupId"
                 [selectedComponentIds]="selectedComponentIds"
                 [dataReady]="(dataReady$ | async) ?? false"
-                [skipInitialCenter]="(skipTransform$ | async) ?? false"
+                [skipInitialCenter]="skipTransform()"
+                (selectComponents)="onSelectComponents($event)"
+                (deselectAll)="onDeselectAll()"
+                (initialized)="onCanvasInitialized()"
                 (transformChange)="onTransformChange($event)"
                 (processGroupDoubleClick)="onProcessGroupDoubleClick($event)">
             </reusable-canvas>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, input } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -24,19 +24,22 @@ import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { selectUrl } from '@nifi/shared';
+import { ComponentType, selectUrl } from '@nifi/shared';
 
 import { ConnectorCanvasComponent } from './connector-canvas.component';
 import { CanvasComponent } from '../../../../ui/common/canvas/canvas.component';
 import { Navigation } from '../../../../ui/common/navigation/navigation.component';
 import { setConfiguration } from '../../../../state/canvas-ui/canvas-ui.actions';
 import * as ConnectorCanvasSelectors from '../../state/connector-canvas/connector-canvas.selectors';
-import { selectParentProcessGroupId } from '../../state/connector-canvas/connector-canvas.selectors';
+import { selectParentProcessGroupId, selectRouteParams } from '../../state/connector-canvas/connector-canvas.selectors';
 import {
+    deselectAllComponents,
     enterProcessGroup,
     leaveProcessGroup,
     loadConnectorFlow,
-    resetConnectorCanvasState
+    resetConnectorCanvasState,
+    selectComponents,
+    setSkipTransform
 } from '../../state/connector-canvas/connector-canvas.actions';
 import { resetConnectorCanvasEntityState } from '../../state/connector-canvas-entity/connector-canvas-entity.actions';
 
@@ -61,6 +64,10 @@ class MockReusableCanvasComponent {
     selectedComponentIds = input<string[]>([]);
     dataReady = input(false);
     skipInitialCenter = input(false);
+    selectComponents = output<Array<{ id: string; type: ComponentType }>>();
+    deselectAll = output<void>();
+    initialized = output<void>();
+    centerOnSelection = vi.fn();
 }
 
 @Component({
@@ -86,6 +93,8 @@ interface SetupOptions {
     processGroupId?: string | null;
     url?: string;
     parentProcessGroupId?: string | null;
+    skipTransform?: boolean;
+    routeParams?: Record<string, string>;
 }
 
 const DEFAULT_CONNECTOR_ID = 'connector-1';
@@ -97,6 +106,8 @@ function buildMockSelectors(options: SetupOptions = {}) {
     const processGroupId = options.processGroupId !== undefined ? options.processGroupId : DEFAULT_PROCESS_GROUP_ID;
     const url = options.url ?? `/connectors/${connectorId}/canvas/${processGroupId}`;
     const parentProcessGroupId = options.parentProcessGroupId !== undefined ? options.parentProcessGroupId : null;
+    const skipTransform = options.skipTransform ?? false;
+    const routeParamsValue = options.routeParams ?? { id: connectorId, processGroupId };
 
     return [
         { selector: ConnectorCanvasSelectors.selectLabels, value: [] },
@@ -108,11 +119,12 @@ function buildMockSelectors(options: SetupOptions = {}) {
         { selector: ConnectorCanvasSelectors.selectConnections, value: [] },
         { selector: ConnectorCanvasSelectors.selectRegistryClients, value: [] },
         { selector: ConnectorCanvasSelectors.selectLoadingStatus, value: loadingStatus },
-        { selector: ConnectorCanvasSelectors.selectSkipTransform, value: false },
+        { selector: ConnectorCanvasSelectors.selectSkipTransform, value: skipTransform },
         { selector: ConnectorCanvasSelectors.selectConnectorIdFromRoute, value: connectorId },
         { selector: ConnectorCanvasSelectors.selectProcessGroupIdFromRoute, value: processGroupId },
         { selector: selectParentProcessGroupId, value: parentProcessGroupId },
-        { selector: selectUrl, value: url }
+        { selector: selectUrl, value: url },
+        { selector: selectRouteParams, value: routeParamsValue }
     ];
 }
 
@@ -430,6 +442,106 @@ describe('ConnectorCanvasComponent', () => {
             ).toHaveLength(0);
 
             document.body.removeChild(inputEl);
+        }));
+    });
+
+    describe('Selection routing', () => {
+        it('should populate selectedComponentIds from route params with single selection', fakeAsync(() => {
+            const { fixture, component } = setup({
+                routeParams: {
+                    id: DEFAULT_CONNECTOR_ID,
+                    processGroupId: DEFAULT_PROCESS_GROUP_ID,
+                    type: ComponentType.Processor,
+                    componentId: 'proc-1'
+                }
+            });
+            fixture.detectChanges();
+            tick();
+
+            expect(component.selectedComponentIds).toEqual(['proc-1']);
+        }));
+
+        it('should populate selectedComponentIds from route params with bulk selection', fakeAsync(() => {
+            const { fixture, component } = setup({
+                routeParams: {
+                    id: DEFAULT_CONNECTOR_ID,
+                    processGroupId: DEFAULT_PROCESS_GROUP_ID,
+                    ids: 'proc-1,conn-2,pg-3'
+                }
+            });
+            fixture.detectChanges();
+            tick();
+
+            expect(component.selectedComponentIds).toEqual(['proc-1', 'conn-2', 'pg-3']);
+        }));
+
+        it('should clear selectedComponentIds when no selection route params', fakeAsync(() => {
+            const { fixture, component } = setup({
+                routeParams: {
+                    id: DEFAULT_CONNECTOR_ID,
+                    processGroupId: DEFAULT_PROCESS_GROUP_ID
+                }
+            });
+            fixture.detectChanges();
+            tick();
+
+            expect(component.selectedComponentIds).toEqual([]);
+        }));
+
+        it('should dispatch selectComponents when onSelectComponents is called', () => {
+            const { component, dispatchSpy } = setup();
+            dispatchSpy.mockClear();
+
+            component.onSelectComponents([{ id: 'proc-1', type: ComponentType.Processor }]);
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                selectComponents({
+                    request: {
+                        components: [{ id: 'proc-1', componentType: ComponentType.Processor }]
+                    }
+                })
+            );
+        });
+
+        it('should dispatch deselectAllComponents when onDeselectAll is called', () => {
+            const { component, dispatchSpy } = setup();
+            dispatchSpy.mockClear();
+
+            component.onDeselectAll();
+
+            expect(dispatchSpy).toHaveBeenCalledWith(deselectAllComponents());
+        });
+    });
+
+    describe('Canvas initialized', () => {
+        it('should clear skipTransform without centering when skipTransform is true and components are selected', fakeAsync(() => {
+            const { fixture, component, dispatchSpy } = setup({
+                skipTransform: true,
+                routeParams: {
+                    id: DEFAULT_CONNECTOR_ID,
+                    processGroupId: DEFAULT_PROCESS_GROUP_ID,
+                    type: ComponentType.Processor,
+                    componentId: 'proc-1'
+                }
+            });
+            fixture.detectChanges();
+            tick();
+            dispatchSpy.mockClear();
+
+            component.onCanvasInitialized();
+
+            expect(dispatchSpy).toHaveBeenCalledWith(setSkipTransform({ skipTransform: false }));
+        }));
+
+        it('should not dispatch anything when no components are selected', fakeAsync(() => {
+            const { fixture, component, dispatchSpy } = setup();
+            fixture.detectChanges();
+            tick();
+            dispatchSpy.mockClear();
+
+            component.onCanvasInitialized();
+
+            expect(dispatchSpy).not.toHaveBeenCalled();
         }));
     });
 });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.spec.ts
@@ -24,14 +24,14 @@ import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { ComponentType, selectUrl } from '@nifi/shared';
+import { ComponentType, selectRouteParams, selectUrl } from '@nifi/shared';
 
 import { ConnectorCanvasComponent } from './connector-canvas.component';
 import { CanvasComponent } from '../../../../ui/common/canvas/canvas.component';
 import { Navigation } from '../../../../ui/common/navigation/navigation.component';
 import { setConfiguration } from '../../../../state/canvas-ui/canvas-ui.actions';
 import * as ConnectorCanvasSelectors from '../../state/connector-canvas/connector-canvas.selectors';
-import { selectParentProcessGroupId, selectRouteParams } from '../../state/connector-canvas/connector-canvas.selectors';
+import { selectParentProcessGroupId } from '../../state/connector-canvas/connector-canvas.selectors';
 import {
     deselectAllComponents,
     enterProcessGroup,

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.ts
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-import { Component, OnDestroy, OnInit, DestroyRef, inject, HostListener } from '@angular/core';
+import { Component, OnDestroy, OnInit, DestroyRef, inject, HostListener, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { MatButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
-import { selectUrl } from '@nifi/shared';
+import { ComponentType, selectUrl } from '@nifi/shared';
 import { DocumentedType, RegistryClientEntity } from '../../../../state/shared';
 import { combineLatest, distinctUntilChanged, filter, map, Observable, of } from 'rxjs';
 import { NiFiState } from '../../../../state';
@@ -33,6 +33,7 @@ import { Navigation } from '../../../../ui/common/navigation/navigation.componen
 import * as ConnectorCanvasActions from '../../state/connector-canvas/connector-canvas.actions';
 import * as ConnectorCanvasSelectors from '../../state/connector-canvas/connector-canvas.selectors';
 import * as ConnectorCanvasEntityActions from '../../state/connector-canvas-entity/connector-canvas-entity.actions';
+import { selectRouteParams } from '../../state/connector-canvas/connector-canvas.selectors';
 
 @Component({
     selector: 'connector-canvas',
@@ -46,10 +47,13 @@ export class ConnectorCanvasComponent implements OnInit, OnDestroy {
     private router = inject(Router);
     private dialog = inject(MatDialog);
 
+    canvasComponent = viewChild.required(CanvasComponent);
+
     currentConnectorId = '';
     currentProcessGroupId: string | null = null;
     selectedComponentIds: string[] = [];
     canNavigateToParent = false;
+    skipTransform = this.store.selectSignal(ConnectorCanvasSelectors.selectSkipTransform);
 
     // Subscribe to connector canvas state (flow data)
     labels$: Observable<unknown[]> = this.store.select(ConnectorCanvasSelectors.selectLabels);
@@ -73,8 +77,6 @@ export class ConnectorCanvasComponent implements OnInit, OnDestroy {
     hasError$: Observable<boolean> = this.store
         .select(ConnectorCanvasSelectors.selectLoadingStatus)
         .pipe(map((status) => status === 'error'));
-
-    skipTransform$ = this.store.select(ConnectorCanvasSelectors.selectSkipTransform);
 
     ngOnInit(): void {
         // Configure global canvas UI state - read-only view (no editing)
@@ -115,6 +117,20 @@ export class ConnectorCanvasComponent implements OnInit, OnDestroy {
                 );
             });
 
+        // Subscribe to route params for selection tracking
+        this.store
+            .select(selectRouteParams)
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((params) => {
+                if (params?.['type'] && params?.['componentId']) {
+                    this.selectedComponentIds = [params['componentId']];
+                } else if (params?.['ids']) {
+                    this.selectedComponentIds = params['ids'].split(',');
+                } else {
+                    this.selectedComponentIds = [];
+                }
+            });
+
         // Subscribe to parent process group ID for navigation
         this.store
             .select(ConnectorCanvasSelectors.selectParentProcessGroupId)
@@ -135,6 +151,33 @@ export class ConnectorCanvasComponent implements OnInit, OnDestroy {
 
     onProcessGroupDoubleClick(event: { processGroupId: string }): void {
         this.store.dispatch(ConnectorCanvasActions.enterProcessGroup({ request: { id: event.processGroupId } }));
+    }
+
+    onSelectComponents(components: Array<{ id: string; type: ComponentType }>): void {
+        this.store.dispatch(
+            ConnectorCanvasActions.selectComponents({
+                request: {
+                    components: components.map((c) => ({
+                        id: c.id,
+                        componentType: c.type
+                    }))
+                }
+            })
+        );
+    }
+
+    onDeselectAll(): void {
+        this.store.dispatch(ConnectorCanvasActions.deselectAllComponents());
+    }
+
+    onCanvasInitialized(): void {
+        if (this.selectedComponentIds.length > 0) {
+            if (this.skipTransform()) {
+                this.store.dispatch(ConnectorCanvasActions.setSkipTransform({ skipTransform: false }));
+            } else {
+                this.canvasComponent().centerOnSelection(false, 1);
+            }
+        }
     }
 
     leaveGroupAction(): void {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.ts
@@ -22,7 +22,7 @@ import { MatButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
-import { ComponentType, selectUrl } from '@nifi/shared';
+import { ComponentType, selectRouteParams, selectUrl } from '@nifi/shared';
 import { DocumentedType, RegistryClientEntity } from '../../../../state/shared';
 import { combineLatest, distinctUntilChanged, filter, map, Observable, of } from 'rxjs';
 import { NiFiState } from '../../../../state';
@@ -33,7 +33,6 @@ import { Navigation } from '../../../../ui/common/navigation/navigation.componen
 import * as ConnectorCanvasActions from '../../state/connector-canvas/connector-canvas.actions';
 import * as ConnectorCanvasSelectors from '../../state/connector-canvas/connector-canvas.selectors';
 import * as ConnectorCanvasEntityActions from '../../state/connector-canvas-entity/connector-canvas-entity.actions';
-import { selectRouteParams } from '../../state/connector-canvas/connector-canvas.selectors';
 
 @Component({
     selector: 'connector-canvas',


### PR DESCRIPTION
**Title:** NIFI-15818: Route-backed component selection for the connector canvas

**Body:**

## Summary

- Implements route-backed component selection for the connector canvas so that selecting a component on the canvas updates the URL and deep-linking to a component URL centers the viewport on it
- Adds `selectComponents`, `deselectAllComponents`, and `navigateWithoutTransform` actions with corresponding effects, reducer handlers, and component wiring
- Fixes a corner case where dispatching `selectComponents` with an empty components array would navigate to an invalid route; it now correctly delegates to `deselectAllComponents`

## Details

**Selection routing:** Clicking a single component routes to `/connectors/:id/canvas/:processGroupId/:type/:componentId`. Selecting multiple components routes to `.../bulk/:id1,:id2,...`. Clicking the canvas background deselects all and returns to the base canvas route. All selection-initiated navigations use `replaceUrl: true` to avoid polluting browser history.

**`skipTransform` mechanism:** When the user selects a component on the canvas, `navigateWithoutTransform` sets `skipTransform: true` in the reducer so the resulting route change does not auto-center the viewport. When a deep link is opened directly, `skipTransform` is false, so `onCanvasInitialized` calls `centerOnSelection()` to center the viewport on the selected component(s).

**`leaveProcessGroup$` update:** Refactored to use the `navigateWithoutTransform` action (instead of direct `router.navigate` + `setSkipTransform`) after navigating to the parent process group and waiting for the flow to load. This auto-selects the child process group in the parent view, giving the user a visual reference of where they came from.

**Test cleanup:** Converted all effects tests from the `new Promise<void>((resolve) => { setup().then(...) })` anti-pattern to `async/await` with `firstValueFrom` from RxJS.