### PR TITLE
NIFI-15856 - JsonRecordSetWriter silently ignores Timestamp Format

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/WriteJsonResult.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/WriteJsonResult.java
@@ -67,7 +67,7 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
     private final String mimeType;
     private final boolean prettyPrint;
     private final boolean allowScientificNotation;
-    private final boolean reuseInputSerialization;
+    private final boolean serializedInputHandlingEnabled;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -84,7 +84,7 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
 
     public WriteJsonResult(final ComponentLog logger, final RecordSchema recordSchema, final SchemaAccessWriter schemaAccess, final OutputStream out, final boolean prettyPrint,
         final NullSuppression nullSuppression, final OutputGrouping outputGrouping, final String dateFormat, final String timeFormat, final String timestampFormat,
-        final String mimeType, final boolean allowScientificNotation, final boolean reuseInputSerialization) throws IOException {
+        final String mimeType, final boolean allowScientificNotation, final boolean serializedInputHandlingEnabled) throws IOException {
 
         super(out);
         this.logger = logger;
@@ -94,7 +94,7 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
         this.outputGrouping = outputGrouping;
         this.mimeType = mimeType;
         this.allowScientificNotation = allowScientificNotation;
-        this.reuseInputSerialization = reuseInputSerialization;
+        this.serializedInputHandlingEnabled = serializedInputHandlingEnabled;
 
         this.dateFormat = dateFormat;
         this.timeFormat = timeFormat;
@@ -182,7 +182,7 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
      * Determines whether the record's original serialized JSON bytes can be emitted verbatim as a throughput optimization,
      * bypassing field-by-field re-serialization. All of the following conditions must hold for the fast path to apply:
      * <ol>
-     *   <li>The caller enabled the optimization (the {@code reuseInputSerialization} constructor argument is {@code true}).</li>
+     *   <li>The caller enabled the optimization (the {@code serializedInputHandlingEnabled} constructor argument is {@code true}).</li>
      *   <li>The record carries a {@link SerializedForm} produced by the upstream reader. Today this is only set by
      *       {@code JsonTreeRowRecordReader}; readers such as {@code JsonPathRowRecordReader} that transform the input
      *       cannot reuse their input bytes and therefore never trigger the fast path.</li>
@@ -195,10 +195,10 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
      * When the fast path is taken, the writer emits the cached bytes via {@link JsonGenerator#writeRawValue(String)} and
      * therefore does <em>not</em> apply the writer's Timestamp Format, Date Format, Time Format, or Suppress Null Values
      * settings to that record. Operators that need those writer-side properties to be honored uniformly must construct
-     * this writer with {@code reuseInputSerialization = false}.
+     * this writer with {@code serializedInputHandlingEnabled = false}.
      */
     private boolean isUseSerializeForm(final Record record, final RecordSchema writeSchema) {
-        if (!reuseInputSerialization) {
+        if (!serializedInputHandlingEnabled) {
             return false;
         }
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/WriteJsonResult.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/WriteJsonResult.java
@@ -178,6 +178,25 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
         return WriteResult.of(incrementRecordCount(), attributes);
     }
 
+    /**
+     * Determines whether the record's original serialized JSON bytes can be emitted verbatim as a throughput optimization,
+     * bypassing field-by-field re-serialization. All of the following conditions must hold for the fast path to apply:
+     * <ol>
+     *   <li>The caller enabled the optimization (the {@code reuseInputSerialization} constructor argument is {@code true}).</li>
+     *   <li>The record carries a {@link SerializedForm} produced by the upstream reader. Today this is only set by
+     *       {@code JsonTreeRowRecordReader}; readers such as {@code JsonPathRowRecordReader} that transform the input
+     *       cannot reuse their input bytes and therefore never trigger the fast path.</li>
+     *   <li>The serialized form's MIME type matches the writer's configured MIME type and the reader's record schema is
+     *       equal to the writer's record schema (no projection, no field renames, no type coercion).</li>
+     *   <li>The cached bytes are a {@code String}.</li>
+     *   <li>The cached bytes' pretty-print state matches the writer's {@code prettyPrint} setting.</li>
+     *   <li>If scientific notation is disabled on the writer, the cached bytes do not contain scientific notation.</li>
+     * </ol>
+     * When the fast path is taken, the writer emits the cached bytes via {@link JsonGenerator#writeRawValue(String)} and
+     * therefore does <em>not</em> apply the writer's Timestamp Format, Date Format, Time Format, or Suppress Null Values
+     * settings to that record. Operators that need those writer-side properties to be honored uniformly must construct
+     * this writer with {@code reuseInputSerialization = false}.
+     */
     private boolean isUseSerializeForm(final Record record, final RecordSchema writeSchema) {
         if (!reuseInputSerialization) {
             return false;

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/WriteJsonResult.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/WriteJsonResult.java
@@ -67,17 +67,24 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
     private final String mimeType;
     private final boolean prettyPrint;
     private final boolean allowScientificNotation;
+    private final boolean reuseInputSerialization;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public WriteJsonResult(final ComponentLog logger, final RecordSchema recordSchema, final SchemaAccessWriter schemaAccess, final OutputStream out, final boolean prettyPrint,
             final NullSuppression nullSuppression, final OutputGrouping outputGrouping, final String dateFormat, final String timeFormat, final String timestampFormat) throws IOException {
-        this(logger, recordSchema, schemaAccess, out, prettyPrint, nullSuppression, outputGrouping, dateFormat, timeFormat, timestampFormat, "application/json", false);
+        this(logger, recordSchema, schemaAccess, out, prettyPrint, nullSuppression, outputGrouping, dateFormat, timeFormat, timestampFormat, "application/json", false, true);
     }
 
     public WriteJsonResult(final ComponentLog logger, final RecordSchema recordSchema, final SchemaAccessWriter schemaAccess, final OutputStream out, final boolean prettyPrint,
         final NullSuppression nullSuppression, final OutputGrouping outputGrouping, final String dateFormat, final String timeFormat, final String timestampFormat,
         final String mimeType, final boolean allowScientificNotation) throws IOException {
+        this(logger, recordSchema, schemaAccess, out, prettyPrint, nullSuppression, outputGrouping, dateFormat, timeFormat, timestampFormat, mimeType, allowScientificNotation, true);
+    }
+
+    public WriteJsonResult(final ComponentLog logger, final RecordSchema recordSchema, final SchemaAccessWriter schemaAccess, final OutputStream out, final boolean prettyPrint,
+        final NullSuppression nullSuppression, final OutputGrouping outputGrouping, final String dateFormat, final String timeFormat, final String timestampFormat,
+        final String mimeType, final boolean allowScientificNotation, final boolean reuseInputSerialization) throws IOException {
 
         super(out);
         this.logger = logger;
@@ -87,6 +94,7 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
         this.outputGrouping = outputGrouping;
         this.mimeType = mimeType;
         this.allowScientificNotation = allowScientificNotation;
+        this.reuseInputSerialization = reuseInputSerialization;
 
         this.dateFormat = dateFormat;
         this.timeFormat = timeFormat;
@@ -171,6 +179,10 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
     }
 
     private boolean isUseSerializeForm(final Record record, final RecordSchema writeSchema) {
+        if (!reuseInputSerialization) {
+            return false;
+        }
+
         final Optional<SerializedForm> serializedForm = record.getSerializedForm();
         if (serializedForm.isEmpty()) {
             return false;

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonRecordSetWriter.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonRecordSetWriter.java
@@ -150,7 +150,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
     private volatile OutputGrouping outputGrouping;
     private volatile String compressionFormat;
     private volatile int compressionLevel;
-    private volatile boolean reuseInputSerialization;
+    private volatile boolean serializedInputHandlingEnabled;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -219,7 +219,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
 
         this.compressionFormat = context.getProperty(COMPRESSION_FORMAT).getValue();
         this.compressionLevel = context.getProperty(COMPRESSION_LEVEL).asInteger();
-        this.reuseInputSerialization = HANDLING_ENABLED.getValue().equals(context.getProperty(SERIALIZED_JSON_INPUT_HANDLING).getValue());
+        this.serializedInputHandlingEnabled = HANDLING_ENABLED.getValue().equals(context.getProperty(SERIALIZED_JSON_INPUT_HANDLING).getValue());
     }
 
     @Override
@@ -264,7 +264,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
         }
 
         return new WriteJsonResult(logger, schema, getSchemaAccessWriter(schema, variables), compressionOut, prettyPrint, nullSuppression, outputGrouping,
-                getDateFormat().orElse(null), getTimeFormat().orElse(null), getTimestampFormat().orElse(null), mimeType, allowScientificNotation, reuseInputSerialization);
+                getDateFormat().orElse(null), getTimeFormat().orElse(null), getTimestampFormat().orElse(null), mimeType, allowScientificNotation, serializedInputHandlingEnabled);
     }
 
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonRecordSetWriter.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonRecordSetWriter.java
@@ -123,6 +123,20 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
             .allowableValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
             .dependsOn(COMPRESSION_FORMAT, COMPRESSION_FORMAT_GZIP)
             .build();
+    public static final PropertyDescriptor REUSE_INPUT_SERIALIZATION = new PropertyDescriptor.Builder()
+            .name("Reuse Input Serialization")
+            .description("""
+                    Controls a throughput optimization that only applies to pure JSON pass-through flows. When set to true, and all of the \
+                    following conditions are met, the writer will emit the record's original JSON bytes verbatim instead of re-serializing from typed field \
+                    values: (1) the upstream reader is JsonTreeReader, (2) no data change, (3) the reader's and writer's record schemas are identical, \
+                    (4) the writer is not using compression, and (5) the Pretty Print JSON and Allow Scientific Notation settings are compatible with the \
+                    cached bytes. When the optimization kicks in, the Timestamp Format, Date Format, Time Format, and Suppress Null Values properties \
+                    have no effect on those records. Set this to false to have those properties honored uniformly for every record.""")
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .allowableValues("true", "false")
+            .defaultValue("true")
+            .required(true)
+            .build();
 
     private volatile boolean prettyPrint;
     private volatile boolean allowScientificNotation;
@@ -130,6 +144,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
     private volatile OutputGrouping outputGrouping;
     private volatile String compressionFormat;
     private volatile int compressionLevel;
+    private volatile boolean reuseInputSerialization;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -140,6 +155,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
         properties.add(OUTPUT_GROUPING);
         properties.add(COMPRESSION_FORMAT);
         properties.add(COMPRESSION_LEVEL);
+        properties.add(REUSE_INPUT_SERIALIZATION);
         return properties;
     }
 
@@ -197,6 +213,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
 
         this.compressionFormat = context.getProperty(COMPRESSION_FORMAT).getValue();
         this.compressionLevel = context.getProperty(COMPRESSION_LEVEL).asInteger();
+        this.reuseInputSerialization = context.getProperty(REUSE_INPUT_SERIALIZATION).asBoolean();
     }
 
     @Override
@@ -241,7 +258,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
         }
 
         return new WriteJsonResult(logger, schema, getSchemaAccessWriter(schema, variables), compressionOut, prettyPrint, nullSuppression, outputGrouping,
-                getDateFormat().orElse(null), getTimeFormat().orElse(null), getTimestampFormat().orElse(null), mimeType, allowScientificNotation);
+                getDateFormat().orElse(null), getTimeFormat().orElse(null), getTimestampFormat().orElse(null), mimeType, allowScientificNotation, reuseInputSerialization);
     }
 
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonRecordSetWriter.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonRecordSetWriter.java
@@ -124,14 +124,11 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
             .dependsOn(COMPRESSION_FORMAT, COMPRESSION_FORMAT_GZIP)
             .build();
     public static final PropertyDescriptor REUSE_INPUT_SERIALIZATION = new PropertyDescriptor.Builder()
