### PR TITLE
NIFI-15860 Add Registered Flow ID Version Path to MDC Attributes

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -221,7 +221,9 @@ public final class StandardProcessGroup implements ProcessGroup {
     private static final String DEFAULT_BACKPRESSURE_DATA_SIZE = "1 GB";
     private static final Pattern INVALID_DIRECTORY_NAME_CHARACTERS = Pattern.compile("[\\s\\<\\>:\\'\\\"\\/\\\\\\|\\?\\*]");
     private static final String PATH_SEPARATOR = "/";
+    private static final String VERSION_SEPARATOR = ":";
     private static final String STANDARD_PROCESS_GROUP_NAME = "StandardProcessGroup";
+    private static final String UNREGISTERED_PATH_SEGMENT = "UNREGISTERED";
 
     private final Map<String, String> loggingAttributes = new ConcurrentHashMap<>();
     private volatile String logFileSuffix;
@@ -4660,6 +4662,10 @@ public final class StandardProcessGroup implements ProcessGroup {
         idPathBuilder.append(PATH_SEPARATOR);
         idPathBuilder.append(id);
 
+        final StringBuilder registeredFlowIdentifierPathBuilder = new StringBuilder();
+        final VersionControlInformation versionControlInformation = getVersionControlInformation();
+        boolean versionControlFound = appendRegisteredFlowIdentifierVersion(registeredFlowIdentifierPathBuilder, versionControlInformation);
+
         ProcessGroup parentProcessGroup = getParent();
         while (parentProcessGroup != null) {
             namePathBuilder.insert(0, PATH_SEPARATOR);
@@ -4667,6 +4673,12 @@ public final class StandardProcessGroup implements ProcessGroup {
 
             idPathBuilder.insert(0, PATH_SEPARATOR);
             idPathBuilder.insert(1, parentProcessGroup.getIdentifier());
+
+            final VersionControlInformation parentVersionControlInformation = parentProcessGroup.getVersionControlInformation();
+            final boolean parentVersionControlFound = appendRegisteredFlowIdentifierVersion(registeredFlowIdentifierPathBuilder, parentVersionControlInformation);
+            if (parentVersionControlFound) {
+                versionControlFound = true;
+            }
 
             parentProcessGroup = parentProcessGroup.getParent();
         }
@@ -4676,6 +4688,32 @@ public final class StandardProcessGroup implements ProcessGroup {
 
         final String namePath = namePathBuilder.toString();
         loggingAttributes.put(LoggingAttribute.PROCESS_GROUP_NAME_PATH.attribute, namePath);
+
+        if (versionControlFound) {
+            final String registeredFlowIdentifierPath = registeredFlowIdentifierPathBuilder.toString();
+            loggingAttributes.put(LoggingAttribute.REGISTERED_FLOW_IDENTIFIER_PATH.attribute, registeredFlowIdentifierPath);
+        }
+    }
+
+    private boolean appendRegisteredFlowIdentifierVersion(final StringBuilder pathBuilder, final VersionControlInformation versionControlInformation) {
+        final boolean versionControlFound;
+
+        pathBuilder.insert(0, PATH_SEPARATOR);
+        if (versionControlInformation == null) {
+            versionControlFound = false;
+            pathBuilder.insert(1, UNREGISTERED_PATH_SEGMENT);
+        } else {
+            versionControlFound = true;
+
+            final String version = versionControlInformation.getVersion();
+            pathBuilder.insert(1, version);
+            pathBuilder.insert(1, VERSION_SEPARATOR);
+
+            final String flowIdentifier = versionControlInformation.getFlowIdentifier();
+            pathBuilder.insert(1, flowIdentifier);
+        }
+
+        return versionControlFound;
     }
 
     enum LoggingAttribute {
@@ -4688,6 +4726,8 @@ public final class StandardProcessGroup implements ProcessGroup {
         PROCESS_GROUP_NAME_PATH("processGroupNamePath"),
 
         REGISTERED_FLOW_IDENTIFIER("registeredFlowIdentifier"),
+
+        REGISTERED_FLOW_IDENTIFIER_PATH("registeredFlowIdentifierPath"),
 
         REGISTERED_FLOW_VERSION("registeredFlowVersion");
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/groups/StandardProcessGroupTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/groups/StandardProcessGroupTest.java
@@ -59,9 +59,11 @@ class StandardProcessGroupTest {
     private static final String PARENT_ID_PATH = "/87654321-1234/12345678-4321";
     private static final String PARENT_NAME = "ParentGroup";
     private static final String PARENT_NAME_PATH = "/ParentGroup/TestGroup";
+    private static final String PARENT_REGISTERED_FLOW_IDENTIFIER_PATH = "/87654321-4321:1.0.0/UNREGISTERED";
 
     private static final String REGISTERED_FLOW_IDENTIFIER = "87654321-4321";
     private static final String REGISTERED_FLOW_VERSION = "1.0.0";
+    private static final String REGISTERED_FLOW_IDENTIFIER_PATH = "/87654321-4321:1.0.0";
 
     @Mock
     private ControllerServiceProvider controllerServiceProvider;
@@ -178,6 +180,34 @@ class StandardProcessGroupTest {
     }
 
     @Test
+    void testGetLoggingAttributesWithParentVersionControlInformation() {
+        processGroup.setName(NAME);
+
+        when(versionControlInformation.getFlowIdentifier()).thenReturn(REGISTERED_FLOW_IDENTIFIER);
+        when(versionControlInformation.getVersion()).thenReturn(REGISTERED_FLOW_VERSION);
+
+        when(parentProcessGroup.getIdentifier()).thenReturn(PARENT_ID);
+        when(parentProcessGroup.getName()).thenReturn(PARENT_NAME);
+        when(parentProcessGroup.getVersionControlInformation()).thenReturn(versionControlInformation);
+        processGroup.setParent(parentProcessGroup);
+
+        final Map<String, String> loggingAttributes = processGroup.getLoggingAttributes();
+
+        assertNotNull(loggingAttributes);
+        assertFalse(loggingAttributes.isEmpty());
+
+        final Map<String, String> expected = Map.of(
+                StandardProcessGroup.LoggingAttribute.PROCESS_GROUP_ID.getAttribute(), ID,
+                StandardProcessGroup.LoggingAttribute.PROCESS_GROUP_ID_PATH.getAttribute(), PARENT_ID_PATH,
+                StandardProcessGroup.LoggingAttribute.PROCESS_GROUP_NAME.getAttribute(), NAME,
+                StandardProcessGroup.LoggingAttribute.PROCESS_GROUP_NAME_PATH.getAttribute(), PARENT_NAME_PATH,
+                StandardProcessGroup.LoggingAttribute.REGISTERED_FLOW_IDENTIFIER_PATH.getAttribute(), PARENT_REGISTERED_FLOW_IDENTIFIER_PATH
+        );
+
+        assertEquals(expected, loggingAttributes);
+    }
+
+    @Test
     void testGetLoggingAttributesWithVersionControlInformation() {
         processGroup.setName(NAME);
 
@@ -197,7 +227,8 @@ class StandardProcessGroupTest {
                 StandardProcessGroup.LoggingAttribute.PROCESS_GROUP_NAME.getAttribute(), NAME,
                 StandardProcessGroup.LoggingAttribute.PROCESS_GROUP_NAME_PATH.getAttribute(), NAME_PATH,
                 StandardProcessGroup.LoggingAttribute.REGISTERED_FLOW_IDENTIFIER.getAttribute(), REGISTERED_FLOW_IDENTIFIER,
-                StandardProcessGroup.LoggingAttribute.REGISTERED_FLOW_VERSION.getAttribute(), REGISTERED_FLOW_VERSION
+                StandardProcessGroup.LoggingAttribute.REGISTERED_FLOW_VERSION.getAttribute(), REGISTERED_FLOW_VERSION,
+                StandardProcessGroup.LoggingAttribute.REGISTERED_FLOW_IDENTIFIER_PATH.getAttribute(), REGISTERED_FLOW_IDENTIFIER_PATH
         );
 
         assertEquals(expected, loggingAttributes);


### PR DESCRIPTION
# Summary

[NIFI-15860](https://issues.apache.org/jira/browse/NIFI-15860) Adds `registeredFlowIdentifierPath` as a Logging Attribute for Process Groups, based on the presence Version Control Information associated with the current Process Group or any parent Process Groups.

The Registered Flow Identifier Path follows a structure similar to the Process Group ID Path and Process Group Name Path attributes, where each path segment corresponds to a Process Group, starting with the root Process Group.

Process Groups that are not under version control use a placeholder value of `UNREGISTERED`. Registered Process Groups contain both the Registered Flow Identifier and the Registered Version, separated by a colon character. A child Process Group with a parent that is registered would produce a `registeredFlowIdentifierPath` as follows:

```
/12345678-1234-1234-1234-123456789012:1.0.0/UNREGISTERED
```

Additional unit tests exercise the updated Logging Attributes methods.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
