### PR TITLE
NIFI-15840 Added rollback in ExecuteGroovyScript to allow script access to FlowFile.

### DIFF
--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
@@ -450,10 +450,11 @@ public class ExecuteGroovyScript extends AbstractProcessor {
         //create wrapped session to control list of newly created and files got from this session.
         //so transfer original input to failure will be possible
         GroovyProcessSessionWrap session = new GroovyProcessSessionWrap(processSession, toFailureOnError);
+        FlowFile flowFile = null;
         if (toFailureOnError) {
             // FlowFile must be read otherwise if there is a failure before the script is executed, a
             // never ending loop occurs since the GroovyProcessSessionWrap has nothing to send to the failure relationship.
-            FlowFile flowFile = session.get();
+            flowFile = session.get();
             if (flowFile == null) {
                 return;
             }
@@ -466,7 +467,7 @@ public class ExecuteGroovyScript extends AbstractProcessor {
 
         try {
             Script script = getGroovyScript(); //compilation must be moved to validation
-            Map bindings = script.getBinding().getVariables();
+            Map<String, Object> bindings = script.getBinding().getVariables();
 
             bindings.clear();
             Map<String, String> attributes = new HashMap<>();
@@ -509,6 +510,11 @@ public class ExecuteGroovyScript extends AbstractProcessor {
             bindings.put("SQL", sql);
             bindings.put("RecordReader", recordReader);
             bindings.put("RecordWriter", recordSetWriter);
+
+            // Must perform rollback to allow the script access to the FlowFile.
+            if (flowFile != null) {
+                session.rollback();
+            }
 
             script.run();
             bindings.clear();
@@ -590,7 +596,7 @@ public class ExecuteGroovyScript extends AbstractProcessor {
 
     /** simple HashMap with exception on access of non-existent key */
     private static class AccessMap extends HashMap<String, Object> {
-        private String parentKey;
+        private final String parentKey;
         AccessMap(String parentKey) {
             this.parentKey = parentKey;
         }

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
@@ -525,6 +525,8 @@ public class ExecuteGroovyScript extends AbstractProcessor {
             getLogger().error(t.toString(), t);
             onFailSQL(sql);
             if (toFailureOnError) {
+                // FlowFile must be retrieved in order send to the failure relationship as it may not have been retrieved in the script.
+                session.get();
                 //transfer all received to failure with two new attributes: ERROR_MESSAGE and ERROR_STACKTRACE.
                 session.revertReceivedTo(REL_FAILURE, StackTraceUtils.deepSanitize(t));
             } else {

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScriptTest.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScriptTest.java
@@ -576,7 +576,7 @@ public class ExecuteGroovyScriptTest {
         runner.assertValid();
 
         runner.setEnvironmentVariableValue("test", "cannot be converted to a date");
-        runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
+        runner.enqueue("test content");
 
         runner.run();
 
@@ -597,11 +597,40 @@ public class ExecuteGroovyScriptTest {
         runner.setProperty(ExecuteGroovyScript.FAIL_STRATEGY, ExecuteGroovyScript.TRANSFER_TO_FAILURE);
         runner.assertValid();
 
-        runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
+        runner.enqueue("test content");
 
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ExecuteGroovyScript.REL_SUCCESS, 1);
+    }
+
+    @Test
+    void testTransferToFailureStrategyWhereScriptFailsBeforeSessionGet() {
+        runner.setProperty(ExecuteGroovyScript.SCRIPT_BODY, """
+                throw new RuntimeException("fail before session.get")
+                """);
+        runner.setProperty(ExecuteGroovyScript.FAIL_STRATEGY, ExecuteGroovyScript.TRANSFER_TO_FAILURE);
+        runner.assertValid();
+        runner.enqueue("test content");
+
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(ExecuteGroovyScript.REL_FAILURE, 1);
+    }
+
+    @Test
+    void testTransferToFailureStrategyWhereScriptFailsAfterSessionGet() {
+        runner.setProperty(ExecuteGroovyScript.SCRIPT_BODY, """
+                session.get()
+                throw new RuntimeException("fail after session.get")
+                """);
+        runner.setProperty(ExecuteGroovyScript.FAIL_STRATEGY, ExecuteGroovyScript.TRANSFER_TO_FAILURE);
+        runner.assertValid();
+        runner.enqueue("test content");
+
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(ExecuteGroovyScript.REL_FAILURE, 1);
     }
 
     @Test
@@ -628,7 +657,7 @@ public class ExecuteGroovyScriptTest {
         String expectedContent = string;
 
         if (windows) {
-            expectedContent = expectedContent.replaceAll("\n", "\r\n");
+            expectedContent = expectedContent.replace("\n", "\r\n");
         }
 
         return expectedContent;

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScriptTest.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScriptTest.java
@@ -588,6 +588,23 @@ public class ExecuteGroovyScriptTest {
     }
 
     @Test
+    void testTransferToFailureStrategyWhereScriptHandlesRelationship() {
+        runner.setProperty(ExecuteGroovyScript.SCRIPT_BODY, """
+                def ff = session.get()
+                if (!ff) return
+                session.transfer(ff, REL_SUCCESS)
+                """);
+        runner.setProperty(ExecuteGroovyScript.FAIL_STRATEGY, ExecuteGroovyScript.TRANSFER_TO_FAILURE);
+        runner.assertValid();
+
+        runner.enqueue("test content".getBytes(StandardCharsets.UTF_8));
+
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(ExecuteGroovyScript.REL_SUCCESS, 1);
+    }
+
+    @Test
     void testMigrateProperties() {
         final Map<String, String> expectedRenamed = Map.ofEntries(
                 Map.entry("groovyx-script-file", ExecuteGroovyScript.SCRIPT_FILE.getName()),


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15840](https://issues.apache.org/jira/browse/NIFI-15840)
This PR fixes the bug in `ExecuteGroovyScript` so it should not fail with "Failure Strategy = transfer to failure"  when there is a Groovy script that accesses a FlowFile.
In addition to this fix, this PR resolved some of the Intellij warnings.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

-  Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
