### PR TITLE
NIFI-15863 - User edits to newly-introduced component properties silently classified as environmental changes

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
@@ -997,7 +997,7 @@ public class FlowDifferenceFilters {
             componentNode = null;
         }
 
-        if (!isNotDynamicProperty(fieldName.get(), componentNode)) {
+        if (isDynamicProperty(fieldName.get(), componentNode)) {
             return false;
         }
 
@@ -1009,12 +1009,12 @@ public class FlowDifferenceFilters {
         return Objects.equals(difference.getValueB(), descriptor.getDefaultValue());
     }
 
-    private static boolean isNotDynamicProperty(final String propertyName, final ComponentNode componentNode) {
+    private static boolean isDynamicProperty(final String propertyName, final ComponentNode componentNode) {
         final ConfigurableComponent component = componentNode == null ? null : componentNode.getComponent();
         final List<PropertyDescriptor> descriptors = component == null ? List.of() : component.getPropertyDescriptors();
         return descriptors.stream()
                 .map(PropertyDescriptor::getName)
-                .anyMatch(propertyName::equals);
+                .noneMatch(propertyName::equals);
     }
 
     private static Optional<String> getComponentInstanceIdentifier(final FlowDifference difference) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
@@ -943,26 +943,31 @@ public class FlowDifferenceFilters {
 
     /**
      * Determines whether a PROPERTY_ADDED difference is an environmental change because the added property is a
-     * non-dynamic property defined in the component code that did not exist in the versioned snapshot. Non-dynamic
-     * properties are declared through {@link ConfigurableComponent#getPropertyDescriptors()} and cannot be added by
-     * users. When a PROPERTY_ADDED diff exists for such a property and the snapshot did not already define it, it
-     * means the component's code was updated (e.g., via NiFi upgrade or bundle version change) and migration added
-     * the property. This is an environmental change regardless of whether a corresponding BUNDLE_CHANGED diff is
-     * present, because the VCI baseline may already have resolved bundles (e.g., after
-     * {@code discoverCompatibleBundles} during import).
+     * non-dynamic property defined in the component code that did not exist in the versioned snapshot and whose
+     * current value still matches the descriptor's default. Non-dynamic properties are declared through
+     * {@link ConfigurableComponent#getPropertyDescriptors()} and cannot be added by users. When a PROPERTY_ADDED diff
+     * exists for such a property and the snapshot did not already define it, it means the component's code was updated
+     * (e.g., via NiFi upgrade or bundle version change) and migration or default-value application introduced the
+     * property. This is an environmental change regardless of whether a corresponding BUNDLE_CHANGED diff is present,
+     * because the VCI baseline may already have resolved bundles (e.g., after {@code discoverCompatibleBundles} during
+     * import).
      *
      * <p>If the snapshot (component A) already contains a property descriptor for the property in question, the
      * property was part of the component definition when the flow was committed and the user has intentionally set
      * a value. In that case, this method returns {@code false} so the change is treated as a local modification.</p>
      *
+     * <p>If the added value differs from the descriptor's default, the change is treated as a user modification and
+     * this method returns {@code false}. This ensures that user edits to migration-introduced properties are surfaced
+     * as local changes rather than being silently absorbed into the environmental view.</p>
+     *
      * <p>Only Processors and Controller Services are considered because these are the component types that carry
      * properties within versioned process groups.</p>
      *
-     * <p>Trade-off: if a user subsequently edits a migration-added property, that edit will also be classified as
-     * environmental because the diff relative to the registry is still PROPERTY_ADDED (the registry version predates
-     * the migration). This means such edits will not make the flow dirty. However, the change remains visible in the
-     * "Show Local Changes" environmental view, and when the user commits for any other reason, the full flow
-     * (including the edited property) is saved to the registry.</p>
+     * <p>Trade-off: if a component's {@code migrateProperties} implementation sets a newly-introduced static property
+     * to a value that differs from the descriptor's default, that change will now be classified as a local
+     * modification rather than environmental. The affected user can re-baseline by committing the flow once after the
+     * NAR upgrade. This is preferable to the previous behavior, which silently swallowed user edits to
+     * migration-added properties.</p>
      */
     private static boolean isPropertyAddedFromMigration(final FlowDifference difference, final FlowManager flowManager) {
         if (difference.getDifferenceType() != DifferenceType.PROPERTY_ADDED) {
@@ -992,7 +997,16 @@ public class FlowDifferenceFilters {
             componentNode = null;
         }
 
-        return isNotDynamicProperty(fieldName.get(), componentNode);
+        if (!isNotDynamicProperty(fieldName.get(), componentNode)) {
+            return false;
+        }
+
+        final PropertyDescriptor descriptor = componentNode == null ? null : componentNode.getPropertyDescriptor(fieldName.get());
+        if (descriptor == null) {
+            return true;
+        }
+
+        return Objects.equals(difference.getValueB(), descriptor.getDefaultValue());
     }
 
     private static boolean isNotDynamicProperty(final String propertyName, final ComponentNode componentNode) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
@@ -667,17 +667,24 @@ public class TestFlowDifferenceFilters {
 
         final String propertyName = "Table";
         final String instanceId = "processor-instance";
+        final String defaultValue = "defaultTable";
+
+        final PropertyDescriptor descriptor = new PropertyDescriptor.Builder()
+                .name(propertyName)
+                .defaultValue(defaultValue)
+                .build();
 
         Mockito.when(flowManager.getProcessorNode(instanceId)).thenReturn(processorNode);
         Mockito.when(processorNode.getComponent()).thenReturn(configurableComponent);
+        Mockito.when(processorNode.getPropertyDescriptor(propertyName)).thenReturn(descriptor);
         Mockito.when(configurableComponent.getPropertyDescriptors()).thenReturn(List.of(
-                new PropertyDescriptor.Builder().name(propertyName).build(),
+                descriptor,
                 new PropertyDescriptor.Builder().name("Other Property").build()));
 
         final VersionedProcessor registryProcessor = new VersionedProcessor();
         final InstantiatedVersionedProcessor localProcessor = new InstantiatedVersionedProcessor(instanceId, "group-id");
         final FlowDifference difference = new StandardFlowDifference(
-                DifferenceType.PROPERTY_ADDED, registryProcessor, localProcessor, propertyName, null, "someValue", "Property added");
+                DifferenceType.PROPERTY_ADDED, registryProcessor, localProcessor, propertyName, null, defaultValue, "Property added");
 
         assertTrue(FlowDifferenceFilters.isEnvironmentalChange(difference, null, flowManager));
     }
@@ -690,16 +697,22 @@ public class TestFlowDifferenceFilters {
 
         final String propertyName = "New Service Property";
         final String instanceId = "service-instance";
+        final String defaultValue = "defaultServiceValue";
+
+        final PropertyDescriptor descriptor = new PropertyDescriptor.Builder()
+                .name(propertyName)
+                .defaultValue(defaultValue)
+                .build();
 
         Mockito.when(flowManager.getControllerServiceNode(instanceId)).thenReturn(controllerServiceNode);
         Mockito.when(controllerServiceNode.getComponent()).thenReturn(configurableComponent);
-        Mockito.when(configurableComponent.getPropertyDescriptors()).thenReturn(List.of(
-                new PropertyDescriptor.Builder().name(propertyName).build()));
+        Mockito.when(controllerServiceNode.getPropertyDescriptor(propertyName)).thenReturn(descriptor);
+        Mockito.when(configurableComponent.getPropertyDescriptors()).thenReturn(List.of(descriptor));
 
         final VersionedControllerService registryService = new VersionedControllerService();
         final InstantiatedVersionedControllerService localService = new InstantiatedVersionedControllerService(instanceId, "group-id");
         final FlowDifference difference = new StandardFlowDifference(
-                DifferenceType.PROPERTY_ADDED, registryService, localService, propertyName, null, "value", "Property added on service");
+                DifferenceType.PROPERTY_ADDED, registryService, localService, propertyName, null, defaultValue, "Property added on service");
 
         assertTrue(FlowDifferenceFilters.isEnvironmentalChange(difference, null, flowManager));
     }
@@ -794,6 +807,63 @@ public class TestFlowDifferenceFilters {
                 DifferenceType.PROPERTY_ADDED, registryService, localService, propertyName, null, "userValue", "Property set by user");
 
         assertFalse(FlowDifferenceFilters.isEnvironmentalChange(difference, null, flowManager));
+    }
+
+    @Test
+    public void testUserEditOfMigrationAddedPropertyIsNotEnvironmentalChange() {
+        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final ProcessorNode processorNode = Mockito.mock(ProcessorNode.class);
+        final ConfigurableComponent configurableComponent = Mockito.mock(ConfigurableComponent.class);
+
+        final String propertyName = "Record Structure";
+        final String instanceId = "processor-instance";
+        final String defaultValue = "first-option";
+        final String userValue = "second-option";
+
+        final PropertyDescriptor descriptor = new PropertyDescriptor.Builder()
+                .name(propertyName)
+                .defaultValue(defaultValue)
+                .build();
+
+        Mockito.when(flowManager.getProcessorNode(instanceId)).thenReturn(processorNode);
+        Mockito.when(processorNode.getComponent()).thenReturn(configurableComponent);
+        Mockito.when(processorNode.getPropertyDescriptor(propertyName)).thenReturn(descriptor);
+        Mockito.when(configurableComponent.getPropertyDescriptors()).thenReturn(List.of(descriptor));
+
+        final VersionedProcessor registryProcessor = new VersionedProcessor();
+        final InstantiatedVersionedProcessor localProcessor = new InstantiatedVersionedProcessor(instanceId, "group-id");
+        final FlowDifference difference = new StandardFlowDifference(
+                DifferenceType.PROPERTY_ADDED, registryProcessor, localProcessor, propertyName, null, userValue, "User edited migration-added property");
+
+        assertFalse(FlowDifferenceFilters.isEnvironmentalChange(difference, null, flowManager));
+    }
+
+    @Test
+    public void testMigrationAddedPropertyWithNonNullDefaultMatchingLocalValueIsEnvironmentalChange() {
+        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final ProcessorNode processorNode = Mockito.mock(ProcessorNode.class);
+        final ConfigurableComponent configurableComponent = Mockito.mock(ConfigurableComponent.class);
+
+        final String propertyName = "Record Type";
+        final String instanceId = "processor-instance";
+        final String defaultValue = "default-option";
+
+        final PropertyDescriptor descriptor = new PropertyDescriptor.Builder()
+                .name(propertyName)
+                .defaultValue(defaultValue)
+                .build();
+
+        Mockito.when(flowManager.getProcessorNode(instanceId)).thenReturn(processorNode);
+        Mockito.when(processorNode.getComponent()).thenReturn(configurableComponent);
+        Mockito.when(processorNode.getPropertyDescriptor(propertyName)).thenReturn(descriptor);
+        Mockito.when(configurableComponent.getPropertyDescriptors()).thenReturn(List.of(descriptor));
+
+        final VersionedProcessor registryProcessor = new VersionedProcessor();
+        final InstantiatedVersionedProcessor localProcessor = new InstantiatedVersionedProcessor(instanceId, "group-id");
+        final FlowDifference difference = new StandardFlowDifference(
+                DifferenceType.PROPERTY_ADDED, registryProcessor, localProcessor, propertyName, null, defaultValue, "Property added by migration with default value");
+
+        assertTrue(FlowDifferenceFilters.isEnvironmentalChange(difference, null, flowManager));
     }
 
     @Test


### PR DESCRIPTION
# Summary

NIFI-15863 - User edits to newly-introduced component properties silently classified as environmental changes

When a newer bundle declares a static property that did not exist in the versioned flow snapshot, `FlowDifferenceFilters.isPropertyAddedFromMigration` (added in [NIFI-15776](https://issues.apache.org/jira/browse/NIFI-15776)) classifies the resulting `PROPERTY_ADDED` diff as environmental regardless of value. If the user later edits that property the diff relative to the registry is still `PROPERTY_ADDED` (the property descriptor is absent from the snapshot), so the edit is also swallowed as environmental: the flow is not marked dirty and the change cannot be committed through normal local-change workflows.

[NIFI-15830](https://issues.apache.org/jira/browse/NIFI-15830) refined related behavior but only addressed cases detected through `isNewPropertyWithDefaultValue`, which compares valueB against the descriptor default. It did not tighten `isPropertyAddedFromMigration`, which continues to return true for any statically-declared property missing from the snapshot, independent of the value. As a result, user edits away from the default on a newly-introduced property remain indistinguishable from the framework-applied default and are still filtered out.

We need to tighten `isPropertyAddedFromMigration` to only treat a `PROPERTY_ADDED` diff as environmental when valueB equals the descriptor's default value. This preserves the [NIFI-15776](https://issues.apache.org/jira/browse/NIFI-15776) / [NIFI-15830](https://issues.apache.org/jira/browse/NIFI-15830) behavior for bundle upgrades (framework-applied defaults remain filtered), while surfacing genuine user edits as local changes.

Narrow regression: if a component's `migrateProperties` explicitly assigns a new static property to a non-default value, that value will now show as a local change and the user must commit once after upgrade.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
