### PR TITLE
NIFI-15851 Upgrade aircompressor from 0.27 to 2.0.3 for Iceberg

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -22,11 +22,3 @@ ignore:
     package:
       name: jackson-core
       version: 2.19.2
-  # Reason: Referencing libraries require code changes for upgraded version
-  # Mitigating Factors: Snappy and LZ4 decompression depend on component configuration
-  # Reference: org.apache.kafka:kafka-clients:4.2.0
-  # Reference: org.apache.iceberg:iceberg-core:1.10.1
-  - vulnerability: GHSA-vx9q-rhv9-3jvg
-    package:
-      name: aircompressor
-      version: 0.27

--- a/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
@@ -63,6 +63,12 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!-- Override aircompressor 0.27 from iceberg-core -->
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>aircompressor</artifactId>
+                <version>2.0.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
# Summary

[NIFI-15851](https://issues.apache.org/jira/browse/NIFI-15851) Upgrades the `io.airlift:aircompressor` library from 0.27 to [2.0.3](https://github.com/airlift/aircompressor/releases/tag/2.0.3) for `nifi-iceberg-bundle` modules. Version 2.0.3 includes backported vulnerability resolution for CVE-2025-67721 and provides compatibility with the earlier version.

Upgrading this dependency version removes the need for the Grype scan overrides.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
