### PR TITLE
NIFI-15858 - Bump Spring to 7.0.7, Maven to 3.9.15, MySQL Binlog to 0.40.7, and others

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/nifi-extension-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.box</groupId>
                 <artifactId>box-java-sdk</artifactId>
-                <version>5.6.0</version>
+                <version>5.7.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/pom.xml
@@ -36,7 +36,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>mysql-binlog-connector-java</artifactId>
-            <version>0.40.6</version>
+            <version>0.40.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/pom.xml
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.9.14</version>
+            <version>3.9.15</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring.data.redis.version>4.0.4</spring.data.redis.version>
+        <spring.data.redis.version>4.0.5</spring.data.redis.version>
         <jedis.version>7.4.1</jedis.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-salesforce</artifactId>
-            <version>4.18.1</version>
+            <version>4.19.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/pom.xml
@@ -22,7 +22,7 @@ language governing permissions and limitations under the License. -->
 
     <properties>
         <jna.version>5.18.1</jna.version>
-        <javassist.version>3.30.2-GA</javassist.version>
+        <javassist.version>3.31.0-GA</javassist.version>
     </properties>
 
     <build>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/util/ResponseBuilderUtilsTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/util/ResponseBuilderUtilsTest.java
@@ -26,11 +26,11 @@ class ResponseBuilderUtilsTest {
 
     private static final String FILENAME_ASCII = "image.jpg";
 
-    private static final String DISPOSITION_ASCII = "attachment; filename=\"=?UTF-8?Q?%s?=\"; filename*=UTF-8''%s".formatted(FILENAME_ASCII, FILENAME_ASCII);
+    private static final String DISPOSITION_ASCII = "attachment; filename=\"%s\"; filename*=UTF-8''%s".formatted(FILENAME_ASCII, FILENAME_ASCII);
 
     private static final String FILENAME_SPACED = "image label.jpg";
 
-    private static final String DISPOSITION_ENCODED = "attachment; filename=\"=?UTF-8?Q?image_label.jpg?=\"; filename*=UTF-8''image%20label.jpg";
+    private static final String DISPOSITION_ENCODED = "attachment; filename=\"image label.jpg\"; filename*=UTF-8''image%20label.jpg";
 
     @Test
     void testSetContentDisposition() {

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
@@ -244,7 +244,7 @@
         <dependency>
             <groupId>org.springframework.ldap</groupId>
             <artifactId>spring-ldap-core</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.42.34</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.42.36</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.6</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -201,7 +201,7 @@
         <jetty.version>12.1.8</jetty.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.security.version>7.0.4</spring.security.version>
-        <spring.version>7.0.6</spring.version>
+        <spring.version>7.0.7</spring.version>
         <swagger.annotations.version>2.2.48</swagger.annotations.version>
 
         <!-- Testing and quality -->
@@ -605,7 +605,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.22.1</version>
+                <version>1.22.2</version>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>
@@ -913,7 +913,7 @@
                                     </plugins>
                                 </requireSameVersions>
                                 <requireMavenVersion>
-                                    <version>3.9.14</version>
+                                    <version>3.9.15</version>
                                 </requireMavenVersion>
                                 <requireReleaseDeps>
                                     <message>Dependencies outside of Apache NiFi must not use SNAPSHOT versions</message>


### PR DESCRIPTION
# Summary

NIFI-15858 - Bump Spring to 7.0.7, Maven to 3.9.15, MySQL Binlog to 0.40.7, and others

- Apache Maven from 3.9.14 to 3.9.15 - https://github.com/apache/maven/releases/tag/maven-3.9.15
- Box SDK from 5.6.0 to 5.7.0 - https://github.com/box/box-java-sdk/releases/tag/v5.7.0
- MySQL Binlog from 0.40.6 to 0.40.7 - https://github.com/debezium/mysql-binlog-connector-java/releases/tag/v0.40.7
- Spring Data Redis from 4.0.4 to 4.0.5 - https://github.com/spring-projects/spring-data-redis/releases/tag/4.0.5
- Spring LDAP Core from 4.0.2 to 4.0.3 - https://github.com/spring-projects/spring-ldap/releases/tag/4.0.3
- Spring Framework from 7.0.6 to 7.0.7 - https://github.com/spring-projects/spring-framework/releases/tag/v7.0.7
- Camel Salesforce from 4.18.1 to 4.19.0 - https://github.com/apache/camel/releases/tag/camel-4.19.0
- Javassist from 3.30.2-GA to 3.31.0-GA - https://github.com/jboss-javassist/javassist/releases/tag/rel_3_31_0_ga
- AWS SDK from 2.42.34 to 2.42.36 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Jsoup from 1.22.1 to 1.22.2 - https://jsoup.org/news/release-1.22.2

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
