### PR TITLE
NIFI-15849 - Fix Bitbucket Data Center sourceCommitId missing on first snapshot save

### DIFF
--- a/nifi-extension-bundles/nifi-atlassian-bundle/nifi-atlassian-extensions/src/main/java/org/apache/nifi/atlassian/bitbucket/BitbucketRepositoryClient.java
+++ b/nifi-extension-bundles/nifi-atlassian-bundle/nifi-atlassian-extensions/src/main/java/org/apache/nifi/atlassian/bitbucket/BitbucketRepositoryClient.java
@@ -511,10 +511,10 @@ public class BitbucketRepositoryClient implements GitRepositoryClient {
             multipartBuilder.addPart(FIELD_MESSAGE, StandardHttpContentType.TEXT_PLAIN, message.getBytes(StandardCharsets.UTF_8));
         }
 
-        // Use expectedCommitSha for atomic commit - Bitbucket DC will reject if the file has changed since this commit
         final String expectedCommitSha = request.getExpectedCommitSha();
-        if (expectedCommitSha != null && !expectedCommitSha.isBlank()) {
-            multipartBuilder.addPart(FIELD_SOURCE_COMMIT_ID, StandardHttpContentType.TEXT_PLAIN, expectedCommitSha.getBytes(StandardCharsets.UTF_8));
+        final String sourceCommitId = (expectedCommitSha != null && !expectedCommitSha.isBlank()) ? expectedCommitSha : request.getExistingContentSha();
+        if (sourceCommitId != null && !sourceCommitId.isBlank()) {
+            multipartBuilder.addPart(FIELD_SOURCE_COMMIT_ID, StandardHttpContentType.TEXT_PLAIN, sourceCommitId.getBytes(StandardCharsets.UTF_8));
         }
 
         final HttpUriBuilder uriBuilder = getRepositoryUriBuilder().addPathSegment("browse");

--- a/nifi-extension-bundles/nifi-atlassian-bundle/nifi-atlassian-extensions/src/test/java/org/apache/nifi/atlassian/bitbucket/BitbucketRepositoryClientTest.java
+++ b/nifi-extension-bundles/nifi-atlassian-bundle/nifi-atlassian-extensions/src/test/java/org/apache/nifi/atlassian/bitbucket/BitbucketRepositoryClientTest.java
@@ -276,7 +276,60 @@ class BitbucketRepositoryClientTest {
     }
 
     @Test
-    void testCreateContentDataCenterUnchanged() throws FlowRegistryException {
+    void testCreateContentDataCenterWithExpectedCommitSha() throws FlowRegistryException {
+        stubDataCenterGetAndPutChains();
+
+        final BitbucketRepositoryClient dcClient = buildDataCenterClient();
+        final GitCreateContentRequest request = createRequest(null, EXPECTED_FILE_COMMIT);
+        final String commitSha = dcClient.createContent(request);
+        assertEquals(RESULT_COMMIT_SHA, commitSha);
+    }
+
+    @Test
+    void testCreateContentDataCenterFallsBackToExistingContentSha() throws FlowRegistryException {
+        stubDataCenterGetAndPutChains();
+
+        final BitbucketRepositoryClient dcClient = buildDataCenterClient();
+        final GitCreateContentRequest request = createRequest("existing-content-sha", null);
+        final String commitSha = dcClient.createContent(request);
+        assertEquals(RESULT_COMMIT_SHA, commitSha);
+    }
+
+    @Test
+    void testCreateContentDataCenterPrefersExpectedCommitShaOverExistingContentSha() throws FlowRegistryException {
+        stubDataCenterGetAndPutChains();
+
+        final BitbucketRepositoryClient dcClient = buildDataCenterClient();
+        final GitCreateContentRequest request = createRequest("existing-content-sha", EXPECTED_FILE_COMMIT);
+        final String commitSha = dcClient.createContent(request);
+        assertEquals(RESULT_COMMIT_SHA, commitSha);
+    }
+
+    @Test
+    void testCreateContentDataCenterNoBothShas() throws FlowRegistryException {
+        stubDataCenterGetAndPutChains();
+
+        final BitbucketRepositoryClient dcClient = buildDataCenterClient();
+        final GitCreateContentRequest request = createRequest(null, null);
+        final String commitSha = dcClient.createContent(request);
+        assertEquals(RESULT_COMMIT_SHA, commitSha);
+    }
+
+    private BitbucketRepositoryClient buildDataCenterClient() throws FlowRegistryException {
+        return BitbucketRepositoryClient.builder()
+                .clientId("test-client")
+                .apiUrl("https://bitbucket.example.com")
+                .formFactor(BitbucketFormFactor.DATA_CENTER)
+                .authenticationType(BitbucketAuthenticationType.ACCESS_TOKEN)
+                .accessToken("test-token")
+                .projectKey("TEST")
+                .repoName("test-repo")
+                .webClient(webClientProvider)
+                .logger(logger)
+                .build();
+    }
+
+    private void stubDataCenterGetAndPutChains() {
         final HttpRequestUriSpec getSpec = mock(HttpRequestUriSpec.class);
         final HttpRequestBodySpec dcGetBody = mock(HttpRequestBodySpec.class);
         lenient().when(webClientService.get()).thenReturn(getSpec);
@@ -302,21 +355,5 @@ class BitbucketRepositoryClientTest {
         lenient().when(putAfterHeaders.header(anyString(), anyString())).thenReturn(putAfterHeaders);
         final HttpResponseEntity putResponse = mockResponse(HttpURLConnection.HTTP_OK, "{}");
         lenient().when(putAfterHeaders.retrieve()).thenReturn(putResponse);
-
-        final BitbucketRepositoryClient dcClient = BitbucketRepositoryClient.builder()
-                .clientId("test-client")
-                .apiUrl("https://bitbucket.example.com")
-                .formFactor(BitbucketFormFactor.DATA_CENTER)
-                .authenticationType(BitbucketAuthenticationType.ACCESS_TOKEN)
-                .accessToken("test-token")
-                .projectKey("TEST")
-                .repoName("test-repo")
-                .webClient(webClientProvider)
-                .logger(logger)
-                .build();
-
-        final GitCreateContentRequest request = createRequest(null, EXPECTED_FILE_COMMIT);
-        final String commitSha = dcClient.createContent(request);
-        assertEquals(RESULT_COMMIT_SHA, commitSha);
     }
 }


### PR DESCRIPTION
# Summary

NIFI-15849 - Fix Bitbucket Data Center sourceCommitId missing on first snapshot save

When a user starts version control on Bitbucket Data Center, NiFi performs two back-to-back commits: `registerFlow()` creates the initial file, then `registerFlowSnapshot()` updates it with the actual flow content. On the second call, `expectedCommitSha` is null because there's no prior "version" from the user's perspective -- but the file already exists from the first commit. Without `sourceCommitId` in the `PUT` request, Bitbucket Data Center rejects the update to the existing file, returning a non-JSON error response that NiFi can't parse. The fix falls back to `existingContentSha` (which for Bitbucket is also a commit SHA) so that the `sourceCommitId` is always provided when the file already exists.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
