### PR TITLE
NIFI-15871 - Bump Spring Security to 7.0.5, Test containers to 2.0.5, and others

### DIFF
--- a/nifi-commons/nifi-hashicorp-vault/pom.xml
+++ b/nifi-commons/nifi-hashicorp-vault/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <artifactId>nifi-hashicorp-vault</artifactId>
     <properties>
-        <spring.vault.version>4.0.1</spring.vault.version>
+        <spring.vault.version>4.0.2</spring.vault.version>
     </properties>
     <dependencies>
         <dependency>

--- a/nifi-extension-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.box</groupId>
                 <artifactId>box-java-sdk</artifactId>
-                <version>5.7.0</version>
+                <version>5.8.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.slack.api</groupId>
             <artifactId>bolt-socket-mode</artifactId>
-            <version>1.48.0</version>
+            <version>1.48.1</version>
         </dependency>
         <!-- Required by bolt-socket-mode but the library itself doesn't have the dependency. -->
         <dependency>

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
@@ -20,7 +20,7 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <snmp4j.version>3.9.7</snmp4j.version>
+        <snmp4j.version>3.10.0</snmp4j.version>
         <snmp4j-agent.version>3.8.3</snmp4j-agent.version>
     </properties>
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>9.6.0</version>
+            <version>9.7.0</version>
             <exclusions>
                 <!-- Exclude unused protobuf-java -->
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.42.36</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.42.39</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.6</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -200,7 +200,7 @@
         <jersey.bom.version>4.0.2</jersey.bom.version>
         <jetty.version>12.1.8</jetty.version>
         <servlet-api.version>6.1.0</servlet-api.version>
-        <spring.security.version>7.0.4</spring.security.version>
+        <spring.security.version>7.0.5</spring.security.version>
         <spring.version>7.0.7</spring.version>
         <swagger.annotations.version>2.2.48</swagger.annotations.version>
 
@@ -209,7 +209,7 @@
         <mockito.version>5.23.0</mockito.version>
         <pmd.version>7.23.0</pmd.version>
         <checkstyle.version>13.4.0</checkstyle.version>
-        <testcontainers.version>2.0.4</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.14</jacoco.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
# Summary

NIFI-15871 - Bump Spring Security to 7.0.5, Test containers to 2.0.5, and others

- Spring Vault from 4.0.1 to 4.0.2 - https://github.com/spring-projects/spring-vault/releases/tag/4.0.2
- Spring Security from 7.0.4 to 7.0.5 - https://github.com/spring-projects/spring-security/releases/tag/7.0.5
- Box SDK from 5.7.0 to 5.8.0 - https://github.com/box/box-java-sdk/releases/tag/v5.8.0
- Slack Bolt from 1.48.0 to 1.48.1 - https://github.com/slackapi/java-slack-sdk/releases/tag/v1.48.1
- SNMP4J from 3.9.7 to 3.10.0 - https://snmp4j.org/CHANGES.txt
- MySQL Java Connector from 9.6.0 to 9.7.0 - https://dev.mysql.com/doc/relnotes/connector-j/en/news-9-7-0.html
- AWS SDK BOM from 2.42.36 to 2.42.39 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Test Containers from 2.0.4 to 2.0.5 - https://github.com/testcontainers/testcontainers-java/releases/tag/2.0.5

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
