### PR TITLE
NIFI-15876 Switch to Java Security Interfaces for PBKDF2

### DIFF
--- a/nifi-commons/nifi-security-crypto-key/src/main/java/org/apache/nifi/security/crypto/key/pbkdf2/Pbkdf2DerivedKeyProvider.java
+++ b/nifi-commons/nifi-security-crypto-key/src/main/java/org/apache/nifi/security/crypto/key/pbkdf2/Pbkdf2DerivedKeyProvider.java
@@ -20,21 +20,19 @@ import org.apache.nifi.security.crypto.key.DerivedKey;
 import org.apache.nifi.security.crypto.key.DerivedKeyProvider;
 import org.apache.nifi.security.crypto.key.DerivedKeySpec;
 import org.apache.nifi.security.crypto.key.DerivedSecretKey;
-import org.bouncycastle.crypto.CipherParameters;
-import org.bouncycastle.crypto.Digest;
-import org.bouncycastle.crypto.digests.SHA512Digest;
-import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator;
-import org.bouncycastle.crypto.params.KeyParameter;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 
 /**
- * PBKDF2 implementation of Derived Key Provider based on Bouncy Castle components with HMAC SHA-512 pseudorandom function
+ * PBKDF2 implementation of Derived Key Provider with HMAC SHA-512 pseudorandom function
  */
 public class Pbkdf2DerivedKeyProvider implements DerivedKeyProvider<Pbkdf2DerivedKeyParameterSpec> {
-    private static final Charset PASSWORD_CHARACTER_SET = StandardCharsets.UTF_8;
+    private static final String ALGORITHM = "PBKDF2WithHmacSHA512";
 
     private static final int BITS = 8;
 
@@ -54,18 +52,27 @@ public class Pbkdf2DerivedKeyProvider implements DerivedKeyProvider<Pbkdf2Derive
     }
 
     private byte[] getDerivedKeyBytes(final DerivedKeySpec<Pbkdf2DerivedKeyParameterSpec> derivedKeySpec) {
-        final Digest digest = new SHA512Digest();
-        final PKCS5S2ParametersGenerator generator = new PKCS5S2ParametersGenerator(digest);
-
-        final byte[] password = new String(derivedKeySpec.getPassword()).getBytes(PASSWORD_CHARACTER_SET);
         final Pbkdf2DerivedKeyParameterSpec parameterSpec = derivedKeySpec.getParameterSpec();
         final byte[] salt = parameterSpec.getSalt();
         final int iterations = parameterSpec.getIterations();
-        generator.init(password, salt, iterations);
-
         final int derivedKeyLengthBits = derivedKeySpec.getDerivedKeyLength() * BITS;
-        final CipherParameters cipherParameters = generator.generateDerivedParameters(derivedKeyLengthBits);
-        final KeyParameter keyParameter = (KeyParameter) cipherParameters;
-        return keyParameter.getKey();
+
+        final PBEKeySpec keySpec = new PBEKeySpec(derivedKeySpec.getPassword(), salt, iterations, derivedKeyLengthBits);
+        final SecretKeyFactory secretKeyFactory = getSecretKeyFactory();
+
+        try {
+            final SecretKey secretKey = secretKeyFactory.generateSecret(keySpec);
+            return secretKey.getEncoded();
+        } catch (final InvalidKeySpecException e) {
+            throw new IllegalStateException("PBKDF2 key generation failed", e);
+        }
+    }
+
+    private SecretKeyFactory getSecretKeyFactory() {
+        try {
+            return SecretKeyFactory.getInstance(ALGORITHM);
+        } catch (final NoSuchAlgorithmException e) {
+            throw new IllegalStateException("PBKDF2 algorithm not found", e);
+        }
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-15876](https://issues.apache.org/jira/browse/NIFI-15876) Changes from Bouncy Castle classes to standard Java Security interfaces for the secret key derivation with PBKDF2 and HMAC SHA-512. The framework uses this key derivation as part of the implementation for sensitive property encryption when configured with the default `NIFI_PBKDF2_AES_GCM_256` algorithm.

With standard Java Security interfaces and implementations supporting the `PBKDF2WithHmacSHA512` algorithm, and existing unit tests that exercise this class, the change reduces dependence on Bouncy Castle in favor of standard Java Security implementation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [X] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
