### PR TITLE
NIFI-15870 Improve error message when flow upgrade fails because a referenced controller service is ENABLED

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContext.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContext.java
@@ -801,8 +801,17 @@ public class StandardParameterContext implements ParameterContext {
 
             final ControllerServiceState serviceState = serviceNode.getState();
             if (serviceState != ControllerServiceState.DISABLED && (isDeletion || duringUpdate)) {
-                throw new IllegalStateException("Cannot " + action + " parameter '" + parameterName + "' because it is referenced by "
-                        + serviceNode + ", which currently has a state of " + serviceState);
+                final String baseMessage = "Cannot " + action + " parameter '" + parameterName + "' because it is referenced by "
+                        + serviceNode + ", which currently has a state of " + serviceState;
+                if (isDeletion) {
+                    throw new IllegalStateException(baseMessage);
+                }
+
+                final String serviceDisplayName = serviceNode.getName();
+                throw new IllegalStateException(baseMessage + ".\n\nTo resolve this:\n"
+                        + "1. Disable the '" + serviceDisplayName + "' controller service (and any components that reference it, if prompted).\n"
+                        + "2. Retry the flow upgrade.\n"
+                        + "3. Re-enable the '" + serviceDisplayName + "' controller service once the upgrade completes.");
             }
 
             if (parameter != null) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/parameter/TestStandardParameterContext.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/parameter/TestStandardParameterContext.java
@@ -555,6 +555,9 @@ public class TestStandardParameterContext {
         final ParameterContext context = createStandardParameterContext(referenceManager);
         final ControllerServiceNode serviceNode = mock(ControllerServiceNode.class);
         enableControllerService(serviceNode);
+        Mockito.when(serviceNode.getName()).thenReturn("My Service");
+        Mockito.when(serviceNode.getComponentType()).thenReturn("MyService");
+        Mockito.when(serviceNode.getIdentifier()).thenReturn("service-id");
 
         final ParameterDescriptor abcDescriptor = new ParameterDescriptor.Builder().name("abc").sensitive(true).build();
         final Map<String, Parameter> parameters = new HashMap<>();
@@ -570,24 +573,38 @@ public class TestStandardParameterContext {
         for (final ControllerServiceState state : EnumSet.of(ControllerServiceState.ENABLED, ControllerServiceState.ENABLING, ControllerServiceState.DISABLING)) {
             setControllerServiceState(serviceNode, state);
 
-            try {
-                context.setParameters(parameters);
-                fail("Was able to update parameter being referenced by Controller Service that is " + state);
-            } catch (final IllegalStateException expected) {
-            }
+            final IllegalStateException updateException = assertThrows(IllegalStateException.class, () -> context.setParameters(parameters),
+                    "Was able to update parameter being referenced by Controller Service that is " + state);
+
+            final String updateMessage = updateException.getMessage();
+            // Preserves the original prefix verbatim so upstream wrapping remains consistent.
+            assertTrue(updateMessage.startsWith("Cannot update parameter 'abc' because it is referenced by "),
+                    "Unexpected update error prefix: " + updateMessage);
+            assertTrue(updateMessage.contains(", which currently has a state of " + state),
+                    "Expected state in update error message: " + updateMessage);
+            assertTrue(updateMessage.contains("To resolve this:"), "Expected remediation guidance in message: " + updateMessage);
+            assertTrue(updateMessage.contains("Disable the 'My Service' controller service"),
+                    "Expected disable remediation step in message: " + updateMessage);
+            assertTrue(updateMessage.contains("Retry the flow upgrade."), "Expected retry remediation step in message: " + updateMessage);
+            assertTrue(updateMessage.contains("Re-enable the 'My Service' controller service once the upgrade completes."),
+                    "Expected re-enable remediation step in message: " + updateMessage);
 
             assertEquals("123", context.getParameter("abc").get().getValue());
         }
 
+        setControllerServiceState(serviceNode, ControllerServiceState.DISABLING);
         parameters.clear();
-        context.setParameters(parameters);
+        parameters.put("abc", null);
+        final IllegalStateException deleteException = assertThrows(IllegalStateException.class, () -> context.setParameters(parameters),
+                "Was able to remove parameter being referenced by Controller Service that is DISABLING");
 
-        parameters.put("abc", createParameter(abcDescriptor, null));
-        try {
-            context.setParameters(parameters);
-            fail("Was able to remove parameter being referenced by Controller Service that is DISABLING");
-        } catch (final IllegalStateException expected) {
-        }
+        final String deleteMessage = deleteException.getMessage();
+        // Deletion keeps the original message without remediation guidance.
+        assertTrue(deleteMessage.startsWith("Cannot remove parameter 'abc' because it is referenced by "),
+                "Unexpected delete error prefix: " + deleteMessage);
+        assertTrue(deleteMessage.contains(", which currently has a state of "),
+                "Expected state in delete error message: " + deleteMessage);
+        assertFalse(deleteMessage.contains("To resolve this:"), "Delete message should not contain remediation guidance: " + deleteMessage);
     }
 
     private ParameterContext createStandardParameterContext(final ParameterReferenceManager referenceManager) {


### PR DESCRIPTION

When a parameter referenced by an enabled controller service is updated (e.g. during a versioned flow upgrade), StandardParameterContext now appends remediation guidance to the existing error message, instructing the user to disable the referencing controller service, retry the upgrade, and re-enable the service. The original message prefix is preserved verbatim so upstream wrapping is unchanged, and the delete path is left untouched.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15870](https://issues.apache.org/jira/browse/NIFI-15870)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-15870`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-15870`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
