### PR TITLE
NIFI-15842 Fix fetching secrets with null fullyQualifiedName

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/components/connector/secrets/ParameterProviderSecretsManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/components/connector/secrets/ParameterProviderSecretsManager.java
@@ -167,19 +167,19 @@ public class ParameterProviderSecretsManager implements SecretsManager {
                 .map(SecretReference::getFullyQualifiedName)
                 .filter(Objects::nonNull)
                 .toList();
-            if (secretNames.isEmpty()) {
+            if (!secretNames.isEmpty()) {
+                final List<Secret> retrievedSecrets = provider.getSecrets(secretNames);
+                final Map<String, Secret> secretsByName = retrievedSecrets.stream()
+                    .collect(Collectors.toMap(Secret::getFullyQualifiedName, Function.identity()));
+
+                for (final SecretReference secretReference : references) {
+                    final Secret secret = secretsByName.get(secretReference.getFullyQualifiedName());
+                    secrets.put(secretReference, secret);
+                }
+            } else {
                 for (final SecretReference secretReference : references) {
                     secrets.put(secretReference, null);
                 }
-                continue;
-            }
-            final List<Secret> retrievedSecrets = provider.getSecrets(secretNames);
-            final Map<String, Secret> secretsByName = retrievedSecrets.stream()
-                .collect(Collectors.toMap(Secret::getFullyQualifiedName, Function.identity()));
-
-            for (final SecretReference secretReference : references) {
-                final Secret secret = secretsByName.get(secretReference.getFullyQualifiedName());
-                secrets.put(secretReference, secret);
             }
         }
 
@@ -224,23 +224,23 @@ public class ParameterProviderSecretsManager implements SecretsManager {
                 .map(SecretReference::getFullyQualifiedName)
                 .filter(Objects::nonNull)
                 .toList();
-            if (secretNames.isEmpty()) {
+            if (!secretNames.isEmpty()) {
+                final List<Secret> retrievedSecrets = provider.getSecrets(secretNames);
+                final Map<String, Secret> secretsByName = retrievedSecrets.stream()
+                    .collect(Collectors.toMap(Secret::getFullyQualifiedName, Function.identity()));
+
+                for (final SecretReference secretReference : references) {
+                    final String fqn = secretReference.getFullyQualifiedName();
+                    final Secret secret = secretsByName.get(fqn);
+                    results.put(secretReference, secret);
+
+                    if (secret != null && fqn != null) {
+                        cacheSecret(fqn, secret);
+                    }
+                }
+            } else {
                 for (final SecretReference secretReference : references) {
                     results.put(secretReference, null);
-                }
-                continue;
-            }
-            final List<Secret> retrievedSecrets = provider.getSecrets(secretNames);
-            final Map<String, Secret> secretsByName = retrievedSecrets.stream()
-                .collect(Collectors.toMap(Secret::getFullyQualifiedName, Function.identity()));
-
-            for (final SecretReference secretReference : references) {
-                final String fqn = secretReference.getFullyQualifiedName();
-                final Secret secret = secretsByName.get(fqn);
-                results.put(secretReference, secret);
-
-                if (secret != null && fqn != null) {
-                    cacheSecret(fqn, secret);
                 }
             }
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/components/connector/secrets/ParameterProviderSecretsManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/components/connector/secrets/ParameterProviderSecretsManager.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -162,8 +163,16 @@ public class ParameterProviderSecretsManager implements SecretsManager {
                 continue;
             }
 
-            final List<String> secretNames = new ArrayList<>();
-            references.forEach(ref -> secretNames.add(ref.getFullyQualifiedName()));
+            final List<String> secretNames = references.stream()
+                .map(SecretReference::getFullyQualifiedName)
+                .filter(Objects::nonNull)
+                .toList();
+            if (secretNames.isEmpty()) {
+                for (final SecretReference secretReference : references) {
+                    secrets.put(secretReference, null);
+                }
+                continue;
+            }
             final List<Secret> retrievedSecrets = provider.getSecrets(secretNames);
             final Map<String, Secret> secretsByName = retrievedSecrets.stream()
                 .collect(Collectors.toMap(Secret::getFullyQualifiedName, Function.identity()));
@@ -211,8 +220,16 @@ public class ParameterProviderSecretsManager implements SecretsManager {
                 continue;
             }
 
-            final List<String> secretNames = new ArrayList<>();
-            references.forEach(ref -> secretNames.add(ref.getFullyQualifiedName()));
+            final List<String> secretNames = references.stream()
+                .map(SecretReference::getFullyQualifiedName)
+                .filter(Objects::nonNull)
+                .toList();
+            if (secretNames.isEmpty()) {
+                for (final SecretReference secretReference : references) {
+                    results.put(secretReference, null);
+                }
+                continue;
+            }
             final List<Secret> retrievedSecrets = provider.getSecrets(secretNames);
             final Map<String, Secret> secretsByName = retrievedSecrets.stream()
                 .collect(Collectors.toMap(Secret::getFullyQualifiedName, Function.identity()));


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15842](https://issues.apache.org/jira/browse/NIFI-15842)

- Filter null `fullyQualifiedName` values from the secret names list in `ParameterProviderSecretsManager` before passing to `SecretProvider.getSecrets()`
- Prevents NPE in the default `ParameterProvider.fetchParameters(context, list)` implementation when the list contains null entries

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