-            .name("Reuse Input Serialization")
+            .name("Use Input Serialization")
             .description("""
-                    Controls a throughput optimization that only applies to pure JSON pass-through flows. When set to true, and all of the \
-                    following conditions are met, the writer will emit the record's original JSON bytes verbatim instead of re-serializing from typed field \
-                    values: (1) the upstream reader is JsonTreeReader, (2) no data change, (3) the reader's and writer's record schemas are identical, \
-                    (4) the writer is not using compression, and (5) the Pretty Print JSON and Allow Scientific Notation settings are compatible with the \
-                    cached bytes. When the optimization kicks in, the Timestamp Format, Date Format, Time Format, and Suppress Null Values properties \
-                    have no effect on those records. Set this to false to have those properties honored uniformly for every record.""")
+                    When set to true (default), the writer may emit the upstream reader's original JSON bytes verbatim when it can do so safely, as a \
+                    throughput optimization. In that case, the Timestamp Format, Date Format, Time Format, and Suppress Null Values properties may not be \
+                    applied to those records. Set this to false to force re-serialization so that these properties are honored uniformly for every record.""")
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .allowableValues("true", "false")
             .defaultValue("true")

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonRecordSetWriter.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonRecordSetWriter.java
@@ -67,6 +67,15 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
     public static final AllowableValue OUTPUT_ONELINE = new AllowableValue("output-oneline", "One Line Per Object",
             "Output records with one JSON object per line, delimited by a newline character");
 
