### PR TITLE
NIFI-15838 - Preserve prioritizer order in Git flow registry serialization

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/serialize/SortedStringCollectionsModule.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/serialize/SortedStringCollectionsModule.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 public class SortedStringCollectionsModule extends SimpleModule {
 
-    final Set<String> fieldsToSkipSorting = Set.of("inheritedParameterContexts");
+    final Set<String> fieldsToSkipSorting = Set.of("inheritedParameterContexts", "prioritizers");
 
     @Override
     public void setupModule(final SetupContext context) {

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/test/java/org/apache/nifi/registry/flow/git/serialize/JacksonFlowSnapshotSerializerTest.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/test/java/org/apache/nifi/registry/flow/git/serialize/JacksonFlowSnapshotSerializerTest.java
@@ -19,6 +19,9 @@ package org.apache.nifi.registry.flow.git.serialize;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.nifi.flow.ConnectableComponent;
+import org.apache.nifi.flow.ConnectableComponentType;
+import org.apache.nifi.flow.VersionedConnection;
 import org.apache.nifi.flow.VersionedListenPortDefinition;
 import org.apache.nifi.flow.VersionedParameter;
 import org.apache.nifi.flow.VersionedParameterContext;
@@ -30,7 +33,9 @@ import org.apache.nifi.flow.VersionedResourceType;
 import org.apache.nifi.registry.flow.RegisteredFlowSnapshot;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -114,6 +119,56 @@ public class JacksonFlowSnapshotSerializerTest {
         assertEquals("name1", parameters.get(0).get("name").asText());
         assertEquals("name2", parameters.get(1).get("name").asText());
         assertEquals("name3", parameters.get(2).get("name").asText());
+    }
+
+    @Test
+    public void testPrioritizerOrderPreserved() throws IOException {
+        final JacksonFlowSnapshotSerializer serializer = new JacksonFlowSnapshotSerializer();
+
+        final List<String> prioritizers = List.of(
+                "org.apache.nifi.prioritizer.PriorityAttributePrioritizer",
+                "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer",
+                "org.apache.nifi.prioritizer.NewestFlowFileFirstPrioritizer"
+        );
+
+        final ConnectableComponent source = new ConnectableComponent();
+        source.setId("source-id");
+        source.setType(ConnectableComponentType.PROCESSOR);
+        source.setGroupId("pg1");
+
+        final ConnectableComponent destination = new ConnectableComponent();
+        destination.setId("destination-id");
+        destination.setType(ConnectableComponentType.PROCESSOR);
+        destination.setGroupId("pg1");
+
+        final VersionedConnection connection = new VersionedConnection();
+        connection.setIdentifier("conn1");
+        connection.setSource(source);
+        connection.setDestination(destination);
+        connection.setPrioritizers(prioritizers);
+        connection.setSelectedRelationships(Set.of("success"));
+
+        final VersionedProcessGroup processGroup = new VersionedProcessGroup();
+        processGroup.setIdentifier("pg1");
+        processGroup.setConnections(Set.of(connection));
+
+        final RegisteredFlowSnapshot flowSnapshot = new RegisteredFlowSnapshot();
+        flowSnapshot.setFlowContents(processGroup);
+
+        final String jsonString = serializer.serialize(flowSnapshot);
+
+        final JsonNode flow = OBJECT_MAPPER.readTree(jsonString);
+        final ArrayNode connections = (ArrayNode) flow.get("flowContents").get("connections");
+        assertEquals(1, connections.size());
+
+        final ArrayNode serializedPrioritizers = (ArrayNode) connections.get(0).get("prioritizers");
+        assertEquals(3, serializedPrioritizers.size());
+        assertEquals("org.apache.nifi.prioritizer.PriorityAttributePrioritizer", serializedPrioritizers.get(0).asText());
+        assertEquals("org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer", serializedPrioritizers.get(1).asText());
+        assertEquals("org.apache.nifi.prioritizer.NewestFlowFileFirstPrioritizer", serializedPrioritizers.get(2).asText());
+
+        final RegisteredFlowSnapshot deserialized = serializer.deserialize(new ByteArrayInputStream(jsonString.getBytes(StandardCharsets.UTF_8)));
+        assertEquals(prioritizers, deserialized.getFlowContents().getConnections().iterator().next().getPrioritizers());
     }
 
 }


### PR DESCRIPTION
# Summary

NIFI-15838 - Preserve prioritizer order in Git flow registry serialization

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
