### PR TITLE
NIFI-15850 - Bump Bouncycastle to 1.84, Guava to 33.6.0-jre, GCP SDK to 26.80.0, and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -72,7 +72,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.3.4</version>
+                <version>1.3.5</version>
                 <exclusions>
                     <!--
                         Reactor Netty 1.3 includes HTTP/3 support requiring native QUIC libraries.

--- a/nifi-commons/pom.xml
+++ b/nifi-commons/pom.xml
@@ -71,7 +71,7 @@
         <module>nifi-connector-common</module>
     </modules>
     <properties>
-        <guava.version>33.5.0-jre</guava.version>
+        <guava.version>33.6.0-jre</guava.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
@@ -20,7 +20,7 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <amqp-client.version>5.29.0</amqp-client.version>
+        <amqp-client.version>5.30.0</amqp-client.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -27,7 +27,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <guava.version>33.5.0-jre</guava.version>
+        <guava.version>33.6.0-jre</guava.version>
         <protobuf.version>4.34.1</protobuf.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.8.4</version>
+            <version>3.8.5</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.8.4</version>
+            <version>3.8.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
+                <version>33.6.0-jre</version>
             </dependency>
             <!-- Override Apache Qpid Proton J for Azure EventHubs to resolve PROTON-2347 -->
             <dependency>
@@ -78,7 +78,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.3.4</version>
+                <version>1.3.5</version>
                 <exclusions>
                     <!--
                         Reactor Netty 1.3 includes HTTP/3 support requiring native QUIC libraries.

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-standard-services/pom.xml
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-standard-services/pom.xml
@@ -27,7 +27,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <couchbase.version>3.11.1</couchbase.version>
+        <couchbase.version>3.11.2</couchbase.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.5.0-jre</version>
+            <version>33.6.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.79.0</google.libraries.version>
+        <google.libraries.version>26.80.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
+                <version>33.6.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -26,8 +26,8 @@
     <packaging>jar</packaging>
     <properties>
         <janusgraph.version>1.2.0-20251114-142114.b424a8f</janusgraph.version>
-        <guava.version>33.5.0-jre</guava.version>
-        <amqp-client.version>5.29.0</amqp-client.version>
+        <guava.version>33.6.0-jre</guava.version>
+        <amqp-client.version>5.30.0</amqp-client.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/pom.xml
@@ -19,8 +19,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <neo4j.driver.version>6.0.4</neo4j.driver.version>
-        <neo4j.docker.version>2025.11</neo4j.docker.version>
+        <neo4j.driver.version>6.0.5</neo4j.driver.version>
+        <neo4j.docker.version>2026.03</neo4j.docker.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
+                <version>33.6.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
@@ -40,7 +40,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
+                <version>33.6.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/pom.xml
@@ -37,7 +37,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
+                <version>33.6.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -21,7 +21,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <guava.version>33.5.0-jre</guava.version>
+        <guava.version>33.6.0-jre</guava.version>
         <protobuf.version>4.34.1</protobuf.version>
         <grpc.version>1.80.0</grpc.version>
         <snowflake-jdbc-thin.version>4.1.0</snowflake-jdbc-thin.version>

--- a/nifi-extension-bundles/nifi-sql-reporting-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-sql-reporting-bundle/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>nifi-sql-reporting-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <guava.version>33.5.0-jre</guava.version>
+        <guava.version>33.6.0-jre</guava.version>
     </properties>
     <modules>
         <module>nifi-sql-reporting-tasks</module>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -209,7 +209,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
+                <version>33.6.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.networknt</groupId>

--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -24,7 +24,7 @@
     <packaging>pom</packaging>
     <description>NiFi: Framework Bundle</description>
     <properties>
-        <guava.version>33.5.0-jre</guava.version>
+        <guava.version>33.6.0-jre</guava.version>
         <org.opensaml.version>5.1.6</org.opensaml.version>
     </properties>
     <modules>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -114,7 +114,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
+                <version>33.6.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>4.0.5</spring.boot.version>
-        <flyway.version>12.3.0</flyway.version>
+        <flyway.version>12.4.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.6.0.202603022253-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.42.33</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.42.34</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.6</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -184,7 +184,7 @@
         <!-- Security -->
         <nimbus-jose-jwt.version>10.9</nimbus-jose-jwt.version>
         <nimbus-oauth2-oidc.version>11.37</nimbus-oauth2-oidc.version>
-        <org.bouncycastle.version>1.83</org.bouncycastle.version>
+        <org.bouncycastle.version>1.84</org.bouncycastle.version>
 
         <!-- Utilities -->
         <caffeine.version>3.2.3</caffeine.version>


### PR DESCRIPTION
# Summary

NIFI-15850 - Bump Bouncycastle to 1.84, Guava to 33.6.0-jre, GCP SDK to 26.80.0, and others

- Reactor Netty from 1.3.4 to 1.3.5 - https://github.com/reactor/reactor-netty/releases/tag/v1.3.5
- Guava from 33.5.0-jre to 33.6.0-jre - https://github.com/google/guava/releases/tag/v33.6.0
- RabbitMQ AMQP client from 5.29.0 to 5.30.0 - https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.30.0
- Reactor Core from 3.8.4 to 3.8.5 - https://github.com/reactor/reactor-core/releases/tag/v3.8.5
- Couchbase from 3.11.1 to 3.11.2 - https://github.com/couchbase/couchbase-jvm-clients/releases/tag/3.11.2
- Google Cloud SDK from 26.79.0 to 26.80.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.80.0
- Neo4J Driver from 6.0.4 to 6.0.5 - https://github.com/neo4j/neo4j-java-driver/releases/tag/6.0.5
- FlywayDB from 12.3.0 to 12.4.0 - https://github.com/flyway/flyway/releases/tag/flyway-12.4.0
- AWS SDK from 2.42.33 to 2.42.34 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Bouncycastle from 1.83 to 1.84 - https://www.bouncycastle.org/download/bouncy-castle-java/#release-notes

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