+    public static final AllowableValue HANDLING_ENABLED = new AllowableValue("ENABLED", "Enabled",
+            """
+                    The writer may emit the input reader's original JSON bytes verbatim when it can do so safely, as a throughput optimization. \
+                    Timestamp Format, Date Format, Time Format, and Suppress Null Values may not be applied to those records.""");
+    public static final AllowableValue HANDLING_DISABLED = new AllowableValue("DISABLED", "Disabled",
+            """
+                    The writer re-serializes every record from typed field values, so Timestamp Format, Date Format, Time Format, and Suppress Null \
+                    Values are honored uniformly.""");
+
     public static final String COMPRESSION_FORMAT_GZIP = "gzip";
     public static final String COMPRESSION_FORMAT_BZIP2 = "bzip2";
     public static final String COMPRESSION_FORMAT_XZ_LZMA2 = "xz-lzma2";
@@ -123,15 +132,15 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
             .allowableValues("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
             .dependsOn(COMPRESSION_FORMAT, COMPRESSION_FORMAT_GZIP)
             .build();
-    public static final PropertyDescriptor REUSE_INPUT_SERIALIZATION = new PropertyDescriptor.Builder()
-            .name("Use Input Serialization")
+    public static final PropertyDescriptor SERIALIZED_JSON_INPUT_HANDLING = new PropertyDescriptor.Builder()
+            .name("Serialized JSON Input Handling")
             .description("""
-                    When set to true (default), the writer may emit the upstream reader's original JSON bytes verbatim when it can do so safely, as a \
+                    When enabled, the writer may emit the input reader's original JSON bytes verbatim when it can do so safely, as a \
                     throughput optimization. In that case, the Timestamp Format, Date Format, Time Format, and Suppress Null Values properties may not be \
-                    applied to those records. Set this to false to force re-serialization so that these properties are honored uniformly for every record.""")
+                    applied to those records. When disabled, the writer re-serializes every record so that these properties are honored uniformly.""")
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
-            .allowableValues("true", "false")
-            .defaultValue("true")
+            .allowableValues(HANDLING_ENABLED, HANDLING_DISABLED)
+            .defaultValue(HANDLING_ENABLED.getValue())
             .required(true)
             .build();
 
@@ -152,7 +161,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
         properties.add(OUTPUT_GROUPING);
         properties.add(COMPRESSION_FORMAT);
         properties.add(COMPRESSION_LEVEL);
-        properties.add(REUSE_INPUT_SERIALIZATION);
+        properties.add(SERIALIZED_JSON_INPUT_HANDLING);
         return properties;
     }
 
@@ -210,7 +219,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
 
         this.compressionFormat = context.getProperty(COMPRESSION_FORMAT).getValue();
         this.compressionLevel = context.getProperty(COMPRESSION_LEVEL).asInteger();
-        this.reuseInputSerialization = context.getProperty(REUSE_INPUT_SERIALIZATION).asBoolean();
+        this.reuseInputSerialization = HANDLING_ENABLED.getValue().equals(context.getProperty(SERIALIZED_JSON_INPUT_HANDLING).getValue());
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
@@ -656,8 +656,7 @@ class TestWriteJsonResult {
         }
 
         final String output = baos.toString(StandardCharsets.UTF_8);
-        assertTrue(output.contains("\"ignoredExtra\":\"preserved\""),
-                "Default constructor preserves legacy fast-path behavior: raw bytes should be emitted verbatim");
+        assertEquals("[{\"name\":\"John Doe\",\"age\":42,\"ignoredExtra\":\"preserved\"}]", output);
     }
 
     @Test
@@ -685,7 +684,7 @@ class TestWriteJsonResult {
 
         final String output = baos.toString(StandardCharsets.UTF_8);
         assertFalse(output.contains("ignoredExtra"),
-                "When Reuse Input Serialization is false, the writer must re-serialize from typed values and ignore raw bytes");
+                "When Use Input Serialization is false, the writer must re-serialize from typed values and ignore raw bytes");
         assertEquals("[{\"name\":\"John Doe\",\"age\":42}]", output);
     }
 
@@ -699,32 +698,34 @@ class TestWriteJsonResult {
         final Map<String, Object> values = new HashMap<>();
         values.put("event", eventTimestamp);
 
-        final String rawForm = "{\"event\":\"2025-03-20T17:33:11.000+0000\"}";
+        final String timestampValue = "2025-03-20T17:33:11.000+0000";
+        final String timestampFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
+        final String rawForm = "{\"event\":\"%s\"}".formatted(timestampValue);
         final SerializedForm serializedForm = SerializedForm.of(rawForm, "application/json");
         final Record record = new MapRecord(schema, values, serializedForm);
 
         final ByteArrayOutputStream fastPathBaos = new ByteArrayOutputStream();
         try (final WriteJsonResult writer = new WriteJsonResult(Mockito.mock(ComponentLog.class), schema, new SchemaNameAsAttribute(), fastPathBaos, false,
                 NullSuppression.NEVER_SUPPRESS, OutputGrouping.OUTPUT_ARRAY, RecordFieldType.DATE.getDefaultFormat(),
-                RecordFieldType.TIME.getDefaultFormat(), "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+                RecordFieldType.TIME.getDefaultFormat(), timestampFormat,
                 "application/json", false, true)) {
             writer.write(RecordSet.of(schema, record));
         }
 
-        assertTrue(fastPathBaos.toString(StandardCharsets.UTF_8).contains("+0000"),
-                "With Reuse Input Serialization enabled, raw '+0000' form is passed through even though Timestamp Format would normalize to 'Z'");
+        assertTrue(fastPathBaos.toString(StandardCharsets.UTF_8).contains(timestampValue),
+                "With Use Input Serialization enabled, raw '+0000' form is passed through even though Timestamp Format would normalize to 'Z'");
 
         final ByteArrayOutputStream slowPathBaos = new ByteArrayOutputStream();
         try (final WriteJsonResult writer = new WriteJsonResult(Mockito.mock(ComponentLog.class), schema, new SchemaNameAsAttribute(), slowPathBaos, false,
                 NullSuppression.NEVER_SUPPRESS, OutputGrouping.OUTPUT_ARRAY, RecordFieldType.DATE.getDefaultFormat(),
-                RecordFieldType.TIME.getDefaultFormat(), "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+                RecordFieldType.TIME.getDefaultFormat(), timestampFormat,
                 "application/json", false, false)) {
             writer.write(RecordSet.of(schema, record));
         }
 
         final String slowPathOutput = slowPathBaos.toString(StandardCharsets.UTF_8);
         assertFalse(slowPathOutput.contains("+0000"),
-                "With Reuse Input Serialization disabled, writer's Timestamp Format must be applied even when SerializedForm is present");
+                "With Use Input Serialization disabled, writer's Timestamp Format must be applied even when SerializedForm is present");
         assertTrue(slowPathOutput.contains("\"event\":\"2025-03-20T17:33:11.000"),
                 "Re-serialized timestamp should reflect the configured format");
     }
@@ -754,7 +755,7 @@ class TestWriteJsonResult {
 
         final String output = baos.toString(StandardCharsets.UTF_8);
         assertFalse(output.contains("middleName"),
-                "Suppress Null Values must be honored when Reuse Input Serialization is false, even though the input JSON contained the null field");
+                "Suppress Null Values must be honored when Use Input Serialization is false, even though the input JSON contained the null field");
         assertEquals("[{\"name\":\"John Doe\"}]", output);
     }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
@@ -684,7 +684,7 @@ class TestWriteJsonResult {
 
         final String output = baos.toString(StandardCharsets.UTF_8);
         assertFalse(output.contains("ignoredExtra"),
-                "When Use Input Serialization is false, the writer must re-serialize from typed values and ignore raw bytes");
+                "When Serialized JSON Input Handling is DISABLED, the writer must re-serialize from typed values and ignore raw bytes");
         assertEquals("[{\"name\":\"John Doe\",\"age\":42}]", output);
     }
 
@@ -713,7 +713,7 @@ class TestWriteJsonResult {
         }
 
         assertTrue(fastPathBaos.toString(StandardCharsets.UTF_8).contains(timestampValue),
-                "With Use Input Serialization enabled, raw '+0000' form is passed through even though Timestamp Format would normalize to 'Z'");
+                "With Serialized JSON Input Handling ENABLED, raw '+0000' form is passed through even though Timestamp Format would normalize to 'Z'");
 
         final ByteArrayOutputStream slowPathBaos = new ByteArrayOutputStream();
         try (final WriteJsonResult writer = new WriteJsonResult(Mockito.mock(ComponentLog.class), schema, new SchemaNameAsAttribute(), slowPathBaos, false,
@@ -725,7 +725,7 @@ class TestWriteJsonResult {
 
         final String slowPathOutput = slowPathBaos.toString(StandardCharsets.UTF_8);
         assertFalse(slowPathOutput.contains("+0000"),
-                "With Use Input Serialization disabled, writer's Timestamp Format must be applied even when SerializedForm is present");
+                "With Serialized JSON Input Handling DISABLED, writer's Timestamp Format must be applied even when SerializedForm is present");
         assertTrue(slowPathOutput.contains("\"event\":\"2025-03-20T17:33:11.000"),
                 "Re-serialized timestamp should reflect the configured format");
     }
@@ -755,7 +755,7 @@ class TestWriteJsonResult {
 
         final String output = baos.toString(StandardCharsets.UTF_8);
         assertFalse(output.contains("middleName"),
-                "Suppress Null Values must be honored when Use Input Serialization is false, even though the input JSON contained the null field");
+                "Suppress Null Values must be honored when Serialized JSON Input Handling is DISABLED, even though the input JSON contained the null field");
         assertEquals("[{\"name\":\"John Doe\"}]", output);
     }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestWriteJsonResult {
@@ -630,5 +631,130 @@ class TestWriteJsonResult {
 
         final String output = new String(data, StandardCharsets.UTF_8);
         assertEquals(json, output);
+    }
+
+    @Test
+    void testReuseInputSerializationDefaultTrueUsesFastPath() throws IOException {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("name", RecordFieldType.STRING.getDataType()));
+        fields.add(new RecordField("age", RecordFieldType.INT.getDataType()));
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+
+        final Map<String, Object> values = new HashMap<>();
+        values.put("name", "John Doe");
+        values.put("age", 42);
+
+        final String rawForm = "{\"name\":\"John Doe\",\"age\":42,\"ignoredExtra\":\"preserved\"}";
+        final SerializedForm serializedForm = SerializedForm.of(rawForm, "application/json");
+        final Record record = new MapRecord(schema, values, serializedForm);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (final WriteJsonResult writer = new WriteJsonResult(Mockito.mock(ComponentLog.class), schema, new SchemaNameAsAttribute(), baos, false,
+                NullSuppression.NEVER_SUPPRESS, OutputGrouping.OUTPUT_ARRAY, RecordFieldType.DATE.getDefaultFormat(),
+                RecordFieldType.TIME.getDefaultFormat(), RecordFieldType.TIMESTAMP.getDefaultFormat())) {
+            writer.write(RecordSet.of(schema, record));
+        }
+
+        final String output = baos.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("\"ignoredExtra\":\"preserved\""),
+                "Default constructor preserves legacy fast-path behavior: raw bytes should be emitted verbatim");
+    }
+
+    @Test
+    void testReuseInputSerializationFalseForcesReserialization() throws IOException {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("name", RecordFieldType.STRING.getDataType()));
+        fields.add(new RecordField("age", RecordFieldType.INT.getDataType()));
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+
+        final Map<String, Object> values = new HashMap<>();
+        values.put("name", "John Doe");
+        values.put("age", 42);
+
+        final String rawForm = "{\"name\":\"John Doe\",\"age\":42,\"ignoredExtra\":\"preserved\"}";
+        final SerializedForm serializedForm = SerializedForm.of(rawForm, "application/json");
+        final Record record = new MapRecord(schema, values, serializedForm);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (final WriteJsonResult writer = new WriteJsonResult(Mockito.mock(ComponentLog.class), schema, new SchemaNameAsAttribute(), baos, false,
+                NullSuppression.NEVER_SUPPRESS, OutputGrouping.OUTPUT_ARRAY, RecordFieldType.DATE.getDefaultFormat(),
+                RecordFieldType.TIME.getDefaultFormat(), RecordFieldType.TIMESTAMP.getDefaultFormat(),
+                "application/json", false, false)) {
+            writer.write(RecordSet.of(schema, record));
+        }
+
+        final String output = baos.toString(StandardCharsets.UTF_8);
+        assertFalse(output.contains("ignoredExtra"),
+                "When Reuse Input Serialization is false, the writer must re-serialize from typed values and ignore raw bytes");
+        assertEquals("[{\"name\":\"John Doe\",\"age\":42}]", output);
+    }
+
+    @Test
+    void testReuseInputSerializationFalseHonorsTimestampFormat() throws IOException {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("event", RecordFieldType.TIMESTAMP.getDataType()));
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+
+        final Timestamp eventTimestamp = Timestamp.valueOf("2025-03-20 17:33:11.000");
+        final Map<String, Object> values = new HashMap<>();
+        values.put("event", eventTimestamp);
+
+        final String rawForm = "{\"event\":\"2025-03-20T17:33:11.000+0000\"}";
+        final SerializedForm serializedForm = SerializedForm.of(rawForm, "application/json");
+        final Record record = new MapRecord(schema, values, serializedForm);
+
+        final ByteArrayOutputStream fastPathBaos = new ByteArrayOutputStream();
+        try (final WriteJsonResult writer = new WriteJsonResult(Mockito.mock(ComponentLog.class), schema, new SchemaNameAsAttribute(), fastPathBaos, false,
+                NullSuppression.NEVER_SUPPRESS, OutputGrouping.OUTPUT_ARRAY, RecordFieldType.DATE.getDefaultFormat(),
+                RecordFieldType.TIME.getDefaultFormat(), "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+                "application/json", false, true)) {
+            writer.write(RecordSet.of(schema, record));
+        }
+
+        assertTrue(fastPathBaos.toString(StandardCharsets.UTF_8).contains("+0000"),
+                "With Reuse Input Serialization enabled, raw '+0000' form is passed through even though Timestamp Format would normalize to 'Z'");
+
+        final ByteArrayOutputStream slowPathBaos = new ByteArrayOutputStream();
+        try (final WriteJsonResult writer = new WriteJsonResult(Mockito.mock(ComponentLog.class), schema, new SchemaNameAsAttribute(), slowPathBaos, false,
+                NullSuppression.NEVER_SUPPRESS, OutputGrouping.OUTPUT_ARRAY, RecordFieldType.DATE.getDefaultFormat(),
+                RecordFieldType.TIME.getDefaultFormat(), "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+                "application/json", false, false)) {
+            writer.write(RecordSet.of(schema, record));
+        }
+
+        final String slowPathOutput = slowPathBaos.toString(StandardCharsets.UTF_8);
+        assertFalse(slowPathOutput.contains("+0000"),
+                "With Reuse Input Serialization disabled, writer's Timestamp Format must be applied even when SerializedForm is present");
+        assertTrue(slowPathOutput.contains("\"event\":\"2025-03-20T17:33:11.000"),
+                "Re-serialized timestamp should reflect the configured format");
+    }
+
+    @Test
+    void testReuseInputSerializationFalseHonorsSuppressNulls() throws IOException {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("name", RecordFieldType.STRING.getDataType()));
+        fields.add(new RecordField("middleName", RecordFieldType.STRING.getDataType()));
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+
+        final Map<String, Object> values = new HashMap<>();
+        values.put("name", "John Doe");
+        values.put("middleName", null);
+
+        final String rawForm = "{\"name\":\"John Doe\",\"middleName\":null}";
+        final SerializedForm serializedForm = SerializedForm.of(rawForm, "application/json");
+        final Record record = new MapRecord(schema, values, serializedForm);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (final WriteJsonResult writer = new WriteJsonResult(Mockito.mock(ComponentLog.class), schema, new SchemaNameAsAttribute(), baos, false,
+                NullSuppression.ALWAYS_SUPPRESS, OutputGrouping.OUTPUT_ARRAY, RecordFieldType.DATE.getDefaultFormat(),
+                RecordFieldType.TIME.getDefaultFormat(), RecordFieldType.TIMESTAMP.getDefaultFormat(),
+                "application/json", false, false)) {
+            writer.write(RecordSet.of(schema, record));
+        }
+
+        final String output = baos.toString(StandardCharsets.UTF_8);
+        assertFalse(output.contains("middleName"),
+                "Suppress Null Values must be honored when Reuse Input Serialization is false, even though the input JSON contained the null field");
+        assertEquals("[{\"name\":\"John Doe\"}]", output);
     }
 }


### PR DESCRIPTION
# Summary

NIFI-15856 - JsonRecordSetWriter silently ignores Timestamp Format

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
