### PR TITLE
NIFI-15841 - Relax versioning of a parent PG with locally modified child PGs

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -4087,8 +4087,6 @@ public final class StandardProcessGroup implements ProcessGroup {
 
     @Override
     public void verifyCanSaveToFlowRegistry(final String registryId, final FlowLocation flowLocation, final String saveAction) {
-        verifyNoDescendantsWithLocalModifications("be saved to a Flow Registry");
-
         final StandardVersionControlInformation vci = versionControlInfo.get();
         if (vci != null) {
             final String flowId = flowLocation.getFlowId();

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/RegistryClientIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/RegistryClientIT.java
@@ -550,6 +550,51 @@ public class RegistryClientIT extends NiFiSystemIT {
         }
     }
 
+    /**
+     * Test that a parent Process Group can be committed to a Flow Registry even when a child Process Group
+     * that is separately under Version Control has local modifications. The parent's snapshot only stores
+     * version coordinate references for child versioned PGs, so uncommitted changes in the child are
+     * irrelevant to the parent's save operation.
+     *
+     * Scenario:
+     * 1. Create parent PG with a processor and child PG with a processor
+     * 2. Commit child PG (v1), then commit parent PG (v1)
+     * 3. Modify a processor in the child PG so the child becomes LOCALLY_MODIFIED
+     * 4. Commit the parent PG as v2 -- this should succeed
+     */
+    @Test
+    public void testSaveParentFlowVersionWithLocallyModifiedChild() throws NiFiClientException, IOException, InterruptedException {
+        final FlowRegistryClientEntity clientEntity = registerClient();
+        final NiFiClientUtil util = getClientUtil();
+
+        final ProcessGroupEntity parent = util.createProcessGroup("Parent", "root");
+        final ProcessorEntity parentProcessor = util.createProcessor("GenerateFlowFile", parent.getId());
+
+        final ProcessGroupEntity child = util.createProcessGroup("Child", parent.getId());
+        final ProcessorEntity childProcessor = util.createProcessor("TerminateFlowFile", child.getId());
+
+        final VersionControlInformationEntity childVci = util.startVersionControl(child, clientEntity, TEST_FLOWS_BUCKET, "Child");
+        assertEquals("1", childVci.getVersionControlInformation().getVersion());
+
+        final VersionControlInformationEntity parentVci = util.startVersionControl(parent, clientEntity, TEST_FLOWS_BUCKET, "Parent");
+        assertEquals("1", parentVci.getVersionControlInformation().getVersion());
+
+        util.assertFlowUpToDate(parent.getId());
+        util.assertFlowUpToDate(child.getId());
+
+        util.updateProcessorSchedulingPeriod(childProcessor, "2 min");
+        waitFor(() -> VersionControlInformationDTO.LOCALLY_MODIFIED.equals(util.getVersionControlState(child.getId())));
+
+        util.updateProcessorProperties(parentProcessor, Collections.singletonMap("Text", "Modified"));
+
+        final VersionControlInformationEntity parentV2 = util.saveFlowVersion(parent, clientEntity, parentVci);
+        assertEquals("2", parentV2.getVersionControlInformation().getVersion());
+
+        util.assertFlowUpToDate(parent.getId());
+
+        assertEquals(VersionControlInformationDTO.LOCALLY_MODIFIED, util.getVersionControlState(child.getId()));
+    }
+
     @Test
     public void testStopVersionControlThenSetVersionControlInfo() throws NiFiClientException, IOException, InterruptedException {
         final FlowRegistryClientEntity clientEntity = registerClient();


### PR DESCRIPTION
# Summary

NIFI-15841 - Relax versioning of a parent PG with locally modified child PGs

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
