### PR TITLE
NIFI: fix 'occured' -> 'occurred' in 3 files

### DIFF
--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSFileInfo.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSFileInfo.java
@@ -89,7 +89,7 @@ import static org.apache.nifi.processors.hadoop.GetHDFSFileInfo.HDFSFileInfoRequ
         @WritesAttribute(attribute = "hdfs.permissions", description = "The permissions for the object in HDFS. This is formatted as 3 characters for the owner, "
                 + "3 for the group, and 3 for other users. For example rw-rw-r--"),
         @WritesAttribute(attribute = "hdfs.status", description = "The status contains comma separated list of file/dir paths, which couldn't be listed/accessed. "
-                + "Status won't be set if no errors occured."),
+                + "Status won't be set if no errors occurred."),
         @WritesAttribute(attribute = "hdfs.full.tree", description = "When destination is 'attribute', will be populated with full tree of HDFS directory in JSON format."
                 + "WARNING: In case when scan finds thousands or millions of objects, having huge values in attribute could impact flow file repo and GC/heap usage. "
                 + "Use content destination for such cases")

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/dto/SNMPTreeResponse.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/dto/SNMPTreeResponse.java
@@ -55,7 +55,7 @@ public class SNMPTreeResponse {
     public void logErrors(final ComponentLog logger) {
         events.stream()
                 .filter(TreeEvent::isError)
-                .forEach(event -> logger.error("Error occured in SNMP walk event: {}", event.getErrorMessage()));
+                .forEach(event -> logger.error("Error occurred in SNMP walk event: {}", event.getErrorMessage()));
     }
 
     public boolean isError() {

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SetSNMP.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SetSNMP.java
@@ -55,7 +55,7 @@ import java.util.Set;
         " the attribute to the corresponding OID given in the attribute name.")
 @WritesAttributes({
         @WritesAttribute(attribute = SNMPUtils.SNMP_PROP_PREFIX + "<OID>", description = "Response variable binding: OID (e.g. 1.3.6.1.4.1.343) and its value."),
-        @WritesAttribute(attribute = SNMPUtils.SNMP_PROP_PREFIX + "errorIndex", description = "Denotes the variable binding in which the error occured."),
+        @WritesAttribute(attribute = SNMPUtils.SNMP_PROP_PREFIX + "errorIndex", description = "Denotes the variable binding in which the error occurred."),
         @WritesAttribute(attribute = SNMPUtils.SNMP_PROP_PREFIX + "errorStatus", description = "The snmp4j error status of the PDU."),
         @WritesAttribute(attribute = SNMPUtils.SNMP_PROP_PREFIX + "errorStatusText", description = "The description of error status."),
         @WritesAttribute(attribute = SNMPUtils.SNMP_PROP_PREFIX + "nonRepeaters", description = "The number of non repeater variable bindings in a GETBULK PDU (currently not supported)."),


### PR DESCRIPTION
Minor spelling correction in three Java files — `occured` → `occurred`.

Two of the three fixes are in user-visible `@WritesAttribute` descriptions rendered in processor documentation:

- `nifi-hadoop-bundle/.../GetHDFSFileInfo.java` — `hdfs.status`: `"Status won't be set if no errors occurred."`
- `nifi-snmp-bundle/.../SetSNMP.java` — `errorIndex`: `"Denotes the variable binding in which the error occurred."`

The third is an `ComponentLog.error` message emitted for every errored SNMP walk event:

- `nifi-snmp-bundle/.../SNMPTreeResponse.java` — `"Error occurred in SNMP walk event: {}"`

No functional changes.