### PR TITLE
NIFI-15853 - Support fetchable allowable values in the connector wizard. added searchable select component.

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-configure/connector-configure.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-configure/connector-configure.component.ts
@@ -47,7 +47,7 @@ import { ContextErrorBanner } from '../../../../ui/common/context-error-banner/c
 import { ErrorContextKey } from '../../../../state/error';
 import { ConnectorMessageHost } from '../../service/connector-message-host.service';
 
-function runtimeWizardConfig(): ConnectorWizardConfig {
+function connectorWizardConfigFactory(): ConnectorWizardConfig {
     const router = inject(Router);
     const clusterConnectionService = inject(ClusterConnectionService);
     return {
@@ -78,7 +78,7 @@ function runtimeWizardConfig(): ConnectorWizardConfig {
     providers: [
         StandardConnectorWizardStore,
         { provide: ConnectorWizardStore, useExisting: StandardConnectorWizardStore },
-        { provide: CONNECTOR_WIZARD_CONFIG, useFactory: runtimeWizardConfig }
+        { provide: CONNECTOR_WIZARD_CONFIG, useFactory: connectorWizardConfigFactory }
     ],
     host: {
         class: 'block h-full'

--- a/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
@@ -262,13 +262,6 @@
         min-height: 2.25rem;
     }
 
-    // mat-select mat-option ellipsis
-    .mat-mdc-option .mdc-list-item__primary-text {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap !important;
-    }
-
     .mat-typography.text-base {
         font-family: var(--mat-sys-body-medium-font);
         line-height: var(--mat-sys-body-medium-line-height);
@@ -666,5 +659,112 @@
 
     .markdown-clipboard-toolbar.hover {
         opacity: 1;
+    }
+
+    .searchable-overlay {
+        .mat-mdc-form-field {
+            width: 100%;
+        }
+
+        .search-filter {
+            .mdc-text-field--focused {
+                outline: none;
+                border-radius: 6px;
+                border-color: var(--mat-sys-primary);
+            }
+
+            @include mat.form-field-overrides(
+                (
+                    outlined-container-shape: 6px
+                )
+            );
+
+            button.primary-icon-button {
+                @include mat.icon-button-overrides(
+                    (
+                        state-layer-size: 16px,
+                        icon-size: 10px
+                    )
+                );
+            }
+
+            .fa {
+                display: flex;
+                justify-content: center;
+                color: inherit;
+            }
+        }
+
+        &.mat-mdc-select-panel,
+        .mat-mdc-menu-content {
+            padding: 0 0 8px 0;
+        }
+    }
+
+    //form-field
+    .mat-mdc-form-field-icon-prefix {
+        .fa {
+            font-size: 16px;
+            color: var(--themed-reusable-text-primary);
+            padding: 0 4px 0 0;
+        }
+    }
+
+    .mdc-text-field--outlined,
+    .mat-mdc-form-field-has-icon-prefix .mat-mdc-text-field-wrapper {
+        padding-left: 12px;
+        padding-right: 12px;
+    }
+
+    // mat-select
+    @include mat.select-overrides(
+        (
+            trigger-text-size: var(--mat-sys-body-medium-size),
+            trigger-text-line-height: 16px,
+            trigger-text-tracking: normal
+        )
+    );
+
+    // mat-select panel appearance
+    .mat-mdc-select-panel {
+        margin-top: 8px;
+        border-color: var(--mat-sys-outline);
+        border-width: 1px;
+        border-top-left-radius: 6px !important;
+        border-top-right-radius: 6px !important;
+        border-bottom-left-radius: 6px;
+        border-bottom-right-radius: 6px;
+    }
+
+    // mat-option
+    .mat-mdc-option[disabled] {
+        color: var(--mat-sys-on-surface-variant);
+        opacity: 1;
+    }
+
+    // mat-select mat-option sizing, alignment, typography
+    .mat-mdc-option {
+        min-height: 32px;
+        padding-top: 8px;
+        padding-bottom: 8px;
+        padding-left: 12px;
+        padding-right: 12px;
+        font-weight: 400;
+
+        .mdc-list-item__primary-text {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap !important;
+            font-weight: 500;
+            color: inherit;
+        }
+
+        .fa {
+            font-size: 16px;
+            min-width: 16px;
+            flex: 0 0 16px;
+            color: inherit;
+            margin-right: 4px;
+        }
     }
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
@@ -699,25 +699,6 @@
         .mat-mdc-menu-content {
             padding: 0 0 8px 0;
         }
-
-    }
-
-    // Hover row in the searchable-select panel: Material 3's default state-layer is not present
-    // in this bundle, so emulate it directly with the hover-state-layer tokens.
-    .searchable-overlay .mat-mdc-option:not(.mdc-list-item--disabled):hover {
-        background-color: color-mix(
-            in srgb,
-            var(--mat-sys-on-surface) calc(var(--mat-sys-hover-state-layer-opacity) * 100%),
-            transparent
-        );
-    }
-
-    // Keyboard-active row in the searchable-select panel: use a 2px outline rather than a
-    // background so the keyboard focus indicator stays visually distinct from the hover state.
-    .searchable-overlay .mat-mdc-option-active:not(.mdc-list-item--disabled) {
-        background-color: transparent;
-        outline: 2px solid var(--mat-sys-primary);
-        outline-offset: -2px;
     }
 
     //form-field

--- a/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
@@ -699,6 +699,25 @@
         .mat-mdc-menu-content {
             padding: 0 0 8px 0;
         }
+
+    }
+
+    // Hover row in the searchable-select panel: Material 3's default state-layer is not present
+    // in this bundle, so emulate it directly with the hover-state-layer tokens.
+    .searchable-overlay .mat-mdc-option:not(.mdc-list-item--disabled):hover {
+        background-color: color-mix(
+            in srgb,
+            var(--mat-sys-on-surface) calc(var(--mat-sys-hover-state-layer-opacity) * 100%),
+            transparent
+        );
+    }
+
+    // Keyboard-active row in the searchable-select panel: use a 2px outline rather than a
+    // background so the keyboard focus indicator stays visually distinct from the hover state.
+    .searchable-overlay .mat-mdc-option-active:not(.mdc-list-item--disabled) {
+        background-color: transparent;
+        outline: 2px solid var(--mat-sys-primary);
+        outline-offset: -2px;
     }
 
     //form-field

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.html
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.html
@@ -1,0 +1,130 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+@let prop = property();
+@if (prop) {
+    @switch (prop.type) {
+        @case ('BOOLEAN') {
+            <mat-checkbox [formControl]="formControl" data-qa="property-input-boolean">
+                <span class="text-sm">{{ prop.name }}</span>
+                @if (prop.description) {
+                    <span class="text-xs tertiary-color block">{{ prop.description }}</span>
+                }
+            </mat-checkbox>
+        }
+        @default {
+            @if (shouldUseSelect()) {
+                <div class="w-full">
+                    <div class="text-xs tertiary-color mb-1">
+                        {{ prop.name }}
+                        @if (prop.required) {
+                            <span aria-hidden="true"> *</span>
+                        }
+                    </div>
+                    <searchable-select
+                        [formControl]="formControl"
+                        [options]="selectOptions"
+                        [multiple]="isMultiSelect()"
+                        [placeholder]="getSelectPlaceholder()"
+                        [searchPlaceholder]="'Search'"
+                        [allowClear]="!prop.required"
+                        [hint]="prop.description || ''"
+                        [showHint]="!!prop.description"
+                        [validationError]="getValidationErrorMessage()"
+                        data-qa="property-input-select">
+                    </searchable-select>
+                    @if (isDynamicValuesLoading()) {
+                        <div class="flex items-center gap-2 mt-1" data-qa="property-input-loading">
+                            <mat-progress-spinner diameter="14" mode="indeterminate"></mat-progress-spinner>
+                            <span class="text-xs tertiary-color">Loading values...</span>
+                        </div>
+                    }
+                </div>
+            } @else if (shouldUseTextarea()) {
+                <mat-form-field class="w-full" subscriptSizing="dynamic">
+                    <mat-label>{{ prop.name }}</mat-label>
+                    <textarea
+                        matInput
+                        [formControl]="formControl"
+                        rows="4"
+                        placeholder="Comma-separated list of values"
+                        [required]="prop.required"
+                        (blur)="markAsTouched()"
+                        data-qa="property-input-textarea"></textarea>
+                    @if (isDynamicValuesFetchFailed()) {
+                        <mat-hint data-qa="property-input-textarea-fetch-error-hint">
+                            Unable to load predefined values
+                        </mat-hint>
+                    } @else if (isDynamicValuesFetchEmpty()) {
+                        <mat-hint data-qa="property-input-textarea-fetch-empty-hint">
+                            No predefined values available
+                        </mat-hint>
+                    } @else if (prop.description) {
+                        <mat-hint>{{ prop.description }}</mat-hint>
+                    }
+                    @if (parentControl?.hasError('required') && parentControl?.touched) {
+                        <mat-error>This field is required</mat-error>
+                    }
+                    @if (parentControl?.hasError('verificationError')) {
+                        <mat-error data-qa="verification-error">{{
+                            parentControl?.getError('verificationError')
+                        }}</mat-error>
+                    }
+                    @if (parentControl?.hasError('pattern') && parentControl?.touched) {
+                        <mat-error>Invalid format</mat-error>
+                    }
+                    @if (parentControl?.hasError('assetContentMissing') && parentControl?.touched) {
+                        <mat-error>Asset content is missing</mat-error>
+                    }
+                </mat-form-field>
+            } @else {
+                <mat-form-field class="w-full" subscriptSizing="dynamic">
+                    <mat-label>{{ prop.name }}</mat-label>
+                    <input
+                        matInput
+                        [formControl]="formControl"
+                        [type]="getInputType(prop.type)"
+                        [required]="prop.required"
+                        (blur)="markAsTouched()"
+                        data-qa="property-input-text" />
+                    @if (isDynamicValuesFetchFailed()) {
+                        <mat-hint data-qa="property-input-fetch-error-hint">
+                            Unable to load predefined values
+                        </mat-hint>
+                    } @else if (isDynamicValuesFetchEmpty()) {
+                        <mat-hint data-qa="property-input-fetch-empty-hint"> No predefined values available </mat-hint>
+                    } @else if (prop.description) {
+                        <mat-hint>{{ prop.description }}</mat-hint>
+                    }
+                    @if (parentControl?.hasError('required') && parentControl?.touched) {
+                        <mat-error>This field is required</mat-error>
+                    }
+                    @if (parentControl?.hasError('verificationError')) {
+                        <mat-error data-qa="verification-error">{{
+                            parentControl?.getError('verificationError')
+                        }}</mat-error>
+                    }
+                    @if (parentControl?.hasError('pattern') && parentControl?.touched) {
+                        <mat-error>Invalid format</mat-error>
+                    }
+                    @if (parentControl?.hasError('assetContentMissing') && parentControl?.touched) {
+                        <mat-error>Asset content is missing</mat-error>
+                    }
+                </mat-form-field>
+            }
+        }
+    }
+}

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.spec.ts
@@ -1,0 +1,469 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, signal, WritableSignal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+
+import { ConnectorPropertyInput } from './connector-property-input.component';
+import { AllowableValue, ConnectorPropertyDescriptor, PropertyAllowableValuesState } from '../../types';
+
+function makeProp(overrides: Partial<ConnectorPropertyDescriptor> = {}): ConnectorPropertyDescriptor {
+    return {
+        name: 'my-prop',
+        type: 'STRING',
+        required: false,
+        dependencies: [],
+        ...overrides
+    };
+}
+
+function makeAllowable(value: string, displayName: string = value): AllowableValue {
+    return {
+        allowableValue: { value, displayName },
+        canRead: true
+    };
+}
+
+/**
+ * Host fixture that owns the parent FormControl and reactively passes signal inputs
+ * to ConnectorPropertyInput. Use setters on the returned harness to drive updates.
+ */
+@Component({
+    standalone: true,
+    imports: [ReactiveFormsModule, ConnectorPropertyInput],
+    template: `
+        <connector-property-input
+            [formControl]="control"
+            [property]="property()"
+            [dynamicAllowableValuesState]="dynamicAllowableValuesState()"
+            (requestAllowableValues)="onRequestAllowableValues()">
+        </connector-property-input>
+    `
+})
+class HostComponent {
+    control = new FormControl<string | null>(null);
+    property: WritableSignal<ConnectorPropertyDescriptor> = signal(makeProp());
+    dynamicAllowableValuesState: WritableSignal<PropertyAllowableValuesState | null> = signal(null);
+    requestSpy = vi.fn();
+
+    onRequestAllowableValues(): void {
+        this.requestSpy();
+    }
+}
+
+class MockResizeObserver {
+    disconnect = vi.fn();
+    observe = vi.fn();
+    unobserve = vi.fn();
+    constructor(_callback: ResizeObserverCallback) {
+        /* noop */
+    }
+}
+
+async function setup(
+    options: {
+        property?: ConnectorPropertyDescriptor;
+        dynamicState?: PropertyAllowableValuesState | null;
+        initialValue?: string | null;
+    } = {}
+) {
+    await TestBed.configureTestingModule({
+        imports: [HostComponent, NoopAnimationsModule, MatIconTestingModule]
+    }).compileComponents();
+
+    const fixture: ComponentFixture<HostComponent> = TestBed.createComponent(HostComponent);
+    const host = fixture.componentInstance;
+
+    if (options.property) {
+        host.property.set(options.property);
+    }
+    if (options.dynamicState !== undefined) {
+        host.dynamicAllowableValuesState.set(options.dynamicState);
+    }
+    if (options.initialValue !== undefined) {
+        host.control.setValue(options.initialValue);
+    }
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const inputDebug = fixture.debugElement.query(By.directive(ConnectorPropertyInput));
+    const inputComponent = inputDebug.componentInstance as ConnectorPropertyInput;
+
+    return { fixture, host, inputComponent };
+}
+
+describe('ConnectorPropertyInput', () => {
+    const originalResizeObserver = (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+
+    beforeAll(() => {
+        (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+            MockResizeObserver as unknown as typeof ResizeObserver;
+    });
+
+    afterAll(() => {
+        if (originalResizeObserver) {
+            (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver = originalResizeObserver;
+        } else {
+            delete (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+        }
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('requestAllowableValues emission', () => {
+        it('emits once on init for a fetchable property with no static values', async () => {
+            const { host } = await setup({
+                property: makeProp({ allowableValuesFetchable: true })
+            });
+            expect(host.requestSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not emit when the property has static allowable values', async () => {
+            const { host } = await setup({
+                property: makeProp({
+                    allowableValuesFetchable: true,
+                    allowableValues: [makeAllowable('a'), makeAllowable('b')]
+                })
+            });
+            expect(host.requestSpy).not.toHaveBeenCalled();
+        });
+
+        it('does not emit when the property is not fetchable', async () => {
+            const { host } = await setup({
+                property: makeProp({ allowableValuesFetchable: false })
+            });
+            expect(host.requestSpy).not.toHaveBeenCalled();
+        });
+
+        it('does not emit a second time when the dynamic values arrive', async () => {
+            const { host, fixture } = await setup({
+                property: makeProp({ allowableValuesFetchable: true })
+            });
+            expect(host.requestSpy).toHaveBeenCalledTimes(1);
+
+            host.dynamicAllowableValuesState.set({ loading: false, error: null, values: [makeAllowable('a')] });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(host.requestSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('select rendering', () => {
+        it('renders a searchable-select when the property has static allowable values', async () => {
+            const { fixture } = await setup({
+                property: makeProp({
+                    allowableValues: [makeAllowable('a'), makeAllowable('b')]
+                })
+            });
+
+            const select = fixture.debugElement.query(By.css('[data-qa="property-input-select"]'));
+            expect(select).toBeTruthy();
+            expect(select.nativeElement.tagName.toLowerCase()).toBe('searchable-select');
+        });
+
+        it('populates searchable-select options from the static allowable values', async () => {
+            const { inputComponent } = await setup({
+                property: makeProp({
+                    allowableValues: [makeAllowable('v1', 'Value One'), makeAllowable('v2', 'Value Two')]
+                })
+            });
+
+            expect(inputComponent.selectOptions).toEqual([
+                { value: 'v1', label: 'Value One' },
+                { value: 'v2', label: 'Value Two' }
+            ]);
+        });
+
+        it('populates searchable-select options from dynamic allowable values when available', async () => {
+            const { inputComponent, host, fixture } = await setup({
+                property: makeProp({ allowableValuesFetchable: true })
+            });
+
+            host.dynamicAllowableValuesState.set({
+                loading: false,
+                error: null,
+                values: [makeAllowable('dyn-1', 'Dynamic 1'), makeAllowable('dyn-2', 'Dynamic 2')]
+            });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(inputComponent.selectOptions).toEqual([
+                { value: 'dyn-1', label: 'Dynamic 1' },
+                { value: 'dyn-2', label: 'Dynamic 2' }
+            ]);
+        });
+
+        it('shows a loading spinner while a dynamic fetch is in flight', async () => {
+            const { fixture } = await setup({
+                property: makeProp({ allowableValuesFetchable: true }),
+                dynamicState: { loading: true, error: null, values: null }
+            });
+
+            const spinner = fixture.debugElement.query(By.css('[data-qa="property-input-loading"]'));
+            expect(spinner).toBeTruthy();
+        });
+    });
+
+    describe('fallback to text input', () => {
+        it('falls back to a text input when the dynamic fetch reports an error', async () => {
+            const { fixture } = await setup({
+                property: makeProp({ allowableValuesFetchable: true }),
+                dynamicState: { loading: false, error: 'boom', values: null }
+            });
+
+            const select = fixture.debugElement.query(By.css('[data-qa="property-input-select"]'));
+            const textInput = fixture.debugElement.query(By.css('[data-qa="property-input-text"]'));
+            const errorHint = fixture.debugElement.query(By.css('[data-qa="property-input-fetch-error-hint"]'));
+
+            expect(select).toBeNull();
+            expect(textInput).toBeTruthy();
+            expect(errorHint).toBeTruthy();
+        });
+
+        it('falls back to a text input when the dynamic fetch returns an empty list', async () => {
+            const { fixture } = await setup({
+                property: makeProp({ allowableValuesFetchable: true }),
+                dynamicState: { loading: false, error: null, values: [] }
+            });
+
+            const select = fixture.debugElement.query(By.css('[data-qa="property-input-select"]'));
+            const textInput = fixture.debugElement.query(By.css('[data-qa="property-input-text"]'));
+            const emptyHint = fixture.debugElement.query(By.css('[data-qa="property-input-fetch-empty-hint"]'));
+
+            expect(select).toBeNull();
+            expect(textInput).toBeTruthy();
+            expect(emptyHint).toBeTruthy();
+        });
+    });
+
+    describe('text input rendering', () => {
+        it('renders a text input for a plain STRING property with no allowable values', async () => {
+            const { fixture } = await setup({
+                property: makeProp()
+            });
+
+            const textInput = fixture.debugElement.query(By.css('[data-qa="property-input-text"]'));
+            expect(textInput).toBeTruthy();
+        });
+    });
+
+    describe('boolean rendering', () => {
+        it('renders a checkbox for BOOLEAN properties', async () => {
+            const { fixture } = await setup({
+                property: makeProp({ type: 'BOOLEAN' })
+            });
+
+            const checkbox = fixture.debugElement.query(By.css('[data-qa="property-input-boolean"]'));
+            expect(checkbox).toBeTruthy();
+        });
+    });
+
+    describe('STRING_LIST rendering', () => {
+        it('renders a textarea for a STRING_LIST property with no allowable values', async () => {
+            const { fixture } = await setup({
+                property: makeProp({ type: 'STRING_LIST' })
+            });
+
+            const textarea = fixture.debugElement.query(By.css('[data-qa="property-input-textarea"]'));
+            const select = fixture.debugElement.query(By.css('[data-qa="property-input-select"]'));
+
+            expect(textarea).toBeTruthy();
+            expect(textarea.nativeElement.tagName.toLowerCase()).toBe('textarea');
+            expect(select).toBeNull();
+        });
+
+        it('renders a multi-select for a STRING_LIST property with static allowable values', async () => {
+            const { fixture, inputComponent } = await setup({
+                property: makeProp({
+                    type: 'STRING_LIST',
+                    allowableValues: [makeAllowable('a'), makeAllowable('b')]
+                })
+            });
+
+            const select = fixture.debugElement.query(By.css('[data-qa="property-input-select"]'));
+            const textarea = fixture.debugElement.query(By.css('[data-qa="property-input-textarea"]'));
+
+            expect(select).toBeTruthy();
+            expect(textarea).toBeNull();
+            expect(inputComponent.isMultiSelect()).toBe(true);
+            expect(select.componentInstance.multiple()).toBe(true);
+        });
+
+        it('renders a multi-select for a STRING_LIST property with fetched dynamic values', async () => {
+            const { fixture, host, inputComponent } = await setup({
+                property: makeProp({ type: 'STRING_LIST', allowableValuesFetchable: true })
+            });
+
+            host.dynamicAllowableValuesState.set({
+                loading: false,
+                error: null,
+                values: [makeAllowable('topic-1'), makeAllowable('topic-2')]
+            });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const select = fixture.debugElement.query(By.css('[data-qa="property-input-select"]'));
+            expect(select).toBeTruthy();
+            expect(inputComponent.isMultiSelect()).toBe(true);
+            expect(select.componentInstance.multiple()).toBe(true);
+        });
+
+        it('falls back to a textarea with an error hint when the dynamic fetch fails', async () => {
+            const { fixture } = await setup({
+                property: makeProp({ type: 'STRING_LIST', allowableValuesFetchable: true }),
+                dynamicState: { loading: false, error: 'boom', values: null }
+            });
+
+            const textarea = fixture.debugElement.query(By.css('[data-qa="property-input-textarea"]'));
+            const select = fixture.debugElement.query(By.css('[data-qa="property-input-select"]'));
+            const errorHint = fixture.debugElement.query(
+                By.css('[data-qa="property-input-textarea-fetch-error-hint"]')
+            );
+
+            expect(select).toBeNull();
+            expect(textarea).toBeTruthy();
+            expect(errorHint).toBeTruthy();
+        });
+
+        it('falls back to a textarea with an empty hint when the dynamic fetch returns an empty list', async () => {
+            const { fixture } = await setup({
+                property: makeProp({ type: 'STRING_LIST', allowableValuesFetchable: true }),
+                dynamicState: { loading: false, error: null, values: [] }
+            });
+
+            const textarea = fixture.debugElement.query(By.css('[data-qa="property-input-textarea"]'));
+            const select = fixture.debugElement.query(By.css('[data-qa="property-input-select"]'));
+            const emptyHint = fixture.debugElement.query(
+                By.css('[data-qa="property-input-textarea-fetch-empty-hint"]')
+            );
+
+            expect(select).toBeNull();
+            expect(textarea).toBeTruthy();
+            expect(emptyHint).toBeTruthy();
+        });
+    });
+
+    describe('already-hydrated dynamicAllowableValuesState', () => {
+        it('still emits requestAllowableValues exactly once when values are hydrated before first paint', async () => {
+            const { host } = await setup({
+                property: makeProp({ allowableValuesFetchable: true }),
+                dynamicState: {
+                    loading: false,
+                    error: null,
+                    values: [makeAllowable('pre-1'), makeAllowable('pre-2')]
+                }
+            });
+
+            expect(host.requestSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('renders the searchable-select immediately when values are hydrated before first paint', async () => {
+            const { fixture, inputComponent } = await setup({
+                property: makeProp({ allowableValuesFetchable: true }),
+                dynamicState: {
+                    loading: false,
+                    error: null,
+                    values: [makeAllowable('pre-1', 'Pre One'), makeAllowable('pre-2', 'Pre Two')]
+                }
+            });
+
+            const select = fixture.debugElement.query(By.css('[data-qa="property-input-select"]'));
+            expect(select).toBeTruthy();
+            expect(inputComponent.selectOptions).toEqual([
+                { value: 'pre-1', label: 'Pre One' },
+                { value: 'pre-2', label: 'Pre Two' }
+            ]);
+        });
+    });
+
+    describe('property descriptor rebinding', () => {
+        it('re-emits requestAllowableValues when the descriptor changes to a different fetchable property', async () => {
+            const { host, fixture } = await setup({
+                property: makeProp({ name: 'first-prop', allowableValuesFetchable: true })
+            });
+            expect(host.requestSpy).toHaveBeenCalledTimes(1);
+
+            host.property.set(makeProp({ name: 'second-prop', allowableValuesFetchable: true }));
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(host.requestSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('does not re-emit requestAllowableValues when the descriptor reference changes but the name stays the same', async () => {
+            const { host, fixture } = await setup({
+                property: makeProp({ name: 'same-prop', allowableValuesFetchable: true })
+            });
+            expect(host.requestSpy).toHaveBeenCalledTimes(1);
+
+            host.property.set(makeProp({ name: 'same-prop', allowableValuesFetchable: true, description: 'updated' }));
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(host.requestSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('textarea validation parity', () => {
+        async function setupStringList(errors: Record<string, unknown>): Promise<{
+            fixture: ComponentFixture<HostComponent>;
+            host: HostComponent;
+        }> {
+            const { fixture, host } = await setup({
+                property: makeProp({ type: 'STRING_LIST' })
+            });
+
+            host.control.setErrors(errors);
+            host.control.markAsTouched();
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            return { fixture, host };
+        }
+
+        it('shows an "Invalid format" error on the textarea when the parent has a pattern error', async () => {
+            const { fixture } = await setupStringList({ pattern: { requiredPattern: '^\\w+$', actualValue: '!!!' } });
+
+            const errors = fixture.debugElement.queryAll(By.css('mat-error'));
+            const errorTexts = errors.map((el) => el.nativeElement.textContent.trim());
+            expect(errorTexts).toContain('Invalid format');
+        });
+
+        it('shows the verification error on the textarea when the parent carries a verificationError', async () => {
+            const { fixture } = await setupStringList({ verificationError: 'Backend rejected list' });
+
+            const errorEl = fixture.debugElement.query(By.css('[data-qa="verification-error"]'));
+            expect(errorEl).toBeTruthy();
+            expect(errorEl.nativeElement.textContent.trim()).toBe('Backend rejected list');
+        });
+    });
+});

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.ts
@@ -15,27 +15,32 @@
  * limitations under the License.
  */
 
-import { Component, DestroyRef, DoCheck, inject, input, output } from '@angular/core';
+import { Component, DestroyRef, DoCheck, effect, inject, input, OnInit, output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor, FormControl, NgControl, ReactiveFormsModule } from '@angular/forms';
-import { MatFormField, MatError, MatLabel, MatHint } from '@angular/material/form-field';
+import { MatError, MatFormField, MatHint, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
-import { MatSelect, MatOption } from '@angular/material/select';
 import { MatCheckbox } from '@angular/material/checkbox';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import {
+    AllowableValue,
+    AssetInfo,
     ConnectorPropertyDescriptor,
     PropertyAllowableValuesState,
-    AssetInfo,
-    UploadProgressInfo,
-    Secret
+    SearchableSelectOption,
+    Secret,
+    UploadProgressInfo
 } from '../../types';
+import { SearchableSelect } from '../searchable-select/searchable-select.component';
 
 /**
  * Form control for a single connector property.
  * Renders different input types based on the property descriptor:
  * STRING/INTEGER/DOUBLE/FLOAT -> text input, BOOLEAN -> checkbox,
- * SECRET -> select with secrets. ASSET uploads are handled at the
- * configuration-step level rather than within this component.
+ * STRING_LIST without allowable values -> textarea (comma-separated),
+ * allowable values (static or fetched) -> searchable-select
+ * (multi-select when the property type is STRING_LIST).
+ * SECRET, ASSET, and ASSET_LIST handling is deferred to follow-up PRs.
  *
  * Uses an internal FormControl bound to the actual input elements so that
  * mat-form-field can detect error state. Validation state is synced from
@@ -51,73 +56,16 @@ import {
         MatLabel,
         MatHint,
         MatInput,
-        MatSelect,
-        MatOption,
-        MatCheckbox
+        MatCheckbox,
+        MatProgressSpinner,
+        SearchableSelect
     ],
-    template: `
-        @let prop = property();
-        @if (prop) {
-            @switch (prop.type) {
-                @case ('BOOLEAN') {
-                    <mat-checkbox [formControl]="formControl" data-qa="property-input-boolean">
-                        <span class="text-sm">{{ prop.name }}</span>
-                        @if (prop.description) {
-                            <span class="text-xs tertiary-color block">{{ prop.description }}</span>
-                        }
-                    </mat-checkbox>
-                }
-                @default {
-                    <mat-form-field class="w-full" subscriptSizing="dynamic">
-                        <mat-label>{{ prop.name }}</mat-label>
-                        @if (prop.allowableValues && prop.allowableValues.length > 0) {
-                            <mat-select
-                                [formControl]="formControl"
-                                [required]="prop.required"
-                                (blur)="markAsTouched()"
-                                data-qa="property-input-select">
-                                @for (av of prop.allowableValues; track av.allowableValue.value) {
-                                    <mat-option [value]="av.allowableValue.value">
-                                        {{ av.allowableValue.displayName }}
-                                    </mat-option>
-                                }
-                            </mat-select>
-                        } @else {
-                            <input
-                                matInput
-                                [formControl]="formControl"
-                                [type]="getInputType(prop.type)"
-                                [required]="prop.required"
-                                (blur)="markAsTouched()"
-                                data-qa="property-input-text" />
-                        }
-                        @if (prop.description) {
-                            <mat-hint>{{ prop.description }}</mat-hint>
-                        }
-                        @if (parentControl?.hasError('required') && parentControl?.touched) {
-                            <mat-error>This field is required</mat-error>
-                        }
-                        @if (parentControl?.hasError('verificationError')) {
-                            <mat-error data-qa="verification-error">{{
-                                parentControl?.getError('verificationError')
-                            }}</mat-error>
-                        }
-                        @if (parentControl?.hasError('pattern') && parentControl?.touched) {
-                            <mat-error>Invalid format</mat-error>
-                        }
-                        @if (parentControl?.hasError('assetContentMissing') && parentControl?.touched) {
-                            <mat-error>Asset content is missing</mat-error>
-                        }
-                    </mat-form-field>
-                }
-            }
-        }
-    `,
+    templateUrl: './connector-property-input.component.html',
     host: {
         class: 'block'
     }
 })
-export class ConnectorPropertyInput implements ControlValueAccessor, DoCheck {
+export class ConnectorPropertyInput implements ControlValueAccessor, DoCheck, OnInit {
     private ngControl = inject(NgControl, { optional: true, self: true });
     private destroyRef = inject(DestroyRef);
 
@@ -136,6 +84,15 @@ export class ConnectorPropertyInput implements ControlValueAccessor, DoCheck {
 
     formControl = new FormControl();
 
+    // Cached options to avoid recomputing on every change detection cycle
+    selectOptions: SearchableSelectOption<string>[] = [];
+
+    // One-shot guard so we only emit requestAllowableValues once per control instance
+    // per property descriptor. Reset when the descriptor's property name changes so a
+    // host that rebinds [property] to a different descriptor re-issues the fetch.
+    private hasFetchedDynamicValues = false;
+    private lastSeenPropertyName: string | null = null;
+
     get parentControl(): FormControl | null {
         return this.ngControl?.control as FormControl | null;
     }
@@ -149,16 +106,39 @@ export class ConnectorPropertyInput implements ControlValueAccessor, DoCheck {
         if (this.ngControl) {
             this.ngControl.valueAccessor = this;
         }
+
+        // Recompute select options whenever the property descriptor or the dynamic
+        // allowable values state changes. The initial emission of requestAllowableValues
+        // happens in ngOnInit; if the descriptor identity changes later (different
+        // property name) we reset the guard and re-issue the fetch from here.
+        effect(() => {
+            const prop = this.property();
+            this.dynamicAllowableValuesState();
+            this.selectOptions = this.computeSelectOptions();
+
+            const currentName = prop?.name ?? null;
+            if (this.lastSeenPropertyName !== null && currentName !== this.lastSeenPropertyName) {
+                this.hasFetchedDynamicValues = false;
+                this.triggerDynamicValuesFetch();
+            }
+            this.lastSeenPropertyName = currentName;
+        });
     }
 
-    writeValue(value: any): void {
+    ngOnInit(): void {
+        this.lastSeenPropertyName = this.property()?.name ?? null;
+        this.triggerDynamicValuesFetch();
+    }
+
+    writeValue(value: unknown): void {
+        let normalized = value;
         if (this.property()?.type === 'BOOLEAN') {
-            value = value === true || value === 'true';
+            normalized = value === true || value === 'true';
         }
-        this.formControl.setValue(value, { emitEvent: false });
+        this.formControl.setValue(normalized, { emitEvent: false });
     }
 
-    registerOnChange(fn: (value: any) => void): void {
+    registerOnChange(fn: (value: unknown) => void): void {
         if (!this.valueChangesSubscribed) {
             this.valueChangesSubscribed = true;
             this.formControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => {
@@ -223,6 +203,205 @@ export class ConnectorPropertyInput implements ControlValueAccessor, DoCheck {
             default:
                 return 'text';
         }
+    }
+
+    // ========================================================================================
+    // Allowable-values helpers (PR1 subset: STRING + fetchable dynamic)
+    // ========================================================================================
+
+    /**
+     * True when the descriptor carries a non-empty static allowableValues array.
+     */
+    hasStaticAllowableValues(): boolean {
+        const prop = this.property();
+        if (!prop) {
+            return false;
+        }
+        return prop.allowableValues !== undefined && prop.allowableValues !== null && prop.allowableValues.length > 0;
+    }
+
+    /**
+     * True when a dynamic fetch is currently in flight for this property.
+     */
+    isDynamicValuesLoading(): boolean {
+        return this.dynamicAllowableValuesState()?.loading === true;
+    }
+
+    /**
+     * True when a dynamic fetch completed with an error.
+     */
+    isDynamicValuesFetchFailed(): boolean {
+        const state = this.dynamicAllowableValuesState();
+        return state?.error !== null && state?.error !== undefined;
+    }
+
+    /**
+     * True when a dynamic fetch completed successfully but returned an empty list.
+     * In that case we fall back to a text input so the user can still enter a value.
+     */
+    isDynamicValuesFetchEmpty(): boolean {
+        const prop = this.property();
+        if (!prop?.allowableValuesFetchable) {
+            return false;
+        }
+        const state = this.dynamicAllowableValuesState();
+        return (
+            state !== null &&
+            state !== undefined &&
+            !state.loading &&
+            !state.error &&
+            state.values !== null &&
+            state.values.length === 0
+        );
+    }
+
+    /**
+     * Whether the property should be rendered as a searchable-select dropdown.
+     *
+     * Returns true when:
+     * - Has static allowable values, OR
+     * - Has dynamic allowable values already fetched, OR
+     * - Is fetchable and still loading (or has not yet started fetching).
+     *
+     * Returns false when a dynamic fetch failed or came back empty: in both
+     * cases we fall back to a plain text input so the field remains editable.
+     */
+    shouldUseSelect(): boolean {
+        const prop = this.property();
+        if (!prop || prop.type === 'BOOLEAN') {
+            return false;
+        }
+
+        if (this.isDynamicValuesFetchFailed() || this.isDynamicValuesFetchEmpty()) {
+            return false;
+        }
+
+        if (this.hasStaticAllowableValues()) {
+            return true;
+        }
+
+        const state = this.dynamicAllowableValuesState();
+        if (state?.values && state.values.length > 0) {
+            return true;
+        }
+
+        if (prop.allowableValuesFetchable && this.isDynamicValuesLoading()) {
+            return true;
+        }
+
+        if (prop.allowableValuesFetchable && !state) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether the property should be rendered as a plain text input.
+     * Used for STRING/INTEGER/DOUBLE/FLOAT when a select is not appropriate.
+     * STRING_LIST falls into the textarea branch instead.
+     */
+    shouldUseTextInput(): boolean {
+        const prop = this.property();
+        if (!prop) {
+            return false;
+        }
+        if (prop.type === 'BOOLEAN' || prop.type === 'STRING_LIST') {
+            return false;
+        }
+        return !this.shouldUseSelect();
+    }
+
+    /**
+     * Whether the property should be rendered as a multi-line textarea.
+     * Used for STRING_LIST properties when no allowable values are available
+     * (either the descriptor has none and is not fetchable, or the dynamic
+     * fetch came back empty or failed). The user enters a comma-separated list.
+     */
+    shouldUseTextarea(): boolean {
+        const prop = this.property();
+        if (!prop || prop.type !== 'STRING_LIST') {
+            return false;
+        }
+        return !this.shouldUseSelect();
+    }
+
+    /**
+     * Whether the searchable-select should be rendered in multi-select mode.
+     * True when the property is STRING_LIST and we have allowable values to
+     * pick from (static or successfully fetched).
+     */
+    isMultiSelect(): boolean {
+        return this.property()?.type === 'STRING_LIST' && this.shouldUseSelect();
+    }
+
+    /**
+     * Placeholder text for the searchable-select dropdown.
+     */
+    getSelectPlaceholder(): string {
+        if (this.isDynamicValuesLoading()) {
+            return 'Loading values...';
+        }
+        return 'Select a value';
+    }
+
+    /**
+     * Returns a validation error message to forward to searchable-select when
+     * the parent control reports a known error. Keeps the searchable-select
+     * in charge of displaying its own mat-error.
+     */
+    getValidationErrorMessage(): string {
+        const parent = this.parentControl;
+        if (!parent || !parent.touched) {
+            return '';
+        }
+        if (parent.hasError('required')) {
+            return 'This field is required';
+        }
+        if (parent.hasError('verificationError')) {
+            return parent.getError('verificationError');
+        }
+        if (parent.hasError('pattern')) {
+            return 'Invalid format';
+        }
+        return '';
+    }
+
+    /**
+     * Emits requestAllowableValues exactly once per fetchable property instance
+     * when the descriptor is fetchable and has no static allowable values.
+     */
+    private triggerDynamicValuesFetch(): void {
+        const prop = this.property();
+        if (prop?.allowableValuesFetchable && !this.hasFetchedDynamicValues && !this.hasStaticAllowableValues()) {
+            this.hasFetchedDynamicValues = true;
+            this.requestAllowableValues.emit();
+        }
+    }
+
+    /**
+     * Compute SearchableSelectOptions from whichever source is available:
+     * dynamic values when successfully fetched, otherwise static values.
+     */
+    private computeSelectOptions(): SearchableSelectOption<string>[] {
+        const prop = this.property();
+        if (!prop || prop.type === 'BOOLEAN') {
+            return [];
+        }
+
+        let allowableValues: AllowableValue[] = [];
+
+        const state = this.dynamicAllowableValuesState();
+        if (state?.values && state.values.length > 0) {
+            allowableValues = state.values;
+        } else if (this.hasStaticAllowableValues()) {
+            allowableValues = prop.allowableValues || [];
+        }
+
+        return allowableValues.map((av) => ({
+            value: av.allowableValue.value,
+            label: av.allowableValue.displayName
+        }));
     }
 
     private syncValidationState(): void {

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.ts
@@ -60,10 +60,7 @@ import { SearchableSelect } from '../searchable-select/searchable-select.compone
         MatProgressSpinner,
         SearchableSelect
     ],
-    templateUrl: './connector-property-input.component.html',
-    host: {
-        class: 'block'
-    }
+    templateUrl: './connector-property-input.component.html'
 })
 export class ConnectorPropertyInput implements ControlValueAccessor, DoCheck, OnInit {
     private ngControl = inject(NgControl, { optional: true, self: true });

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/index.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/index.ts
@@ -45,3 +45,5 @@ export * from './property-group-card/property-group-card.component';
 export * from './side-panel-container/side-panel-container.component';
 export * from './connector-property-input/connector-property-input.component';
 export * from './connector-detail-header/connector-detail-header.component';
+export * from './searchable-select/searchable-select.component';
+export * from './multi-select-option/multi-select-option.component';

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.html
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.html
@@ -1,0 +1,43 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ng-content select="mat-icon"></ng-content>
+
+<!--full width minus the 36px needed for the checkbox and its margin-->
+<span class="w-[calc(100%-36px)] mdc-list-item__primary-text" #text><ng-content></ng-content></span>
+
+<!-- Render checkmark at the end for selection (normal or virtual). -->
+@if (shouldShowCheckmark) {
+    <mat-pseudo-checkbox
+        class="mat-mdc-option-pseudo-checkbox"
+        [disabled]="disabled"
+        state="checked"
+        aria-hidden="true"
+        appearance="minimal"></mat-pseudo-checkbox>
+}
+
+<!-- See a11y notes inside optgroup.ts for context behind this element. -->
+@if (group && group._inert) {
+    <span class="cdk-visually-hidden">({{ group.label }})</span>
+}
+
+<div
+    class="mat-mdc-option-ripple mat-focus-indicator"
+    aria-hidden="true"
+    mat-ripple
+    [matRippleTrigger]="_getHostElement()"
+    [matRippleDisabled]="disabled || disableRipple"></div>

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.scss
@@ -100,4 +100,15 @@ multi-select-option {
             color: var(--mat-option-selected-state-label-text-color, var(--mat-sys-on-secondary-container));
         }
     }
+
+    // When hover/focus/active overrides the selected background, revert the checkmark
+    // to the regular label color so it remains visible against the state layer.
+    &:hover .mat-pseudo-checkbox,
+    &:focus .mat-pseudo-checkbox,
+    &.mat-mdc-option-active .mat-pseudo-checkbox {
+        --mat-pseudo-checkbox-minimal-selected-checkmark-color: var(
+            --mat-option-label-text-color,
+            var(--mat-sys-on-surface)
+        );
+    }
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.scss
@@ -15,32 +15,9 @@
  * limitations under the License.
  */
 
-// ViewEncapsulation.None on MultiSelectOption means these rules apply inside the
-// searchable-select overlay without leaking beyond .multi-select-option. They give
-// the custom option a Material-like layout that the subclass otherwise loses when
-// the host class binding replaces MatOption's defaults.
 .multi-select-option {
     display: flex;
     flex-direction: row;
-    align-items: flex-start;
-    min-height: 32px;
-    padding: 6px 12px;
-    cursor: pointer;
-
-    &.mdc-list-item--disabled {
-        cursor: not-allowed;
-        opacity: 1;
-        color: var(--mat-sys-on-surface);
-
-        .mdc-list-item__primary-text {
-            color: inherit;
-            opacity: 0.38;
-        }
-    }
-
-    .mdc-list-item__primary-text {
-        color: inherit;
-    }
 
     .mat-pseudo-checkbox {
         height: 16px;
@@ -51,29 +28,5 @@
     .mat-pseudo-checkbox-minimal.mat-pseudo-checkbox-checked::after {
         height: 4px;
         width: 10px;
-    }
-
-    &:not(.mdc-list-item--disabled):hover {
-        background-color: color-mix(
-            in srgb,
-            var(--mat-sys-on-surface) calc(var(--mat-sys-hover-state-layer-opacity) * 100%),
-            transparent
-        );
-    }
-
-    &.mdc-list-item--selected:not(.mdc-list-item--disabled) {
-        color: var(--mat-sys-primary);
-
-        .mdc-list-item__primary-text {
-            color: inherit;
-        }
-    }
-
-    // Keyboard-active row: use a 2px outline rather than a background so the keyboard
-    // focus indicator stays visually distinct from the hover state.
-    &.mat-mdc-option-active:not(.mdc-list-item--disabled) {
-        background-color: transparent;
-        outline: 2px solid var(--mat-sys-primary);
-        outline-offset: -2px;
     }
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.scss
@@ -1,0 +1,79 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ViewEncapsulation.None on MultiSelectOption means these rules apply inside the
+// searchable-select overlay without leaking beyond .multi-select-option. They give
+// the custom option a Material-like layout that the subclass otherwise loses when
+// the host class binding replaces MatOption's defaults.
+.multi-select-option {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    min-height: 32px;
+    padding: 6px 12px;
+    cursor: pointer;
+
+    &.mdc-list-item--disabled {
+        cursor: not-allowed;
+        opacity: 1;
+        color: var(--mat-sys-on-surface);
+
+        .mdc-list-item__primary-text {
+            color: inherit;
+            opacity: 0.38;
+        }
+    }
+
+    .mdc-list-item__primary-text {
+        color: inherit;
+    }
+
+    .mat-pseudo-checkbox {
+        height: 16px;
+        width: 16px;
+        margin-left: 4px;
+    }
+
+    .mat-pseudo-checkbox-minimal.mat-pseudo-checkbox-checked::after {
+        height: 4px;
+        width: 10px;
+    }
+
+    &:not(.mdc-list-item--disabled):hover {
+        background-color: color-mix(
+            in srgb,
+            var(--mat-sys-on-surface) calc(var(--mat-sys-hover-state-layer-opacity) * 100%),
+            transparent
+        );
+    }
+
+    &.mdc-list-item--selected:not(.mdc-list-item--disabled) {
+        color: var(--mat-sys-primary);
+
+        .mdc-list-item__primary-text {
+            color: inherit;
+        }
+    }
+
+    // Keyboard-active row: use a 2px outline rather than a background so the keyboard
+    // focus indicator stays visually distinct from the hover state.
+    &.mat-mdc-option-active:not(.mdc-list-item--disabled) {
+        background-color: transparent;
+        outline: 2px solid var(--mat-sys-primary);
+        outline-offset: -2px;
+    }
+}

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.scss
@@ -15,6 +15,31 @@
  * limitations under the License.
  */
 
+@use '@angular/material' as mat;
+
+// Forward --mat-option-* CSS custom properties onto multi-select-option elements.
+// mat.theme() only emits system-level --mat-sys-* tokens; component-specific tokens
+// need to be set explicitly for custom elements that extend MatOption.
+multi-select-option {
+    @include mat.option-overrides(
+        (
+            hover-state-layer-color: color-mix(
+                    in srgb,
+                    var(--mat-sys-on-surface) calc(var(--mat-sys-hover-state-layer-opacity) * 100%),
+                    transparent
+                ),
+            focus-state-layer-color: color-mix(
+                    in srgb,
+                    var(--mat-sys-on-surface) calc(var(--mat-sys-focus-state-layer-opacity) * 100%),
+                    transparent
+                ),
+            selected-state-layer-color: var(--mat-sys-secondary-container),
+            selected-state-label-text-color: var(--mat-sys-on-secondary-container),
+            label-text-color: var(--mat-sys-on-surface)
+        )
+    );
+}
+
 .multi-select-option {
     display: flex;
     flex-direction: row;
@@ -23,10 +48,56 @@
         height: 16px;
         width: 16px;
         margin-left: 4px;
+        --mat-pseudo-checkbox-minimal-selected-checkmark-color: var(
+            --mat-option-selected-state-label-text-color,
+            var(--mat-sys-on-secondary-container)
+        );
     }
 
     .mat-pseudo-checkbox-minimal.mat-pseudo-checkbox-checked::after {
         height: 4px;
         width: 10px;
+    }
+
+    // State layer rules mirrored from @angular/material/core/option/option.scss (Material 3, v20).
+    // multi-select-option extends MatOption but has its own template/styles, so MatOption's
+    // compiled CSS is not automatically loaded. The mat.option-overrides() above sets the
+    // --mat-option-* tokens; these rules consume them (with color-mix fallbacks).
+    // On Angular Material upgrades, diff against: @angular/material/core/option/option.scss
+
+    &.mdc-list-item {
+        background: transparent;
+    }
+
+    &:hover:not(.mdc-list-item--disabled) {
+        background-color: var(
+            --mat-option-hover-state-layer-color,
+            color-mix(
+                in srgb,
+                var(--mat-sys-on-surface) calc(var(--mat-sys-hover-state-layer-opacity) * 100%),
+                transparent
+            )
+        );
+    }
+
+    &:focus.mdc-list-item,
+    &.mat-mdc-option-active.mdc-list-item {
+        background-color: var(
+            --mat-option-focus-state-layer-color,
+            color-mix(
+                in srgb,
+                var(--mat-sys-on-surface) calc(var(--mat-sys-focus-state-layer-opacity) * 100%),
+                transparent
+            )
+        );
+        outline: 0;
+    }
+
+    &.mdc-list-item--selected:not(.mdc-list-item--disabled):not(.mat-mdc-option-active, :focus, :hover) {
+        background-color: var(--mat-option-selected-state-layer-color, var(--mat-sys-secondary-container));
+
+        .mdc-list-item__primary-text {
+            color: var(--mat-option-selected-state-label-text-color, var(--mat-sys-on-secondary-container));
+        }
     }
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeDetectionStrategy, Component, HostBinding, Input, ViewEncapsulation } from '@angular/core';
+import { MatOption } from '@angular/material/select';
+import { MatPseudoCheckbox, MatRipple } from '@angular/material/core';
+
+/**
+ * Extension of MatOption that shows a trailing checkmark when selected and supports a
+ * "virtual" selection flag so mat-select can track selections for rows rendered outside
+ * the viewport when used with CDK virtual scrolling.
+ */
+@Component({
+    selector: 'multi-select-option',
+    standalone: true,
+    imports: [MatPseudoCheckbox, MatRipple],
+    templateUrl: './multi-select-option.component.html',
+    styleUrl: './multi-select-option.component.scss',
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [{ provide: MatOption, useExisting: MultiSelectOption }],
+    // Include the Material option classes that MatOption's own host metadata applies.
+    // Angular does not merge host bindings across inheritance, so overriding `class`
+    // with only 'multi-select-option' drops 'mat-mdc-option' + 'mdc-list-item' and
+    // strips Material's default option layout and spacing.
+    host: { class: 'multi-select-option mat-mdc-option mdc-list-item', role: 'option' }
+})
+export class MultiSelectOption extends MatOption {
+    /**
+     * Virtual selection state - for virtual scrolling when mat-select can't track selection
+     */
+    @Input() virtuallySelected = false;
+
+    /**
+     * Host binding to apply selection styling when virtually selected
+     */
+    @HostBinding('class.mdc-list-item--selected')
+    @HostBinding('class.mat-mdc-option-active')
+    get isVisuallySelected(): boolean {
+        return this.selected || this.virtuallySelected;
+    }
+
+    /**
+     * Determines if checkmark should be shown
+     */
+    get shouldShowCheckmark(): boolean {
+        return this.selected || this.virtuallySelected;
+    }
+}

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.ts
@@ -44,7 +44,6 @@ export class MultiSelectOption extends MatOption {
      * Host binding to apply selection styling when virtually selected
      */
     @HostBinding('class.mdc-list-item--selected')
-    @HostBinding('class.mat-mdc-option-active')
     get isVisuallySelected(): boolean {
         return this.selected || this.virtuallySelected;
     }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/multi-select-option/multi-select-option.component.ts
@@ -26,18 +26,13 @@ import { MatPseudoCheckbox, MatRipple } from '@angular/material/core';
  */
 @Component({
     selector: 'multi-select-option',
-    standalone: true,
     imports: [MatPseudoCheckbox, MatRipple],
     templateUrl: './multi-select-option.component.html',
     styleUrl: './multi-select-option.component.scss',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [{ provide: MatOption, useExisting: MultiSelectOption }],
-    // Include the Material option classes that MatOption's own host metadata applies.
-    // Angular does not merge host bindings across inheritance, so overriding `class`
-    // with only 'multi-select-option' drops 'mat-mdc-option' + 'mdc-list-item' and
-    // strips Material's default option layout and spacing.
-    host: { class: 'multi-select-option mat-mdc-option mdc-list-item', role: 'option' }
+    host: { class: 'multi-select-option', role: 'option' }
 })
 export class MultiSelectOption extends MatOption {
     /**

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.html
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.html
@@ -1,0 +1,320 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<div class="searchable-select">
+    <mat-form-field subscriptSizing="dynamic">
+        <mat-select
+            panelClass="searchable-overlay"
+            [disabled]="loadError()"
+            [placeholder]="placeholder()"
+            [multiple]="multiple()"
+            [value]="matSelectValue"
+            [disableOptionCentering]="true"
+            (openedChange)="selectionPanelToggled($event)"
+            (valueChange)="onValueChanged($event)"
+            (keydown)="onMatSelectKeydown($event)"
+            [typeaheadDebounceInterval]="0"
+            [disableRipple]="false">
+            <mat-select-trigger>
+                <div class="select-trigger flex items-center justify-between w-full">
+                    <span class="flex-1 truncate">{{ displayValueSignal() }}</span>
+                    @if (shouldShowClearButton()) {
+                        <button
+                            type="button"
+                            mat-flat-button
+                            aria-label="Clear selection"
+                            (click)="clearSelection($event)"
+                            (keydown)="onClearSelectionKeydown($event)"
+                            class="flex-shrink-0 searchable-select-icon-button mr-2">
+                            <i class="fa fa-times clear-search-filter"></i>
+                        </button>
+                    }
+                </div>
+            </mat-select-trigger>
+            <div class="search-filter-container">
+                <mat-form-field class="search-filter" subscriptSizing="dynamic">
+                    <div class="flex items-center">
+                        <i class="fa fa-search mr-2" matPrefix aria-hidden="true"></i>
+
+                        <input
+                            #searchInput
+                            [(ngModel)]="searchString"
+                            matInput
+                            [placeholder]="searchPlaceholder()"
+                            [attr.aria-label]="a11ySearchLabel()"
+                            role="combobox"
+                            aria-expanded="true"
+                            aria-autocomplete="list"
+                            [attr.aria-owns]="optionsListId"
+                            autocomplete="off"
+                            data-1p-ignore
+                            (keydown)="onSearchInputKeydown($event)" />
+
+                        @if (searchString) {
+                            <button
+                                #clearSearchBtn
+                                type="button"
+                                data-qa="searchable-select-clear-search-btn"
+                                [attr.aria-label]="a11yClearSearchLabel()"
+                                (keydown)="focusSearchAndOrClear($event)"
+                                (click)="focusSearchAndOrClear($event)"
+                                mat-flat-button
+                                class="searchable-select-icon-button ml-2">
+                                <i class="fa fa-times clear-search-filter" matSuffix aria-hidden="true"></i>
+                            </button>
+                        }
+                    </div>
+                </mat-form-field>
+            </div>
+
+            <!-- Unified ghost options for both virtual and non-virtual modes -->
+            @for (ghostOption of getGhostOptions(); track ghostOption.value) {
+                <multi-select-option
+                    [value]="ghostOption.value"
+                    [disabled]="disabled || ghostOption.disabled"
+                    class="ghost-option"
+                    style="display: none; position: absolute; visibility: hidden">
+                    @if (ghostOption.svgIcon) {
+                        <mat-icon class="flex-shrink-0" [svgIcon]="ghostOption.svgIcon"></mat-icon>
+                    }
+                    <div class="flex flex-col gap-y-1 w-full">
+                        <div
+                            class="text-md truncate"
+                            [ngClass]="ghostOption.labelCssClasses"
+                            [title]="ghostOption.label">
+                            {{ ghostOption.label }}
+                        </div>
+                        @if (ghostOption.description) {
+                            <div class="text-sm tertiary-color">
+                                {{ ghostOption.description }}
+                            </div>
+                        }
+                    </div>
+                </multi-select-option>
+            }
+
+            @if (searchInProgress && !loadError()) {
+                <div class="flex w-full items-center justify-center py-2 px-3" role="note" aria-live="polite">
+                    <mat-progress-spinner diameter="16" mode="indeterminate"></mat-progress-spinner>
+                </div>
+            } @else {
+                @if (enableVirtualScrolling()) {
+                    <!-- Virtual scrolling for user interaction -->
+                    <cdk-virtual-scroll-viewport
+                        #virtualScrollViewport
+                        [itemSize]="virtualScrollItemSize()"
+                        [minBufferPx]="virtualScrollMinBufferPx()"
+                        [maxBufferPx]="virtualScrollMaxBufferPx()"
+                        class="virtual-scroll-viewport w-full"
+                        [style.height]="getVirtualScrollHeight()"
+                        [id]="optionsListId"
+                        role="listbox">
+                        <ng-container
+                            *cdkVirtualFor="
+                                let item of getVirtualVisibleItems();
+                                trackBy: trackByVirtualItem;
+                                let virtualIndex = index
+                            ">
+                            @if (isFooterItem(item)) {
+                                <div
+                                    class="flex w-full items-center justify-center py-2 px-3"
+                                    [style.height.px]="virtualScrollItemSize()"
+                                    role="note"
+                                    aria-live="polite">
+                                    @if (isMoreItem(item)) {
+                                        <div class="text-md truncate tertiary-color" title="More options available">
+                                            More options available
+                                        </div>
+                                    } @else {
+                                        <span class="text-md truncate error-color" [title]="loadErrorMessage()">
+                                            {{ loadErrorMessage() }}
+                                        </span>
+                                    }
+                                </div>
+                            } @else if (isGroupHeaderItem(item)) {
+                                <div
+                                    class="tertiary-color pt-3 pr-1 pb-1 pl-3 flex text-sm font-semibold"
+                                    [class.border-t]="!isFirstGroupHeader(item)"
+                                    [style.height.px]="virtualScrollItemSize()"
+                                    role="presentation">
+                                    {{ getGroupHeaderLabel(item) }}
+                                </div>
+                            } @else {
+                                <multi-select-option
+                                    [value]="getItemValue(item)"
+                                    [disabled]="disabled || getItemDisabled(item)"
+                                    [virtuallySelected]="isVirtualOptionSelected(getItemValue(item))"
+                                    [id]="
+                                        isOptionActiveByValue(getItemValue(item))
+                                            ? activeOptionId
+                                            : getOptionId(virtualIndex)
+                                    "
+                                    [attr.aria-selected]="isVirtualOptionSelected(getItemValue(item))"
+                                    [class.mat-mdc-option-active]="isOptionActiveByValue(getItemValue(item))"
+                                    role="option">
+                                    @if (getItemSvgIcon(item)) {
+                                        <mat-icon class="flex-shrink-0" [svgIcon]="getItemSvgIcon(item)"></mat-icon>
+                                    }
+                                    <div class="flex flex-col gap-y-1 w-full">
+                                        <div
+                                            class="text-md truncate"
+                                            [ngClass]="getItemLabelCss(item)"
+                                            [title]="getItemLabel(item)">
+                                            {{ getItemLabel(item) }}
+                                        </div>
+                                        @if (getItemDescription(item)) {
+                                            <div class="text-sm tertiary-color">
+                                                {{ getItemDescription(item) }}
+                                            </div>
+                                        }
+                                    </div>
+                                </multi-select-option>
+                            }
+                        </ng-container>
+                        @if (getVisibleOptions().length === 0) {
+                            <multi-select-option
+                                [value]="null"
+                                disabled
+                                style="display: none; position: absolute; visibility: hidden"></multi-select-option>
+                        }
+                    </cdk-virtual-scroll-viewport>
+                } @else {
+                    <!-- Standard implementation (non-virtual) -->
+                    <div [id]="optionsListId" role="listbox">
+                        @if (hasGroupedOptions() && groupedOptions(); as groups) {
+                            @for (group of groups; track group.groupId; let isLast = $last) {
+                                <div
+                                    [class.border-b]="!isLast"
+                                    role="group"
+                                    [attr.aria-labelledby]="group.groupLabel ? getGroupHeaderId(group.groupId) : null">
+                                    @if (group.groupLabel) {
+                                        <div
+                                            class="pt-3 pr-1 pb-1 pl-3 tertiary-color flex items-center text-sm font-semibold"
+                                            [id]="getGroupHeaderId(group.groupId)"
+                                            role="presentation">
+                                            {{ group.groupLabel }}
+                                        </div>
+                                    }
+                                    @for (option of group.options; track option.value; let optIdx = $index) {
+                                        <multi-select-option
+                                            [value]="option.value"
+                                            [disabled]="disabled || option.disabled"
+                                            [id]="getOptionId(group.groupId + '-' + optIdx)"
+                                            [class.mat-mdc-option-active]="isOptionActiveByValue(option.value)"
+                                            role="option">
+                                            @if (option.svgIcon) {
+                                                <mat-icon class="flex-shrink-0" [svgIcon]="option.svgIcon"></mat-icon>
+                                            }
+                                            <div class="flex flex-col gap-y-1 w-full">
+                                                <div
+                                                    class="text-md truncate"
+                                                    [ngClass]="option.labelCssClasses"
+                                                    [title]="option.label">
+                                                    {{ option.label }}
+                                                </div>
+                                                @if (option.description) {
+                                                    <div class="text-sm tertiary-color">
+                                                        {{ option.description }}
+                                                    </div>
+                                                }
+                                            </div>
+                                        </multi-select-option>
+                                    }
+                                </div>
+                            }
+                        } @else {
+                            @for (option of filteredOptions(); track option.value; let i = $index) {
+                                @if (!option.hidden) {
+                                    <multi-select-option
+                                        [value]="option.value"
+                                        [disabled]="disabled || option.disabled"
+                                        [id]="getOptionId(i)"
+                                        [class.mat-mdc-option-active]="activeTemplateIndex() === i"
+                                        role="option">
+                                        @if (option.svgIcon) {
+                                            <mat-icon class="flex-shrink-0" [svgIcon]="option.svgIcon"></mat-icon>
+                                        }
+                                        <div class="flex flex-col gap-y-1 w-full">
+                                            <div
+                                                class="text-md truncate"
+                                                [ngClass]="option.labelCssClasses"
+                                                [title]="option.label">
+                                                {{ option.label }}
+                                            </div>
+                                            @if (option.description) {
+                                                <div class="text-sm tertiary-color">
+                                                    {{ option.description }}
+                                                </div>
+                                            }
+                                        </div>
+                                    </multi-select-option>
+                                }
+                            }
+                        }
+                        @if (filteredLength === 0) {
+                            <multi-select-option
+                                [value]="null"
+                                disabled
+                                style="display: none; position: absolute; visibility: hidden"></multi-select-option>
+                        }
+
+                        @if (asyncSearchEnabled() && filteredLength !== 0 && asyncSearchOptionsHaveMore()) {
+                            <div
+                                class="flex w-full items-center justify-center py-2 px-3"
+                                role="note"
+                                aria-live="polite">
+                                <div class="text-md truncate tertiary-color" title="More options available">
+                                    More options available
+                                </div>
+                            </div>
+                        }
+                        @if (loadError() && filteredLength === 0) {
+                            <div
+                                class="flex w-full items-center justify-center py-2 px-3"
+                                role="note"
+                                aria-live="polite">
+                                <span class="text-md truncate error-color" [title]="loadErrorMessage()">
+                                    {{ loadErrorMessage() }}
+                                </span>
+                            </div>
+                        }
+                    </div>
+                }
+                @if (filteredLength === 0 && !loadError()) {
+                    <div class="flex w-full items-center justify-center py-2 px-3" role="note" aria-live="polite">
+                        <div class="text-md truncate tertiary-color" title="No results">No results</div>
+                    </div>
+                }
+            }
+        </mat-select>
+
+        @if (validationError() && !verificationError()) {
+            <mat-error class="mt-[-8px] tracking-[0.4px]">{{ validationError() }}</mat-error>
+        }
+
+        @if (hint() && showHint() && !validationError() && !verificationError()) {
+            <mat-hint class="tracking-[0.4px]">{{ hint() }}</mat-hint>
+        }
+    </mat-form-field>
+
+    @if (verificationError()) {
+        <mat-error class="mt-[-8px] tracking-[0.4px]" data-qa="verification-error">{{ verificationError() }}</mat-error>
+    }
+
+    @if (loadError()) {
+        <mat-error class="mt-[-8px] tracking-[0.4px]">{{ loadErrorMessage() || 'Failed to load options' }}</mat-error>
+    }
+</div>

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.html
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.html
@@ -47,10 +47,7 @@
             <div class="search-filter-container">
                 <mat-form-field class="search-filter" subscriptSizing="dynamic">
                     <div class="flex items-center">
-                        <i
-                            class="fa fa-search mr-2 text-base leading-none text-inherit"
-                            matPrefix
-                            aria-hidden="true"></i>
+                        <i class="fa fa-search mr-2 leading-none text-inherit" matPrefix aria-hidden="true"></i>
 
                         <input
                             #searchInput
@@ -93,7 +90,7 @@
                     }
                     <div class="flex flex-col gap-y-1 w-full">
                         <div
-                            class="text-md truncate"
+                            class="truncate"
                             [ngClass]="ghostOption.labelCssClasses"
                             data-qa="searchable-select-option-label"
                             ellipsisTooltip>
@@ -137,11 +134,11 @@
                                     role="note"
                                     aria-live="polite">
                                     @if (isMoreItem(item)) {
-                                        <div class="text-md truncate tertiary-color" ellipsisTooltip>
+                                        <div class="truncate tertiary-color" ellipsisTooltip>
                                             More options available
                                         </div>
                                     } @else {
-                                        <span class="text-md truncate error-color" ellipsisTooltip>
+                                        <span class="truncate error-color" ellipsisTooltip>
                                             {{ loadErrorMessage() }}
                                         </span>
                                     }
@@ -172,7 +169,7 @@
                                     }
                                     <div class="flex flex-col gap-y-1 w-full">
                                         <div
-                                            class="text-md truncate"
+                                            class="truncate"
                                             [ngClass]="getItemLabelCss(item)"
                                             data-qa="searchable-select-option-label"
                                             ellipsisTooltip>
@@ -223,7 +220,7 @@
                                             }
                                             <div class="flex flex-col gap-y-1 w-full">
                                                 <div
-                                                    class="text-md truncate"
+                                                    class="truncate"
                                                     [ngClass]="option.labelCssClasses"
                                                     data-qa="searchable-select-option-label"
                                                     ellipsisTooltip>
@@ -253,7 +250,7 @@
                                         }
                                         <div class="flex flex-col gap-y-1 w-full">
                                             <div
-                                                class="text-md truncate"
+                                                class="truncate"
                                                 [ngClass]="option.labelCssClasses"
                                                 data-qa="searchable-select-option-label"
                                                 ellipsisTooltip>
@@ -281,9 +278,7 @@
                                 class="flex w-full items-center justify-center py-2 px-3"
                                 role="note"
                                 aria-live="polite">
-                                <div class="text-md truncate tertiary-color" ellipsisTooltip>
-                                    More options available
-                                </div>
+                                <div class="truncate tertiary-color" ellipsisTooltip>More options available</div>
                             </div>
                         }
                         @if (loadError() && filteredLength === 0) {
@@ -291,7 +286,7 @@
                                 class="flex w-full items-center justify-center py-2 px-3"
                                 role="note"
                                 aria-live="polite">
-                                <span class="text-md truncate error-color" ellipsisTooltip>
+                                <span class="truncate error-color" ellipsisTooltip>
                                     {{ loadErrorMessage() }}
                                 </span>
                             </div>
@@ -300,7 +295,7 @@
                 }
                 @if (filteredLength === 0 && !loadError()) {
                     <div class="flex w-full items-center justify-center py-2 px-3" role="note" aria-live="polite">
-                        <div class="text-md truncate tertiary-color" ellipsisTooltip>No results</div>
+                        <div class="truncate tertiary-color" ellipsisTooltip>No results</div>
                     </div>
                 }
             }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.html
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.html
@@ -38,7 +38,7 @@
                             aria-label="Clear selection"
                             (click)="clearSelection($event)"
                             (keydown)="onClearSelectionKeydown($event)"
-                            class="flex-shrink-0 searchable-select-icon-button mr-2">
+                            class="shrink-0 searchable-select-icon-button mr-2">
                             <i class="fa fa-times clear-search-filter"></i>
                         </button>
                     }
@@ -88,11 +88,11 @@
                     class="ghost-option"
                     style="display: none; position: absolute; visibility: hidden">
                     @if (ghostOption.svgIcon) {
-                        <mat-icon class="flex-shrink-0" [svgIcon]="ghostOption.svgIcon"></mat-icon>
+                        <mat-icon class="shrink-0" [svgIcon]="ghostOption.svgIcon"></mat-icon>
                     }
                     <div class="flex flex-col gap-y-1 w-full">
                         <div
-                            class="text-md truncate"
+                            class="text-base truncate"
                             [ngClass]="ghostOption.labelCssClasses"
                             [title]="ghostOption.label">
                             {{ ghostOption.label }}
@@ -135,11 +135,11 @@
                                     role="note"
                                     aria-live="polite">
                                     @if (isMoreItem(item)) {
-                                        <div class="text-md truncate tertiary-color" title="More options available">
+                                        <div class="text-base truncate tertiary-color" title="More options available">
                                             More options available
                                         </div>
                                     } @else {
-                                        <span class="text-md truncate error-color" [title]="loadErrorMessage()">
+                                        <span class="text-base truncate error-color" [title]="loadErrorMessage()">
                                             {{ loadErrorMessage() }}
                                         </span>
                                     }
@@ -166,11 +166,11 @@
                                     [class.mat-mdc-option-active]="isOptionActiveByValue(getItemValue(item))"
                                     role="option">
                                     @if (getItemSvgIcon(item)) {
-                                        <mat-icon class="flex-shrink-0" [svgIcon]="getItemSvgIcon(item)"></mat-icon>
+                                        <mat-icon class="shrink-0" [svgIcon]="getItemSvgIcon(item)"></mat-icon>
                                     }
                                     <div class="flex flex-col gap-y-1 w-full">
                                         <div
-                                            class="text-md truncate"
+                                            class="text-base truncate"
                                             [ngClass]="getItemLabelCss(item)"
                                             [title]="getItemLabel(item)">
                                             {{ getItemLabel(item) }}
@@ -216,11 +216,11 @@
                                             [class.mat-mdc-option-active]="isOptionActiveByValue(option.value)"
                                             role="option">
                                             @if (option.svgIcon) {
-                                                <mat-icon class="flex-shrink-0" [svgIcon]="option.svgIcon"></mat-icon>
+                                                <mat-icon class="shrink-0" [svgIcon]="option.svgIcon"></mat-icon>
                                             }
                                             <div class="flex flex-col gap-y-1 w-full">
                                                 <div
-                                                    class="text-md truncate"
+                                                    class="text-base truncate"
                                                     [ngClass]="option.labelCssClasses"
                                                     [title]="option.label">
                                                     {{ option.label }}
@@ -245,11 +245,11 @@
                                         [class.mat-mdc-option-active]="activeTemplateIndex() === i"
                                         role="option">
                                         @if (option.svgIcon) {
-                                            <mat-icon class="flex-shrink-0" [svgIcon]="option.svgIcon"></mat-icon>
+                                            <mat-icon class="shrink-0" [svgIcon]="option.svgIcon"></mat-icon>
                                         }
                                         <div class="flex flex-col gap-y-1 w-full">
                                             <div
-                                                class="text-md truncate"
+                                                class="text-base truncate"
                                                 [ngClass]="option.labelCssClasses"
                                                 [title]="option.label">
                                                 {{ option.label }}
@@ -276,7 +276,7 @@
                                 class="flex w-full items-center justify-center py-2 px-3"
                                 role="note"
                                 aria-live="polite">
-                                <div class="text-md truncate tertiary-color" title="More options available">
+                                <div class="text-base truncate tertiary-color" title="More options available">
                                     More options available
                                 </div>
                             </div>
@@ -286,7 +286,7 @@
                                 class="flex w-full items-center justify-center py-2 px-3"
                                 role="note"
                                 aria-live="polite">
-                                <span class="text-md truncate error-color" [title]="loadErrorMessage()">
+                                <span class="text-base truncate error-color" [title]="loadErrorMessage()">
                                     {{ loadErrorMessage() }}
                                 </span>
                             </div>
@@ -295,7 +295,7 @@
                 }
                 @if (filteredLength === 0 && !loadError()) {
                     <div class="flex w-full items-center justify-center py-2 px-3" role="note" aria-live="polite">
-                        <div class="text-md truncate tertiary-color" title="No results">No results</div>
+                        <div class="text-base truncate tertiary-color" title="No results">No results</div>
                     </div>
                 }
             }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.html
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.html
@@ -91,10 +91,7 @@
                         <mat-icon class="shrink-0" [svgIcon]="ghostOption.svgIcon"></mat-icon>
                     }
                     <div class="flex flex-col gap-y-1 w-full">
-                        <div
-                            class="text-base truncate"
-                            [ngClass]="ghostOption.labelCssClasses"
-                            [title]="ghostOption.label">
+                        <div class="text-base truncate" [ngClass]="ghostOption.labelCssClasses" ellipsisTooltip>
                             {{ ghostOption.label }}
                         </div>
                         @if (ghostOption.description) {
@@ -135,11 +132,11 @@
                                     role="note"
                                     aria-live="polite">
                                     @if (isMoreItem(item)) {
-                                        <div class="text-base truncate tertiary-color" title="More options available">
+                                        <div class="text-base truncate tertiary-color" ellipsisTooltip>
                                             More options available
                                         </div>
                                     } @else {
-                                        <span class="text-base truncate error-color" [title]="loadErrorMessage()">
+                                        <span class="text-base truncate error-color" ellipsisTooltip>
                                             {{ loadErrorMessage() }}
                                         </span>
                                     }
@@ -172,7 +169,7 @@
                                         <div
                                             class="text-base truncate"
                                             [ngClass]="getItemLabelCss(item)"
-                                            [title]="getItemLabel(item)">
+                                            ellipsisTooltip>
                                             {{ getItemLabel(item) }}
                                         </div>
                                         @if (getItemDescription(item)) {
@@ -222,7 +219,7 @@
                                                 <div
                                                     class="text-base truncate"
                                                     [ngClass]="option.labelCssClasses"
-                                                    [title]="option.label">
+                                                    ellipsisTooltip>
                                                     {{ option.label }}
                                                 </div>
                                                 @if (option.description) {
@@ -251,7 +248,7 @@
                                             <div
                                                 class="text-base truncate"
                                                 [ngClass]="option.labelCssClasses"
-                                                [title]="option.label">
+                                                ellipsisTooltip>
                                                 {{ option.label }}
                                             </div>
                                             @if (option.description) {
@@ -276,7 +273,7 @@
                                 class="flex w-full items-center justify-center py-2 px-3"
                                 role="note"
                                 aria-live="polite">
-                                <div class="text-base truncate tertiary-color" title="More options available">
+                                <div class="text-base truncate tertiary-color" ellipsisTooltip>
                                     More options available
                                 </div>
                             </div>
@@ -286,7 +283,7 @@
                                 class="flex w-full items-center justify-center py-2 px-3"
                                 role="note"
                                 aria-live="polite">
-                                <span class="text-base truncate error-color" [title]="loadErrorMessage()">
+                                <span class="text-base truncate error-color" ellipsisTooltip>
                                     {{ loadErrorMessage() }}
                                 </span>
                             </div>
@@ -295,7 +292,7 @@
                 }
                 @if (filteredLength === 0 && !loadError()) {
                     <div class="flex w-full items-center justify-center py-2 px-3" role="note" aria-live="polite">
-                        <div class="text-base truncate tertiary-color" title="No results">No results</div>
+                        <div class="text-base truncate tertiary-color" ellipsisTooltip>No results</div>
                     </div>
                 }
             }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.html
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.html
@@ -34,12 +34,12 @@
                     @if (shouldShowClearButton()) {
                         <button
                             type="button"
-                            mat-flat-button
+                            mat-icon-button
                             aria-label="Clear selection"
                             (click)="clearSelection($event)"
                             (keydown)="onClearSelectionKeydown($event)"
-                            class="shrink-0 searchable-select-icon-button mr-2">
-                            <i class="fa fa-times clear-search-filter"></i>
+                            class="shrink-0 primary-icon-button mr-2 rounded size-4 p-0">
+                            <i class="fa fa-times text-xs clear-search-filter"></i>
                         </button>
                     }
                 </div>
@@ -47,7 +47,10 @@
             <div class="search-filter-container">
                 <mat-form-field class="search-filter" subscriptSizing="dynamic">
                     <div class="flex items-center">
-                        <i class="fa fa-search mr-2" matPrefix aria-hidden="true"></i>
+                        <i
+                            class="fa fa-search mr-2 text-base leading-none text-inherit"
+                            matPrefix
+                            aria-hidden="true"></i>
 
                         <input
                             #searchInput
@@ -59,8 +62,6 @@
                             aria-expanded="true"
                             aria-autocomplete="list"
                             [attr.aria-owns]="optionsListId"
-                            autocomplete="off"
-                            data-1p-ignore
                             (keydown)="onSearchInputKeydown($event)" />
 
                         @if (searchString) {
@@ -71,9 +72,9 @@
                                 [attr.aria-label]="a11yClearSearchLabel()"
                                 (keydown)="focusSearchAndOrClear($event)"
                                 (click)="focusSearchAndOrClear($event)"
-                                mat-flat-button
-                                class="searchable-select-icon-button ml-2">
-                                <i class="fa fa-times clear-search-filter" matSuffix aria-hidden="true"></i>
+                                mat-icon-button
+                                class="primary-icon-button ml-2">
+                                <i class="fa fa-times text-xs text-inherit clear-search-filter" matSuffix></i>
                             </button>
                         }
                     </div>
@@ -91,7 +92,11 @@
                         <mat-icon class="shrink-0" [svgIcon]="ghostOption.svgIcon"></mat-icon>
                     }
                     <div class="flex flex-col gap-y-1 w-full">
-                        <div class="text-base truncate" [ngClass]="ghostOption.labelCssClasses" ellipsisTooltip>
+                        <div
+                            class="text-md truncate"
+                            [ngClass]="ghostOption.labelCssClasses"
+                            data-qa="searchable-select-option-label"
+                            ellipsisTooltip>
                             {{ ghostOption.label }}
                         </div>
                         @if (ghostOption.description) {
@@ -132,11 +137,11 @@
                                     role="note"
                                     aria-live="polite">
                                     @if (isMoreItem(item)) {
-                                        <div class="text-base truncate tertiary-color" ellipsisTooltip>
+                                        <div class="text-md truncate tertiary-color" ellipsisTooltip>
                                             More options available
                                         </div>
                                     } @else {
-                                        <span class="text-base truncate error-color" ellipsisTooltip>
+                                        <span class="text-md truncate error-color" ellipsisTooltip>
                                             {{ loadErrorMessage() }}
                                         </span>
                                     }
@@ -167,8 +172,9 @@
                                     }
                                     <div class="flex flex-col gap-y-1 w-full">
                                         <div
-                                            class="text-base truncate"
+                                            class="text-md truncate"
                                             [ngClass]="getItemLabelCss(item)"
+                                            data-qa="searchable-select-option-label"
                                             ellipsisTooltip>
                                             {{ getItemLabel(item) }}
                                         </div>
@@ -217,8 +223,9 @@
                                             }
                                             <div class="flex flex-col gap-y-1 w-full">
                                                 <div
-                                                    class="text-base truncate"
+                                                    class="text-md truncate"
                                                     [ngClass]="option.labelCssClasses"
+                                                    data-qa="searchable-select-option-label"
                                                     ellipsisTooltip>
                                                     {{ option.label }}
                                                 </div>
@@ -246,8 +253,9 @@
                                         }
                                         <div class="flex flex-col gap-y-1 w-full">
                                             <div
-                                                class="text-base truncate"
+                                                class="text-md truncate"
                                                 [ngClass]="option.labelCssClasses"
+                                                data-qa="searchable-select-option-label"
                                                 ellipsisTooltip>
                                                 {{ option.label }}
                                             </div>
@@ -273,7 +281,7 @@
                                 class="flex w-full items-center justify-center py-2 px-3"
                                 role="note"
                                 aria-live="polite">
-                                <div class="text-base truncate tertiary-color" ellipsisTooltip>
+                                <div class="text-md truncate tertiary-color" ellipsisTooltip>
                                     More options available
                                 </div>
                             </div>
@@ -283,7 +291,7 @@
                                 class="flex w-full items-center justify-center py-2 px-3"
                                 role="note"
                                 aria-live="polite">
-                                <span class="text-base truncate error-color" ellipsisTooltip>
+                                <span class="text-md truncate error-color" ellipsisTooltip>
                                     {{ loadErrorMessage() }}
                                 </span>
                             </div>
@@ -292,7 +300,7 @@
                 }
                 @if (filteredLength === 0 && !loadError()) {
                     <div class="flex w-full items-center justify-center py-2 px-3" role="note" aria-live="polite">
-                        <div class="text-base truncate tertiary-color" ellipsisTooltip>No results</div>
+                        <div class="text-md truncate tertiary-color" ellipsisTooltip>No results</div>
                     </div>
                 }
             }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.scss
@@ -18,8 +18,6 @@
 .searchable-select {
     .mat-mdc-select-value {
         overflow: unset;
-        // Breathing room between the mat-form-field left edge and the selected value text.
-        padding-left: 12px;
     }
 
     .mat-mdc-form-field {
@@ -33,30 +31,5 @@
         top: 0;
         background: inherit;
         z-index: 10;
-        // Small gap between the sticky search input and the first option so the
-        // list does not visually collide with the filter control.
-        padding-bottom: 4px;
-    }
-
-    // The search field wraps its prefix icon inside a flex div, so matPrefix is
-    // never hoisted out and Material doesn't apply its has-icon-prefix padding.
-    // Pad the text field wrapper here so the magnifying glass and placeholder
-    // sit a comfortable distance from the left edge.
-    .search-filter .mat-mdc-text-field-wrapper {
-        padding-left: 12px;
-        padding-right: 12px;
-    }
-
-    .fa {
-        color: inherit;
-    }
-}
-
-.select-trigger {
-    button.searchable-select-icon-button {
-        border-radius: 4px;
-        min-width: 16px;
-        height: 16px;
-        padding: 0;
     }
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.scss
@@ -1,0 +1,62 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.searchable-select {
+    .mat-mdc-select-value {
+        overflow: unset;
+        // Breathing room between the mat-form-field left edge and the selected value text.
+        padding-left: 12px;
+    }
+
+    .mat-mdc-form-field {
+        width: 100%;
+    }
+}
+
+.searchable-overlay {
+    .search-filter-container {
+        position: sticky;
+        top: 0;
+        background: inherit;
+        z-index: 10;
+        // Small gap between the sticky search input and the first option so the
+        // list does not visually collide with the filter control.
+        padding-bottom: 4px;
+    }
+
+    // The search field wraps its prefix icon inside a flex div, so matPrefix is
+    // never hoisted out and Material doesn't apply its has-icon-prefix padding.
+    // Pad the text field wrapper here so the magnifying glass and placeholder
+    // sit a comfortable distance from the left edge.
+    .search-filter .mat-mdc-text-field-wrapper {
+        padding-left: 12px;
+        padding-right: 12px;
+    }
+
+    .fa {
+        color: inherit;
+    }
+}
+
+.select-trigger {
+    button.searchable-select-icon-button {
+        border-radius: 4px;
+        min-width: 16px;
+        height: 16px;
+        padding: 0;
+    }
+}

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.spec.ts
@@ -845,7 +845,7 @@ describe('SearchableSelect', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            const optionElements = document.querySelectorAll('multi-select-option .text-md');
+            const optionElements = document.querySelectorAll('multi-select-option .text-base');
             const normalOption = Array.from(optionElements).find((el) => el.textContent?.trim() === 'Normal Option');
 
             expect(normalOption).toBeTruthy();

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.spec.ts
@@ -845,7 +845,9 @@ describe('SearchableSelect', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            const optionElements = document.querySelectorAll('multi-select-option .text-base');
+            const optionElements = document.querySelectorAll(
+                'multi-select-option [data-qa="searchable-select-option-label"]'
+            );
             const normalOption = Array.from(optionElements).find((el) => el.textContent?.trim() === 'Normal Option');
 
             expect(normalOption).toBeTruthy();

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.spec.ts
@@ -1,0 +1,1916 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ElementRef, signal } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatSelect } from '@angular/material/select';
+
+import { SearchableSelect } from './searchable-select.component';
+import { SearchableSelectOption } from '../../types';
+
+describe('SearchableSelect', () => {
+    interface SetupOptions {
+        multiple?: boolean;
+        enableVirtualScrolling?: boolean;
+        options?: SearchableSelectOption<string>[];
+        searchString?: string;
+        placeholder?: string;
+        allowClear?: boolean;
+        loadError?: boolean;
+        loadErrorMessage?: string;
+    }
+
+    class MockResizeObserver {
+        disconnect = vi.fn();
+        observe = vi.fn();
+        unobserve = vi.fn();
+        constructor(_callback: ResizeObserverCallback) {
+            // noop
+        }
+    }
+
+    const originalResizeObserver = (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+
+    beforeAll(() => {
+        (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+            MockResizeObserver as unknown as typeof ResizeObserver;
+    });
+
+    afterAll(() => {
+        if (originalResizeObserver) {
+            (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver = originalResizeObserver;
+        } else {
+            delete (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+        }
+    });
+
+    async function setup({
+        multiple = false,
+        enableVirtualScrolling = false,
+        options = [],
+        searchString = '',
+        placeholder = 'Select...',
+        allowClear = false,
+        loadError = false,
+        loadErrorMessage = ''
+    }: SetupOptions = {}) {
+        await TestBed.configureTestingModule({
+            imports: [SearchableSelect, MatIconTestingModule, NoopAnimationsModule]
+        }).compileComponents();
+
+        const fixture = TestBed.createComponent(SearchableSelect<string>);
+        const component = fixture.componentInstance;
+
+        fixture.componentRef.setInput('multiple', multiple);
+        fixture.componentRef.setInput('enableVirtualScrolling', enableVirtualScrolling);
+        fixture.componentRef.setInput('options', options);
+        fixture.componentRef.setInput('placeholder', placeholder);
+        fixture.componentRef.setInput('allowClear', allowClear);
+        fixture.componentRef.setInput('loadError', loadError);
+        fixture.componentRef.setInput('loadErrorMessage', loadErrorMessage);
+
+        component.registerOnChange(() => {
+            /* noop default */
+        });
+        component.registerOnTouched(() => {
+            /* noop */
+        });
+
+        component.searchString = searchString;
+
+        fixture.detectChanges();
+        fixture.detectChanges();
+
+        return { fixture, component };
+    }
+
+    it('should create', async () => {
+        const { component } = await setup();
+        expect(component).toBeTruthy();
+    });
+
+    describe('Search Functionality', () => {
+        const mockOptions: SearchableSelectOption<string>[] = [
+            { value: 'one', label: 'one test' },
+            { value: 'two', label: 'two test' },
+            { value: 'three', label: 'three test' }
+        ];
+
+        it('should filter options by search string', async () => {
+            const { component, fixture } = await setup({ options: mockOptions, searchString: 'o' });
+
+            let searchMatches = component.filteredOptions().filter((f) => !f.hidden);
+            expect(searchMatches).toHaveLength(2);
+
+            component.searchString = 'test';
+            fixture.detectChanges();
+            searchMatches = component.filteredOptions().filter((f) => !f.hidden);
+            expect(searchMatches).toHaveLength(3);
+
+            component.searchString = 'one';
+            fixture.detectChanges();
+            searchMatches = component.filteredOptions().filter((f) => !f.hidden);
+            expect(searchMatches).toHaveLength(1);
+        });
+
+        it('should be case insensitive', async () => {
+            const { component } = await setup({ options: mockOptions, searchString: 'ONE' });
+            const visible = component.filteredOptions().filter((o) => !o.hidden);
+            expect(visible.length).toBe(1);
+            expect(visible[0].value).toBe('one');
+        });
+
+        it('should show all options when search is cleared', async () => {
+            const { component } = await setup({ options: mockOptions, searchString: 'one' });
+            let visible = component.filteredOptions().filter((o) => !o.hidden);
+            expect(visible.length).toBe(1);
+
+            component.searchString = '';
+            visible = component.filteredOptions().filter((o) => !o.hidden);
+            expect(visible.length).toBe(mockOptions.length);
+        });
+
+        it('should handle special characters in search', async () => {
+            const specialOptions = [
+                { value: 'one', label: 'one_test ?' },
+                { value: 'two', label: 'two test **' },
+                { value: 'three', label: 'three test **' }
+            ];
+
+            const { component, fixture } = await setup({ options: specialOptions });
+
+            component.searchString = 'one_test';
+            fixture.detectChanges();
+            let searchMatches = component.filteredOptions().filter((f) => !f.hidden);
+            expect(searchMatches).toHaveLength(1);
+
+            component.searchString = '**';
+            fixture.detectChanges();
+            searchMatches = component.filteredOptions().filter((f) => !f.hidden);
+            expect(searchMatches).toHaveLength(2);
+
+            component.searchString = '///';
+            fixture.detectChanges();
+            searchMatches = component.filteredOptions().filter((f) => !f.hidden);
+            expect(searchMatches).toHaveLength(0);
+        });
+
+        it('should focus search input when panel opens', async () => {
+            const { component, fixture } = await setup({ options: mockOptions, searchString: 'o' });
+
+            component.selectionPanelToggled(true);
+            component.select().open();
+            fixture.detectChanges();
+            await new Promise((r) => setTimeout(r, 0));
+            fixture.detectChanges();
+
+            const searchInput = component.searchInput();
+            const overlayContainer = document.querySelector('.cdk-overlay-container');
+            const clearSearchBtn = overlayContainer?.querySelector(
+                'button[data-qa="searchable-select-clear-search-btn"]'
+            ) as HTMLButtonElement | null;
+
+            expect(searchInput.nativeElement.value).toBe('o');
+            expect(searchInput.nativeElement.getAttribute('aria-label')).toBe('Search');
+            expect(clearSearchBtn?.getAttribute('aria-label')).toBe('Clear search');
+            expect(clearSearchBtn).toBeTruthy();
+        });
+
+        it('should clear search input when clear button is clicked', async () => {
+            const { component, fixture } = await setup({ options: mockOptions, searchString: 'test' });
+
+            component.selectionPanelToggled(true);
+            component.select().open();
+            fixture.detectChanges();
+            await new Promise((r) => setTimeout(r, 0));
+            fixture.detectChanges();
+
+            const searchInput = component.searchInput();
+            const overlayContainer = document.querySelector('.cdk-overlay-container');
+            const clearSearchBtn = overlayContainer?.querySelector(
+                'button[data-qa="searchable-select-clear-search-btn"]'
+            ) as HTMLButtonElement | null;
+
+            vi.spyOn(searchInput.nativeElement, 'focus');
+            clearSearchBtn?.click();
+
+            fixture.detectChanges();
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(searchInput.nativeElement.value).toBe('');
+            expect(searchInput.nativeElement.focus).toHaveBeenCalled();
+        });
+
+        it('should update aria labels for accessibility', async () => {
+            const { component, fixture } = await setup({
+                options: mockOptions,
+                searchString: 'test'
+            });
+
+            fixture.componentRef.setInput('a11ySearchLabel', 'Search Input Label');
+            fixture.componentRef.setInput('a11yClearSearchLabel', 'Clear Search Button Label');
+            component.selectionPanelToggled(true);
+            component.select().open();
+
+            fixture.detectChanges();
+            await new Promise((r) => setTimeout(r, 0));
+            fixture.detectChanges();
+
+            const searchInput = component.searchInput();
+            const overlayContainer = document.querySelector('.cdk-overlay-container');
+            const clearSearchBtn = overlayContainer?.querySelector(
+                'button[data-qa="searchable-select-clear-search-btn"]'
+            ) as HTMLButtonElement | null;
+
+            expect(searchInput.nativeElement.getAttribute('aria-label')).toBe('Search Input Label');
+            if (clearSearchBtn) {
+                expect(clearSearchBtn.getAttribute('aria-label')).toBe('Clear Search Button Label');
+            }
+        });
+    });
+
+    describe('Keyboard Navigation', () => {
+        it('should handle tab navigation to clear button', async () => {
+            const { component } = await setup();
+
+            const tabEvent = {
+                key: 'Tab',
+                code: 'Tab',
+                preventDefault: vi.fn(),
+                stopPropagation: vi.fn()
+            } as unknown as KeyboardEvent;
+
+            component.clearSearchBtn = signal({
+                focus: vi.fn()
+            } as unknown as never) as never;
+
+            component.onSearchInputKeydown(tabEvent);
+
+            expect(tabEvent.preventDefault).toHaveBeenCalled();
+            expect(tabEvent.stopPropagation).toHaveBeenCalled();
+            expect(component.clearSearchBtn()?.focus).toHaveBeenCalled();
+        });
+
+        it('should handle space key events', async () => {
+            const { component } = await setup();
+
+            const spaceEvent = {
+                key: 'A',
+                code: 'Space',
+                preventDefault: vi.fn(),
+                stopPropagation: vi.fn()
+            } as unknown as KeyboardEvent;
+
+            component.onSearchInputKeydown(spaceEvent);
+            expect(spaceEvent.stopPropagation).toHaveBeenCalled();
+        });
+
+        it('should handle page navigation keys', async () => {
+            const { component } = await setup();
+
+            const mockEvent = {
+                key: 'PageDown',
+                preventDefault: vi.fn(),
+                stopPropagation: vi.fn(),
+                stopImmediatePropagation: vi.fn()
+            } as unknown as KeyboardEvent;
+
+            component.onSearchInputKeydown(mockEvent);
+
+            expect(mockEvent.preventDefault).toHaveBeenCalled();
+            expect(mockEvent.stopPropagation).toHaveBeenCalled();
+        });
+
+        it('should initialize navigation state correctly', async () => {
+            const { component } = await setup();
+
+            expect(component['_activeOptionIndex']).toBe(-1);
+            expect(component['_isNavigating']).toBe(false);
+            expect(component['_allowNextValueChange']).toBe(false);
+        });
+
+        it('should reset navigation state on filter', async () => {
+            const { component } = await setup();
+
+            component['_activeOptionIndex'] = 2;
+            component['_isNavigating'] = true;
+
+            component['filter']('test');
+
+            expect(component['_activeOptionIndex']).toBe(-1);
+            expect(component['_isNavigating']).toBe(false);
+        });
+    });
+
+    describe('Focus Management', () => {
+        it('should handle focus and clear for keydown events', async () => {
+            const { component } = await setup();
+
+            component.searchString = 'test';
+            component.searchInput = signal({
+                nativeElement: { focus: vi.fn() }
+            } as unknown as ElementRef<HTMLInputElement>) as never;
+
+            const enterEvent = {
+                type: 'keydown',
+                code: 'Enter',
+                stopPropagation: vi.fn(),
+                preventDefault: vi.fn()
+            } as unknown as KeyboardEvent;
+
+            component.focusSearchAndOrClear(enterEvent);
+
+            expect(enterEvent.stopPropagation).toHaveBeenCalled();
+            expect(enterEvent.preventDefault).toHaveBeenCalled();
+        });
+
+        it('should handle focus and clear for click events', async () => {
+            const { component } = await setup();
+
+            component.searchString = 'test';
+            component.searchInput = signal({
+                nativeElement: { focus: vi.fn() }
+            } as unknown as ElementRef<HTMLInputElement>) as never;
+
+            const clickEvent = {
+                type: 'click',
+                stopPropagation: vi.fn(),
+                preventDefault: vi.fn()
+            } as unknown as MouseEvent;
+
+            component.focusSearchAndOrClear(clickEvent);
+
+            expect(clickEvent.stopPropagation).toHaveBeenCalled();
+            expect(clickEvent.preventDefault).toHaveBeenCalled();
+            expect(component.searchInput().nativeElement.focus).toHaveBeenCalled();
+            expect(component.searchString).toBeNull();
+        });
+    });
+
+    describe('Option Display', () => {
+        it('should display option descriptions when provided', async () => {
+            const optionsWithDescriptions = [
+                { value: 'one', label: 'Option One', description: 'First option description' },
+                { value: 'two', label: 'Option Two' },
+                { value: 'three', label: 'Option Three', description: 'Third option description' }
+            ];
+
+            const { component, fixture } = await setup({ options: optionsWithDescriptions });
+
+            component.filteredOptions.set(
+                component.options().map((opt: SearchableSelectOption<string>) => ({ ...opt, hidden: false }))
+            );
+            fixture.detectChanges();
+
+            const matSelect = fixture.debugElement.query(By.directive(MatSelect));
+            expect(matSelect).toBeTruthy();
+
+            matSelect.componentInstance.open();
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const options = document.querySelectorAll('multi-select-option');
+            expect(options.length).toBe(3);
+
+            const descriptions = document.querySelectorAll('.tertiary-color');
+            expect(descriptions.length).toBeGreaterThanOrEqual(2);
+
+            const descriptionTexts = Array.from(descriptions).map((el) => el.textContent?.trim());
+            expect(descriptionTexts).toContain('First option description');
+            expect(descriptionTexts).toContain('Third option description');
+
+            matSelect.componentInstance.close();
+            fixture.detectChanges();
+        });
+    });
+
+    describe('Display Value', () => {
+        const mockOptions = [
+            { value: 'one', label: 'First Option', description: 'Description 1' },
+            { value: 'two', label: 'Second Option', description: 'Description 2' },
+            { value: 'three', label: 'Third Option', description: 'Description 3' }
+        ];
+
+        it('should return empty string when no value is selected', async () => {
+            const { component } = await setup({ options: mockOptions });
+
+            component.select = signal({ value: null } as unknown as MatSelect) as never;
+            expect(component.displayValue).toBe('');
+        });
+
+        it('should display single selection label', async () => {
+            const { component } = await setup({ options: mockOptions });
+
+            component.select = signal({ value: 'two' } as unknown as MatSelect) as never;
+            component['_virtualSelectedValues'] = ['two'];
+            expect(component.displayValue).toBe('Second Option');
+        });
+
+        it('should display comma-separated labels for multiple selections', async () => {
+            const { component } = await setup({ options: mockOptions, multiple: true });
+
+            component.select = signal({ value: ['one', 'three'] } as unknown as MatSelect) as never;
+            component['_virtualSelectedValues'] = ['one', 'three'];
+            expect(component.displayValue).toBe('First Option, Third Option');
+        });
+
+        it('should handle invalid values gracefully', async () => {
+            const { component } = await setup({ options: mockOptions, multiple: true });
+
+            component.select = signal({ value: ['one', 'invalid', 'three'] } as unknown as MatSelect) as never;
+            component['_virtualSelectedValues'] = ['one', 'three'];
+            expect(component.displayValue).toBe('First Option, Third Option');
+        });
+
+        it('should return empty string for invalid single selection', async () => {
+            const { component } = await setup({ options: mockOptions });
+
+            component.select = signal({ value: 'invalid' } as unknown as MatSelect) as never;
+            expect(component.displayValue).toBe('');
+        });
+
+        it('should return empty string when no value is selected (getDisplayValue)', async () => {
+            const { component } = await setup({ options: mockOptions });
+
+            component.select = signal({ value: null } as unknown as MatSelect) as never;
+            expect(component.getDisplayValue()).toBe('');
+        });
+
+        it('should display only the label for single selection (getDisplayValue)', async () => {
+            const { component } = await setup({ options: mockOptions });
+
+            component.select = signal({ value: 'two' } as unknown as MatSelect) as never;
+            component['_virtualSelectedValues'] = ['two'];
+            expect(component.getDisplayValue()).toBe('Second Option');
+        });
+
+        it('should display comma-separated labels for multiple selections (getDisplayValue)', async () => {
+            const { component } = await setup({ options: mockOptions, multiple: true });
+
+            component.select = signal({ value: ['one', 'three'] } as unknown as MatSelect) as never;
+            component['_virtualSelectedValues'] = ['one', 'three'];
+            expect(component.getDisplayValue()).toBe('First Option, Third Option');
+        });
+
+        it('should handle invalid values gracefully (getDisplayValue)', async () => {
+            const { component } = await setup({ options: mockOptions, multiple: true });
+
+            component.select = signal({ value: ['one', 'invalid', 'three'] } as unknown as MatSelect) as never;
+            component['_virtualSelectedValues'] = ['one', 'three'];
+            expect(component.getDisplayValue()).toBe('First Option, Third Option');
+        });
+
+        it('should return empty string for invalid single selection (getDisplayValue)', async () => {
+            const { component } = await setup({ options: mockOptions });
+
+            component.select = signal({ value: 'invalid' } as unknown as MatSelect) as never;
+            expect(component.getDisplayValue()).toBe('');
+        });
+    });
+
+    describe('ControlValueAccessor', () => {
+        const mockOptions: SearchableSelectOption<string>[] = [
+            { value: 'one', label: 'one test' },
+            { value: 'two', label: 'two test' },
+            { value: 'three', label: 'three test' }
+        ];
+
+        it('should accept a single value via writeValue and expose it in matSelectValue', async () => {
+            const { component, fixture } = await setup({ options: mockOptions });
+            component.writeValue('two');
+            fixture.detectChanges();
+            expect(component.matSelectValue).toBe('two');
+        });
+
+        it('should accept an array of values via writeValue in multiple mode', async () => {
+            const { component, fixture } = await setup({ multiple: true, options: mockOptions });
+            component.writeValue(['one', 'three']);
+            fixture.detectChanges();
+            const value = component.matSelectValue as string[];
+            expect(Array.isArray(value)).toBe(true);
+            expect(value).toContain('one');
+            expect(value).toContain('three');
+        });
+
+        it('should emit changes through the registered onChange callback', async () => {
+            const { component, fixture } = await setup({ multiple: true, options: mockOptions });
+            const onChange = vi.fn();
+            component.registerOnChange(onChange);
+
+            component.onValueChanged(['one', 'two'] as never);
+            fixture.detectChanges();
+            expect(onChange).toHaveBeenCalledWith(['one', 'two']);
+        });
+
+        it('should update disabled state from setDisabledState', async () => {
+            const { component, fixture } = await setup();
+            component.setDisabledState(true);
+            fixture.detectChanges();
+            expect(component.disabled).toBe(true);
+
+            component.setDisabledState(false);
+            fixture.detectChanges();
+            expect(component.disabled).toBe(false);
+        });
+    });
+
+    describe('Value Change Management', () => {
+        interface DuplicateDetectionSetupOptions extends SetupOptions {
+            initialSelectedValues?: string[];
+        }
+
+        async function setupDuplicateDetection({
+            initialSelectedValues = ['option1', 'option2'],
+            ...options
+        }: DuplicateDetectionSetupOptions = {}) {
+            const defaultOptions = [
+                { value: 'option1', label: 'Option 1' },
+                { value: 'option2', label: 'Option 2' },
+                { value: 'option3', label: 'Option 3' }
+            ];
+
+            const { component, fixture } = await setup({
+                multiple: true,
+                enableVirtualScrolling: true,
+                options: defaultOptions,
+                ...options
+            });
+
+            await fixture.whenStable();
+            component.writeValue(initialSelectedValues);
+
+            const mockOnChange = vi.fn();
+            component.onChange = mockOnChange;
+
+            return { component, fixture, mockOnChange };
+        }
+
+        it('should handle duplicate detection for unselection', async () => {
+            const { component, mockOnChange } = await setupDuplicateDetection();
+
+            const eventWithDuplicate = ['option1', 'option2', 'option3', 'option3'];
+            component.onValueChanged(eventWithDuplicate);
+
+            expect(mockOnChange).not.toHaveBeenCalled();
+        });
+
+        it('should remove duplicated values and emit change when selection changes', async () => {
+            const { component, mockOnChange } = await setupDuplicateDetection();
+
+            const eventWithDuplicate = ['option1', 'option1', 'option3'];
+            component.onValueChanged(eventWithDuplicate);
+
+            expect(mockOnChange).toHaveBeenCalledWith(['option3']);
+        });
+
+        it('should handle selection without duplicates', async () => {
+            const { component, mockOnChange } = await setupDuplicateDetection();
+
+            const eventWithoutDuplicates = ['option1', 'option2', 'option3'];
+            component.onValueChanged(eventWithoutDuplicates);
+
+            expect(mockOnChange).toHaveBeenCalledWith(['option1', 'option2', 'option3']);
+        });
+
+        it('should handle multiple duplicates correctly', async () => {
+            const { component, mockOnChange } = await setupDuplicateDetection();
+
+            const eventWithMultipleDuplicates = ['option1', 'option1', 'option2', 'option3', 'option3', 'option4'];
+            component.onValueChanged(eventWithMultipleDuplicates);
+
+            expect(mockOnChange).toHaveBeenCalledWith(['option2', 'option4']);
+        });
+
+        it('should handle empty selection', async () => {
+            const { component, mockOnChange } = await setupDuplicateDetection();
+
+            const emptyEvent: string[] = [];
+            component.onValueChanged(emptyEvent);
+
+            expect(mockOnChange).toHaveBeenCalledWith([]);
+        });
+
+        it('should handle complete unselection through duplication', async () => {
+            const { component, mockOnChange } = await setupDuplicateDetection({
+                initialSelectedValues: ['option1']
+            });
+
+            const duplicateEvent = ['option1', 'option1'];
+            component.onValueChanged(duplicateEvent);
+
+            expect(mockOnChange).toHaveBeenCalledWith([]);
+        });
+
+        it('should manage permission-based value changes for single-select', async () => {
+            const { component } = await setup({ multiple: false });
+
+            component['_allowNextValueChange'] = true;
+            expect(component['_allowNextValueChange']).toBe(true);
+
+            component['_allowNextValueChange'] = false;
+            expect(component['_allowNextValueChange']).toBe(false);
+        });
+    });
+
+    describe('Virtual Scrolling - Ghost Deduplication and Emission Guard', () => {
+        it('should dedupe by label when different values share the same label (ghost copies)', async () => {
+            const options = [
+                { value: 'roleA_1', label: 'ROLE_A' },
+                { value: 'roleA_2', label: 'ROLE_A' },
+                { value: 'roleB', label: 'ROLE_B' }
+            ];
+
+            const { component } = await setup({ multiple: true, enableVirtualScrolling: true, options });
+
+            const mockOnChange = vi.fn();
+            component.onChange = mockOnChange;
+
+            component.onValueChanged(['roleA_1', 'roleA_2', 'roleB']);
+
+            expect(mockOnChange).toHaveBeenCalledTimes(1);
+            expect(mockOnChange).toHaveBeenCalledWith(['roleB']);
+        });
+
+        it('should not emit multiple times for a single onValueChanged call with duplicates', async () => {
+            const options = [
+                { value: 'option1', label: 'Option 1' },
+                { value: 'option2', label: 'Option 2' },
+                { value: 'option3', label: 'Option 3' }
+            ];
+
+            const { component } = await setup({ multiple: true, enableVirtualScrolling: true, options });
+
+            const mockOnChange = vi.fn();
+            component.onChange = mockOnChange;
+
+            component.onValueChanged(['option1', 'option1', 'option3']);
+            expect(mockOnChange).toHaveBeenCalledTimes(1);
+            expect(mockOnChange).toHaveBeenCalledWith(['option3']);
+        });
+
+        it('should suppress duplicate emissions when the selection set does not change (order-insensitive)', async () => {
+            const options = [
+                { value: 'option1', label: 'Option 1' },
+                { value: 'option2', label: 'Option 2' },
+                { value: 'option3', label: 'Option 3' }
+            ];
+
+            const { component } = await setup({ multiple: true, enableVirtualScrolling: true, options });
+
+            const mockOnChange = vi.fn();
+            component.onChange = mockOnChange;
+
+            component.onValueChanged(['option1', 'option2']);
+            component.onValueChanged(['option2', 'option1']);
+
+            expect(mockOnChange).toHaveBeenCalledTimes(1);
+            expect(mockOnChange).toHaveBeenCalledWith(['option1', 'option2']);
+        });
+
+        it('should not register mat-select onChange in virtual mode to avoid duplicate emission paths', async () => {
+            const { component } = await setup({ enableVirtualScrolling: true });
+
+            const registerSpy = vi.fn();
+            component.select = signal({ registerOnChange: registerSpy } as unknown as MatSelect) as never;
+
+            const externalOnChange = vi.fn();
+            component.registerOnChange(externalOnChange);
+
+            expect(registerSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not register mat-select onChange in non-virtual mode to avoid duplicate emission paths', async () => {
+            const { component } = await setup({ enableVirtualScrolling: false });
+
+            const registerSpy = vi.fn();
+            component.select = signal({ registerOnChange: registerSpy } as unknown as MatSelect) as never;
+
+            const externalOnChange = vi.fn();
+            component.registerOnChange(externalOnChange);
+
+            expect(registerSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Virtual Scrolling', () => {
+        it('should track virtual selected values', async () => {
+            const { component } = await setup({ enableVirtualScrolling: true });
+
+            component['_virtualSelectedValues'] = ['opt1', 'opt2'];
+            const selectedValues = component['getCurrentSelectedValues']();
+            expect(selectedValues).toEqual(['opt1', 'opt2']);
+        });
+
+        it('should provide ghost options for virtual mode', async () => {
+            const { component } = await setup({ enableVirtualScrolling: true });
+
+            component['_virtualSelectedValues'] = ['opt1'];
+            const ghostOptions = component.getGhostOptions();
+            expect(ghostOptions.length).toBeGreaterThanOrEqual(0);
+        });
+
+        it('should calculate virtual scroll height', async () => {
+            const { component, fixture } = await setup({ enableVirtualScrolling: true });
+
+            fixture.componentRef.setInput('virtualScrollItemSize', 50);
+            const height = component.getVirtualScrollHeight();
+
+            expect(typeof height).toBe('string');
+            expect(height.endsWith('px')).toBe(true);
+        });
+
+        it('should update display value signal', async () => {
+            const { component } = await setup();
+
+            component['updateDisplayValueSignal']();
+            expect(typeof component['displayValueSignal']()).toBe('string');
+        });
+
+        it('should handle falsy values correctly (0, false, empty string)', async () => {
+            const { component, fixture } = await setup();
+
+            const numberComponent = component as unknown as SearchableSelect<number>;
+            fixture.componentRef.setInput('options', [
+                { value: 0, label: 'Zero Option' },
+                { value: 1, label: 'One Option' }
+            ]);
+            fixture.detectChanges();
+            numberComponent.select = signal({ value: 0 } as unknown as MatSelect) as never;
+            (numberComponent as unknown as { _virtualSelectedValues: number[] })._virtualSelectedValues = [0];
+            expect(numberComponent.getDisplayValue()).toBe('Zero Option');
+
+            const booleanComponent = component as unknown as SearchableSelect<boolean>;
+            fixture.componentRef.setInput('options', [
+                { value: false, label: 'False Option' },
+                { value: true, label: 'True Option' }
+            ]);
+            fixture.detectChanges();
+            booleanComponent.select = signal({ value: false } as unknown as MatSelect) as never;
+            (booleanComponent as unknown as { _virtualSelectedValues: boolean[] })._virtualSelectedValues = [false];
+            expect(booleanComponent.getDisplayValue()).toBe('False Option');
+
+            const stringComponent = component as SearchableSelect<string>;
+            fixture.componentRef.setInput('options', [
+                { value: '', label: 'Empty String Option' },
+                { value: 'test', label: 'Test Option' }
+            ]);
+            fixture.detectChanges();
+            stringComponent.select = signal({ value: '' } as unknown as MatSelect) as never;
+            stringComponent['_virtualSelectedValues'] = [''];
+            expect(stringComponent.getDisplayValue()).toBe('Empty String Option');
+        });
+    });
+
+    describe('Emission Tracking Reset', () => {
+        it('should reset emission tracking to allow same value to be emitted again', async () => {
+            const options = [
+                { value: 'option1', label: 'Option 1' },
+                { value: 'option2', label: 'Option 2' }
+            ];
+
+            const { component } = await setup({ multiple: true, options });
+
+            const mockOnChange = vi.fn();
+            component.onChange = mockOnChange;
+
+            component.onValueChanged(['option1']);
+            expect(mockOnChange).toHaveBeenCalledTimes(1);
+            expect(mockOnChange).toHaveBeenCalledWith(['option1']);
+
+            component.onValueChanged(['option1']);
+            expect(mockOnChange).toHaveBeenCalledTimes(1);
+
+            component.resetEmissionTracking();
+
+            component.onValueChanged(['option1']);
+            expect(mockOnChange).toHaveBeenCalledTimes(2);
+            expect(mockOnChange).toHaveBeenLastCalledWith(['option1']);
+        });
+    });
+
+    describe('CSS Classes Support', () => {
+        let component: SearchableSelect<string>;
+        let fixture: Awaited<ReturnType<typeof setup>>['fixture'];
+
+        beforeEach(async () => {
+            const setupResult = await setup();
+            component = setupResult.component;
+            fixture = setupResult.fixture;
+
+            fixture.componentRef.setInput('options', [
+                { value: 'normal', label: 'Normal Option' },
+                { value: 'styled', label: 'Styled Option', labelCssClasses: ['custom-class', 'another-class'] },
+                { value: 'nil', label: 'Nil Option', labelCssClasses: ['neutral-color', 'unset'] }
+            ]);
+            component.filteredOptions.set(component.options().map((opt) => ({ ...opt, hidden: false })));
+            fixture.detectChanges();
+        });
+
+        it('should apply CSS classes to options when provided', async () => {
+            const matSelect = fixture.debugElement.query(By.directive(MatSelect));
+            matSelect.componentInstance.open();
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const styledElements = document.querySelectorAll('.custom-class');
+            expect(styledElements.length).toBeGreaterThan(0);
+
+            const nilElements = document.querySelectorAll('.neutral-color.unset');
+            expect(nilElements.length).toBeGreaterThan(0);
+
+            matSelect.componentInstance.close();
+            fixture.detectChanges();
+        });
+
+        it('should not apply CSS classes when not provided', async () => {
+            const matSelect = fixture.debugElement.query(By.directive(MatSelect));
+            matSelect.componentInstance.open();
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const optionElements = document.querySelectorAll('multi-select-option .text-md');
+            const normalOption = Array.from(optionElements).find((el) => el.textContent?.trim() === 'Normal Option');
+
+            expect(normalOption).toBeTruthy();
+            expect(normalOption?.classList.contains('custom-class')).toBe(false);
+            expect(normalOption?.classList.contains('neutral-color')).toBe(false);
+
+            matSelect.componentInstance.close();
+            fixture.detectChanges();
+        });
+    });
+
+    describe('Async Search Mode', () => {
+        describe('selectedOptionCache', () => {
+            it('should populate cache when options are set', async () => {
+                const { component, fixture } = await setup();
+                const options = [
+                    { value: 'opt1', label: 'Option 1' },
+                    { value: 'opt2', label: 'Option 2', svgIcon: 'test-icon' }
+                ];
+
+                fixture.componentRef.setInput('options', options);
+                fixture.detectChanges();
+
+                const cache = component['selectedOptionCache'];
+                expect(cache.get('opt1')).toMatchObject({
+                    value: 'opt1',
+                    label: 'Option 1'
+                });
+                expect(cache.get('opt2')).toMatchObject({
+                    value: 'opt2',
+                    label: 'Option 2',
+                    svgIcon: 'test-icon'
+                });
+            });
+
+            it('should preserve cache across option updates', async () => {
+                const { component, fixture } = await setup();
+
+                fixture.componentRef.setInput('options', [
+                    { value: 'opt1', label: 'Option 1' },
+                    { value: 'opt2', label: 'Option 2' }
+                ]);
+                fixture.detectChanges();
+
+                fixture.componentRef.setInput('options', [
+                    { value: 'opt2', label: 'Option 2' },
+                    { value: 'opt3', label: 'Option 3' }
+                ]);
+                fixture.detectChanges();
+
+                const cache = component['selectedOptionCache'];
+                expect(cache.get('opt1')).toBeDefined();
+                expect(cache.get('opt2')).toBeDefined();
+                expect(cache.get('opt3')).toBeDefined();
+            });
+
+            it('should handle options with all metadata fields', async () => {
+                const { component, fixture } = await setup();
+                const options = [
+                    {
+                        value: 'complex',
+                        label: 'Complex Option',
+                        description: 'A complex option with all fields',
+                        svgIcon: 'complex-icon',
+                        hidden: false
+                    }
+                ];
+
+                fixture.componentRef.setInput('options', options);
+                fixture.detectChanges();
+
+                const cache = component['selectedOptionCache'];
+                expect(cache.get('complex')).toMatchObject({
+                    value: 'complex',
+                    label: 'Complex Option',
+                    description: 'A complex option with all fields',
+                    svgIcon: 'complex-icon'
+                });
+            });
+        });
+
+        describe('Display Value with Cache Fallback', () => {
+            it('should use cache for display value when asyncSearchEnabled and option not in current batch', async () => {
+                const { component, fixture } = await setup({ multiple: false });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+
+                fixture.componentRef.setInput('options', [
+                    { value: 'opt1', label: 'Option 1' },
+                    { value: 'opt2', label: 'Option 2' }
+                ]);
+                fixture.detectChanges();
+
+                component.select = signal({ value: 'opt1' } as unknown as MatSelect) as never;
+
+                fixture.componentRef.setInput('options', [
+                    { value: 'opt3', label: 'Option 3' },
+                    { value: 'opt4', label: 'Option 4' }
+                ]);
+
+                expect(component.getDisplayValue()).toBe('Option 1');
+            });
+
+            it('should use cache for multiple selected values not in current options', async () => {
+                const { component, fixture } = await setup({ multiple: true });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+
+                fixture.componentRef.setInput('options', [
+                    { value: 'opt1', label: 'Option 1' },
+                    { value: 'opt2', label: 'Option 2' },
+                    { value: 'opt3', label: 'Option 3' }
+                ]);
+                fixture.detectChanges();
+
+                component.select = signal({ value: ['opt1', 'opt2'] } as unknown as MatSelect) as never;
+
+                fixture.componentRef.setInput('options', [
+                    { value: 'opt2', label: 'Option 2' },
+                    { value: 'opt4', label: 'Option 4' }
+                ]);
+                fixture.detectChanges();
+
+                const displayValue = component.getDisplayValue();
+                expect(displayValue).toBe('Option 1, Option 2');
+            });
+
+            it('should not use cache when asyncSearchEnabled is false', async () => {
+                const { component, fixture } = await setup({ multiple: false });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', false);
+                fixture.detectChanges();
+
+                fixture.componentRef.setInput('options', [
+                    { value: 'opt1', label: 'Option 1' },
+                    { value: 'opt2', label: 'Option 2' }
+                ]);
+                fixture.detectChanges();
+
+                component.select = signal({ value: 'opt1' } as unknown as MatSelect) as never;
+
+                fixture.componentRef.setInput('options', [{ value: 'opt3', label: 'Option 3' }]);
+                fixture.detectChanges();
+
+                expect(component.getDisplayValue()).toBe('');
+            });
+
+            it('should fall back to string value when cache miss occurs', async () => {
+                const { component, fixture } = await setup({ multiple: false });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+
+                fixture.componentRef.setInput('options', []);
+
+                component.select = signal({ value: 'unknown' } as unknown as MatSelect) as never;
+                fixture.detectChanges();
+
+                expect(component.getDisplayValue()).toBe('unknown');
+            });
+        });
+
+        describe('Ghost Options for mat-select Consistency', () => {
+            it('should create ghost options for selected values not in current options when asyncSearchEnabled', async () => {
+                const { component, fixture } = await setup({ multiple: true, enableVirtualScrolling: true });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+
+                fixture.componentRef.setInput('options', [
+                    { value: 'opt1', label: 'Option 1' },
+                    { value: 'opt2', label: 'Option 2' },
+                    { value: 'opt3', label: 'Option 3' }
+                ]);
+                fixture.detectChanges();
+
+                component['_virtualSelectedValues'] = ['opt1', 'opt2', 'opt3'];
+
+                fixture.componentRef.setInput('options', [
+                    { value: 'opt1', label: 'Option 1' },
+                    { value: 'opt4', label: 'Option 4' }
+                ]);
+                fixture.detectChanges();
+
+                const ghostOptions = component.getGhostOptions();
+
+                const ghostValues = ghostOptions.map((ghost) => ghost.value);
+                expect(ghostValues).toContain('opt2');
+                expect(ghostValues).toContain('opt3');
+
+                ghostOptions.forEach((ghost) => {
+                    if (ghost.value === 'opt2' || ghost.value === 'opt3') {
+                        expect(ghost.hidden).toBe(true);
+                    }
+                });
+            });
+
+            it('should not create ghost options when asyncSearchEnabled is false', async () => {
+                const { component, fixture } = await setup({ multiple: true });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', false);
+                fixture.detectChanges();
+
+                fixture.componentRef.setInput('options', [{ value: 'opt1', label: 'Option 1' }]);
+                component['_virtualSelectedValues'] = ['opt1', 'opt2'];
+
+                const ghostOptions = component.getGhostOptions();
+                const ghostValues = ghostOptions.map((ghost) => ghost.value);
+                expect(ghostValues).not.toContain('opt2');
+            });
+
+            it('should use cache labels for ghost options', async () => {
+                const { component, fixture } = await setup({ multiple: true, enableVirtualScrolling: true });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+
+                fixture.componentRef.setInput('options', [{ value: 'cached', label: 'Cached Option' }]);
+                fixture.detectChanges();
+
+                component['_virtualSelectedValues'] = ['cached'];
+
+                fixture.componentRef.setInput('options', [{ value: 'other', label: 'Other Option' }]);
+                fixture.detectChanges();
+
+                const ghostOptions = component.getGhostOptions();
+                const cachedGhost = ghostOptions.find((ghost) => ghost.value === 'cached');
+
+                expect(cachedGhost).toBeDefined();
+                expect(cachedGhost!.label).toBe('Cached Option');
+                expect(cachedGhost!.hidden).toBe(true);
+            });
+        });
+
+        describe('Panel Close Behavior', () => {
+            it('should reset search and emit searchChange when panel closes in async mode', async () => {
+                const { component, fixture } = await setup();
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+                const searchChangeSpy = vi.spyOn(component.searchChange, 'emit');
+
+                component['_searchString'] = 'test search';
+
+                component.selectionPanelToggled(false);
+
+                expect(component.searchString).toBeNull();
+                expect(searchChangeSpy).toHaveBeenCalledWith('');
+            });
+
+            it('should reset search in non-async mode when panel closes', async () => {
+                const { component, fixture } = await setup();
+
+                fixture.componentRef.setInput('asyncSearchEnabled', false);
+                fixture.detectChanges();
+
+                component.searchString = 'test search';
+                expect(component.searchString).toBe('test search');
+
+                component.selectionPanelToggled(false);
+
+                expect(component.searchString).toBeNull();
+            });
+
+            it('should not affect behavior when panel opens', async () => {
+                const { component, fixture } = await setup();
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+                const searchChangeSpy = vi.spyOn(component.searchChange, 'emit');
+
+                component.searchString = 'initial search';
+
+                component.selectionPanelToggled(true);
+
+                expect(searchChangeSpy).not.toHaveBeenCalledWith('');
+                expect(component.searchString).toBe('initial search');
+            });
+        });
+
+        describe('Filtering Behavior', () => {
+            it('should skip internal filtering when asyncSearchEnabled is true', async () => {
+                const { component, fixture } = await setup({ enableVirtualScrolling: true });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+                fixture.componentRef.setInput('options', [
+                    { value: 'apple', label: 'Apple' },
+                    { value: 'banana', label: 'Banana' },
+                    { value: 'cherry', label: 'Cherry' }
+                ]);
+                fixture.detectChanges();
+
+                component.searchString = 'app';
+
+                const visibleOptions = component.getVisibleOptions();
+                expect(visibleOptions).toHaveLength(3);
+                expect(visibleOptions.map((o) => o.value)).toEqual(['apple', 'banana', 'cherry']);
+            });
+
+            it('should preserve search string in async mode for clear button visibility', async () => {
+                const { component, fixture } = await setup();
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+
+                component.searchString = 'test search';
+
+                expect(component.searchString).toBe('test search');
+            });
+
+            it('should filter options in non-async mode', async () => {
+                const { component, fixture } = await setup();
+
+                fixture.componentRef.setInput('asyncSearchEnabled', false);
+                fixture.detectChanges();
+                fixture.componentRef.setInput('options', [
+                    { value: 'apple', label: 'Apple' },
+                    { value: 'banana', label: 'Banana' },
+                    { value: 'cherry', label: 'Cherry' }
+                ]);
+                fixture.detectChanges();
+
+                component.searchString = 'app';
+
+                const visibleOptions = component.getVisibleOptions();
+                expect(visibleOptions).toHaveLength(1);
+                expect(visibleOptions[0].value).toBe('apple');
+            });
+
+            it('should emit searchChange when search length meets minimum in async mode', async () => {
+                const { component, fixture } = await setup();
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+                fixture.componentRef.setInput('minSearchLength', 2);
+
+                const mockSelect = {
+                    panelOpen: true
+                } as unknown as MatSelect;
+                component.select = signal(mockSelect) as never;
+
+                const searchChangeSpy = vi.spyOn(component.searchChange, 'emit');
+
+                component.searchString = 'a';
+                await new Promise((resolve) => setTimeout(resolve, 350));
+                expect(searchChangeSpy).not.toHaveBeenCalledWith('a');
+
+                component.searchString = 'ab';
+                await new Promise((resolve) => setTimeout(resolve, 350));
+                expect(searchChangeSpy).toHaveBeenCalledWith('ab');
+            });
+        });
+
+        describe('Virtual Scrolling with Async Search', () => {
+            it('should include "more options" footer when asyncSearchOptionsHaveMore is true', async () => {
+                const { component, fixture } = await setup({ enableVirtualScrolling: true });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+                fixture.componentRef.setInput('asyncSearchOptionsHaveMore', true);
+                fixture.componentRef.setInput('options', [
+                    { value: 'opt1', label: 'Option 1' },
+                    { value: 'opt2', label: 'Option 2' }
+                ]);
+                fixture.detectChanges();
+
+                const virtualItems = component.getVirtualVisibleItems();
+
+                expect(virtualItems).toHaveLength(3);
+                expect(virtualItems[2]).toEqual({ __kind: 'more' });
+            });
+
+            it('should not include footer when asyncSearchOptionsHaveMore is false', async () => {
+                const { component, fixture } = await setup({ enableVirtualScrolling: true });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+                fixture.componentRef.setInput('asyncSearchOptionsHaveMore', false);
+                fixture.componentRef.setInput('options', [
+                    { value: 'opt1', label: 'Option 1' },
+                    { value: 'opt2', label: 'Option 2' }
+                ]);
+                fixture.detectChanges();
+
+                const virtualItems = component.getVirtualVisibleItems();
+
+                expect(virtualItems).toHaveLength(2);
+                expect(virtualItems.every((item) => 'value' in item)).toBe(true);
+            });
+
+            it('should not include footer when options are empty even if hasMore is true', async () => {
+                const { component, fixture } = await setup({ enableVirtualScrolling: true });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+                fixture.componentRef.setInput('asyncSearchOptionsHaveMore', true);
+                fixture.componentRef.setInput('options', []);
+
+                const virtualItems = component.getVirtualVisibleItems();
+
+                expect(virtualItems).toHaveLength(0);
+            });
+        });
+
+        describe('updateDisplayValueSignal with Async Cache', () => {
+            it('should update display value signal using cache in async mode', async () => {
+                const { component, fixture } = await setup({ multiple: false });
+
+                fixture.componentRef.setInput('asyncSearchEnabled', true);
+                fixture.detectChanges();
+
+                fixture.componentRef.setInput('options', [{ value: 'test', label: 'Test Option' }]);
+                fixture.detectChanges();
+                component.select = signal({ value: 'test' } as unknown as MatSelect) as never;
+
+                fixture.componentRef.setInput('options', [{ value: 'other', label: 'Other Option' }]);
+                fixture.detectChanges();
+
+                component['updateDisplayValueSignal']();
+
+                expect(component['displayValueSignal']()).toBe('Test Option');
+            });
+        });
+
+        describe('Option Selection Panel Behavior', () => {
+            describe('onValueChanged', () => {
+                it('should close panel after selection in single-select mode', async () => {
+                    const { component } = await setup({
+                        multiple: false,
+                        options: [
+                            { value: 'opt1', label: 'Option 1' },
+                            { value: 'opt2', label: 'Option 2' }
+                        ]
+                    });
+
+                    const mockClose = vi.fn();
+                    const mockWriteValue = vi.fn();
+                    const mockOnChange = vi.fn();
+
+                    component.select = signal({
+                        close: mockClose,
+                        panelOpen: true,
+                        writeValue: mockWriteValue
+                    } as unknown as MatSelect) as never;
+
+                    component.onChange = mockOnChange;
+
+                    component.onValueChanged('opt1');
+
+                    expect(mockClose).toHaveBeenCalled();
+                });
+
+                it('should keep panel open after selection in multi-select mode', async () => {
+                    const { component } = await setup({ multiple: true, enableVirtualScrolling: false });
+
+                    const mockClose = vi.fn();
+                    const mockOnChange = vi.fn();
+
+                    component.select = signal({
+                        close: mockClose,
+                        panelOpen: true,
+                        writeValue: vi.fn()
+                    } as unknown as MatSelect) as never;
+
+                    component.onChange = mockOnChange;
+
+                    component['_virtualSelectedValues'] = ['opt1'];
+
+                    component.onValueChanged(['opt1', 'opt2']);
+
+                    expect(mockClose).not.toHaveBeenCalled();
+                });
+
+                it('should update display value signal after selection when value changes', async () => {
+                    const { component } = await setup({
+                        multiple: false,
+                        options: [
+                            { value: 'opt1', label: 'Option 1' },
+                            { value: 'opt2', label: 'Option 2' }
+                        ]
+                    });
+
+                    const mockClose = vi.fn();
+                    const mockWriteValue = vi.fn();
+                    const mockOnChange = vi.fn();
+
+                    component.select = signal({
+                        close: mockClose,
+                        panelOpen: true,
+                        writeValue: mockWriteValue
+                    } as unknown as MatSelect) as never;
+
+                    component.onChange = mockOnChange;
+
+                    const updateDisplayValueSignalSpy = vi.spyOn(
+                        component as unknown as { updateDisplayValueSignal: () => void },
+                        'updateDisplayValueSignal'
+                    );
+
+                    component['_virtualSelectedValues'] = [];
+                    component['_allowNextValueChange'] = true;
+                    component.onValueChanged('opt1');
+
+                    expect(updateDisplayValueSignalSpy).toHaveBeenCalled();
+                });
+
+                it('should handle virtual scrolling mode properly in multi-select', async () => {
+                    const { component } = await setup({ multiple: true, enableVirtualScrolling: true });
+
+                    const mockClose = vi.fn();
+                    const mockOnChange = vi.fn();
+
+                    component.select = signal({
+                        close: mockClose,
+                        panelOpen: true,
+                        writeValue: vi.fn()
+                    } as unknown as MatSelect) as never;
+
+                    component.onChange = mockOnChange;
+
+                    component['_virtualSelectedValues'] = ['opt1'];
+
+                    component.onValueChanged(['opt1', 'opt2']);
+
+                    expect(mockClose).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('Clear Selection Functionality', () => {
+            const mockOptions: SearchableSelectOption<string>[] = [
+                { value: 'opt1', label: 'Option 1' },
+                { value: 'opt2', label: 'Option 2' },
+                { value: 'opt3', label: 'Option 3' }
+            ];
+
+            describe('shouldShowClearButton', () => {
+                it('should return true when allowClear is true and there is a selected value', async () => {
+                    const { component, fixture } = await setup({
+                        enableVirtualScrolling: true,
+                        options: mockOptions
+                    });
+
+                    fixture.componentRef.setInput('allowClear', true);
+                    component['_virtualSelectedValues'] = ['opt1'];
+                    fixture.detectChanges();
+
+                    expect(component.shouldShowClearButton()).toBe(true);
+                });
+
+                it('should return false when allowClear is false', async () => {
+                    const { component, fixture } = await setup({
+                        enableVirtualScrolling: true,
+                        options: mockOptions
+                    });
+
+                    fixture.componentRef.setInput('allowClear', false);
+                    component['_virtualSelectedValues'] = ['opt1'];
+                    fixture.detectChanges();
+
+                    expect(component.shouldShowClearButton()).toBe(false);
+                });
+
+                it('should return false when there is no selected value', async () => {
+                    const { component, fixture } = await setup({
+                        enableVirtualScrolling: true,
+                        options: mockOptions
+                    });
+
+                    fixture.componentRef.setInput('allowClear', true);
+                    component['_virtualSelectedValues'] = [];
+                    fixture.detectChanges();
+
+                    expect(component.shouldShowClearButton()).toBe(false);
+                });
+
+                it('should return true for multi-select with selected values', async () => {
+                    const { component, fixture } = await setup({
+                        multiple: true,
+                        enableVirtualScrolling: true,
+                        options: mockOptions
+                    });
+
+                    fixture.componentRef.setInput('allowClear', true);
+                    component['_virtualSelectedValues'] = ['opt1', 'opt2'];
+                    fixture.detectChanges();
+
+                    expect(component.shouldShowClearButton()).toBe(true);
+                });
+
+                it('should work with non-virtual scrolling mode', async () => {
+                    const { component, fixture } = await setup({
+                        enableVirtualScrolling: false,
+                        options: mockOptions
+                    });
+
+                    fixture.componentRef.setInput('allowClear', true);
+
+                    component.select = signal({
+                        value: 'opt1'
+                    } as unknown as MatSelect) as never;
+
+                    fixture.detectChanges();
+
+                    expect(component.shouldShowClearButton()).toBe(true);
+                });
+            });
+
+            describe('clearSelection', () => {
+                it('should clear selection in single-select mode with virtual scrolling', async () => {
+                    const { component } = await setup({
+                        enableVirtualScrolling: true,
+                        options: mockOptions
+                    });
+
+                    const mockOnChange = vi.fn();
+                    component.onChange = mockOnChange;
+                    component['_virtualSelectedValues'] = ['opt1'];
+                    component['_lastEmittedValue'] = 'opt1';
+
+                    const mockEvent = new Event('click');
+                    vi.spyOn(mockEvent, 'stopPropagation');
+                    vi.spyOn(mockEvent, 'preventDefault');
+
+                    component.clearSelection(mockEvent);
+
+                    expect(mockEvent.stopPropagation).toHaveBeenCalled();
+                    expect(mockEvent.preventDefault).toHaveBeenCalled();
+                    expect(component['_virtualSelectedValues']).toEqual([]);
+                    expect(mockOnChange).toHaveBeenCalledWith(null);
+                });
+
+                it('should clear selection in multi-select mode with virtual scrolling', async () => {
+                    const { component } = await setup({
+                        multiple: true,
+                        enableVirtualScrolling: true,
+                        options: mockOptions
+                    });
+
+                    const mockOnChange = vi.fn();
+                    component.onChange = mockOnChange;
+                    component['_virtualSelectedValues'] = ['opt1', 'opt2'];
+                    component['_lastEmittedValue'] = ['opt1', 'opt2'];
+
+                    const mockEvent = new Event('click');
+                    component.clearSelection(mockEvent);
+
+                    expect(component['_virtualSelectedValues']).toEqual([]);
+                    expect(mockOnChange).toHaveBeenCalledWith([]);
+                });
+
+                it('should clear selection in single-select mode without virtual scrolling', async () => {
+                    const { component } = await setup({
+                        enableVirtualScrolling: false,
+                        options: mockOptions
+                    });
+
+                    const mockOnChange = vi.fn();
+                    const mockWriteValue = vi.fn();
+
+                    component.onChange = mockOnChange;
+                    component.select = signal({
+                        writeValue: mockWriteValue,
+                        value: 'opt1'
+                    } as unknown as MatSelect) as never;
+
+                    component['_lastIntentionalValue'] = 'opt1';
+                    component['_lastEmittedValue'] = 'opt1';
+
+                    const mockEvent = new Event('click');
+                    component.clearSelection(mockEvent);
+
+                    expect(mockWriteValue).toHaveBeenCalledWith(null);
+                    expect(component['_lastIntentionalValue']).toBeNull();
+                    expect(mockOnChange).toHaveBeenCalledWith(null);
+                });
+
+                it('should clear selection in multi-select mode without virtual scrolling', async () => {
+                    const { component } = await setup({
+                        multiple: true,
+                        enableVirtualScrolling: false,
+                        options: mockOptions
+                    });
+
+                    const mockOnChange = vi.fn();
+                    const mockWriteValue = vi.fn();
+
+                    component.onChange = mockOnChange;
+                    component.select = signal({
+                        writeValue: mockWriteValue,
+                        value: ['opt1', 'opt2']
+                    } as unknown as MatSelect) as never;
+
+                    component['_lastEmittedValue'] = ['opt1', 'opt2'];
+
+                    const mockEvent = new Event('click');
+                    component.clearSelection(mockEvent);
+
+                    expect(mockWriteValue).toHaveBeenCalledWith([]);
+                    expect(mockOnChange).toHaveBeenCalledWith([]);
+                });
+
+                it('should update display value signal after clearing', async () => {
+                    const { component } = await setup({
+                        enableVirtualScrolling: false,
+                        options: mockOptions
+                    });
+
+                    const mockOnChange = vi.fn();
+                    const mockWriteValue = vi.fn();
+
+                    component.onChange = mockOnChange;
+                    component.select = signal({
+                        writeValue: mockWriteValue,
+                        value: 'opt1'
+                    } as unknown as MatSelect) as never;
+
+                    const updateDisplayValueSignalSpy = vi.spyOn(
+                        component as unknown as { updateDisplayValueSignal: () => void },
+                        'updateDisplayValueSignal'
+                    );
+
+                    const mockEvent = new Event('click');
+                    component.clearSelection(mockEvent);
+
+                    expect(updateDisplayValueSignalSpy).toHaveBeenCalled();
+                });
+
+                it('should stop propagation and prevent default', async () => {
+                    const { component } = await setup({
+                        enableVirtualScrolling: true,
+                        options: mockOptions
+                    });
+
+                    const mockOnChange = vi.fn();
+                    component.registerOnChange(mockOnChange);
+
+                    const mockEvent = new Event('click');
+                    const stopPropagationSpy = vi.spyOn(mockEvent, 'stopPropagation');
+                    const preventDefaultSpy = vi.spyOn(mockEvent, 'preventDefault');
+
+                    component.clearSelection(mockEvent);
+
+                    expect(stopPropagationSpy).toHaveBeenCalled();
+                    expect(preventDefaultSpy).toHaveBeenCalled();
+                });
+            });
+
+            describe('onClearSelectionKeydown', () => {
+                it('should trigger clearSelection when Enter key is pressed', async () => {
+                    const { component } = await setup({ options: mockOptions });
+
+                    const mockOnChange = vi.fn();
+                    component.registerOnChange(mockOnChange);
+
+                    const clearSelectionSpy = vi.spyOn(component, 'clearSelection');
+                    const mockEvent = new KeyboardEvent('keydown', { code: 'Enter' });
+                    vi.spyOn(mockEvent, 'stopPropagation');
+                    vi.spyOn(mockEvent, 'preventDefault');
+
+                    component.onClearSelectionKeydown(mockEvent);
+
+                    expect(mockEvent.stopPropagation).toHaveBeenCalled();
+                    expect(mockEvent.preventDefault).toHaveBeenCalled();
+                    expect(clearSelectionSpy).toHaveBeenCalledWith(mockEvent);
+                });
+
+                it('should trigger clearSelection when Space key is pressed', async () => {
+                    const { component } = await setup({ options: mockOptions });
+
+                    const mockOnChange = vi.fn();
+                    component.registerOnChange(mockOnChange);
+
+                    const clearSelectionSpy = vi.spyOn(component, 'clearSelection');
+                    const mockEvent = new KeyboardEvent('keydown', { code: 'Space' });
+                    vi.spyOn(mockEvent, 'stopPropagation');
+                    vi.spyOn(mockEvent, 'preventDefault');
+
+                    component.onClearSelectionKeydown(mockEvent);
+
+                    expect(mockEvent.stopPropagation).toHaveBeenCalled();
+                    expect(mockEvent.preventDefault).toHaveBeenCalled();
+                    expect(clearSelectionSpy).toHaveBeenCalledWith(mockEvent);
+                });
+
+                it('should not trigger clearSelection for other keys', async () => {
+                    const { component } = await setup({ options: mockOptions });
+
+                    const clearSelectionSpy = vi.spyOn(component, 'clearSelection');
+                    const mockEvent = new KeyboardEvent('keydown', { code: 'KeyA' });
+                    vi.spyOn(mockEvent, 'stopPropagation');
+                    vi.spyOn(mockEvent, 'preventDefault');
+
+                    component.onClearSelectionKeydown(mockEvent);
+
+                    expect(mockEvent.stopPropagation).not.toHaveBeenCalled();
+                    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+                    expect(clearSelectionSpy).not.toHaveBeenCalled();
+                });
+
+                it('should not trigger clearSelection for Escape key', async () => {
+                    const { component } = await setup({ options: mockOptions });
+
+                    const clearSelectionSpy = vi.spyOn(component, 'clearSelection');
+                    const mockEvent = new KeyboardEvent('keydown', { code: 'Escape' });
+
+                    component.onClearSelectionKeydown(mockEvent);
+
+                    expect(clearSelectionSpy).not.toHaveBeenCalled();
+                });
+
+                it('should not trigger clearSelection for Tab key', async () => {
+                    const { component } = await setup({ options: mockOptions });
+
+                    const clearSelectionSpy = vi.spyOn(component, 'clearSelection');
+                    const mockEvent = new KeyboardEvent('keydown', { code: 'Tab' });
+
+                    component.onClearSelectionKeydown(mockEvent);
+
+                    expect(clearSelectionSpy).not.toHaveBeenCalled();
+                });
+            });
+        });
+    });
+
+    describe('Load Error State', () => {
+        it('should reflect loadError input', async () => {
+            const { component } = await setup({ options: [], loadError: true, loadErrorMessage: 'Nope' });
+            expect(component.loadError()).toBe(true);
+            expect(component.loadErrorMessage()).toBe('Nope');
+        });
+    });
+
+    describe('Grouping Functionality', () => {
+        const groupedOptions = [
+            { value: 'aws-1', label: 'Secret-1', group: 'AWS Secrets Manager' },
+            { value: 'aws-2', label: 'Secret-2', group: 'AWS Secrets Manager' },
+            { value: 'aws-3', label: 'Secret-3', group: 'AWS Secrets Manager' },
+            { value: 'az-1', label: 'Secret-4', group: 'Azure Key Vault' },
+            { value: 'az-2', label: 'Secret-5', group: 'Azure Key Vault' }
+        ];
+
+        async function setupGrouped(options: SetupOptions = {}) {
+            const { fixture, component } = await setup({
+                options: groupedOptions,
+                ...options
+            });
+
+            fixture.detectChanges();
+
+            return { fixture, component };
+        }
+
+        describe('groupedOptions computed signal', () => {
+            it('should return null when no options have group property', async () => {
+                const ungroupedOptions = [
+                    { value: 'opt-1', label: 'Option 1' },
+                    { value: 'opt-2', label: 'Option 2' }
+                ];
+                const { component } = await setup({ options: ungroupedOptions });
+
+                expect(component['groupedOptions']()).toBeNull();
+            });
+
+            it('should organize options into groups when options have group property', async () => {
+                const { component } = await setupGrouped();
+
+                const groups = component['groupedOptions']();
+                expect(groups).not.toBeNull();
+                expect(groups!.length).toBe(2);
+
+                const awsGroup = groups!.find((g) => g.groupId === 'AWS Secrets Manager');
+                expect(awsGroup).toBeDefined();
+                expect(awsGroup!.groupLabel).toBe('AWS Secrets Manager');
+                expect(awsGroup!.options.length).toBe(3);
+
+                const azureGroup = groups!.find((g) => g.groupId === 'Azure Key Vault');
+                expect(azureGroup).toBeDefined();
+                expect(azureGroup!.groupLabel).toBe('Azure Key Vault');
+                expect(azureGroup!.options.length).toBe(2);
+            });
+
+            it('should order groups alphabetically', async () => {
+                const { component } = await setupGrouped();
+
+                const groups = component['groupedOptions']();
+                expect(groups).not.toBeNull();
+                expect(groups![0].groupId).toBe('AWS Secrets Manager');
+                expect(groups![1].groupId).toBe('Azure Key Vault');
+            });
+
+            it('should place ungrouped options first with no header', async () => {
+                const mixedOptions = [{ value: 'ungrouped-1', label: 'Ungrouped Option' }, ...groupedOptions];
+
+                const { component } = await setup({ options: mixedOptions });
+
+                const groups = component['groupedOptions']();
+                expect(groups).not.toBeNull();
+                expect(groups!.length).toBe(3);
+
+                expect(groups![0].groupId).toBe('__ungrouped__');
+                expect(groups![0].groupLabel).toBe('');
+                expect(groups![0].options.length).toBe(1);
+            });
+        });
+
+        describe('Filtering with groups', () => {
+            it('should hide groups with no matching options when filtering', async () => {
+                const { component, fixture } = await setupGrouped();
+
+                component.searchString = 'Secret-4';
+                fixture.detectChanges();
+
+                const groups = component['groupedOptions']();
+                expect(groups).not.toBeNull();
+                const visibleGroups = groups!.filter((g) => g.options.length > 0);
+                expect(visibleGroups.length).toBe(1);
+                expect(visibleGroups[0].groupId).toBe('Azure Key Vault');
+            });
+
+            it('should show all groups when filter is cleared', async () => {
+                const { component, fixture } = await setupGrouped();
+
+                component.searchString = 'Secret-4';
+                fixture.detectChanges();
+
+                component.searchString = null;
+                fixture.detectChanges();
+
+                const groups = component['groupedOptions']();
+                expect(groups!.filter((g) => g.options.length > 0).length).toBe(2);
+            });
+        });
+
+        describe('getVisibleOptions with grouping', () => {
+            it('should return flat list of all visible options for keyboard navigation', async () => {
+                const { component } = await setupGrouped();
+
+                const visibleOptions = component.getVisibleOptions();
+                expect(visibleOptions.length).toBe(5);
+                expect(visibleOptions.map((o) => o.value)).toEqual(['aws-1', 'aws-2', 'aws-3', 'az-1', 'az-2']);
+            });
+        });
+
+        describe('Virtual scrolling with groups', () => {
+            it('should include group headers in virtual items', async () => {
+                const { component } = await setupGrouped({ enableVirtualScrolling: true });
+
+                const virtualItems = component.getVirtualVisibleItems();
+
+                expect(virtualItems.length).toBe(7);
+
+                expect(component.isGroupHeaderItem(virtualItems[0])).toBe(true);
+                expect(component.getGroupHeaderLabel(virtualItems[0])).toBe('AWS Secrets Manager');
+
+                expect(component.isOptionItem(virtualItems[1])).toBe(true);
+                expect(component.isOptionItem(virtualItems[2])).toBe(true);
+                expect(component.isOptionItem(virtualItems[3])).toBe(true);
+
+                expect(component.isGroupHeaderItem(virtualItems[4])).toBe(true);
+                expect(component.getGroupHeaderLabel(virtualItems[4])).toBe('Azure Key Vault');
+            });
+
+            it('should calculate viewport height including group headers', async () => {
+                const { component, fixture } = await setupGrouped({ enableVirtualScrolling: true });
+
+                fixture.componentRef.setInput('virtualScrollItemSize', 32);
+                fixture.detectChanges();
+
+                const height = component.getVirtualScrollHeight();
+                expect(height).toBe('217px');
+            });
+
+            it('should track virtual items including group headers', async () => {
+                const { component } = await setupGrouped({ enableVirtualScrolling: true });
+
+                const virtualItems = component.getVirtualVisibleItems();
+                const header = virtualItems[0];
+                const option = virtualItems[1];
+
+                expect(component.trackByVirtualItem(0, header)).toBe('__group-header-AWS Secrets Manager');
+
+                expect(component.trackByVirtualItem(1, option)).toBe('aws-1');
+            });
+        });
+
+        describe('getGroupHeaderId', () => {
+            it('should generate unique IDs for group headers', async () => {
+                const { component } = await setupGrouped();
+
+                const awsId = component.getGroupHeaderId('AWS Secrets Manager');
+                const azureId = component.getGroupHeaderId('Azure Key Vault');
+
+                expect(awsId).toContain('group-header-AWS Secrets Manager');
+                expect(azureId).toContain('group-header-Azure Key Vault');
+                expect(awsId).not.toBe(azureId);
+            });
+        });
+    });
+
+    describe('setDisabledState', () => {
+        it('should set disabled property and forward to MatSelect after view init', async () => {
+            const { fixture, component } = await setup({
+                options: [{ value: 'one', label: 'One' }]
+            });
+
+            const matSelect = fixture.debugElement.query(By.directive(MatSelect)).componentInstance as MatSelect;
+            const matSelectSpy = vi.spyOn(matSelect, 'setDisabledState');
+
+            component.setDisabledState(true);
+
+            expect(component.disabled).toBe(true);
+            expect(matSelectSpy).toHaveBeenCalledWith(true);
+        });
+
+        it('should re-enable after being disabled', async () => {
+            const { fixture, component } = await setup({
+                options: [{ value: 'one', label: 'One' }]
+            });
+
+            const matSelect = fixture.debugElement.query(By.directive(MatSelect)).componentInstance as MatSelect;
+            const matSelectSpy = vi.spyOn(matSelect, 'setDisabledState');
+
+            component.setDisabledState(true);
+            component.setDisabledState(false);
+
+            expect(component.disabled).toBe(false);
+            expect(matSelectSpy).toHaveBeenLastCalledWith(false);
+        });
+
+        it('should defer disabled state when called before view init', async () => {
+            await TestBed.configureTestingModule({
+                imports: [SearchableSelect, MatIconTestingModule, NoopAnimationsModule]
+            }).compileComponents();
+
+            const fixture = TestBed.createComponent(SearchableSelect<string>);
+            const component = fixture.componentInstance;
+            fixture.componentRef.setInput('options', [{ value: 'one', label: 'One' }]);
+
+            component.setDisabledState(true);
+
+            expect(component.disabled).toBe(true);
+            expect(component['_pendingDisabledState']).toBe(true);
+
+            fixture.detectChanges();
+
+            const matSelect = fixture.debugElement.query(By.directive(MatSelect)).componentInstance as MatSelect;
+            expect(matSelect.disabled).toBe(true);
+            expect(component['_pendingDisabledState']).toBeNull();
+        });
+
+        it('should not apply pending state in ngAfterViewInit when no deferred call was made', async () => {
+            const { fixture, component } = await setup({
+                options: [{ value: 'one', label: 'One' }]
+            });
+
+            const matSelect = fixture.debugElement.query(By.directive(MatSelect)).componentInstance as MatSelect;
+            const matSelectSpy = vi.spyOn(matSelect, 'setDisabledState');
+
+            component.ngAfterViewInit();
+
+            expect(matSelectSpy).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.ts
@@ -48,7 +48,7 @@ import {
 } from '@angular/material/select';
 import { MatInput } from '@angular/material/input';
 import { MatIcon } from '@angular/material/icon';
-import { MatButton } from '@angular/material/button';
+import { MatIconButton } from '@angular/material/button';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
@@ -96,7 +96,7 @@ type VirtualItem<T> = FilteredSearchableSelectOption<T> | FooterItem | GroupHead
         CdkVirtualScrollViewport,
         CdkVirtualForOf,
         CdkFixedSizeVirtualScroll,
-        MatButton,
+        MatIconButton,
         MatSuffix,
         MatProgressSpinner,
         EllipsisTooltipDirective
@@ -269,7 +269,7 @@ export class SearchableSelect<T = never> implements ControlValueAccessor, OnInit
 
     select = viewChild.required<MatSelect>(MatSelect);
     searchInput = viewChild.required<ElementRef<HTMLInputElement>>('searchInput');
-    clearSearchBtn = viewChild<MatButton>('clearSearchBtn');
+    clearSearchBtn = viewChild<MatIconButton>('clearSearchBtn');
     virtualScrollViewport = viewChild<CdkVirtualScrollViewport>('virtualScrollViewport');
 
     onChange!: (value: T[] | T | null) => void;

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.ts
@@ -57,6 +57,7 @@ import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
 import { FilteredSearchableSelectOption, SearchableSelectGroup, SearchableSelectOption } from '../../types';
+import { EllipsisTooltipDirective } from '../../directives/ellipsis-tooltip/ellipsis-tooltip.directive';
 import { MultiSelectOption } from '../multi-select-option/multi-select-option.component';
 
 type MatSelectOverlayInternals = MatSelect & {
@@ -97,7 +98,8 @@ type VirtualItem<T> = FilteredSearchableSelectOption<T> | FooterItem | GroupHead
         CdkFixedSizeVirtualScroll,
         MatButton,
         MatSuffix,
-        MatProgressSpinner
+        MatProgressSpinner,
+        EllipsisTooltipDirective
     ],
     templateUrl: './searchable-select.component.html',
     styleUrl: './searchable-select.component.scss',

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/searchable-select/searchable-select.component.ts
@@ -1,0 +1,1441 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    AfterViewInit,
+    ChangeDetectorRef,
+    Component,
+    computed,
+    effect,
+    ElementRef,
+    EventEmitter,
+    forwardRef,
+    inject,
+    input,
+    NgZone,
+    OnDestroy,
+    OnInit,
+    Output,
+    signal,
+    Signal,
+    viewChild,
+    ViewEncapsulation,
+    WritableSignal
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+    MatError,
+    MatFormField,
+    MatHint,
+    MatPrefix,
+    MatSelect,
+    MatSelectTrigger,
+    MatSuffix
+} from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
+import { MatIcon } from '@angular/material/icon';
+import { MatButton } from '@angular/material/button';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { FlexibleConnectedPositionStrategy, OverlayRef } from '@angular/cdk/overlay';
+import { Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
+
+import { FilteredSearchableSelectOption, SearchableSelectGroup, SearchableSelectOption } from '../../types';
+import { MultiSelectOption } from '../multi-select-option/multi-select-option.component';
+
+type MatSelectOverlayInternals = MatSelect & {
+    _overlayDir?: {
+        overlayRef?: OverlayRef;
+    };
+    _elementRef?: ElementRef<HTMLElement>;
+};
+
+// Internal helper types for virtual renderer items
+type FooterItem = { __kind: 'more' | 'error' };
+type GroupHeaderItem = {
+    __kind: 'group-header';
+    groupId: string;
+    groupLabel: string;
+    isFirstGroup: boolean;
+    isLastGroup: boolean;
+};
+type VirtualItem<T> = FilteredSearchableSelectOption<T> | FooterItem | GroupHeaderItem;
+
+@Component({
+    selector: 'searchable-select',
+    standalone: true,
+    imports: [
+        CommonModule,
+        MatSelect,
+        MatSelectTrigger,
+        MatInput,
+        MatIcon,
+        FormsModule,
+        MatFormField,
+        MatPrefix,
+        MatError,
+        MatHint,
+        MultiSelectOption,
+        CdkVirtualScrollViewport,
+        CdkVirtualForOf,
+        CdkFixedSizeVirtualScroll,
+        MatButton,
+        MatSuffix,
+        MatProgressSpinner
+    ],
+    templateUrl: './searchable-select.component.html',
+    styleUrl: './searchable-select.component.scss',
+    providers: [
+        {
+            provide: NG_VALUE_ACCESSOR,
+            useExisting: forwardRef(() => SearchableSelect),
+            multi: true
+        }
+    ],
+    encapsulation: ViewEncapsulation.None
+})
+export class SearchableSelect<T = never> implements ControlValueAccessor, OnInit, OnDestroy, AfterViewInit {
+    private cdr = inject(ChangeDetectorRef);
+    private zone = inject(NgZone);
+    private _options: FilteredSearchableSelectOption<T>[] = [];
+
+    // Cache the display metadata for selected values so the trigger preserves labels
+    // even when async options batches omit those values. Display-only; does not affect list rendering.
+    private selectedOptionCache = new Map<T, SearchableSelectOption<T>>();
+
+    protected filteredLength: number | null = null;
+
+    // Signal input for options
+    options = input<SearchableSelectOption<T>[]>([]);
+
+    // Effect to handle options changes (replaces the setter logic)
+    private optionsEffect = effect(() => {
+        const options = this.options();
+        this.searchInProgress = false;
+        const currentSearch = this._searchString; // preserve user-entered search text
+        options.forEach((o) => {
+            this.selectedOptionCache.set(o.value, {
+                value: o.value,
+                label: o.label,
+                svgIcon: o.svgIcon,
+                description: o.description,
+                disabled: o.disabled,
+                labelCssClasses: o.labelCssClasses
+            });
+        });
+        this._options = options.map((o) => {
+            return {
+                ...o,
+                hidden: false
+            } as FilteredSearchableSelectOption<T>;
+        });
+        if (currentSearch === null) {
+            this.resetFilter();
+        } else {
+            this.filter(currentSearch);
+        }
+        if (this.asyncSearchEnabled()) {
+            this.filteredLength = this._options.length;
+        }
+        this.updateDisplayValueSignal();
+        this.cdr.markForCheck();
+    });
+
+    multiple = input(false);
+    searchPlaceholder = input('');
+    placeholder = input('');
+    allowClear = input(false);
+    a11ySearchLabel = input('Search');
+    a11yClearSearchLabel = input('Clear search');
+
+    enableVirtualScrolling = input(false);
+    virtualScrollItemSize = input(32); // 32 for no description, 54 for description. Both assume no line wrapping.
+    virtualScrollMinBufferPx = input(200);
+    virtualScrollMaxBufferPx = input(400);
+    private virtualScrollMaxHeight = 217;
+
+    searchDebounceMs = input(300);
+    asyncSearchEnabled = input(false);
+    asyncSearchOptionsHaveMore = input(false);
+    minSearchLength = input(1);
+    loadError = input(false);
+    loadErrorMessage = input('');
+
+    hint = input<string>('');
+    showHint = input(true);
+    validationError = input<string>('');
+    verificationError = input<string>('');
+
+    @Output() searchChange = new EventEmitter<string>();
+
+    /** Computed signal that detects if any option has a group property. */
+    protected hasGroupedOptions: Signal<boolean> = computed(() => {
+        return this.filteredOptions().some((opt) => !opt.hidden && opt.group);
+    });
+
+    private _virtualSelectedValues: T[] = [];
+
+    protected displayValueSignal = signal('');
+
+    private _activeOptionIndex = -1;
+    private _isNavigating = false;
+
+    // Permission-based value change system for single-select mode
+    // Prevents Material Design from auto-selecting on arrow keys.
+    private _lastIntentionalValue: T | null = null;
+    private _allowNextValueChange = false;
+
+    filteredOptions: WritableSignal<FilteredSearchableSelectOption<T>[]> = signal([]);
+    searchInProgress = false;
+
+    protected activeTemplateIndex = signal<number>(-1);
+
+    private filteredOptionsEffect = effect(() => {
+        void this.filteredOptions();
+        this.updateActiveTemplateIndex();
+    });
+
+    /**
+     * Computed signal that organizes filtered options into groups when any option has a group property.
+     * Returns null when no options have groups, allowing template to use ungrouped rendering.
+     */
+    protected groupedOptions: Signal<SearchableSelectGroup<T>[] | null> = computed(() => {
+        if (!this.hasGroupedOptions()) {
+            return null;
+        }
+
+        const options = this.filteredOptions();
+        const groupMap = new Map<string, FilteredSearchableSelectOption<T>[]>();
+        const ungrouped: FilteredSearchableSelectOption<T>[] = [];
+
+        options.forEach((opt) => {
+            if (opt.hidden) return;
+            if (opt.group) {
+                if (!groupMap.has(opt.group)) {
+                    groupMap.set(opt.group, []);
+                }
+                groupMap.get(opt.group)!.push(opt);
+            } else {
+                ungrouped.push(opt);
+            }
+        });
+
+        const groups: SearchableSelectGroup<T>[] = [];
+
+        if (ungrouped.length > 0) {
+            groups.push({
+                groupId: '__ungrouped__',
+                groupLabel: '',
+                options: ungrouped
+            });
+        }
+
+        const sortedGroups = Array.from(groupMap.entries())
+            .filter(([, opts]) => opts.length > 0)
+            .sort((a, b) => a[0].localeCompare(b[0]));
+
+        sortedGroups.forEach(([groupId, opts]) => {
+            groups.push({
+                groupId,
+                groupLabel: groupId,
+                options: opts
+            });
+        });
+
+        return groups;
+    });
+
+    getGroupHeaderId(groupId: string): string {
+        return this.getUniqueId(`group-header-${groupId}`);
+    }
+
+    select = viewChild.required<MatSelect>(MatSelect);
+    searchInput = viewChild.required<ElementRef<HTMLInputElement>>('searchInput');
+    clearSearchBtn = viewChild<MatButton>('clearSearchBtn');
+    virtualScrollViewport = viewChild<CdkVirtualScrollViewport>('virtualScrollViewport');
+
+    onChange!: (value: T[] | T | null) => void;
+    onTouched!: () => void;
+    // Reserved state field for future touched-tracking work; today it is only referenced
+    // via the ControlValueAccessor registered onTouched callback.
+    touched = false;
+    disabled = false;
+    private _viewInitialized = false;
+    private _pendingDisabledState: boolean | null = null;
+
+    private _lastEmittedValue: T[] | T | null = null;
+    private _isSyncingMatValue = false;
+
+    private _searchString: string | null = null;
+    set searchString(text: string | null) {
+        this._searchString = text;
+        this.filter(this._searchString);
+
+        if (this.select && this.select() && this.select().panelOpen) {
+            const term = (text ?? '').trim();
+            if (term.length === 0 || term.length >= this.minSearchLength()) {
+                this._searchTerms$.next(term);
+            }
+        }
+    }
+
+    get searchString(): string | null {
+        return this._searchString;
+    }
+
+    get displayValue(): string {
+        this.updateDisplayValueSignal();
+        return this.displayValueSignal();
+    }
+
+    getDisplayValue(): string {
+        const selectedValues = this.getCurrentSelectedValues();
+        if (!selectedValues || selectedValues.length === 0) return '';
+
+        if (this.multiple()) {
+            const labels = selectedValues
+                .map((value) => {
+                    const option = this._options.find((opt) => opt.value === value);
+                    if (option) return option.label;
+                    if (this.asyncSearchEnabled()) {
+                        const cached = this.selectedOptionCache.get(value as T);
+                        return cached ? cached.label : String(value);
+                    }
+                    return '';
+                })
+                .filter((label) => label);
+            return labels.join(', ');
+        } else {
+            const selectedValue = selectedValues[0];
+            if (selectedValue !== null && selectedValue !== undefined) {
+                const option = this._options.find((opt) => opt.value === selectedValue);
+                if (option) return option.label;
+                if (this.asyncSearchEnabled()) {
+                    const cached = this.selectedOptionCache.get(selectedValue as T);
+                    return cached ? cached.label : String(selectedValue);
+                }
+                return '';
+            }
+            return '';
+        }
+    }
+
+    get matSelectValue(): T[] | T | null {
+        if (this.enableVirtualScrolling()) {
+            return this.multiple() ? this._virtualSelectedValues : (this._virtualSelectedValues[0] ?? null);
+        } else {
+            const selectValue = this.select()?.value;
+            return selectValue !== undefined ? selectValue : null;
+        }
+    }
+
+    selectionPanelToggled(open: boolean) {
+        if (open) {
+            setTimeout(() => {
+                const viewport = this.virtualScrollViewport();
+                if (this.enableVirtualScrolling() && viewport) {
+                    viewport.scrollToIndex(0);
+                    viewport.checkViewportSize();
+                    this.syncMatSelectValue();
+                    this.cdr.detectChanges();
+                }
+                this.searchInput().nativeElement.focus();
+                this.startOverlayAutoReposition();
+            }, 0);
+            this._activeOptionIndex = -1;
+            this._isNavigating = false;
+        }
+        if (!open) {
+            this.stopOverlayAutoReposition();
+            if (this.asyncSearchEnabled()) {
+                this.searchString = null;
+                this.searchChange.emit('');
+            } else {
+                this.resetFilter();
+            }
+            this.select().focus();
+            this._activeOptionIndex = -1;
+            this._isNavigating = false;
+            this.updateActiveDescendant();
+            this.updateActiveTemplateIndex();
+        }
+    }
+
+    private resetFilter() {
+        if (this.asyncSearchEnabled()) {
+            this.searchChange.emit('');
+        }
+
+        this._options = this.options().map((o) => ({ ...o, hidden: false }));
+        this.filteredLength = this._options.length;
+        this.filteredOptions.set(this._options);
+        this._searchString = null;
+
+        this._activeOptionIndex = -1;
+        this._isNavigating = false;
+        this.updateActiveDescendant();
+        this.updateActiveTemplateIndex();
+    }
+
+    private filter(text: string | null) {
+        if (this.asyncSearchEnabled()) {
+            const normalized = this._options.map((option) => {
+                option.hidden = false;
+                return option;
+            });
+            this.filteredOptions.set(normalized);
+            this.filteredLength = normalized.length;
+        } else if (text === null) {
+            this.resetFilter();
+        } else {
+            let filteredCount = 0;
+            const filtered = this._options.map((option) => {
+                option.hidden = !option.label.toLowerCase().includes(text.toLowerCase());
+                if (option.hidden) {
+                    filteredCount++;
+                }
+                return option;
+            });
+            this.filteredLength = filtered.length - filteredCount;
+            this.filteredOptions.set(filtered);
+        }
+
+        this._activeOptionIndex = -1;
+        this._isNavigating = false;
+        this.updateActiveDescendant();
+        this.updateActiveTemplateIndex();
+    }
+
+    onValueChanged($event: T[] | T) {
+        // Material Design's mat-select changes the bound value when arrow keys navigate
+        // in single-select mode (but not in multi-select). We normalise both modes so that
+        // arrow keys only move highlight and Enter/click/touch performs the actual selection.
+        if (!this.multiple() && !this.select().panelOpen && this.enableVirtualScrolling()) {
+            this.syncMatSelectValue();
+            this.cdr.detectChanges();
+            return;
+        }
+
+        if (this.enableVirtualScrolling()) {
+            let eventArray: T[];
+            if (Array.isArray($event)) {
+                eventArray = $event || [];
+            } else if ($event != null) {
+                eventArray = [$event];
+            } else {
+                eventArray = [];
+            }
+
+            const incomingSelection = this.canonicalizeSelection(eventArray);
+
+            const currentSet = new Set(this._virtualSelectedValues);
+            const incomingSet = new Set(incomingSelection);
+
+            const hasChanged =
+                currentSet.size !== incomingSet.size ||
+                !Array.from(currentSet).every((val) => incomingSet.has(val)) ||
+                !Array.from(incomingSet).every((val) => currentSet.has(val));
+
+            if (hasChanged) {
+                this.updateVirtualSelectedValues(incomingSelection);
+
+                const formValue = this.multiple()
+                    ? this._virtualSelectedValues
+                    : this._virtualSelectedValues[0] || null;
+
+                this.emitIfChanged(formValue);
+                this.syncMatSelectValue();
+                this.cdr.detectChanges();
+            }
+        } else {
+            if (!this.multiple()) {
+                if (this._allowNextValueChange || this.select().panelOpen) {
+                    this._allowNextValueChange = false;
+                    this._lastIntentionalValue = $event as T;
+                    this.emitIfChanged($event);
+                    this.updateDisplayValueSignal();
+                } else {
+                    // Arrow-key auto-selection detected; revert to the last intentional value.
+                    setTimeout(() => {
+                        this.select().writeValue(this._lastIntentionalValue);
+                        this.updateDisplayValueSignal();
+                    }, 0);
+                    return;
+                }
+            } else {
+                this.emitIfChanged($event);
+                this.updateDisplayValueSignal();
+            }
+        }
+        if (!this.multiple()) {
+            this.select().close();
+        }
+    }
+
+    onSearchInputKeydown(event: KeyboardEvent) {
+        if (event.key === 'Tab') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.clearSearchBtn()?.focus();
+        }
+
+        if (event.code === 'Space') {
+            event.stopPropagation();
+        }
+
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+            this.handleArrowNavigation(event.key);
+        }
+
+        if (event.key === 'PageDown' || event.key === 'PageUp') {
+            event.preventDefault();
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+            this.handlePageNavigation(event.key);
+        }
+
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+            this.handleEnterKey();
+        }
+
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.select().close();
+            this._activeOptionIndex = -1;
+        }
+    }
+
+    onMatSelectKeydown(event: KeyboardEvent): boolean | void {
+        if (event.key === 'ArrowDown' && !this.select().panelOpen) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            this.select().open();
+
+            return false;
+        }
+
+        return;
+    }
+
+    focusSearchAndOrClear(event: KeyboardEvent | MouseEvent) {
+        if (event.type === 'keydown') {
+            const key = (event as KeyboardEvent).code;
+            if (key === 'Enter' || key === 'Space') {
+                this.resetFilter();
+            }
+            if (['Enter', 'Space', 'Tab'].includes(key)) {
+                event.stopPropagation();
+                event.preventDefault();
+                this.searchInput().nativeElement.focus();
+            }
+        }
+
+        if (event.type === 'click') {
+            event.stopPropagation();
+            event.preventDefault();
+            this.resetFilter();
+            this.searchInput().nativeElement.focus();
+        }
+    }
+
+    clearSelection(event: Event) {
+        event.stopPropagation();
+        event.preventDefault();
+
+        if (this.enableVirtualScrolling()) {
+            this.updateVirtualSelectedValues([]);
+            const formValue = this.multiple() ? [] : null;
+            this.onChange(formValue);
+            this.syncMatSelectValue();
+        } else {
+            const formValue = this.multiple() ? [] : null;
+            this.select().writeValue(formValue);
+            this._lastIntentionalValue = null;
+            this.onChange(formValue);
+            this.updateDisplayValueSignal();
+        }
+
+        this.cdr.detectChanges();
+    }
+
+    onClearSelectionKeydown(event: KeyboardEvent) {
+        if (event.code === 'Enter' || event.code === 'Space') {
+            event.stopPropagation();
+            event.preventDefault();
+            this.clearSelection(event);
+        }
+    }
+
+    shouldShowClearButton(): boolean {
+        if (!this.allowClear()) return false;
+        const selectedValues = this.getCurrentSelectedValues();
+        return selectedValues.length > 0;
+    }
+
+    private getCurrentSelectedValues(): T[] {
+        if (this.enableVirtualScrolling()) {
+            return this._virtualSelectedValues;
+        } else {
+            const matSelectValue = this.select()?.value;
+            if (Array.isArray(matSelectValue)) {
+                return matSelectValue;
+            } else if (matSelectValue !== null && matSelectValue !== undefined) {
+                return [matSelectValue];
+            } else {
+                return [];
+            }
+        }
+    }
+
+    /**
+     * Get all selected options that need ghost rendering (unified for both modes).
+     *
+     * For virtual scrolling (both single and multi-select), mat-select needs hidden
+     * <multi-select-option> elements to track selected values that may be scrolled
+     * off-screen.
+     */
+    getGhostOptions(): FilteredSearchableSelectOption<T>[] {
+        const selectedValues = this.getCurrentSelectedValues();
+
+        if (selectedValues.length === 0) {
+            return [];
+        }
+
+        const ghosts: FilteredSearchableSelectOption<T>[] = [];
+
+        if (this.enableVirtualScrolling()) {
+            ghosts.push(...this._options.filter((option) => selectedValues.includes(option.value)));
+        } else if (this.multiple()) {
+            const visibleFilteredOptions = this.filteredOptions().filter((option) => !option.hidden);
+            const visibleValues = new Set(visibleFilteredOptions.map((option) => option.value));
+            ghosts.push(
+                ...this._options.filter(
+                    (option) => selectedValues.includes(option.value) && !visibleValues.has(option.value)
+                )
+            );
+        }
+
+        if (this.asyncSearchEnabled()) {
+            const optionValues = new Set(this._options.map((o) => o.value));
+            selectedValues.forEach((val) => {
+                if (!optionValues.has(val)) {
+                    const cached = this.selectedOptionCache.get(val as T);
+                    const label = cached?.label ?? String(val);
+                    ghosts.push({
+                        value: val as T,
+                        label,
+                        svgIcon: cached?.svgIcon,
+                        description: cached?.description,
+                        disabled: cached?.disabled ?? false,
+                        labelCssClasses: cached?.labelCssClasses,
+                        hidden: true
+                    } as FilteredSearchableSelectOption<T>);
+                }
+            });
+        }
+
+        return ghosts;
+    }
+
+    private handleArrowNavigation(key: string) {
+        const visibleOptions = this.getVisibleOptions();
+        if (visibleOptions.length === 0) return;
+
+        if (key === 'ArrowDown') {
+            if (this._activeOptionIndex < 0) {
+                this._activeOptionIndex = 0;
+            } else {
+                this._activeOptionIndex = Math.min(this._activeOptionIndex + 1, visibleOptions.length - 1);
+            }
+        } else if (key === 'ArrowUp') {
+            if (this._activeOptionIndex < 0) {
+                this._activeOptionIndex = visibleOptions.length - 1;
+            } else {
+                this._activeOptionIndex = Math.max(this._activeOptionIndex - 1, 0);
+            }
+        }
+
+        this._isNavigating = true;
+        this.scrollToActiveOption();
+        this.updateActiveDescendant();
+        this.updateActiveTemplateIndex();
+    }
+
+    private handlePageNavigation(key: string) {
+        const visibleOptions = this.getVisibleOptions();
+        if (visibleOptions.length === 0) return;
+
+        let pageSize: number;
+        if (this.enableVirtualScrolling()) {
+            const viewport = this.virtualScrollViewport();
+            if (viewport) {
+                const viewportSize = viewport.getViewportSize();
+                const itemSize = this.virtualScrollItemSize();
+                pageSize = Math.floor(viewportSize / itemSize);
+            } else {
+                pageSize = 10;
+            }
+        } else {
+            pageSize = 10;
+        }
+
+        pageSize = Math.max(1, pageSize);
+
+        if (key === 'PageDown') {
+            if (this._activeOptionIndex < 0) {
+                this._activeOptionIndex = 0;
+            } else {
+                this._activeOptionIndex = Math.min(this._activeOptionIndex + pageSize, visibleOptions.length - 1);
+            }
+        } else if (key === 'PageUp') {
+            if (this._activeOptionIndex < 0) {
+                this._activeOptionIndex = visibleOptions.length - 1;
+            } else {
+                this._activeOptionIndex = Math.max(this._activeOptionIndex - pageSize, 0);
+            }
+        }
+
+        this._isNavigating = true;
+        this.scrollToActiveOption();
+        this.updateActiveDescendant();
+        this.updateActiveTemplateIndex();
+    }
+
+    private handleEnterKey() {
+        if (this._activeOptionIndex >= 0) {
+            const visibleOptions = this.getVisibleOptions();
+            const activeOption = visibleOptions[this._activeOptionIndex];
+            if (activeOption && !activeOption.disabled) {
+                this._allowNextValueChange = true;
+                this._isNavigating = false;
+                this.toggleOption(activeOption.value);
+            }
+        }
+    }
+
+    private scrollToActiveOption() {
+        if (this._activeOptionIndex >= 0) {
+            if (this.enableVirtualScrolling()) {
+                const viewport = this.virtualScrollViewport();
+                if (viewport) {
+                    const viewportSize = viewport.getViewportSize();
+                    const itemSize = this.virtualScrollItemSize();
+                    const scrollOffset = viewport.measureScrollOffset();
+
+                    const virtualIndex = this.getVirtualIndexForOptionIndex(this._activeOptionIndex);
+
+                    const firstFullyVisibleIndex = Math.floor((scrollOffset + itemSize * 0.5) / itemSize);
+                    const lastFullyVisibleIndex = Math.floor((scrollOffset + viewportSize - itemSize * 0.5) / itemSize);
+
+                    if (virtualIndex < firstFullyVisibleIndex) {
+                        viewport.scrollToIndex(virtualIndex, 'smooth');
+                    } else if (virtualIndex > lastFullyVisibleIndex) {
+                        const targetOffset = (virtualIndex + 1) * itemSize - viewportSize;
+                        viewport.scrollToOffset(Math.max(0, targetOffset), 'smooth');
+                    }
+                }
+            } else {
+                const activeOptionElement = document.getElementById(this.getOptionId(this._activeOptionIndex));
+                if (activeOptionElement) {
+                    activeOptionElement.scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'nearest',
+                        inline: 'nearest'
+                    });
+                }
+            }
+        }
+    }
+
+    private updateActiveDescendant() {
+        const searchInput = this.searchInput()?.nativeElement;
+        if (!searchInput) return;
+
+        if (this._activeOptionIndex >= 0 && this._isNavigating) {
+            const optionId = this.activeOptionId;
+            if (searchInput.setAttribute) {
+                searchInput.setAttribute('aria-activedescendant', optionId);
+            }
+        } else {
+            if (searchInput.removeAttribute) {
+                searchInput.removeAttribute('aria-activedescendant');
+            }
+        }
+    }
+
+    private toggleOption(value: T) {
+        if (this.enableVirtualScrolling()) {
+            if (this.multiple()) {
+                const currentValues = [...this._virtualSelectedValues];
+                const index = currentValues.indexOf(value);
+
+                if (index > -1) {
+                    currentValues.splice(index, 1);
+                } else {
+                    currentValues.push(value);
+                }
+
+                this.updateVirtualSelectedValues(currentValues);
+                const formValue = this._virtualSelectedValues;
+                this.emitIfChanged(formValue);
+                this.syncMatSelectValue();
+            } else {
+                const newValue = this._virtualSelectedValues.includes(value) ? null : value;
+                this.updateVirtualSelectedValues(newValue ? [newValue] : []);
+                this.emitIfChanged(newValue);
+                this.syncMatSelectValue();
+                this.select().close();
+            }
+
+            this.cdr.detectChanges();
+        } else {
+            const visibleOptions = this.getVisibleOptions();
+            const activeOptionWithIndex = visibleOptions[
+                this._activeOptionIndex
+            ] as FilteredSearchableSelectOption<T> & { templateIndex?: number };
+
+            const templateIndex = activeOptionWithIndex?.templateIndex ?? this._activeOptionIndex;
+            const activeOptionId = this.getOptionId(templateIndex);
+            let optionElement = document.getElementById(activeOptionId);
+
+            if (!optionElement) {
+                const allOptions = document.querySelectorAll('multi-select-option');
+                allOptions.forEach((element) => {
+                    const htmlElement = element as HTMLElement & { value: T };
+                    if (htmlElement.value === value) {
+                        optionElement = element as HTMLElement;
+                    }
+                });
+            }
+
+            if (optionElement) {
+                const clickEvent = new MouseEvent('click', {
+                    view: window,
+                    bubbles: true,
+                    cancelable: true
+                });
+                optionElement.dispatchEvent(clickEvent);
+            }
+        }
+    }
+
+    isOptionActive(index: number): boolean {
+        if (!this._isNavigating) return false;
+
+        if (this.enableVirtualScrolling()) {
+            return this._activeOptionIndex === index;
+        } else {
+            const visibleOptions = this.getVisibleOptions();
+            const activeOption = visibleOptions[this._activeOptionIndex] as FilteredSearchableSelectOption<T> & {
+                templateIndex?: number;
+            };
+            const templateIndex = activeOption?.templateIndex;
+            return templateIndex === index;
+        }
+    }
+
+    isOptionActiveByValue(value: T): boolean {
+        if (!this._isNavigating || this._activeOptionIndex < 0) {
+            return false;
+        }
+
+        const visibleOptions = this.getVisibleOptions();
+        const activeOption = visibleOptions[this._activeOptionIndex];
+        return activeOption?.value === value;
+    }
+
+    /**
+     * Get visible options for keyboard navigation - should match what's actually rendered.
+     */
+    getVisibleOptions(): FilteredSearchableSelectOption<T>[] {
+        if (this.enableVirtualScrolling()) {
+            const searchTerm = this._searchString?.toLowerCase();
+
+            if (!searchTerm || this.asyncSearchEnabled()) {
+                return this._options;
+            } else {
+                return this._options.filter((option) => option.label.toLowerCase().includes(searchTerm));
+            }
+        } else if (this.hasGroupedOptions()) {
+            const groups = this.groupedOptions();
+            if (groups) {
+                return groups.flatMap((g) => g.options);
+            }
+            return [];
+        } else {
+            const allFilteredOptions = this.filteredOptions();
+            const visibleWithIndices: (FilteredSearchableSelectOption<T> & { templateIndex: number })[] = [];
+
+            allFilteredOptions.forEach((option, index) => {
+                if (!option.hidden) {
+                    visibleWithIndices.push({ ...option, templateIndex: index });
+                }
+            });
+
+            return visibleWithIndices;
+        }
+    }
+
+    getVirtualVisibleItems(): VirtualItem<T>[] {
+        const options = this.getVisibleOptions();
+
+        if (this.loadError() && options.length === 0) {
+            return [{ __kind: 'error' } as FooterItem];
+        }
+
+        let items: VirtualItem<T>[];
+
+        if (this.hasGroupedOptions()) {
+            const groups = this.groupedOptions();
+            if (groups && groups.length > 0) {
+                items = [];
+                const firstGroupHeaderIndex = groups.findIndex((g) => g.groupLabel);
+                groups.forEach((group, groupIndex) => {
+                    const isFirstGroup = groupIndex === firstGroupHeaderIndex;
+                    const isLastGroup = groupIndex === groups.length - 1;
+                    if (group.groupLabel) {
+                        items.push({
+                            __kind: 'group-header',
+                            groupId: group.groupId,
+                            groupLabel: group.groupLabel,
+                            isFirstGroup,
+                            isLastGroup
+                        } as GroupHeaderItem);
+                    }
+                    group.options.forEach((opt) => {
+                        items.push(opt);
+                    });
+                });
+            } else {
+                items = options as VirtualItem<T>[];
+            }
+        } else {
+            items = options as VirtualItem<T>[];
+        }
+
+        if (this.asyncSearchEnabled() && items.length > 0 && this.asyncSearchOptionsHaveMore()) {
+            return [...items, { __kind: 'more' } as FooterItem];
+        }
+
+        return items;
+    }
+
+    isGroupHeaderItem(item: VirtualItem<T>): item is GroupHeaderItem {
+        return (item as GroupHeaderItem).__kind === 'group-header';
+    }
+
+    getGroupHeaderLabel(item: VirtualItem<T>): string {
+        return this.isGroupHeaderItem(item) ? (item as GroupHeaderItem).groupLabel : '';
+    }
+
+    isFirstGroupHeader(item: VirtualItem<T>): boolean {
+        return this.isGroupHeaderItem(item) ? (item as GroupHeaderItem).isFirstGroup : false;
+    }
+
+    isLastGroupHeader(item: VirtualItem<T>): boolean {
+        return this.isGroupHeaderItem(item) ? (item as GroupHeaderItem).isLastGroup : false;
+    }
+
+    private getVirtualIndexForOptionIndex(optionIndex: number): number {
+        if (!this.hasGroupedOptions()) {
+            return optionIndex;
+        }
+
+        const virtualItems = this.getVirtualVisibleItems();
+        let optionCount = 0;
+
+        for (let i = 0; i < virtualItems.length; i++) {
+            const item = virtualItems[i];
+            if (this.isOptionItem(item)) {
+                if (optionCount === optionIndex) {
+                    return i;
+                }
+                optionCount++;
+            }
+        }
+
+        return virtualItems.length - 1;
+    }
+
+    trackByValue = (index: number, option: FilteredSearchableSelectOption<T>): T => {
+        return option.value;
+    };
+
+    trackByVirtualItem = (index: number, item: VirtualItem<T>): T | string => {
+        if (this.isFooterItem(item)) {
+            return `__footer-${(item as FooterItem).__kind}`;
+        }
+        if (this.isGroupHeaderItem(item)) {
+            return `__group-header-${(item as GroupHeaderItem).groupId}`;
+        }
+        return (item as FilteredSearchableSelectOption<T>).value;
+    };
+
+    isFooterItem(item: VirtualItem<T>): item is FooterItem {
+        const kind = (item as FooterItem).__kind;
+        return kind === 'more' || kind === 'error';
+    }
+
+    isOptionItem(item: VirtualItem<T>): boolean {
+        const kind = (item as FooterItem | GroupHeaderItem).__kind;
+        return kind !== 'more' && kind !== 'error' && kind !== 'group-header';
+    }
+    isMoreItem(item: VirtualItem<T>): item is FooterItem {
+        return (item as unknown as FooterItem).__kind === 'more';
+    }
+
+    asOptionItem(item: VirtualItem<T>): FilteredSearchableSelectOption<T> | null {
+        if (this.isFooterItem(item) || this.isGroupHeaderItem(item)) {
+            return null;
+        }
+        return item as FilteredSearchableSelectOption<T>;
+    }
+
+    getItemValue(item: VirtualItem<T>): T {
+        const opt = this.asOptionItem(item);
+        return opt ? opt.value : (undefined as unknown as T);
+    }
+
+    getItemDisabled(item: VirtualItem<T>): boolean {
+        const opt = this.asOptionItem(item);
+        return !!opt?.disabled;
+    }
+
+    getItemSvgIcon(item: VirtualItem<T>): string {
+        const opt = this.asOptionItem(item);
+        return opt?.svgIcon ?? '';
+    }
+
+    getItemLabelCss(item: VirtualItem<T>): string[] | undefined {
+        const opt = this.asOptionItem(item);
+        return opt?.labelCssClasses;
+    }
+
+    getItemLabel(item: VirtualItem<T>): string {
+        const opt = this.asOptionItem(item);
+        return opt?.label ?? '';
+    }
+
+    getItemDescription(item: VirtualItem<T>): string | undefined {
+        const opt = this.asOptionItem(item);
+        return opt?.description;
+    }
+
+    isVirtualOptionSelected(value: T): boolean {
+        return this._virtualSelectedValues.includes(value);
+    }
+
+    getVirtualScrollHeight(): string {
+        const virtualItems = this.getVirtualVisibleItems();
+        const itemCount = virtualItems.length;
+
+        if (itemCount === 0) {
+            if (this.loadError()) {
+                return `${this.virtualScrollItemSize()}px`;
+            }
+            return '0px';
+        }
+
+        const idealHeight = itemCount * this.virtualScrollItemSize();
+
+        const actualHeight = Math.min(idealHeight, this.virtualScrollMaxHeight);
+
+        return `${actualHeight}px`;
+    }
+
+    private getUniqueId(suffix: string): string {
+        return `${this.componentId}-${suffix}`;
+    }
+
+    get optionsListId(): string {
+        return this.getUniqueId(this.enableVirtualScrolling() ? 'virtual-options-list' : 'options-list');
+    }
+
+    getOptionId(index: number | string): string {
+        return this.getUniqueId(`option-${index}`);
+    }
+
+    get activeOptionId(): string {
+        return this.getUniqueId('option-active');
+    }
+
+    private updateVirtualSelectedValues(values: T[]): void {
+        this._virtualSelectedValues = values;
+        this.updateDisplayValueSignal();
+        this.cdr.markForCheck();
+    }
+
+    private updateActiveTemplateIndex(): void {
+        if (!this._isNavigating) {
+            this.activeTemplateIndex.set(-1);
+            return;
+        }
+
+        if (this.enableVirtualScrolling()) {
+            this.activeTemplateIndex.set(this._activeOptionIndex);
+            return;
+        }
+
+        const allFiltered = this.filteredOptions();
+        if (this._activeOptionIndex < 0) {
+            this.activeTemplateIndex.set(-1);
+            return;
+        }
+
+        let visibleIndex = -1;
+        for (let idx = 0; idx < allFiltered.length; idx++) {
+            const option = allFiltered[idx];
+            if (!option.hidden) {
+                visibleIndex++;
+                if (visibleIndex === this._activeOptionIndex) {
+                    this.activeTemplateIndex.set(idx);
+                    return;
+                }
+            }
+        }
+        this.activeTemplateIndex.set(-1);
+    }
+
+    private updateDisplayValueSignal(): void {
+        const selectedValues = this.getCurrentSelectedValues();
+
+        let displayText = '';
+        if (this.multiple()) {
+            const labels = selectedValues
+                .map((value) => {
+                    const option = this._options.find((opt) => opt.value === value);
+                    if (option) return option.label;
+                    if (this.asyncSearchEnabled()) {
+                        const cached = this.selectedOptionCache.get(value as T);
+                        return cached ? cached.label : String(value);
+                    }
+                    return '';
+                })
+                .filter((label) => label);
+            displayText = labels.join(', ');
+        } else {
+            const selectedValue = selectedValues[0];
+            if (selectedValue !== null && selectedValue !== undefined) {
+                const option = this._options.find((opt) => opt.value === selectedValue);
+                if (option) {
+                    displayText = option.label;
+                } else if (this.asyncSearchEnabled()) {
+                    const cached = this.selectedOptionCache.get(selectedValue as T);
+                    displayText = cached ? cached.label : String(selectedValue);
+                } else {
+                    displayText = '';
+                }
+            }
+        }
+
+        this.displayValueSignal.set(displayText);
+    }
+
+    private syncMatSelectValue(): void {
+        if (!this.enableVirtualScrolling()) return;
+        if (this._isSyncingMatValue) return;
+        this._isSyncingMatValue = true;
+        const valueToSync = this.multiple() ? this._virtualSelectedValues : this._virtualSelectedValues[0] || null;
+        this.select().writeValue(valueToSync);
+        this._isSyncingMatValue = false;
+    }
+
+    // ========================================================================================
+    // ControlValueAccessor Implementation
+    // ========================================================================================
+
+    writeValue(value: T[] | T | null): void {
+        if (this.enableVirtualScrolling()) {
+            let newValues: T[];
+            if (this.multiple()) {
+                newValues = Array.isArray(value) ? value : value ? [value] : [];
+            } else {
+                newValues = value !== null ? [value as T] : [];
+            }
+
+            this.updateVirtualSelectedValues(newValues);
+
+            // Defer mat-select sync so dynamically added controls finish wiring up before we
+            // write into the child mat-select and to avoid feedback loops during form init.
+            setTimeout(() => {
+                this.syncMatSelectValue();
+                this.cdr.detectChanges();
+            }, 0);
+        } else {
+            this.select().writeValue(value);
+
+            if (!this.multiple()) {
+                this._lastIntentionalValue = Array.isArray(value) ? value[0] || null : value;
+            }
+
+            this.updateDisplayValueSignal();
+        }
+
+        if (this.multiple()) {
+            this.scheduleOverlayReposition();
+        }
+    }
+
+    // ========================================================================================
+    // Deduped Emission Logic
+    // ========================================================================================
+
+    private emitIfChanged(next: T[] | T | null): void {
+        const toEmit = next;
+        if (!this.areValuesEqual(toEmit, this._lastEmittedValue)) {
+            this._lastEmittedValue = Array.isArray(toEmit) ? [...(toEmit as T[])] : (toEmit as T | null);
+            this.onChange(toEmit);
+        }
+    }
+
+    private areValuesEqual(a: T[] | T | null, b: T[] | T | null): boolean {
+        if (a === b) {
+            return true;
+        }
+
+        if (a == null || b == null) {
+            return false;
+        }
+
+        const aArr = Array.isArray(a) ? a : [a];
+        const bArr = Array.isArray(b) ? b : [b];
+
+        if (aArr.length !== bArr.length) {
+            return false;
+        }
+
+        const aSet = new Set(aArr);
+        for (const item of bArr) {
+            if (!aSet.has(item)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private canonicalizeSelection(values: T[]): T[] {
+        const labelCounts = new Map<string, number>();
+        const valueToLabel = new Map<T, string>();
+        for (const value of values) {
+            const option = this._options.find((opt) => opt.value === value);
+            const label = option?.label ?? String(value);
+            valueToLabel.set(value, label);
+            labelCounts.set(label, (labelCounts.get(label) || 0) + 1);
+        }
+        return values.filter((value) => (labelCounts.get(valueToLabel.get(value) as string) || 0) === 1);
+    }
+
+    registerOnChange(onChange: (value: T[] | T | null) => void): void {
+        this.onChange = onChange;
+        // Value emissions are routed through onValueChanged/emitIfChanged (via the template's
+        // (valueChange) binding) or direct this.onChange() calls (e.g. clearSelection()).
+        // Registering onChange on the internal mat-select would create a second emission path.
+    }
+
+    registerOnTouched(onTouch: () => NonNullable<unknown>): void {
+        this.onTouched = onTouch;
+        this.select().registerOnTouched(onTouch);
+    }
+
+    setDisabledState(isDisabled: boolean): void {
+        this.disabled = isDisabled;
+        if (this._viewInitialized) {
+            this.select().setDisabledState(isDisabled);
+        } else {
+            this._pendingDisabledState = isDisabled;
+        }
+    }
+
+    private readonly componentId = `searchable-select-${Math.random().toString(36).substring(2, 11)}`;
+
+    private readonly _searchTerms$ = new Subject<string>();
+
+    /**
+     * Reset the emission tracking state to allow the same value to be emitted again.
+     */
+    resetEmissionTracking(): void {
+        this._lastEmittedValue = null;
+    }
+
+    ngOnInit(): void {
+        this._searchTerms$
+            .pipe(distinctUntilChanged(), debounceTime(this.searchDebounceMs()), takeUntil(this._destroyed$))
+            .subscribe((term: string) => {
+                if (this.asyncSearchEnabled()) {
+                    this.searchInProgress = true;
+                    this.searchChange.emit(term);
+                }
+            });
+    }
+
+    ngAfterViewInit(): void {
+        this._viewInitialized = true;
+        if (this._pendingDisabledState !== null) {
+            this.select().setDisabledState(this._pendingDisabledState);
+            this._pendingDisabledState = null;
+        }
+    }
+
+    private readonly _destroyed$ = new Subject<void>();
+    ngOnDestroy(): void {
+        this.stopOverlayAutoReposition();
+        this._destroyed$.next();
+        this._destroyed$.complete();
+    }
+
+    private scheduleOverlayReposition(): void {
+        if (!this.multiple()) {
+            return;
+        }
+
+        const overlayRef = this.getOverlayRef();
+        if (!overlayRef) {
+            return;
+        }
+
+        if (this.overlayRafHandle !== null) {
+            this.cancelAnimationFrame(this.overlayRafHandle);
+        }
+
+        this.zone.runOutsideAngular(() => {
+            this.overlayRafHandle = this.requestAnimationFrame(() => {
+                this.applyOverlayReposition(overlayRef);
+                this.overlayRafHandle = null;
+            });
+        });
+    }
+
+    private startOverlayAutoReposition(): void {
+        if (!this.multiple()) {
+            return;
+        }
+
+        const selectInstance = this.tryGetMatSelectInternals();
+        if (!selectInstance?.panelOpen) {
+            return;
+        }
+
+        const triggerElement = selectInstance._elementRef?.nativeElement;
+        if (!triggerElement) {
+            return;
+        }
+
+        this.stopOverlayAutoReposition();
+
+        if (typeof window !== 'undefined' && 'ResizeObserver' in window) {
+            this.triggerResizeObserver = new ResizeObserver(() => {
+                this.lastTriggerRect = null;
+                this.scheduleOverlayReposition();
+            });
+            this.triggerResizeObserver.observe(triggerElement);
+        }
+
+        if (typeof window === 'undefined') {
+            this.scheduleOverlayReposition();
+            return;
+        }
+
+        this.zone.runOutsideAngular(() => {
+            const monitorGeometry = () => {
+                const activeSelect = this.tryGetMatSelectInternals();
+                if (!activeSelect?.panelOpen) {
+                    this.triggerGeometryRafHandle = null;
+                    return;
+                }
+
+                const currentRect = triggerElement.getBoundingClientRect();
+                if (!this.lastTriggerRect || !this.areRectsEqual(currentRect, this.lastTriggerRect)) {
+                    this.lastTriggerRect = currentRect;
+                    this.scheduleOverlayReposition();
+                }
+
+                this.triggerGeometryRafHandle = this.requestAnimationFrame(monitorGeometry);
+            };
+
+            this.lastTriggerRect = triggerElement.getBoundingClientRect();
+            this.triggerGeometryRafHandle = this.requestAnimationFrame(monitorGeometry);
+        });
+
+        this.scheduleOverlayReposition();
+    }
+
+    private stopOverlayAutoReposition(): void {
+        if (this.triggerResizeObserver) {
+            this.triggerResizeObserver.disconnect();
+            this.triggerResizeObserver = null;
+        }
+
+        if (this.triggerGeometryRafHandle !== null) {
+            this.cancelAnimationFrame(this.triggerGeometryRafHandle);
+            this.triggerGeometryRafHandle = null;
+        }
+
+        if (this.overlayRafHandle !== null) {
+            this.cancelAnimationFrame(this.overlayRafHandle);
+            this.overlayRafHandle = null;
+        }
+
+        this.lastTriggerRect = null;
+    }
+
+    private applyOverlayReposition(overlayRef: OverlayRef): void {
+        const strategy = overlayRef.getConfig().positionStrategy as FlexibleConnectedPositionStrategy;
+        strategy.reapplyLastPosition();
+    }
+
+    private areRectsEqual(a: DOMRect | DOMRectReadOnly, b: DOMRect | DOMRectReadOnly): boolean {
+        return a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height;
+    }
+
+    private requestAnimationFrame(callback: FrameRequestCallback): number {
+        return window.requestAnimationFrame(callback);
+    }
+
+    private cancelAnimationFrame(handle: number): void {
+        window.cancelAnimationFrame(handle);
+        return;
+    }
+
+    private overlayRafHandle: number | null = null;
+    private triggerResizeObserver: ResizeObserver | null = null;
+    private triggerGeometryRafHandle: number | null = null;
+    private lastTriggerRect: DOMRect | DOMRectReadOnly | null = null;
+
+    private tryGetMatSelectInternals(): MatSelectOverlayInternals | null {
+        try {
+            const instance = this.select();
+            return instance as MatSelectOverlayInternals;
+        } catch {
+            return null;
+        }
+    }
+
+    private getOverlayRef(): OverlayRef | undefined {
+        return this.tryGetMatSelectInternals()?._overlayDir?.overlayRef;
+    }
+}

--- a/nifi-frontend/src/main/frontend/libs/shared/src/directives/ellipsis-tooltip/ellipsis-tooltip.directive.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/directives/ellipsis-tooltip/ellipsis-tooltip.directive.spec.ts
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Input } from '@angular/core';
+import { TestBed, fakeAsync, flushMicrotasks } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatTooltip } from '@angular/material/tooltip';
+
+import { EllipsisTooltipDirective } from './ellipsis-tooltip.directive';
+
+@Component({
+    standalone: true,
+    imports: [EllipsisTooltipDirective],
+    template: `
+        <div
+            class="truncate"
+            ellipsisTooltip
+            [tooltipShowDelay]="showDelay"
+            [tooltipHideDelay]="hideDelay"
+            [tooltipPosition]="position">
+            {{ text }}
+        </div>
+    `
+})
+class HostComponent {
+    @Input() text = 'Some text';
+    @Input() showDelay?: number;
+    @Input() hideDelay?: number;
+    @Input() position?: 'above' | 'below' | 'left' | 'right' | 'before' | 'after';
+}
+
+describe('EllipsisTooltipDirective', () => {
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [NoopAnimationsModule, HostComponent]
+        }).compileComponents();
+    });
+
+    it('should set default delays and default position after init', fakeAsync(() => {
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.detectChanges();
+
+        flushMicrotasks();
+
+        fixture.componentRef.setInput('showDelay', 500);
+        fixture.detectChanges();
+
+        const debugEl = fixture.debugElement.query(By.directive(EllipsisTooltipDirective));
+        const tooltip = debugEl.injector.get(MatTooltip);
+
+        expect(tooltip.showDelay).toBe(500);
+        expect(tooltip.hideDelay).toBe(0);
+        expect(tooltip.position).toBe('after');
+    }));
+
+    it('should disable tooltip when not overflowing', fakeAsync(() => {
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.detectChanges();
+
+        const debugEl = fixture.debugElement.query(By.directive(EllipsisTooltipDirective));
+        const host: HTMLElement = debugEl.nativeElement;
+        const tooltip = debugEl.injector.get(MatTooltip);
+
+        Object.defineProperty(host, 'offsetWidth', { value: 100, configurable: true });
+        Object.defineProperty(host, 'scrollWidth', { value: 90, configurable: true });
+
+        flushMicrotasks();
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+
+        expect(tooltip.message).toBe('');
+        expect(tooltip.disabled).toBe(true);
+    }));
+
+    it('should enable tooltip with trimmed full text when overflowing', fakeAsync(() => {
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.componentRef.setInput('text', '   Very long label   ');
+        fixture.detectChanges();
+
+        const debugEl = fixture.debugElement.query(By.directive(EllipsisTooltipDirective));
+        const host: HTMLElement = debugEl.nativeElement;
+        const tooltip = debugEl.injector.get(MatTooltip);
+
+        Object.defineProperty(host, 'offsetWidth', { value: 50, configurable: true });
+        Object.defineProperty(host, 'scrollWidth', { value: 200, configurable: true });
+
+        flushMicrotasks();
+
+        expect(tooltip.message).toBe('Very long label');
+        expect(tooltip.disabled).toBe(false);
+    }));
+
+    it('should respect provided delays and position inputs', fakeAsync(() => {
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.componentRef.setInput('showDelay', 200);
+        fixture.componentRef.setInput('hideDelay', 300);
+        fixture.componentRef.setInput('position', 'above');
+        fixture.detectChanges();
+
+        const debugEl = fixture.debugElement.query(By.directive(EllipsisTooltipDirective));
+        const tooltip = debugEl.injector.get(MatTooltip);
+
+        flushMicrotasks();
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+
+        expect(tooltip.showDelay).toBe(200);
+        expect(tooltip.hideDelay).toBe(300);
+        expect(tooltip.position).toBe('above');
+    }));
+
+    it('should enable tooltip when vertically overflowing (line-clamp)', fakeAsync(() => {
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.componentRef.setInput('text', 'Very long text that will wrap to multiple lines and get clamped');
+        fixture.detectChanges();
+
+        const debugEl = fixture.debugElement.query(By.directive(EllipsisTooltipDirective));
+        const host: HTMLElement = debugEl.nativeElement;
+        const tooltip = debugEl.injector.get(MatTooltip);
+
+        Object.defineProperty(host, 'offsetWidth', { value: 200, configurable: true });
+        Object.defineProperty(host, 'scrollWidth', { value: 180, configurable: true });
+        Object.defineProperty(host, 'offsetHeight', { value: 60, configurable: true });
+        Object.defineProperty(host, 'scrollHeight', { value: 120, configurable: true });
+
+        flushMicrotasks();
+
+        expect(tooltip.message).toBe('Very long text that will wrap to multiple lines and get clamped');
+        expect(tooltip.disabled).toBe(false);
+    }));
+
+    it('should enable tooltip when both horizontally and vertically overflowing', fakeAsync(() => {
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.componentRef.setInput('text', 'Very long text that overflows both ways');
+        fixture.detectChanges();
+
+        const debugEl = fixture.debugElement.query(By.directive(EllipsisTooltipDirective));
+        const host: HTMLElement = debugEl.nativeElement;
+        const tooltip = debugEl.injector.get(MatTooltip);
+
+        Object.defineProperty(host, 'offsetWidth', { value: 50, configurable: true });
+        Object.defineProperty(host, 'scrollWidth', { value: 200, configurable: true });
+        Object.defineProperty(host, 'offsetHeight', { value: 60, configurable: true });
+        Object.defineProperty(host, 'scrollHeight', { value: 120, configurable: true });
+
+        flushMicrotasks();
+
+        expect(tooltip.message).toBe('Very long text that overflows both ways');
+        expect(tooltip.disabled).toBe(false);
+    }));
+
+    it('should disable tooltip when neither horizontally nor vertically overflowing', fakeAsync(() => {
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.detectChanges();
+
+        const debugEl = fixture.debugElement.query(By.directive(EllipsisTooltipDirective));
+        const host: HTMLElement = debugEl.nativeElement;
+        const tooltip = debugEl.injector.get(MatTooltip);
+
+        Object.defineProperty(host, 'offsetWidth', { value: 200, configurable: true });
+        Object.defineProperty(host, 'scrollWidth', { value: 180, configurable: true });
+        Object.defineProperty(host, 'offsetHeight', { value: 120, configurable: true });
+        Object.defineProperty(host, 'scrollHeight', { value: 100, configurable: true });
+
+        flushMicrotasks();
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+
+        expect(tooltip.message).toBe('');
+        expect(tooltip.disabled).toBe(true);
+    }));
+});

--- a/nifi-frontend/src/main/frontend/libs/shared/src/directives/ellipsis-tooltip/ellipsis-tooltip.directive.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/directives/ellipsis-tooltip/ellipsis-tooltip.directive.ts
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AfterViewInit, Directive, ElementRef, Input, NgZone, numberAttribute, OnDestroy, inject } from '@angular/core';
+import { MatTooltip, TooltipPosition } from '@angular/material/tooltip';
+
+/**
+ * Adds a tooltip with the element's full text content when the rendered content is truncated
+ * (horizontal or vertical overflow). The tooltip stays disabled while the text fits.
+ *
+ * Usage:
+ *   <div class="truncate" ellipsisTooltip>Some long text...</div>
+ */
+@Directive({
+    selector: '[ellipsisTooltip]',
+    standalone: true,
+    hostDirectives: [MatTooltip]
+})
+export class EllipsisTooltipDirective implements AfterViewInit, OnDestroy {
+    private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+    private matTooltip = inject(MatTooltip, { self: true });
+    private zone = inject(NgZone);
+
+    private get hostElement(): HTMLElement & { __ellipsis_ro__?: ResizeObserver } {
+        return this.elementRef.nativeElement as HTMLElement & { __ellipsis_ro__?: ResizeObserver };
+    }
+    private mutationObserver: MutationObserver | null = null;
+    private hasScheduledEvaluation = false;
+    private lastTooltipMessage: string | null = null;
+    private lastTooltipDisabled: boolean | null = null;
+    private _tooltipShowDelay = 500;
+    private _tooltipHideDelay = 0;
+    private tooltipPositionWasSet = false;
+    private observersActive = false;
+
+    private readonly onMouseEnter = () => this.activateObservers();
+    private readonly onMouseLeave = () => this.deactivateObservers();
+    private readonly onFocusIn = () => this.activateObservers();
+    private readonly onFocusOut = () => this.deactivateObservers();
+
+    @Input({ transform: numberAttribute })
+    set tooltipShowDelay(value: number) {
+        this._tooltipShowDelay = typeof value === 'number' ? value : 0;
+        this.matTooltip.showDelay = this._tooltipShowDelay;
+    }
+
+    @Input({ transform: numberAttribute })
+    set tooltipHideDelay(value: number) {
+        this._tooltipHideDelay = typeof value === 'number' ? value : 0;
+        this.matTooltip.hideDelay = this._tooltipHideDelay;
+    }
+
+    @Input()
+    set tooltipPosition(value: TooltipPosition | undefined) {
+        if (value == null) {
+            this.tooltipPositionWasSet = false;
+            this.matTooltip.position = 'after';
+            return;
+        }
+        this.tooltipPositionWasSet = true;
+        this.matTooltip.position = value as TooltipPosition;
+    }
+
+    ngAfterViewInit(): void {
+        // Defer the first evaluation to the next microtask to avoid NG0100 (expression-changed-after-checked).
+        this.scheduleEvaluateOverflow();
+
+        this.matTooltip.showDelay = this._tooltipShowDelay;
+        this.matTooltip.hideDelay = this._tooltipHideDelay;
+        if (!this.tooltipPositionWasSet) {
+            this.matTooltip.position = 'after';
+        }
+
+        // Lazily attach observers on interaction to avoid per-item background observers in large lists.
+        const listenerOptions: AddEventListenerOptions = { passive: true, capture: true };
+        this.hostElement.addEventListener('mouseenter', this.onMouseEnter, listenerOptions);
+        this.hostElement.addEventListener('mouseleave', this.onMouseLeave, listenerOptions);
+        this.hostElement.addEventListener('focusin', this.onFocusIn, listenerOptions);
+        this.hostElement.addEventListener('focusout', this.onFocusOut, listenerOptions);
+    }
+
+    ngOnDestroy(): void {
+        this.hostElement.removeEventListener('mouseenter', this.onMouseEnter);
+        this.hostElement.removeEventListener('mouseleave', this.onMouseLeave);
+        this.hostElement.removeEventListener('focusin', this.onFocusIn);
+        this.hostElement.removeEventListener('focusout', this.onFocusOut);
+
+        this.deactivateObservers();
+    }
+
+    private evaluateOverflow(): void {
+        const element = this.elementRef.nativeElement;
+        const isOverflowing = element.offsetWidth < element.scrollWidth || element.offsetHeight < element.scrollHeight;
+
+        if (isOverflowing) {
+            const text = (element.textContent || '').trim();
+            const nextDisabled = text.length === 0;
+            if (this.lastTooltipMessage !== text) {
+                this.matTooltip.message = text;
+                this.lastTooltipMessage = text;
+            }
+            if (this.lastTooltipDisabled !== nextDisabled) {
+                this.matTooltip.disabled = nextDisabled;
+                this.lastTooltipDisabled = nextDisabled;
+            }
+        } else {
+            if (this.lastTooltipMessage !== '') {
+                this.matTooltip.message = '';
+                this.lastTooltipMessage = '';
+            }
+            if (this.lastTooltipDisabled !== true) {
+                this.matTooltip.disabled = true;
+                this.lastTooltipDisabled = true;
+            }
+        }
+    }
+
+    private scheduleEvaluateOverflow(): void {
+        if (this.hasScheduledEvaluation) {
+            return;
+        }
+        this.hasScheduledEvaluation = true;
+        this.zone.runOutsideAngular(() => {
+            Promise.resolve().then(() => {
+                this.zone.run(() => {
+                    this.hasScheduledEvaluation = false;
+                    this.evaluateOverflow();
+                });
+            });
+        });
+    }
+
+    private activateObservers(): void {
+        if (this.observersActive) {
+            return;
+        }
+        this.observersActive = true;
+        this.zone.runOutsideAngular(() => {
+            if (typeof window !== 'undefined' && 'MutationObserver' in window && !this.mutationObserver) {
+                try {
+                    const mo = new MutationObserver(() => this.scheduleEvaluateOverflow());
+                    if (mo && typeof mo.observe === 'function') {
+                        this.mutationObserver = mo;
+                        mo.observe(this.hostElement, {
+                            childList: true,
+                            characterData: true,
+                            subtree: true
+                        });
+                    }
+                } catch {
+                    // noop
+                }
+            }
+
+            if (typeof window !== 'undefined' && 'ResizeObserver' in window && !this.hostElement.__ellipsis_ro__) {
+                const ro = new ResizeObserver(() => this.scheduleEvaluateOverflow());
+                this.hostElement.__ellipsis_ro__ = ro;
+                ro.observe(this.hostElement);
+            }
+        });
+        // Evaluate immediately on activation so the tooltip can show on the first interaction,
+        // and schedule a follow-up microtask in case ripple/measurement work reflows the host.
+        this.evaluateOverflow();
+        this.scheduleEvaluateOverflow();
+    }
+
+    private deactivateObservers(): void {
+        if (!this.observersActive) {
+            return;
+        }
+        this.observersActive = false;
+
+        if (this.mutationObserver && typeof this.mutationObserver.disconnect === 'function') {
+            try {
+                this.mutationObserver.disconnect();
+            } catch {
+                /* noop */
+            }
+        }
+        this.mutationObserver = null;
+
+        const ro: ResizeObserver | undefined = this.hostElement.__ellipsis_ro__;
+        if (ro && typeof ro.disconnect === 'function') {
+            try {
+                ro.disconnect();
+            } catch {
+                /* noop */
+            }
+        }
+        delete this.hostElement.__ellipsis_ro__;
+    }
+}

--- a/nifi-frontend/src/main/frontend/libs/shared/src/directives/index.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/directives/index.ts
@@ -17,5 +17,6 @@
 
 export * from './nifi-tooltip.directive';
 export * from './copy/copy.directive';
+export * from './ellipsis-tooltip/ellipsis-tooltip.directive';
 export * from './spinner/nifi-spinner.directive';
 export * from './spinner/spinner.component';

--- a/nifi-frontend/src/main/frontend/libs/shared/src/types/index.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/types/index.ts
@@ -425,6 +425,34 @@ export interface PropertyAllowableValuesState {
     values: AllowableValue[] | null;
 }
 
+export interface SearchableSelectOption<T = never> {
+    value: T;
+    label: string;
+    description?: string;
+    svgIcon?: string;
+    disabled?: boolean;
+    labelCssClasses?: string[];
+    /** Optional group identifier for grouped display. Grouping is automatically enabled when any option has this property. */
+    group?: string;
+}
+
+export interface FilteredSearchableSelectOption<T = never> extends SearchableSelectOption<T> {
+    hidden: boolean;
+}
+
+/**
+ * Internal type representing a group of options for grouped rendering.
+ * Used by SearchableSelect when any option has a group property.
+ */
+export interface SearchableSelectGroup<T = never> {
+    /** Unique identifier for the group (matches option.group values) */
+    groupId: string;
+    /** Display label for the group header */
+    groupLabel: string;
+    /** Options belonging to this group */
+    options: FilteredSearchableSelectOption<T>[];
+}
+
 export interface StepDocumentationEntity {
     stepDocumentation: string;
 }


### PR DESCRIPTION
# Summary

[NIFI-15853](https://issues.apache.org/jira/browse/NIFI-15853)

This pull request fixes connector wizard properties whose allowable values must be loaded from the backend (`allowableValuesFetchable === true` with no static `allowableValues`). Previously those properties were rendered as a plain text control and never triggered the allowable-values request, so users could not pick from server-provided options.

The fix introduces a reusable **SearchableSelect** component (Material-based, `ControlValueAccessor`) and routes both **static** and **dynamic** allowable values through it. **ConnectorPropertyInput** now emits `requestAllowableValues` exactly once per fetchable control when the step loads (guarded by `hasFetchedDynamicValues`), and resets that guard when the bound descriptor's `property.name` changes so a rebound descriptor can refetch. Loading, error, and empty responses are handled with fallbacks so the field stays usable (text input or textarea as appropriate).

**STRING_LIST** properties now render as a **multi-select** when allowable values exist (static or dynamic), and as a **comma-separated textarea** when they do not — replacing the previous plain text input for that type.

### Scope

- **14 files**, all under `nifi-frontend/src/main/frontend` (~4800 insertions, ~77 deletions on squashed commit `75068da3e3`).

### New / updated shared UI

- **`SearchableSelect`** (`libs/shared/src/components/searchable-select/`): filterable overlay select with optional multi-select, sticky search with clear, optional async search and virtual scrolling, optional grouped options, loading/error/empty states, full keyboard navigation, and accessibility (`role="combobox"`, `aria-*`). Spec file adds broad coverage (107 tests covering single/multi select, filter, keyboard navigation, focus management, virtual scrolling, async search, grouping, value-change deduplication, and disabled states).
- **`MultiSelectOption`**: extends `MatOption` for options inside the overlay; theming (min-height, padding, hover, selected, keyboard focus) is scoped under `.multi-select-option` so other `mat-select` usages are unaffected.
- **`ConnectorPropertyInput`**: template moved to `connector-property-input.component.html`; helpers for input kind and dynamic state (`shouldUseSelect`, `shouldUseTextInput`, `shouldUseTextarea`, `isMultiSelect`, `isDynamicValuesFetchEmpty`, `isDynamicValuesFetchFailed`); textarea branch aligned with text input for validation errors (`required`, `pattern`, `verificationError`, `assetContentMissing` where applicable).
- **Exports**: `libs/shared/src/components/index.ts` and `libs/shared/src/types/index.ts` updated for new components/types.

### Visible UX (intentional)

- Static `allowableValues` dropdowns now use **searchable-select** instead of **mat-select** (search filter + clear control) so static and dynamic flows share one widget.
- **STRING_LIST** is multi-select or textarea as described above.
- Option row styling is isolated to searchable-select's option component; other selects in NiFi are not restyled globally.

### Out of scope / follow-ups

- **ASSET** / **ASSET_LIST** handling (called out in component doc comment as deferred).
- **SECRET** dropdown and **BOOLEAN** slide-toggle alignment with the new patterns.
- **Dependency-aware refetch** when a parent property changes (dynamic allowable values are still fetched once per control lifecycle / descriptor identity as implemented here).

### Screenshots
_Fetched allowable values from the KafkaToS3 connector for topic names_
<img width="1430" height="1188" alt="Screenshot 2026-04-17 at 09 49 00" src="https://github.com/user-attachments/assets/370e52d1-9e32-48a9-84ff-0f4a89890eb7" />

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-15853`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-15853`
- [x] Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull request refers to a feature branch with one commit containing changes

---

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

*(Frontend-only change under `nifi-frontend`; full root `contrib-check` should still be run per project norms before merge.)*

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files