### PR TITLE
NIFI-15852: Dependency upgrades to address dependabot alerts.

### DIFF
--- a/nifi-frontend/src/main/frontend/package-lock.json
+++ b/nifi-frontend/src/main/frontend/package-lock.json
@@ -14487,9 +14487,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-            "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optional": true,
             "optionalDependencies": {
@@ -15844,9 +15844,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "dev": true,
             "funding": [
                 {
@@ -16603,9 +16603,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.12",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-            "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+            "version": "4.12.14",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+            "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
# npm audit report

dompurify  <=3.3.3
Severity: moderate
DOMPurify's ADD_TAGS function form bypasses FORBID_TAGS due to short-circuit evaluation - https://github.com/advisories/GHSA-39q2-94rc-95cp
fix available via `npm audit fix`
node_modules/dompurify

follow-redirects  <=1.15.11
Severity: moderate
follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets - https://github.com/advisories/GHSA-r4q5-vmmm-2653
fix available via `npm audit fix`
node_modules/follow-redirects

hono  <4.12.14
Severity: moderate
hono Improperly Handles JSX Attribute Names Allows HTML Injection in hono/jsx SSR - https://github.com/advisories/GHSA-458j-xx4x-4375
fix available via `npm audit fix`
node_modules/hono