### PR TITLE
NIFI-15825: Adding support for controller services and queue operations in the connector canvas

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/app.module.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/app.module.ts
@@ -57,6 +57,7 @@ import { BannerTextEffects } from './state/banner-text/banner-text.effects';
 import { MAT_TOOLTIP_DEFAULT_OPTIONS, MatTooltipDefaultOptions } from '@angular/material/tooltip';
 import { CLIPBOARD_OPTIONS, provideMarkdown } from 'ngx-markdown';
 import { CopyEffects } from './state/copy/copy.effects';
+import { EmptyQueueEffects } from './state/empty-queue/empty-queue.effects';
 
 const entry = localStorage.getItem('disable-animations');
 let disableAnimations = '';
@@ -109,7 +110,8 @@ export const customTooltipDefaults: MatTooltipDefaultOptions = {
             DocumentationEffects,
             ClusterSummaryEffects,
             PropertyVerificationEffects,
-            CopyEffects
+            CopyEffects,
+            EmptyQueueEffects
         ),
         StoreDevtoolsModule.instrument({
             maxAge: 25,

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/service/connector.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/service/connector.service.ts
@@ -23,7 +23,7 @@ import { ClusterConnectionService } from '../../../service/cluster-connection.se
 import { ConnectorsResponse, CreateConnectorRequest } from '../state';
 import { ConnectorEntity } from '@nifi/shared';
 import { SearchResultsEntity } from '../../../state/shared';
-import { DropRequestEntity } from '../../flow-designer/state/queue';
+import { DropRequestEntity } from '../../../state/empty-queue';
 
 @Injectable({ providedIn: 'root' })
 export class ConnectorService {
@@ -114,6 +114,12 @@ export class ConnectorService {
     getConnectorFlow(connectorId: string, processGroupId: string): Observable<any> {
         return this.httpClient.get(
             `${ConnectorService.API}/connectors/${connectorId}/flow/process-groups/${processGroupId}`
+        );
+    }
+
+    getConnectorControllerServices(connectorId: string, processGroupId: string): Observable<any> {
+        return this.httpClient.get(
+            `${ConnectorService.API}/connectors/${connectorId}/flow/process-groups/${processGroupId}/controller-services`
         );
     }
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.actions.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.actions.ts
@@ -108,6 +108,35 @@ export const navigateToProvenanceForComponent = createAction(
 );
 
 /**
+ * Navigate to the controller services view for a process group within a connector.
+ * The target process group must be supplied by the caller; the canvas-background
+ * caller passes the current route's process group, and component-menu callers pass
+ * the id of the right-clicked process group.
+ */
+export const navigateToControllerServices = createAction(
+    '[Connector Canvas] Navigate To Controller Services',
+    props<{ processGroupId: string }>()
+);
+
+/**
+ * Navigate to a specific controller service within a process group, deep linking
+ * to the controller services view with the service pre-selected.
+ */
+export const navigateToControllerService = createAction(
+    '[Connector Canvas] Navigate To Controller Service',
+    props<{ processGroupId: string; serviceId: string }>()
+);
+
+/**
+ * Navigate to the queue listing page for a connection.
+ * Uses back navigation to return to the connector canvas.
+ */
+export const navigateToQueueListing = createAction(
+    '[Connector Canvas] Navigate To Queue Listing',
+    props<{ request: { connectionId: string } }>()
+);
+
+/**
  * View the read-only configuration of a canvas component.
  * Triggers an effect that opens the appropriate EditXyz dialog in read-only mode.
  */

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.spec.ts
@@ -36,11 +36,15 @@ import {
     loadConnectorFlowComplete,
     loadConnectorFlowFailure,
     loadConnectorFlowSuccess,
+    navigateToControllerService,
+    navigateToControllerServices,
     navigateToProvenanceForComponent,
+    navigateToQueueListing,
     navigateWithoutTransform,
     selectComponents,
     viewComponentConfiguration
 } from './connector-canvas.actions';
+import { queueEmptied } from '../../../../state/empty-queue/empty-queue.actions';
 import {
     selectConnectorIdFromRoute,
     selectParentProcessGroupId,
@@ -562,6 +566,144 @@ describe('ConnectorCanvasEffects', () => {
                     }
                 }
             });
+        });
+    });
+
+    describe('navigateToQueueListing$', () => {
+        it('should navigate to /queue/:connectionId with back navigation to the originating connection', async () => {
+            const { effects, actions$, mockRouter } = await setup({
+                connectorId: 'conn-1',
+                processGroupIdFromRoute: 'pg-root'
+            });
+            actions$(of(navigateToQueueListing({ request: { connectionId: 'conn-listing-1' } })));
+
+            await firstValueFrom(effects.navigateToQueueListing$);
+
+            expect(mockRouter.navigate).toHaveBeenCalledWith(['/queue', 'conn-listing-1'], {
+                state: {
+                    backNavigation: {
+                        route: [
+                            '/connectors',
+                            'conn-1',
+                            'canvas',
+                            'pg-root',
+                            ComponentType.Connection,
+                            'conn-listing-1'
+                        ],
+                        routeBoundary: ['/queue', 'conn-listing-1'],
+                        context: 'connection'
+                    }
+                }
+            });
+        });
+    });
+
+    describe('navigateToControllerServices$', () => {
+        it('should navigate to controller services using the supplied process group when provided', async () => {
+            const { effects, actions$, mockRouter } = await setup({
+                connectorId: 'conn-1',
+                processGroupIdFromRoute: 'pg-root'
+            });
+            actions$(of(navigateToControllerServices({ processGroupId: 'pg-target' })));
+
+            await firstValueFrom(effects.navigateToControllerServices$);
+
+            expect(mockRouter.navigate).toHaveBeenCalledWith(
+                ['/connectors', 'conn-1', 'canvas', 'pg-target', 'controller-services'],
+                {
+                    state: {
+                        backNavigation: {
+                            route: ['/connectors', 'conn-1', 'canvas', 'pg-root'],
+                            routeBoundary: ['/connectors', 'conn-1', 'canvas', 'pg-target', 'controller-services'],
+                            context: 'process group'
+                        }
+                    }
+                }
+            );
+        });
+    });
+
+    describe('navigateToControllerService$', () => {
+        it('should navigate to a deep-linked controller service with back navigation to the canvas', async () => {
+            const { effects, actions$, mockRouter } = await setup({
+                connectorId: 'conn-1',
+                processGroupIdFromRoute: 'pg-root'
+            });
+            actions$(of(navigateToControllerService({ processGroupId: 'pg-target', serviceId: 'svc-1' })));
+
+            await firstValueFrom(effects.navigateToControllerService$);
+
+            expect(mockRouter.navigate).toHaveBeenCalledWith(
+                ['/connectors', 'conn-1', 'canvas', 'pg-target', 'controller-services', 'svc-1'],
+                {
+                    state: {
+                        backNavigation: {
+                            route: ['/connectors', 'conn-1', 'canvas', 'pg-root'],
+                            routeBoundary: [
+                                '/connectors',
+                                'conn-1',
+                                'canvas',
+                                'pg-target',
+                                'controller-services',
+                                'svc-1'
+                            ],
+                            context: 'process group'
+                        }
+                    }
+                }
+            );
+        });
+    });
+
+    describe('refreshAfterQueueEmptied$', () => {
+        it('should dispatch loadConnectorFlow when the queueEmptied source is connector-canvas', async () => {
+            const { effects, actions$ } = await setup({
+                connectorId: 'conn-1',
+                processGroupIdFromRoute: 'pg-root'
+            });
+            actions$(
+                of(
+                    queueEmptied({
+                        connectionId: 'conn-listing-1',
+                        processGroupId: null,
+                        source: 'connector-canvas'
+                    })
+                )
+            );
+
+            const result = await firstValueFrom(effects.refreshAfterQueueEmptied$);
+
+            expect(result).toEqual(
+                loadConnectorFlow({
+                    connectorId: 'conn-1',
+                    processGroupId: 'pg-root'
+                })
+            );
+        });
+
+        it('should ignore queueEmptied events from the flow designer', async () => {
+            const { effects, actions$ } = await setup({
+                connectorId: 'conn-1',
+                processGroupIdFromRoute: 'pg-root'
+            });
+            actions$(
+                of(
+                    queueEmptied({
+                        connectionId: 'conn-listing-1',
+                        processGroupId: null,
+                        source: 'flow-designer'
+                    })
+                )
+            );
+
+            let emitted: Action | undefined;
+            effects.refreshAfterQueueEmptied$.subscribe((action) => {
+                emitted = action;
+            });
+
+            await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+            expect(emitted).toBeUndefined();
         });
     });
 });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.ts
@@ -43,6 +43,7 @@ import { EditProcessGroup } from '../../../../ui/common/component-dialogs/edit-p
 import { EditRemoteProcessGroup } from '../../../../ui/common/component-dialogs/edit-remote-process-group/edit-remote-process-group.component';
 import * as ConnectorCanvasActions from './connector-canvas.actions';
 import { SelectedComponent } from './connector-canvas.actions';
+import * as EmptyQueueActions from '../../../../state/empty-queue/empty-queue.actions';
 import {
     selectBreadcrumbs,
     selectConnectorIdFromRoute,
@@ -320,6 +321,140 @@ export class ConnectorCanvasEffects {
                 })
             ),
         { dispatch: false }
+    );
+
+    /**
+     * Navigate to the controller services view for the supplied process group.
+     * The current route's process group is still consulted to compute the
+     * back-navigation target so the user returns to the canvas they came from.
+     * The routeBoundary includes the controller-services segment so back
+     * navigation clears as soon as the user navigates away from the controller
+     * services view.
+     */
+    navigateToControllerServices$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ConnectorCanvasActions.navigateToControllerServices),
+                concatLatestFrom(() => [
+                    this.store.select(selectConnectorIdFromRoute),
+                    this.store.select(selectProcessGroupIdFromRoute)
+                ]),
+                tap(([action, connectorId, currentProcessGroupId]) => {
+                    const routeBoundary = [
+                        '/connectors',
+                        connectorId,
+                        'canvas',
+                        action.processGroupId,
+                        'controller-services'
+                    ];
+                    this.router.navigate(routeBoundary, {
+                        state: {
+                            backNavigation: {
+                                route: ['/connectors', connectorId, 'canvas', currentProcessGroupId],
+                                routeBoundary,
+                                context: 'process group'
+                            } as BackNavigation
+                        }
+                    });
+                })
+            ),
+        { dispatch: false }
+    );
+
+    /**
+     * Navigate to a specific controller service within a process group, appending
+     * the serviceId for deep linking.
+     */
+    navigateToControllerService$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ConnectorCanvasActions.navigateToControllerService),
+                concatLatestFrom(() => [
+                    this.store.select(selectConnectorIdFromRoute),
+                    this.store.select(selectProcessGroupIdFromRoute)
+                ]),
+                tap(([action, connectorId, currentProcessGroupId]) => {
+                    const routeBoundary = [
+                        '/connectors',
+                        connectorId,
+                        'canvas',
+                        action.processGroupId,
+                        'controller-services',
+                        action.serviceId
+                    ];
+                    this.router.navigate(routeBoundary, {
+                        state: {
+                            backNavigation: {
+                                route: ['/connectors', connectorId, 'canvas', currentProcessGroupId],
+                                routeBoundary,
+                                context: 'process group'
+                            } as BackNavigation
+                        }
+                    });
+                })
+            ),
+        { dispatch: false }
+    );
+
+    /**
+     * Navigate to the queue listing page for a connection. Provides back navigation
+     * back to the originating connection on the connector canvas.
+     */
+    navigateToQueueListing$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ConnectorCanvasActions.navigateToQueueListing),
+                map((action) => action.request),
+                concatLatestFrom(() => [
+                    this.store.select(selectConnectorIdFromRoute),
+                    this.store.select(selectProcessGroupIdFromRoute)
+                ]),
+                tap(([request, connectorId, processGroupId]) => {
+                    const routeBoundary: string[] = ['/queue', request.connectionId];
+                    this.router.navigate([...routeBoundary], {
+                        state: {
+                            backNavigation: {
+                                route: [
+                                    '/connectors',
+                                    connectorId,
+                                    'canvas',
+                                    processGroupId,
+                                    ComponentType.Connection,
+                                    request.connectionId
+                                ],
+                                routeBoundary,
+                                context: 'connection'
+                            } as BackNavigation
+                        }
+                    });
+                })
+            ),
+        { dispatch: false }
+    );
+
+    /**
+     * Refreshes the connector canvas after a queue has been emptied from this surface.
+     * Listens for the shared queueEmptied event and filters on source so flow-designer
+     * empties do not trigger a connector-canvas refresh.
+     */
+    refreshAfterQueueEmptied$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(EmptyQueueActions.queueEmptied),
+            filter((action) => action.source === 'connector-canvas'),
+            concatLatestFrom(() => [
+                this.store.select(selectConnectorIdFromRoute),
+                this.store.select(selectProcessGroupIdFromRoute)
+            ]),
+            filter(([, connectorId, processGroupId]) => connectorId != null && processGroupId != null),
+            switchMap(([, connectorId, processGroupId]) =>
+                of(
+                    ConnectorCanvasActions.loadConnectorFlow({
+                        connectorId: connectorId!,
+                        processGroupId: processGroupId!
+                    })
+                )
+            )
+        )
     );
 
     /**

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.actions.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.actions.ts
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createAction, props } from '@ngrx/store';
+import { ErrorContext } from '../../../../state/error';
+import { ControllerServiceEntity } from '../../../../state/shared';
+import {
+    LoadConnectorControllerServicesRequest,
+    LoadConnectorControllerServicesResponse,
+    SelectConnectorControllerServiceRequest
+} from './index';
+
+/**
+ * Load controller services for a connector's process group.
+ */
+export const loadConnectorControllerServices = createAction(
+    '[Connector Controller Services] Load Controller Services',
+    props<{ request: LoadConnectorControllerServicesRequest }>()
+);
+
+export const loadConnectorControllerServicesSuccess = createAction(
+    '[Connector Controller Services] Load Controller Services Success',
+    props<{ response: LoadConnectorControllerServicesResponse }>()
+);
+
+export const loadConnectorControllerServicesFailure = createAction(
+    '[Connector Controller Services] Load Controller Services Failure',
+    props<{ errorContext: ErrorContext }>()
+);
+
+/**
+ * Select a controller service (updates route for deep linking).
+ */
+export const selectConnectorControllerService = createAction(
+    '[Connector Controller Services] Select Controller Service',
+    props<{ request: SelectConnectorControllerServiceRequest }>()
+);
+
+/**
+ * Open the read-only view configuration dialog for a controller service.
+ */
+export const openViewControllerServiceDialog = createAction(
+    '[Connector Controller Services] Open View Controller Service Dialog',
+    props<{ controllerService: ControllerServiceEntity }>()
+);
+
+/**
+ * Reset state when leaving the page.
+ */
+export const resetConnectorControllerServicesState = createAction('[Connector Controller Services] Reset State');

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.effects.spec.ts
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Action } from '@ngrx/store';
+import { Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { firstValueFrom, Observable, of, throwError } from 'rxjs';
+import { ConnectorControllerServicesEffects } from './connector-controller-services.effects';
+import {
+    loadConnectorControllerServices,
+    loadConnectorControllerServicesFailure,
+    loadConnectorControllerServicesSuccess,
+    openViewControllerServiceDialog,
+    selectConnectorControllerService
+} from './connector-controller-services.actions';
+import { ConnectorService } from '../../service/connector.service';
+import { ErrorHelper } from '../../../../service/error-helper.service';
+import { ErrorContextKey } from '../../../../state/error';
+import * as ErrorActions from '../../../../state/error/error.actions';
+import { ControllerServiceEntity } from '../../../../state/shared';
+import { EditControllerService } from '../../../../ui/common/controller-service/edit-controller-service/edit-controller-service.component';
+
+function buildService(overrides: Partial<ControllerServiceEntity> = {}): ControllerServiceEntity {
+    return {
+        id: 'svc-1',
+        permissions: { canRead: true, canWrite: true },
+        component: { id: 'svc-1', name: 'My Service', state: 'DISABLED' },
+        ...overrides
+    } as unknown as ControllerServiceEntity;
+}
+
+describe('ConnectorControllerServicesEffects', () => {
+    async function setup() {
+        let actions$: Observable<Action>;
+
+        const mockConnectorService = {
+            getConnectorControllerServices: vi.fn(),
+            getConnectorFlow: vi.fn()
+        };
+
+        const mockErrorHelper = {
+            getErrorString: vi.fn().mockReturnValue('Error message')
+        };
+
+        const mockRouter = {
+            navigate: vi.fn().mockResolvedValue(true)
+        };
+
+        const mockDialog = {
+            open: vi.fn().mockReturnValue({ componentInstance: {} })
+        };
+
+        await TestBed.configureTestingModule({
+            providers: [
+                ConnectorControllerServicesEffects,
+                provideMockActions(() => actions$),
+                { provide: ConnectorService, useValue: mockConnectorService },
+                { provide: ErrorHelper, useValue: mockErrorHelper },
+                { provide: Router, useValue: mockRouter },
+                { provide: MatDialog, useValue: mockDialog }
+            ]
+        }).compileComponents();
+
+        return {
+            effects: TestBed.inject(ConnectorControllerServicesEffects),
+            mockConnectorService,
+            mockRouter,
+            mockDialog,
+            actions$: (stream: Observable<Action>) => {
+                actions$ = stream;
+            }
+        };
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('loadConnectorControllerServices$', () => {
+        it('should combine controller services and flow responses into a load success', async () => {
+            const { effects, actions$, mockConnectorService } = await setup();
+            const breadcrumb = { id: 'pg-1' } as any;
+            const service = buildService();
+            mockConnectorService.getConnectorControllerServices.mockReturnValue(
+                of({ controllerServices: [service], currentTime: '2023-04-01T00:00:00Z' })
+            );
+            mockConnectorService.getConnectorFlow.mockReturnValue(of({ processGroupFlow: { breadcrumb } }));
+            actions$(
+                of(
+                    loadConnectorControllerServices({
+                        request: { connectorId: 'conn-1', processGroupId: 'pg-1' }
+                    })
+                )
+            );
+
+            const result = await firstValueFrom(effects.loadConnectorControllerServices$);
+
+            expect(result).toEqual(
+                loadConnectorControllerServicesSuccess({
+                    response: {
+                        connectorId: 'conn-1',
+                        processGroupId: 'pg-1',
+                        breadcrumb,
+                        controllerServices: [service],
+                        loadedTimestamp: '2023-04-01T00:00:00Z'
+                    }
+                })
+            );
+        });
+
+        it('should emit a load failure with the controller-services error context when the API call fails', async () => {
+            const { effects, actions$, mockConnectorService } = await setup();
+            mockConnectorService.getConnectorControllerServices.mockReturnValue(throwError(() => new Error('boom')));
+            mockConnectorService.getConnectorFlow.mockReturnValue(of({ processGroupFlow: { breadcrumb: null } }));
+            actions$(
+                of(
+                    loadConnectorControllerServices({
+                        request: { connectorId: 'conn-1', processGroupId: 'pg-1' }
+                    })
+                )
+            );
+
+            const result = await firstValueFrom(effects.loadConnectorControllerServices$);
+
+            expect(result).toEqual(
+                loadConnectorControllerServicesFailure({
+                    errorContext: {
+                        errors: ['Error message'],
+                        context: ErrorContextKey.CONTROLLER_SERVICES
+                    }
+                })
+            );
+        });
+    });
+
+    describe('loadConnectorControllerServicesFailure$', () => {
+        it('should map a load failure into a banner error', async () => {
+            const { effects, actions$ } = await setup();
+            const errorContext = { errors: ['boom'], context: ErrorContextKey.CONTROLLER_SERVICES };
+            actions$(of(loadConnectorControllerServicesFailure({ errorContext })));
+
+            const result = await firstValueFrom(effects.loadConnectorControllerServicesFailure$);
+
+            expect(result).toEqual(ErrorActions.addBannerError({ errorContext }));
+        });
+    });
+
+    describe('selectConnectorControllerService$', () => {
+        it('should navigate to the controller service deep link with replaceUrl', async () => {
+            const { effects, actions$, mockRouter } = await setup();
+            actions$(
+                of(
+                    selectConnectorControllerService({
+                        request: { connectorId: 'conn-1', processGroupId: 'pg-1', serviceId: 'svc-1' }
+                    })
+                )
+            );
+
+            await firstValueFrom(effects.selectConnectorControllerService$);
+
+            expect(mockRouter.navigate).toHaveBeenCalledWith(
+                ['/connectors', 'conn-1', 'canvas', 'pg-1', 'controller-services', 'svc-1'],
+                { replaceUrl: true }
+            );
+        });
+    });
+
+    describe('openViewControllerServiceDialog$', () => {
+        it('should open the EditControllerService dialog with the readonly flag set and the entity passed through unchanged', async () => {
+            const { effects, actions$, mockDialog } = await setup();
+            const service = buildService();
+            actions$(of(openViewControllerServiceDialog({ controllerService: service })));
+
+            await firstValueFrom(effects.openViewControllerServiceDialog$);
+
+            expect(mockDialog.open).toHaveBeenCalledTimes(1);
+            const [component, config] = mockDialog.open.mock.calls[0];
+            expect(component).toBe(EditControllerService);
+            expect(config.id).toBe('svc-1');
+            expect(config.data.id).toBe('svc-1');
+            expect(config.data.readonly).toBe(true);
+            expect(config.data.controllerService).toBe(service);
+            expect(config.data.controllerService.permissions.canWrite).toBe(true);
+        });
+    });
+});

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.effects.ts
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable, inject } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { combineLatest, of } from 'rxjs';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { XL_DIALOG } from '@nifi/shared';
+import { ConnectorService } from '../../service/connector.service';
+import { ErrorContextKey } from '../../../../state/error';
+import * as ErrorActions from '../../../../state/error/error.actions';
+import { ErrorHelper } from '../../../../service/error-helper.service';
+import { EditControllerService } from '../../../../ui/common/controller-service/edit-controller-service/edit-controller-service.component';
+import { EditControllerServiceDialogRequest } from '../../../../state/shared';
+import * as ConnectorControllerServicesActions from './connector-controller-services.actions';
+
+@Injectable()
+export class ConnectorControllerServicesEffects {
+    private actions$ = inject(Actions);
+    private router = inject(Router);
+    private dialog = inject(MatDialog);
+    private connectorService = inject(ConnectorService);
+    private errorHelper = inject(ErrorHelper);
+
+    /**
+     * Load controller services for a connector's process group. Combines the
+     * controller services response with the flow response to capture the
+     * breadcrumb that drives navigation context.
+     */
+    loadConnectorControllerServices$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(ConnectorControllerServicesActions.loadConnectorControllerServices),
+            map((action) => action.request),
+            switchMap((request) =>
+                combineLatest([
+                    this.connectorService.getConnectorControllerServices(request.connectorId, request.processGroupId),
+                    this.connectorService.getConnectorFlow(request.connectorId, request.processGroupId)
+                ]).pipe(
+                    map(([controllerServicesResponse, flowResponse]) =>
+                        ConnectorControllerServicesActions.loadConnectorControllerServicesSuccess({
+                            response: {
+                                connectorId: request.connectorId,
+                                processGroupId: request.processGroupId,
+                                controllerServices: controllerServicesResponse.controllerServices ?? [],
+                                breadcrumb: flowResponse.processGroupFlow?.breadcrumb ?? null,
+                                loadedTimestamp: controllerServicesResponse.currentTime ?? new Date().toISOString()
+                            }
+                        })
+                    ),
+                    catchError((error) =>
+                        of(
+                            ConnectorControllerServicesActions.loadConnectorControllerServicesFailure({
+                                errorContext: {
+                                    errors: [this.errorHelper.getErrorString(error)],
+                                    context: ErrorContextKey.CONTROLLER_SERVICES
+                                }
+                            })
+                        )
+                    )
+                )
+            )
+        )
+    );
+
+    /**
+     * Surface load failures via a banner above the controller services view.
+     */
+    loadConnectorControllerServicesFailure$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(ConnectorControllerServicesActions.loadConnectorControllerServicesFailure),
+            map((action) => ErrorActions.addBannerError({ errorContext: action.errorContext }))
+        )
+    );
+
+    /**
+     * Selecting a controller service updates the route so the selection can be
+     * deep linked. Uses replaceUrl so back navigation is not polluted with each
+     * intermediate selection.
+     */
+    selectConnectorControllerService$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ConnectorControllerServicesActions.selectConnectorControllerService),
+                map((action) => action.request),
+                tap((request) => {
+                    this.router.navigate(
+                        [
+                            '/connectors',
+                            request.connectorId,
+                            'canvas',
+                            request.processGroupId,
+                            'controller-services',
+                            request.serviceId
+                        ],
+                        { replaceUrl: true }
+                    );
+                })
+            ),
+        { dispatch: false }
+    );
+
+    /**
+     * Opens the EditControllerService dialog in read-only mode. The dialog
+     * honors the readonly flag on the request and forces a strictly read-only
+     * view regardless of the underlying entity's permissions or run status.
+     */
+    openViewControllerServiceDialog$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ConnectorControllerServicesActions.openViewControllerServiceDialog),
+                tap((action) => {
+                    const dialogRequest: EditControllerServiceDialogRequest = {
+                        id: action.controllerService.id,
+                        controllerService: action.controllerService,
+                        readonly: true
+                    };
+
+                    this.dialog.open(EditControllerService, {
+                        ...XL_DIALOG,
+                        autoFocus: 'dialog',
+                        data: dialogRequest,
+                        id: action.controllerService.id
+                    });
+                })
+            ),
+        { dispatch: false }
+    );
+}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.reducer.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.reducer.spec.ts
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { connectorControllerServicesReducer } from './connector-controller-services.reducer';
+import {
+    loadConnectorControllerServices,
+    loadConnectorControllerServicesFailure,
+    loadConnectorControllerServicesSuccess,
+    resetConnectorControllerServicesState
+} from './connector-controller-services.actions';
+import { ConnectorControllerServicesState, initialConnectorControllerServicesState } from './index';
+import { ErrorContextKey } from '../../../../state/error';
+import { BreadcrumbEntity, ControllerServiceEntity } from '../../../../state/shared';
+
+function buildBreadcrumb(): BreadcrumbEntity {
+    return {
+        id: 'pg-1',
+        permissions: { canRead: true, canWrite: false },
+        breadcrumb: { id: 'pg-1', name: 'Root' },
+        parentBreadcrumb: undefined,
+        versionedFlowState: undefined
+    } as unknown as BreadcrumbEntity;
+}
+
+function buildService(overrides: Partial<ControllerServiceEntity> = {}): ControllerServiceEntity {
+    return {
+        id: 'svc-1',
+        permissions: { canRead: true, canWrite: false },
+        component: { id: 'svc-1', name: 'My Service', state: 'DISABLED' },
+        ...overrides
+    } as unknown as ControllerServiceEntity;
+}
+
+describe('connectorControllerServicesReducer', () => {
+    it('should mark the slice as loading and capture connector + process group IDs on load', () => {
+        const next = connectorControllerServicesReducer(
+            initialConnectorControllerServicesState,
+            loadConnectorControllerServices({
+                request: { connectorId: 'conn-1', processGroupId: 'pg-1' }
+            })
+        );
+
+        expect(next.status).toBe('loading');
+        expect(next.connectorId).toBe('conn-1');
+        expect(next.processGroupId).toBe('pg-1');
+        expect(next.error).toBeNull();
+        expect(next.hasAttemptedLoad).toBe(false);
+    });
+
+    it('should populate breadcrumbs, services, and timestamp on load success', () => {
+        const breadcrumb = buildBreadcrumb();
+        const service = buildService();
+
+        const next = connectorControllerServicesReducer(
+            initialConnectorControllerServicesState,
+            loadConnectorControllerServicesSuccess({
+                response: {
+                    connectorId: 'conn-1',
+                    processGroupId: 'pg-1',
+                    breadcrumb,
+                    controllerServices: [service],
+                    loadedTimestamp: '2023-03-01T12:00:00Z'
+                }
+            })
+        );
+
+        expect(next.status).toBe('success');
+        expect(next.breadcrumb).toEqual(breadcrumb);
+        expect(next.controllerServices).toEqual([service]);
+        expect(next.loadedTimestamp).toBe('2023-03-01T12:00:00Z');
+        expect(next.hasAttemptedLoad).toBe(true);
+    });
+
+    it('should mark the slice as error and surface the first error message on load failure', () => {
+        const next = connectorControllerServicesReducer(
+            initialConnectorControllerServicesState,
+            loadConnectorControllerServicesFailure({
+                errorContext: {
+                    errors: ['Boom', 'Other'],
+                    context: ErrorContextKey.CONTROLLER_SERVICES
+                }
+            })
+        );
+
+        expect(next.status).toBe('error');
+        expect(next.error).toBe('Boom');
+        expect(next.hasAttemptedLoad).toBe(true);
+    });
+
+    it('should fall back to a default error message when no errors are reported', () => {
+        const next = connectorControllerServicesReducer(
+            initialConnectorControllerServicesState,
+            loadConnectorControllerServicesFailure({
+                errorContext: {
+                    errors: [],
+                    context: ErrorContextKey.CONTROLLER_SERVICES
+                }
+            })
+        );
+
+        expect(next.status).toBe('error');
+        expect(next.error).toBe('Failed to load controller services');
+    });
+
+    it('should reset to the initial state', () => {
+        const populated: ConnectorControllerServicesState = {
+            ...initialConnectorControllerServicesState,
+            connectorId: 'conn-1',
+            processGroupId: 'pg-1',
+            controllerServices: [buildService()],
+            status: 'success'
+        };
+
+        const next = connectorControllerServicesReducer(populated, resetConnectorControllerServicesState());
+
+        expect(next).toEqual(initialConnectorControllerServicesState);
+    });
+});

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.reducer.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.reducer.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createReducer, on } from '@ngrx/store';
+import { initialConnectorControllerServicesState } from './index';
+import {
+    loadConnectorControllerServices,
+    loadConnectorControllerServicesSuccess,
+    loadConnectorControllerServicesFailure,
+    resetConnectorControllerServicesState
+} from './connector-controller-services.actions';
+
+export const connectorControllerServicesReducer = createReducer(
+    initialConnectorControllerServicesState,
+
+    on(loadConnectorControllerServices, (state, { request }) => ({
+        ...state,
+        connectorId: request.connectorId,
+        processGroupId: request.processGroupId,
+        status: 'loading' as const,
+        error: null
+    })),
+
+    on(loadConnectorControllerServicesSuccess, (state, { response }) => ({
+        ...state,
+        connectorId: response.connectorId,
+        processGroupId: response.processGroupId,
+        breadcrumb: response.breadcrumb,
+        controllerServices: response.controllerServices,
+        loadedTimestamp: response.loadedTimestamp,
+        status: 'success' as const,
+        error: null,
+        hasAttemptedLoad: true
+    })),
+
+    on(loadConnectorControllerServicesFailure, (state, { errorContext }) => ({
+        ...state,
+        status: 'error' as const,
+        error: errorContext.errors[0] ?? 'Failed to load controller services',
+        hasAttemptedLoad: true
+    })),
+
+    on(resetConnectorControllerServicesState, () => initialConnectorControllerServicesState)
+);

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.selectors.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/connector-controller-services.selectors.ts
@@ -15,15 +15,22 @@
  * limitations under the License.
  */
 
-import { createSelector } from '@ngrx/store';
-import { queueFeatureKey } from '../../../queue/state';
-import { QueueState } from './index';
-import { CanvasState, selectCanvasState } from '../index';
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { selectRouteParams } from '@nifi/shared';
+import { connectorControllerServicesFeatureKey, ConnectorControllerServicesState } from './index';
 
-export const selectQueueState = createSelector(selectCanvasState, (state: CanvasState) => state[queueFeatureKey]);
+export const selectConnectorControllerServicesState = createFeatureSelector<ConnectorControllerServicesState>(
+    connectorControllerServicesFeatureKey
+);
 
-export const selectDropRequestEntity = createSelector(selectQueueState, (state: QueueState) => state.dropEntity);
+export const selectConnectorIdFromRoute = createSelector(selectRouteParams, (params) => params?.['id'] ?? null);
 
-export const selectDropConnectionId = createSelector(selectQueueState, (state: QueueState) => state.connectionId);
+export const selectProcessGroupIdFromRoute = createSelector(
+    selectRouteParams,
+    (params) => params?.['processGroupId'] ?? null
+);
 
-export const selectDropProcessGroupId = createSelector(selectQueueState, (state: QueueState) => state.processGroupId);
+export const selectControllerServiceIdFromRoute = createSelector(
+    selectRouteParams,
+    (params) => params?.['serviceId'] ?? null
+);

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-controller-services/index.ts
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ControllerServiceEntity, BreadcrumbEntity } from '../../../../state/shared';
+
+/**
+ * Connector Controller Services State
+ *
+ * Manages the controller services data viewed within a connector's flow.
+ * The view is strictly read-only -- no enable/disable, configure, or delete
+ * operations are supported from the connector canvas.
+ */
+export const connectorControllerServicesFeatureKey = 'connectorControllerServices';
+
+/**
+ * Request to load controller services for a connector's process group.
+ */
+export interface LoadConnectorControllerServicesRequest {
+    connectorId: string;
+    processGroupId: string;
+}
+
+/**
+ * Response from loading controller services.
+ */
+export interface LoadConnectorControllerServicesResponse {
+    connectorId: string;
+    processGroupId: string;
+    breadcrumb: BreadcrumbEntity | null;
+    controllerServices: ControllerServiceEntity[];
+    loadedTimestamp: string;
+}
+
+/**
+ * Request to select a controller service (for route-based selection).
+ */
+export interface SelectConnectorControllerServiceRequest {
+    connectorId: string;
+    processGroupId: string;
+    serviceId: string;
+}
+
+/**
+ * State for the connector controller services page.
+ */
+export interface ConnectorControllerServicesState {
+    connectorId: string;
+    processGroupId: string;
+    breadcrumb: BreadcrumbEntity | null;
+    controllerServices: ControllerServiceEntity[];
+    loadedTimestamp: string;
+    status: 'pending' | 'loading' | 'success' | 'error';
+    error: string | null;
+    /**
+     * Whether at least one load attempt has resolved (in either success or
+     * failure). Used by the view to distinguish the very first load (where a
+     * skeleton placeholder is appropriate) from subsequent reloads (where the
+     * existing content remains in place with an inline spinner).
+     */
+    hasAttemptedLoad: boolean;
+}
+
+export const initialConnectorControllerServicesState: ConnectorControllerServicesState = {
+    connectorId: '',
+    processGroupId: '',
+    breadcrumb: null,
+    controllerServices: [],
+    loadedTimestamp: '',
+    status: 'pending',
+    error: null,
+    hasAttemptedLoad: false
+};

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/purge-connector/purge-connector.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/purge-connector/purge-connector.effects.spec.ts
@@ -42,7 +42,7 @@ import {
     submitPurgeConnector,
     submitPurgeConnectorSuccess
 } from './purge-connector.actions';
-import { DropRequestEntity } from '../../../flow-designer/state/queue';
+import { DropRequestEntity } from '../../../../state/empty-queue';
 import type { Mock } from 'vitest';
 
 describe('PurgeConnectorEffects', () => {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/purge-connector/purge-connector.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/purge-connector/purge-connector.effects.ts
@@ -28,7 +28,7 @@ import { ConnectorService } from '../../service/connector.service';
 import { ErrorHelper } from '../../../../service/error-helper.service';
 import { CancelDialog } from '../../../../ui/common/cancel-dialog/cancel-dialog.component';
 import { OkDialog } from '../../../../ui/common/ok-dialog/ok-dialog.component';
-import { DropRequest } from '../../../flow-designer/state/queue';
+import { DropRequest } from '../../../../state/empty-queue';
 import * as ErrorActions from '../../../../state/error/error.actions';
 import { ErrorContextKey } from '../../../../state/error';
 import { selectPurgeConnectorId, selectPurgeDropRequestEntity } from './purge-connector.selectors';

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.spec.ts
@@ -49,13 +49,21 @@ import {
     enterProcessGroup,
     leaveProcessGroup,
     loadConnectorFlow,
+    navigateToControllerService,
+    navigateToControllerServices,
     navigateToProvenanceForComponent,
+    navigateToQueueListing,
     resetConnectorCanvasState,
     selectComponents,
     setSkipTransform,
     viewComponentConfiguration
 } from '../../state/connector-canvas/connector-canvas.actions';
-import { resetConnectorCanvasEntityState } from '../../state/connector-canvas-entity/connector-canvas-entity.actions';
+import {
+    cancelConnectorDrain,
+    promptDrainConnector,
+    resetConnectorCanvasEntityState
+} from '../../state/connector-canvas-entity/connector-canvas-entity.actions';
+import { promptEmptyQueueRequest, promptEmptyQueuesRequest } from '../../../../state/empty-queue/empty-queue.actions';
 import { getComponentStateAndOpenDialog } from '../../../../state/component-state/component-state.actions';
 
 // Mock components to avoid loading complex real components
@@ -794,6 +802,23 @@ describe('ConnectorCanvasComponent', () => {
             expect(dispatchSpy).not.toHaveBeenCalled();
         }));
 
+        it('should dispatch navigateToControllerService when search result is a ControllerService', fakeAsync(() => {
+            const { fixture, component, dispatchSpy } = setup();
+            fixture.detectChanges();
+            tick();
+            dispatchSpy.mockClear();
+
+            component.onSearchGoToComponent({
+                id: 'svc-1',
+                type: ComponentType.ControllerService,
+                groupId: 'pg-target'
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                navigateToControllerService({ processGroupId: 'pg-target', serviceId: 'svc-1' })
+            );
+        }));
+
         it('should dispatch skipTransform and navigate when search result is in a different process group', fakeAsync(() => {
             const { fixture, component, dispatchSpy } = setup();
             fixture.detectChanges();
@@ -857,7 +882,7 @@ describe('ConnectorCanvasComponent', () => {
                 expect(result).toBeUndefined();
             });
 
-            it('should return canvas menu with Refresh and Leave Group when targetType is canvas', fakeAsync(() => {
+            it('should return canvas menu with Refresh, Leave Group, and Empty All Queues when targetType is canvas', fakeAsync(() => {
                 const { fixture, component } = setup({ parentProcessGroupId: 'parent-pg' });
                 fixture.detectChanges();
                 tick();
@@ -868,10 +893,17 @@ describe('ConnectorCanvasComponent', () => {
                 expect(menu).toBeDefined();
 
                 const items = menu!.menuItems.filter((item) => !item.isSeparator);
-                expect(items.map((i) => i.text)).toEqual(['Refresh', 'Leave Group']);
+                expect(items.map((i) => i.text)).toEqual([
+                    'Refresh',
+                    'Leave Group',
+                    'Controller Services',
+                    'Empty All Queues',
+                    'Drain',
+                    'Cancel Drain'
+                ]);
             }));
 
-            it('should return component menu with View Configuration, Enter Group, View Data Provenance, View State, and Center In View when targetType is component', fakeAsync(() => {
+            it('should return component menu with all defined items when targetType is component', fakeAsync(() => {
                 const { fixture, component } = setup();
                 fixture.detectChanges();
                 tick();
@@ -887,6 +919,10 @@ describe('ConnectorCanvasComponent', () => {
                     'Enter Group',
                     'View Data Provenance',
                     'View State',
+                    'List Queue',
+                    'Empty Queue',
+                    'Empty All Queues',
+                    'Controller Services',
                     'Center In View'
                 ]);
             }));
@@ -937,6 +973,156 @@ describe('ConnectorCanvasComponent', () => {
 
                 expect(leaveGroup).toBeDefined();
                 expect(leaveGroup!.condition!(null)).toBe(false);
+            }));
+
+            it('should show Controller Services when a process group context is loaded', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildCanvasContext());
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const controllerServices = menu.menuItems.find((i) => i.text === 'Controller Services');
+
+                expect(controllerServices).toBeDefined();
+                expect(controllerServices!.condition!(null)).toBe(true);
+            }));
+
+            it('should hide Controller Services when no process group is loaded', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+                component.currentProcessGroupId = null;
+
+                component.onContextMenuOpened(buildCanvasContext());
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const controllerServices = menu.menuItems.find((i) => i.text === 'Controller Services');
+
+                expect(controllerServices).toBeDefined();
+                expect(controllerServices!.condition!(null)).toBe(false);
+            }));
+
+            it('should show Empty All Queues when a process group context is loaded', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildCanvasContext());
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const emptyAll = menu.menuItems.find((i) => i.text === 'Empty All Queues');
+
+                expect(emptyAll).toBeDefined();
+                expect(emptyAll!.condition!(null)).toBe(true);
+            }));
+
+            it('should hide Empty All Queues when no process group is loaded', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+                component.currentProcessGroupId = null;
+
+                component.onContextMenuOpened(buildCanvasContext());
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const emptyAll = menu.menuItems.find((i) => i.text === 'Empty All Queues');
+
+                expect(emptyAll).toBeDefined();
+                expect(emptyAll!.condition!(null)).toBe(false);
+            }));
+
+            it('should show Drain when the connector entity allows DRAIN_FLOWFILES', fakeAsync(() => {
+                const { fixture, component } = setup();
+                const store = TestBed.inject(MockStore);
+                store.overrideSelector(selectConnectorCanvasEntity, {
+                    id: 'connector-1',
+                    permissions: { canRead: true, canWrite: true },
+                    operatePermissions: { canRead: true, canWrite: true },
+                    component: {
+                        availableActions: [{ name: 'DRAIN_FLOWFILES', allowed: true }]
+                    }
+                } as any);
+                store.refreshState();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildCanvasContext());
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const drain = menu.menuItems.find((i) => i.text === 'Drain');
+
+                expect(drain).toBeDefined();
+                expect(drain!.condition!(null)).toBe(true);
+            }));
+
+            it('should hide Drain when no entity is loaded', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildCanvasContext());
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const drain = menu.menuItems.find((i) => i.text === 'Drain');
+
+                expect(drain).toBeDefined();
+                expect(drain!.condition!(null)).toBe(false);
+            }));
+
+            it('should hide Drain while the entity is saving', fakeAsync(() => {
+                const { fixture, component } = setup();
+                const store = TestBed.inject(MockStore);
+                store.overrideSelector(selectConnectorCanvasEntity, {
+                    id: 'connector-1',
+                    permissions: { canRead: true, canWrite: true },
+                    operatePermissions: { canRead: true, canWrite: true },
+                    component: {
+                        availableActions: [{ name: 'DRAIN_FLOWFILES', allowed: true }]
+                    }
+                } as any);
+                store.overrideSelector(selectConnectorCanvasEntitySaving, true);
+                store.refreshState();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildCanvasContext());
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const drain = menu.menuItems.find((i) => i.text === 'Drain');
+
+                expect(drain).toBeDefined();
+                expect(drain!.condition!(null)).toBe(false);
+            }));
+
+            it('should show Cancel Drain when the connector entity allows CANCEL_DRAIN_FLOWFILES', fakeAsync(() => {
+                const { fixture, component } = setup();
+                const store = TestBed.inject(MockStore);
+                store.overrideSelector(selectConnectorCanvasEntity, {
+                    id: 'connector-1',
+                    permissions: { canRead: true, canWrite: true },
+                    operatePermissions: { canRead: true, canWrite: true },
+                    component: {
+                        availableActions: [{ name: 'CANCEL_DRAIN_FLOWFILES', allowed: true }]
+                    }
+                } as any);
+                store.refreshState();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildCanvasContext());
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const cancelDrain = menu.menuItems.find((i) => i.text === 'Cancel Drain');
+
+                expect(cancelDrain).toBeDefined();
+                expect(cancelDrain!.condition!(null)).toBe(true);
+            }));
+
+            it('should hide Cancel Drain when no entity is loaded', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildCanvasContext());
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const cancelDrain = menu.menuItems.find((i) => i.text === 'Cancel Drain');
+
+                expect(cancelDrain).toBeDefined();
+                expect(cancelDrain!.condition!(null)).toBe(false);
             }));
         });
 
@@ -1202,6 +1388,136 @@ describe('ConnectorCanvasComponent', () => {
                 expect(viewConfig).toBeDefined();
                 expect(viewConfig!.condition!(null)).toBe(false);
             }));
+
+            it('should show List Queue for a single Connection selection', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildComponentContext(ComponentType.Connection, 'conn-1', 1));
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const listQueue = menu.menuItems.find((i) => i.text === 'List Queue');
+
+                expect(listQueue).toBeDefined();
+                expect(listQueue!.condition!(null)).toBe(true);
+            }));
+
+            it('should hide List Queue for non-Connection types', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildComponentContext(ComponentType.Processor, 'proc-1', 1));
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const listQueue = menu.menuItems.find((i) => i.text === 'List Queue');
+
+                expect(listQueue).toBeDefined();
+                expect(listQueue!.condition!(null)).toBe(false);
+            }));
+
+            it('should hide List Queue for multi-selection of Connections', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildComponentContext(ComponentType.Connection, 'conn-1', 2));
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const listQueue = menu.menuItems.find((i) => i.text === 'List Queue');
+
+                expect(listQueue).toBeDefined();
+                expect(listQueue!.condition!(null)).toBe(false);
+            }));
+
+            it('should show Empty Queue for a single Connection selection', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildComponentContext(ComponentType.Connection, 'conn-1', 1));
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const emptyQueue = menu.menuItems.find((i) => i.text === 'Empty Queue');
+
+                expect(emptyQueue).toBeDefined();
+                expect(emptyQueue!.condition!(null)).toBe(true);
+            }));
+
+            it('should hide Empty Queue for non-Connection types', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildComponentContext(ComponentType.Processor, 'proc-1', 1));
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const emptyQueue = menu.menuItems.find((i) => i.text === 'Empty Queue');
+
+                expect(emptyQueue).toBeDefined();
+                expect(emptyQueue!.condition!(null)).toBe(false);
+            }));
+
+            it('should show Empty All Queues for a single ProcessGroup selection', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildComponentContext(ComponentType.ProcessGroup, 'pg-1', 1));
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const emptyAll = menu.menuItems.find((i) => i.text === 'Empty All Queues');
+
+                expect(emptyAll).toBeDefined();
+                expect(emptyAll!.condition!(null)).toBe(true);
+            }));
+
+            it('should hide Empty All Queues on a component menu when not a ProcessGroup', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildComponentContext(ComponentType.Processor, 'proc-1', 1));
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const emptyAll = menu.menuItems.find((i) => i.text === 'Empty All Queues');
+
+                expect(emptyAll).toBeDefined();
+                expect(emptyAll!.condition!(null)).toBe(false);
+            }));
+
+            it('should hide Empty All Queues when ProcessGroup is part of a multi-selection', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildComponentContext(ComponentType.ProcessGroup, 'pg-1', 3));
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const emptyAll = menu.menuItems.find((i) => i.text === 'Empty All Queues');
+
+                expect(emptyAll).toBeDefined();
+                expect(emptyAll!.condition!(null)).toBe(false);
+            }));
+
+            it('should show Controller Services for a single ProcessGroup selection', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildComponentContext(ComponentType.ProcessGroup, 'pg-1', 1));
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const controllerServices = menu.menuItems.find((i) => i.text === 'Controller Services');
+
+                expect(controllerServices).toBeDefined();
+                expect(controllerServices!.condition!(null)).toBe(true);
+            }));
+
+            it('should hide Controller Services on a component menu when not a ProcessGroup', fakeAsync(() => {
+                const { fixture, component } = setup();
+                fixture.detectChanges();
+                tick();
+
+                component.onContextMenuOpened(buildComponentContext(ComponentType.Processor, 'proc-1', 1));
+                const menu = component.contextMenuProvider.getMenu('root')!;
+                const controllerServices = menu.menuItems.find((i) => i.text === 'Controller Services');
+
+                expect(controllerServices).toBeDefined();
+                expect(controllerServices!.condition!(null)).toBe(false);
+            }));
         });
 
         describe('filterMenuItem', () => {
@@ -1428,6 +1744,123 @@ describe('ConnectorCanvasComponent', () => {
                     })
                 );
             }));
+        });
+
+        describe('queue and controller-services actions', () => {
+            it('should dispatch navigateToQueueListing when listQueueAction is invoked', () => {
+                const { component, dispatchSpy } = setup();
+                dispatchSpy.mockClear();
+
+                component.listQueueAction('conn-1');
+
+                expect(dispatchSpy).toHaveBeenCalledWith(
+                    navigateToQueueListing({ request: { connectionId: 'conn-1' } })
+                );
+            });
+
+            it('should dispatch promptEmptyQueueRequest with connector-canvas source when emptyQueueAction is invoked', () => {
+                const { component, dispatchSpy } = setup();
+                dispatchSpy.mockClear();
+
+                component.emptyQueueAction('conn-1');
+
+                expect(dispatchSpy).toHaveBeenCalledWith(
+                    promptEmptyQueueRequest({
+                        request: { connectionId: 'conn-1', source: 'connector-canvas' }
+                    })
+                );
+            });
+
+            it('should dispatch promptEmptyQueuesRequest with connector-canvas source when emptyAllQueuesAction is invoked', () => {
+                const { component, dispatchSpy } = setup();
+                dispatchSpy.mockClear();
+
+                component.emptyAllQueuesAction('pg-1');
+
+                expect(dispatchSpy).toHaveBeenCalledWith(
+                    promptEmptyQueuesRequest({
+                        request: { processGroupId: 'pg-1', source: 'connector-canvas' }
+                    })
+                );
+            });
+
+            it('should dispatch navigateToControllerServices when controllerServicesAction is invoked', () => {
+                const { component, dispatchSpy } = setup();
+                dispatchSpy.mockClear();
+
+                component.controllerServicesAction('pg-target');
+
+                expect(dispatchSpy).toHaveBeenCalledWith(navigateToControllerServices({ processGroupId: 'pg-target' }));
+            });
+        });
+
+        describe('drain actions', () => {
+            const operableConnectorEntity = {
+                id: 'connector-1',
+                permissions: { canRead: true, canWrite: true },
+                operatePermissions: { canRead: true, canWrite: true },
+                component: {
+                    availableActions: [
+                        { name: 'DRAIN_FLOWFILES', allowed: true },
+                        { name: 'CANCEL_DRAIN_FLOWFILES', allowed: true }
+                    ]
+                }
+            };
+
+            it('canDrain should be false when no entity is loaded', () => {
+                const { component } = setup();
+                expect(component.canDrain()).toBe(false);
+            });
+
+            it('canDrain should be false while the entity is saving', () => {
+                const { component, fixture } = setup();
+                const store = TestBed.inject(MockStore);
+                store.overrideSelector(selectConnectorCanvasEntity, operableConnectorEntity);
+                store.overrideSelector(selectConnectorCanvasEntitySaving, true);
+                store.refreshState();
+                fixture.detectChanges();
+
+                expect(component.canDrain()).toBe(false);
+            });
+
+            it('cancelDrainAction should not dispatch when no entity is loaded', () => {
+                const { component, dispatchSpy } = setup();
+                dispatchSpy.mockClear();
+
+                component.cancelDrainConnectorAction();
+
+                expect(dispatchSpy).not.toHaveBeenCalled();
+            });
+
+            it('drainConnectorAction should dispatch promptDrainConnector with the current entity', () => {
+                const { component, fixture, dispatchSpy } = setup();
+                const store = TestBed.inject(MockStore);
+                store.overrideSelector(selectConnectorCanvasEntity, operableConnectorEntity);
+                store.refreshState();
+                fixture.detectChanges();
+                dispatchSpy.mockClear();
+
+                component.drainConnectorAction();
+
+                expect(dispatchSpy).toHaveBeenCalledWith(
+                    promptDrainConnector({ connector: operableConnectorEntity as any })
+                );
+            });
+
+            it('cancelDrainConnectorAction should dispatch cancelConnectorDrain with the current entity', () => {
+                const { component, fixture, dispatchSpy } = setup();
+                const store = TestBed.inject(MockStore);
+                store.overrideSelector(selectConnectorCanvasEntity, operableConnectorEntity);
+                store.refreshState();
+                fixture.detectChanges();
+                dispatchSpy.mockClear();
+
+                component.cancelDrainConnectorAction();
+
+                expect(dispatchSpy).toHaveBeenCalledWith(
+                    cancelConnectorDrain({ connector: operableConnectorEntity as any })
+                );
+            });
         });
     });
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.component.ts
@@ -23,7 +23,14 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatSidenav, MatSidenavContainer, MatSidenavContent } from '@angular/material/sidenav';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
-import { ComponentType, selectRouteParams, selectUrl, Storage } from '@nifi/shared';
+import {
+    canOperateConnector,
+    ComponentType,
+    isConnectorActionAllowed,
+    selectRouteParams,
+    selectUrl,
+    Storage
+} from '@nifi/shared';
 import { DocumentedType, RegistryClientEntity } from '../../../../state/shared';
 import { combineLatest, distinctUntilChanged, filter, map, Observable, of } from 'rxjs';
 import { NiFiState } from '../../../../state';
@@ -46,6 +53,7 @@ import { ErrorContextKey } from '../../../../state/error';
 import * as ConnectorCanvasActions from '../../state/connector-canvas/connector-canvas.actions';
 import * as ConnectorCanvasSelectors from '../../state/connector-canvas/connector-canvas.selectors';
 import * as ConnectorCanvasEntityActions from '../../state/connector-canvas-entity/connector-canvas-entity.actions';
+import * as EmptyQueueActions from '../../../../state/empty-queue/empty-queue.actions';
 import {
     selectConnectorCanvasEntity,
     selectConnectorCanvasEntitySaving
@@ -152,6 +160,33 @@ export class ConnectorCanvasComponent implements OnInit, OnDestroy {
                         condition: () => this.canNavigateToParent,
                         action: () => this.leaveGroupAction(),
                         shortcut: { code: 'ESC' }
+                    },
+                    { isSeparator: true },
+                    {
+                        text: 'Controller Services',
+                        clazz: 'fa fa-list',
+                        condition: () => !!this.currentProcessGroupId,
+                        action: () => this.controllerServicesAction(this.currentProcessGroupId!)
+                    },
+                    { isSeparator: true },
+                    {
+                        text: 'Empty All Queues',
+                        clazz: 'fa fa-minus-circle',
+                        condition: () => !!this.currentProcessGroupId,
+                        action: () => this.emptyAllQueuesAction(this.currentProcessGroupId!)
+                    },
+                    { isSeparator: true },
+                    {
+                        text: 'Drain',
+                        clazz: 'fa',
+                        condition: () => this.canDrain(),
+                        action: () => this.drainConnectorAction()
+                    },
+                    {
+                        text: 'Cancel Drain',
+                        clazz: 'fa',
+                        condition: () => this.canCancelDrain(),
+                        action: () => this.cancelDrainConnectorAction()
                     }
                 ];
             } else if (context?.targetType === 'component') {
@@ -201,6 +236,31 @@ export class ConnectorCanvasComponent implements OnInit, OnDestroy {
                             clicked!.entity.permissions.canRead === true &&
                             clicked!.entity.permissions.canWrite === true,
                         action: () => this.viewProcessorStateAction(clicked!.entity)
+                    },
+                    { isSeparator: true },
+                    {
+                        text: 'List Queue',
+                        clazz: 'fa fa-list',
+                        condition: () => isConnection && isSingleSelection,
+                        action: () => this.listQueueAction(clicked!.entity.id)
+                    },
+                    {
+                        text: 'Empty Queue',
+                        clazz: 'fa fa-minus-circle',
+                        condition: () => isConnection && isSingleSelection,
+                        action: () => this.emptyQueueAction(clicked!.entity.id)
+                    },
+                    {
+                        text: 'Empty All Queues',
+                        clazz: 'fa fa-minus-circle',
+                        condition: () => isProcessGroup && isSingleSelection,
+                        action: () => this.emptyAllQueuesAction(clicked!.entity.id)
+                    },
+                    {
+                        text: 'Controller Services',
+                        clazz: 'fa fa-list',
+                        condition: () => isProcessGroup && isSingleSelection,
+                        action: () => this.controllerServicesAction(clicked!.entity.id)
                     },
                     { isSeparator: true },
                     this.getCenterInViewMenuItem()
@@ -411,6 +471,60 @@ export class ConnectorCanvasComponent implements OnInit, OnDestroy {
         this.canvasComponent().centerOnSelection(true);
     }
 
+    controllerServicesAction(processGroupId: string): void {
+        this.store.dispatch(ConnectorCanvasActions.navigateToControllerServices({ processGroupId }));
+    }
+
+    canDrain(): boolean {
+        const entity = this.connectorEntity();
+        if (!entity || this.entitySaving()) {
+            return false;
+        }
+        return canOperateConnector(entity) && isConnectorActionAllowed(entity, 'DRAIN_FLOWFILES');
+    }
+
+    canCancelDrain(): boolean {
+        const entity = this.connectorEntity();
+        if (!entity || this.entitySaving()) {
+            return false;
+        }
+        return canOperateConnector(entity) && isConnectorActionAllowed(entity, 'CANCEL_DRAIN_FLOWFILES');
+    }
+
+    drainConnectorAction(): void {
+        const entity = this.connectorEntity();
+        if (entity) {
+            this.store.dispatch(ConnectorCanvasEntityActions.promptDrainConnector({ connector: entity }));
+        }
+    }
+
+    cancelDrainConnectorAction(): void {
+        const entity = this.connectorEntity();
+        if (entity) {
+            this.store.dispatch(ConnectorCanvasEntityActions.cancelConnectorDrain({ connector: entity }));
+        }
+    }
+
+    listQueueAction(connectionId: string): void {
+        this.store.dispatch(ConnectorCanvasActions.navigateToQueueListing({ request: { connectionId } }));
+    }
+
+    emptyQueueAction(connectionId: string): void {
+        this.store.dispatch(
+            EmptyQueueActions.promptEmptyQueueRequest({
+                request: { connectionId, source: 'connector-canvas' }
+            })
+        );
+    }
+
+    emptyAllQueuesAction(processGroupId: string): void {
+        this.store.dispatch(
+            EmptyQueueActions.promptEmptyQueuesRequest({
+                request: { processGroupId, source: 'connector-canvas' }
+            })
+        );
+    }
+
     // =========================================================================
     // Keyboard Shortcuts
     // Typed as Event (not KeyboardEvent) because Angular 21's typeCheckHostBindings
@@ -460,6 +574,16 @@ export class ConnectorCanvasComponent implements OnInit, OnDestroy {
     }
 
     onSearchGoToComponent(event: { id: string; type: ComponentType; groupId: string }): void {
+        if (event.type === ComponentType.ControllerService) {
+            this.store.dispatch(
+                ConnectorCanvasActions.navigateToControllerService({
+                    processGroupId: event.groupId,
+                    serviceId: event.id
+                })
+            );
+            return;
+        }
+
         if (event.type === ComponentType.ParameterProvider) {
             this.router.navigate(['/settings', 'parameter-providers', event.id]);
             return;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.module.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-canvas/connector-canvas.module.ts
@@ -37,6 +37,13 @@ const routes: Routes = [
         pathMatch: 'full'
     },
     {
+        path: ':processGroupId/controller-services',
+        loadChildren: () =>
+            import('../connector-controller-services/connector-controller-services.module').then(
+                (m) => m.ConnectorControllerServicesModule
+            )
+    },
+    {
         path: ':processGroupId',
         component: ConnectorCanvasComponent,
         children: [

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-controller-services/connector-controller-services.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-controller-services/connector-controller-services.component.html
@@ -1,0 +1,101 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div class="flex flex-col h-full">
+    <header class="mb-5 nifi-header">
+        <navigation></navigation>
+    </header>
+    <div class="pb-5 px-5 flex-1 flex flex-col">
+        <h3 class="primary-color">Controller Services</h3>
+        @if (serviceState(); as state) {
+            @if (isInitialLoading()) {
+                <div>
+                    <ngx-skeleton-loader count="3"></ngx-skeleton-loader>
+                </div>
+            } @else {
+                <div class="flex flex-col h-full gap-y-2">
+                    <context-error-banner [context]="ErrorContextKey.CONTROLLER_SERVICES"></context-error-banner>
+                    @if (state.breadcrumb) {
+                        <div class="flex justify-between items-center w-full">
+                            <div class="flex-1 min-w-0 mr-4">
+                                <breadcrumbs
+                                    [entity]="state.breadcrumb"
+                                    [currentProcessGroupId]="state.processGroupId"
+                                    [routeGenerator]="getBreadcrumbRouteGenerator()"></breadcrumbs>
+                            </div>
+                            <div class="flex items-center gap-x-3 shrink-0">
+                                @if (shouldShowFilter()) {
+                                    <div class="flex items-center justify-between gap-x-2 current-scope-only">
+                                        <mat-checkbox [(ngModel)]="showCurrentScopeOnly" data-qa="current-scope-filter">
+                                        </mat-checkbox>
+                                        <div class="flex items-center justify-between gap-x-1">
+                                            <label
+                                                class="cursor-pointer select-none whitespace-nowrap nifi-body"
+                                                (click)="toggleFilter()"
+                                                data-qa="current-scope-label">
+                                                Show current scope only
+                                            </label>
+                                            <i
+                                                class="fa fa-info-circle"
+                                                nifiTooltip
+                                                [tooltipComponentType]="TextTip"
+                                                [tooltipInputData]="getFilterTooltip(state.breadcrumb)"
+                                                data-qa="current-scope-help"></i>
+                                        </div>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                    @if (flowConfiguration$ | async; as flowConfiguration) {
+                        <div class="flex-1">
+                            <controller-service-table
+                                [selectedServiceId]="(selectedServiceId$ | async) ?? ''"
+                                [controllerServices]="filteredControllerServices()"
+                                [formatScope]="formatScope(state.breadcrumb)"
+                                [definedByCurrentGroup]="definedByCurrentGroup(state.breadcrumb)"
+                                [currentUser]="(currentUser$ | async)!"
+                                [flowConfiguration]="flowConfiguration"
+                                [canModifyParent]="canModifyParent()"
+                                [readOnly]="true"
+                                (selectControllerService)="selectControllerService($event)"
+                                (viewControllerServiceDocumentation)="viewControllerServiceDocumentation($event)"
+                                (configureControllerService)="configureControllerService($event)"
+                                (viewStateControllerService)="
+                                    viewStateControllerService($event)
+                                "></controller-service-table>
+                        </div>
+                    }
+                    <div class="flex justify-between">
+                        <div class="text-sm flex items-center gap-x-2">
+                            <button
+                                mat-icon-button
+                                class="primary-icon-button"
+                                (click)="refreshControllerServiceListing()">
+                                <i class="fa fa-refresh" [class.fa-spin]="state.status === 'loading'"></i>
+                            </button>
+                            <div>Last updated:</div>
+                            <div class="tertiary-color font-medium">
+                                {{ state.loadedTimestamp }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+        }
+    </div>
+</div>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-controller-services/connector-controller-services.component.scss
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-controller-services/connector-controller-services.component.scss
@@ -15,25 +15,8 @@
  * limitations under the License.
  */
 
-import { DropRequestEntity } from '../../../../state/empty-queue';
-import { ConnectorEntity } from '@nifi/shared';
-
-export const purgeConnectorFeatureKey = 'purgeConnector';
-
-export interface PurgeConnectorState {
-    connectorId: string | null;
-    dropEntity: DropRequestEntity | null;
-    status: 'pending' | 'loading' | 'success';
-}
-
-export interface PurgeConnectorRequest {
-    connector: ConnectorEntity;
-}
-
-export interface PollPurgeConnectorSuccess {
-    dropEntity: DropRequestEntity;
-}
-
-export interface ShowPurgeConnectorResults {
-    dropEntity: DropRequestEntity;
+.current-scope-only {
+    .fa-info-circle {
+        font-size: 14px;
+    }
 }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-controller-services/connector-controller-services.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-controller-services/connector-controller-services.component.spec.ts
@@ -1,0 +1,523 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { provideRouter } from '@angular/router';
+import { ComponentType, selectRouteParams } from '@nifi/shared';
+
+import { ConnectorControllerServicesComponent } from './connector-controller-services.component';
+import {
+    selectConnectorControllerServicesState,
+    selectControllerServiceIdFromRoute
+} from '../../state/connector-controller-services/connector-controller-services.selectors';
+import {
+    loadConnectorControllerServices,
+    openViewControllerServiceDialog,
+    resetConnectorControllerServicesState,
+    selectConnectorControllerService
+} from '../../state/connector-controller-services/connector-controller-services.actions';
+import {
+    ConnectorControllerServicesState,
+    initialConnectorControllerServicesState
+} from '../../state/connector-controller-services';
+import { selectCurrentUser } from '../../../../state/current-user/current-user.selectors';
+import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
+import { getComponentStateAndOpenDialog } from '../../../../state/component-state/component-state.actions';
+import { navigateToComponentDocumentation } from '../../../../state/documentation/documentation.actions';
+import { BreadcrumbEntity, ControllerServiceEntity } from '../../../../state/shared';
+
+const CONNECTOR_ID = 'connector-1';
+const PROCESS_GROUP_ID = 'pg-current';
+
+function buildBreadcrumb(
+    overrides: Partial<BreadcrumbEntity> = {},
+    parentBreadcrumb: BreadcrumbEntity | undefined = undefined
+): BreadcrumbEntity {
+    return {
+        id: PROCESS_GROUP_ID,
+        permissions: { canRead: true, canWrite: true },
+        breadcrumb: { id: PROCESS_GROUP_ID, name: 'Current Group' },
+        parentBreadcrumb,
+        ...overrides
+    } as BreadcrumbEntity;
+}
+
+function buildControllerService(overrides: Partial<ControllerServiceEntity> = {}): ControllerServiceEntity {
+    return {
+        id: 'svc-1',
+        permissions: { canRead: true, canWrite: false },
+        bulletins: [],
+        parentGroupId: PROCESS_GROUP_ID,
+        component: {
+            id: 'svc-1',
+            parentGroupId: PROCESS_GROUP_ID,
+            name: 'My Service',
+            type: 'org.apache.nifi.MyService',
+            bundle: { group: 'org.apache.nifi', artifact: 'nifi-services-nar', version: '2.0.0' },
+            state: 'DISABLED',
+            persistsState: true
+        } as any,
+        ...overrides
+    } as ControllerServiceEntity;
+}
+
+interface SetupOptions {
+    state?: Partial<ConnectorControllerServicesState>;
+    routeParams?: Record<string, string>;
+    selectedServiceId?: string | null;
+}
+
+function buildState(overrides: Partial<ConnectorControllerServicesState> = {}): ConnectorControllerServicesState {
+    return {
+        ...initialConnectorControllerServicesState,
+        connectorId: CONNECTOR_ID,
+        processGroupId: PROCESS_GROUP_ID,
+        breadcrumb: buildBreadcrumb(),
+        controllerServices: [buildControllerService()],
+        loadedTimestamp: '12:00:00 EST',
+        status: 'success',
+        ...overrides
+    };
+}
+
+function setup(options: SetupOptions = {}): {
+    fixture: ComponentFixture<ConnectorControllerServicesComponent>;
+    component: ConnectorControllerServicesComponent;
+    dispatchSpy: ReturnType<typeof vi.spyOn>;
+    store: MockStore;
+} {
+    const routeParams =
+        options.routeParams !== undefined
+            ? options.routeParams
+            : { id: CONNECTOR_ID, processGroupId: PROCESS_GROUP_ID };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+        declarations: [ConnectorControllerServicesComponent],
+        imports: [NoopAnimationsModule],
+        providers: [
+            provideRouter([]),
+            provideMockStore({
+                initialState: {},
+                selectors: [
+                    {
+                        selector: selectConnectorControllerServicesState,
+                        value: buildState(options.state)
+                    },
+                    { selector: selectControllerServiceIdFromRoute, value: options.selectedServiceId ?? null },
+                    { selector: selectRouteParams, value: routeParams },
+                    { selector: selectCurrentUser, value: null },
+                    { selector: selectFlowConfiguration, value: null }
+                ]
+            })
+        ]
+    }).overrideComponent(ConnectorControllerServicesComponent, {
+        set: { template: '' }
+    });
+
+    const store = TestBed.inject(MockStore);
+    const dispatchSpy = vi.spyOn(store, 'dispatch');
+    const fixture = TestBed.createComponent(ConnectorControllerServicesComponent);
+    return { fixture, component: fixture.componentInstance, dispatchSpy, store };
+}
+
+describe('ConnectorControllerServicesComponent', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('Initialization', () => {
+        it('should dispatch loadConnectorControllerServices when route params are available', fakeAsync(() => {
+            const { dispatchSpy } = setup();
+            tick();
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                loadConnectorControllerServices({
+                    request: { connectorId: CONNECTOR_ID, processGroupId: PROCESS_GROUP_ID }
+                })
+            );
+        }));
+
+        it('should not dispatch loadConnectorControllerServices when connectorId is missing from route', fakeAsync(() => {
+            const { dispatchSpy } = setup({ routeParams: { processGroupId: PROCESS_GROUP_ID } });
+            tick();
+
+            const loadDispatches = dispatchSpy.mock.calls.filter(
+                (call) => (call[0] as { type: string }).type === loadConnectorControllerServices.type
+            );
+            expect(loadDispatches).toHaveLength(0);
+        }));
+    });
+
+    describe('Destruction', () => {
+        it('should dispatch resetConnectorControllerServicesState on destroy', () => {
+            const { fixture, dispatchSpy } = setup();
+            dispatchSpy.mockClear();
+
+            fixture.destroy();
+
+            expect(dispatchSpy).toHaveBeenCalledWith(resetConnectorControllerServicesState());
+        });
+    });
+
+    describe('refreshControllerServiceListing', () => {
+        it('should dispatch loadConnectorControllerServices using the captured route ids', fakeAsync(() => {
+            const { component, dispatchSpy } = setup();
+            tick();
+            dispatchSpy.mockClear();
+
+            component.refreshControllerServiceListing();
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                loadConnectorControllerServices({
+                    request: { connectorId: CONNECTOR_ID, processGroupId: PROCESS_GROUP_ID }
+                })
+            );
+        }));
+    });
+
+    describe('Action dispatchers', () => {
+        it('selectControllerService should dispatch with the connector and process group context', fakeAsync(() => {
+            const { component, dispatchSpy } = setup();
+            tick();
+            dispatchSpy.mockClear();
+
+            component.selectControllerService(buildControllerService({ id: 'svc-42' } as any));
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                selectConnectorControllerService({
+                    request: {
+                        connectorId: CONNECTOR_ID,
+                        processGroupId: PROCESS_GROUP_ID,
+                        serviceId: 'svc-42'
+                    }
+                })
+            );
+        }));
+
+        it('configureControllerService should dispatch openViewControllerServiceDialog', fakeAsync(() => {
+            const { component, dispatchSpy } = setup();
+            tick();
+            dispatchSpy.mockClear();
+
+            const entity = buildControllerService();
+            component.configureControllerService(entity);
+
+            expect(dispatchSpy).toHaveBeenCalledWith(openViewControllerServiceDialog({ controllerService: entity }));
+        }));
+
+        it('viewStateControllerService should dispatch with connectorId and canClear true for DISABLED state', fakeAsync(() => {
+            const { component, dispatchSpy } = setup();
+            tick();
+            dispatchSpy.mockClear();
+
+            const entity = buildControllerService({
+                id: 'svc-state',
+                component: {
+                    parentGroupId: PROCESS_GROUP_ID,
+                    name: 'Stateful Service',
+                    type: 'org.apache.nifi.MyService',
+                    bundle: { group: 'g', artifact: 'a', version: 'v' },
+                    state: 'DISABLED',
+                    persistsState: true
+                } as any
+            } as any);
+
+            component.viewStateControllerService(entity);
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                getComponentStateAndOpenDialog({
+                    request: {
+                        componentName: 'Stateful Service',
+                        componentId: 'svc-state',
+                        componentType: ComponentType.ControllerService,
+                        canClear: true,
+                        connectorId: CONNECTOR_ID
+                    }
+                })
+            );
+        }));
+
+        it('viewStateControllerService should set canClear false when the service is not DISABLED', fakeAsync(() => {
+            const { component, dispatchSpy } = setup();
+            tick();
+            dispatchSpy.mockClear();
+
+            const entity = buildControllerService({
+                id: 'svc-state',
+                component: {
+                    parentGroupId: PROCESS_GROUP_ID,
+                    name: 'Enabled Service',
+                    type: 'org.apache.nifi.MyService',
+                    bundle: { group: 'g', artifact: 'a', version: 'v' },
+                    state: 'ENABLED',
+                    persistsState: true
+                } as any
+            } as any);
+
+            component.viewStateControllerService(entity);
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                getComponentStateAndOpenDialog({
+                    request: {
+                        componentName: 'Enabled Service',
+                        componentId: 'svc-state',
+                        componentType: ComponentType.ControllerService,
+                        canClear: false,
+                        connectorId: CONNECTOR_ID
+                    }
+                })
+            );
+        }));
+
+        it('viewControllerServiceDocumentation should dispatch navigateToComponentDocumentation with back navigation route', fakeAsync(() => {
+            const { component, dispatchSpy } = setup();
+            tick();
+            dispatchSpy.mockClear();
+
+            const entity = buildControllerService({
+                id: 'svc-doc',
+                component: {
+                    parentGroupId: PROCESS_GROUP_ID,
+                    name: 'Doc Service',
+                    type: 'org.apache.nifi.DocService',
+                    bundle: { group: 'org.apache.nifi', artifact: 'nifi-doc-nar', version: '2.0.0' },
+                    state: 'DISABLED',
+                    persistsState: false
+                } as any
+            } as any);
+
+            component.viewControllerServiceDocumentation(entity);
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                navigateToComponentDocumentation({
+                    request: {
+                        parameters: {
+                            componentType: ComponentType.ControllerService,
+                            type: 'org.apache.nifi.DocService',
+                            group: 'org.apache.nifi',
+                            artifact: 'nifi-doc-nar',
+                            version: '2.0.0'
+                        },
+                        backNavigation: {
+                            route: [
+                                '/connectors',
+                                CONNECTOR_ID,
+                                'canvas',
+                                PROCESS_GROUP_ID,
+                                'controller-services',
+                                'svc-doc'
+                            ],
+                            routeBoundary: ['/documentation'],
+                            context: 'Controller Service'
+                        }
+                    }
+                })
+            );
+        }));
+    });
+
+    describe('Filter and scope helpers', () => {
+        it('shouldShowFilter is false when the breadcrumb has no parent', fakeAsync(() => {
+            const { component } = setup({
+                state: { breadcrumb: buildBreadcrumb() }
+            });
+            tick();
+
+            expect(component.shouldShowFilter()).toBe(false);
+        }));
+
+        it('shouldShowFilter is true when the breadcrumb has a parent breadcrumb', fakeAsync(() => {
+            const parent = buildBreadcrumb({
+                id: 'pg-parent',
+                breadcrumb: { id: 'pg-parent', name: 'Parent Group' }
+            });
+            const { component } = setup({
+                state: { breadcrumb: buildBreadcrumb({}, parent) }
+            });
+            tick();
+
+            expect(component.shouldShowFilter()).toBe(true);
+        }));
+
+        it('definedByCurrentGroup returns true only for services defined in the current group', () => {
+            const { component } = setup();
+            const breadcrumb = buildBreadcrumb();
+
+            const filter = component.definedByCurrentGroup(breadcrumb);
+
+            expect(filter(buildControllerService({ parentGroupId: PROCESS_GROUP_ID }))).toBe(true);
+            expect(filter(buildControllerService({ parentGroupId: 'pg-other' }))).toBe(false);
+        });
+
+        it('definedByCurrentGroup returns true for all services when breadcrumb is null', () => {
+            const { component } = setup();
+            const filter = component.definedByCurrentGroup(null);
+
+            expect(filter(buildControllerService({ parentGroupId: 'anything' }))).toBe(true);
+        });
+
+        it('formatScope returns the readable breadcrumb name for the parent group', () => {
+            const { component } = setup();
+            const parent = buildBreadcrumb({
+                id: 'pg-parent',
+                breadcrumb: { id: 'pg-parent', name: 'Parent Group' }
+            });
+            const breadcrumb = buildBreadcrumb({}, parent);
+
+            const formatter = component.formatScope(breadcrumb);
+
+            expect(formatter(buildControllerService({ parentGroupId: PROCESS_GROUP_ID }))).toBe('Current Group');
+            expect(formatter(buildControllerService({ parentGroupId: 'pg-parent' }))).toBe('Parent Group');
+        });
+
+        it('formatScope returns the breadcrumb id when permissions deny read', () => {
+            const { component } = setup();
+            const breadcrumb = buildBreadcrumb({
+                permissions: { canRead: false, canWrite: false }
+            });
+
+            const formatter = component.formatScope(breadcrumb);
+
+            expect(formatter(buildControllerService({ parentGroupId: PROCESS_GROUP_ID }))).toBe(PROCESS_GROUP_ID);
+        });
+
+        it('formatScope returns an empty string when the entity is not in any breadcrumb', () => {
+            const { component } = setup();
+            const breadcrumb = buildBreadcrumb();
+            const formatter = component.formatScope(breadcrumb);
+
+            expect(formatter(buildControllerService({ parentGroupId: 'unknown' }))).toBe('');
+        });
+
+        it('formatScope returns an empty-string formatter when no breadcrumb is provided', () => {
+            const { component } = setup();
+            const formatter = component.formatScope(null);
+
+            expect(formatter(buildControllerService())).toBe('');
+        });
+
+        it('toggleFilter inverts showCurrentScopeOnly', () => {
+            const { component } = setup();
+            expect(component.showCurrentScopeOnly()).toBe(false);
+
+            component.toggleFilter();
+            expect(component.showCurrentScopeOnly()).toBe(true);
+
+            component.toggleFilter();
+            expect(component.showCurrentScopeOnly()).toBe(false);
+        });
+
+        it('filteredControllerServices returns all services when the scope filter is off', fakeAsync(() => {
+            const services = [
+                buildControllerService({ id: 's1', parentGroupId: PROCESS_GROUP_ID }),
+                buildControllerService({ id: 's2', parentGroupId: 'pg-other' })
+            ];
+            const { component } = setup({
+                state: { controllerServices: services }
+            });
+            tick();
+
+            expect(component.filteredControllerServices().map((s) => s.id)).toEqual(['s1', 's2']);
+        }));
+
+        it('filteredControllerServices restricts to current group when the scope filter is on', fakeAsync(() => {
+            const services = [
+                buildControllerService({ id: 's1', parentGroupId: PROCESS_GROUP_ID }),
+                buildControllerService({ id: 's2', parentGroupId: 'pg-other' })
+            ];
+            const { component } = setup({
+                state: { controllerServices: services }
+            });
+            tick();
+
+            component.toggleFilter();
+
+            expect(component.filteredControllerServices().map((s) => s.id)).toEqual(['s1']);
+        }));
+
+        it('getFilterTooltip uses the breadcrumb name when readable', () => {
+            const { component } = setup();
+            const tooltip = component.getFilterTooltip(buildBreadcrumb());
+
+            expect(tooltip).toContain("'Current Group'");
+        });
+
+        it('getFilterTooltip falls back to a generic label when breadcrumb is null', () => {
+            const { component } = setup();
+            const tooltip = component.getFilterTooltip(null);
+
+            expect(tooltip).toContain("'this group'");
+        });
+    });
+
+    describe('Loading state', () => {
+        it('isInitialLoading is true while loading on the very first request', fakeAsync(() => {
+            const { component } = setup({
+                state: { status: 'loading', hasAttemptedLoad: false }
+            });
+            tick();
+
+            expect(component.isInitialLoading()).toBe(true);
+        }));
+
+        it('isInitialLoading is false on subsequent loads after data has arrived', fakeAsync(() => {
+            const { component } = setup({
+                state: { status: 'loading', hasAttemptedLoad: true }
+            });
+            tick();
+
+            expect(component.isInitialLoading()).toBe(false);
+        }));
+
+        it('isInitialLoading is false on retry after a failed first load', fakeAsync(() => {
+            const { component } = setup({
+                state: {
+                    status: 'loading',
+                    hasAttemptedLoad: true,
+                    controllerServices: [],
+                    loadedTimestamp: ''
+                }
+            });
+            tick();
+
+            expect(component.isInitialLoading()).toBe(false);
+        }));
+    });
+
+    describe('canModifyParent', () => {
+        it('always returns false to enforce the read-only contract of the connector view', () => {
+            const { component } = setup();
+            const predicate = component.canModifyParent();
+
+            expect(predicate(buildControllerService())).toBe(false);
+        });
+    });
+
+    describe('Breadcrumb route generator', () => {
+        it('produces a connector-canvas-rooted route for the supplied process group id', fakeAsync(() => {
+            const { component } = setup();
+            tick();
+
+            const generator = component.getBreadcrumbRouteGenerator();
+
+            expect(generator('pg-target')).toEqual(['/connectors', CONNECTOR_ID, 'canvas', 'pg-target']);
+        }));
+    });
+});

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-controller-services/connector-controller-services.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-controller-services/connector-controller-services.component.ts
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, OnDestroy, computed, inject, signal } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { combineLatest, distinctUntilChanged, filter } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ComponentType, isDefinedAndNotNull, TextTip } from '@nifi/shared';
+import { BreadcrumbEntity, ControllerServiceEntity } from '../../../../state/shared';
+import { selectCurrentUser } from '../../../../state/current-user/current-user.selectors';
+import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
+import { ErrorContextKey } from '../../../../state/error';
+import { getComponentStateAndOpenDialog } from '../../../../state/component-state/component-state.actions';
+import { navigateToComponentDocumentation } from '../../../../state/documentation/documentation.actions';
+import { DocumentationRequest } from '../../../../state/documentation';
+import { BreadcrumbRouteGenerator } from '../../../../ui/common/breadcrumbs/breadcrumbs.component';
+import {
+    loadConnectorControllerServices,
+    openViewControllerServiceDialog,
+    resetConnectorControllerServicesState,
+    selectConnectorControllerService
+} from '../../state/connector-controller-services/connector-controller-services.actions';
+import {
+    selectConnectorControllerServicesState,
+    selectConnectorIdFromRoute,
+    selectControllerServiceIdFromRoute,
+    selectProcessGroupIdFromRoute
+} from '../../state/connector-controller-services/connector-controller-services.selectors';
+
+/**
+ * A read-only view of controller services scoped to a connector's process group.
+ * Users can view configuration, documentation, and component state but cannot
+ * edit, enable, disable, delete, or otherwise mutate any controller service.
+ *
+ * Route: /connectors/:id/canvas/:processGroupId/controller-services
+ */
+@Component({
+    selector: 'connector-controller-services',
+    templateUrl: './connector-controller-services.component.html',
+    styleUrls: ['./connector-controller-services.component.scss'],
+    standalone: false
+})
+export class ConnectorControllerServicesComponent implements OnDestroy {
+    private store = inject(Store);
+
+    serviceState = this.store.selectSignal(selectConnectorControllerServicesState);
+    selectedServiceId$ = this.store.select(selectControllerServiceIdFromRoute);
+    currentUser$ = this.store.select(selectCurrentUser);
+    flowConfiguration$ = this.store.select(selectFlowConfiguration).pipe(isDefinedAndNotNull());
+
+    protected readonly TextTip = TextTip;
+    protected readonly ErrorContextKey = ErrorContextKey;
+
+    private currentConnectorId = '';
+    private currentProcessGroupId = '';
+
+    showCurrentScopeOnly = signal(false);
+
+    isInitialLoading = computed(() => {
+        const state = this.serviceState();
+        return state.status === 'loading' && !state.hasAttemptedLoad;
+    });
+
+    filteredControllerServices = computed(() => {
+        const state = this.serviceState();
+        if (!state) {
+            return [];
+        }
+
+        const services = state.controllerServices;
+        if (!this.showCurrentScopeOnly()) {
+            return services;
+        }
+
+        const filterFn = this.definedByCurrentGroup(state.breadcrumb);
+        return services.filter(filterFn);
+    });
+
+    shouldShowFilter = computed(() => {
+        const state = this.serviceState();
+        if (!state || !state.breadcrumb) {
+            return false;
+        }
+        return !!state.breadcrumb.parentBreadcrumb;
+    });
+
+    constructor() {
+        combineLatest([this.store.select(selectConnectorIdFromRoute), this.store.select(selectProcessGroupIdFromRoute)])
+            .pipe(
+                filter(([connectorId, processGroupId]) => connectorId != null && processGroupId != null),
+                distinctUntilChanged(
+                    ([prevConnectorId, prevProcessGroupId], [currConnectorId, currProcessGroupId]) =>
+                        prevConnectorId === currConnectorId && prevProcessGroupId === currProcessGroupId
+                ),
+                takeUntilDestroyed()
+            )
+            .subscribe(([connectorId, processGroupId]) => {
+                this.currentConnectorId = connectorId!;
+                this.currentProcessGroupId = processGroupId!;
+                this.store.dispatch(
+                    loadConnectorControllerServices({
+                        request: {
+                            connectorId: connectorId!,
+                            processGroupId: processGroupId!
+                        }
+                    })
+                );
+            });
+    }
+
+    ngOnDestroy(): void {
+        this.store.dispatch(resetConnectorControllerServicesState());
+    }
+
+    refreshControllerServiceListing(): void {
+        this.store.dispatch(
+            loadConnectorControllerServices({
+                request: {
+                    connectorId: this.currentConnectorId,
+                    processGroupId: this.currentProcessGroupId
+                }
+            })
+        );
+    }
+
+    formatScope(breadcrumb: BreadcrumbEntity | null): (entity: ControllerServiceEntity) => string {
+        if (!breadcrumb) {
+            return () => '';
+        }
+
+        const breadcrumbs: BreadcrumbEntity[] = [];
+        let currentBreadcrumb: BreadcrumbEntity | undefined = breadcrumb;
+        while (currentBreadcrumb != null) {
+            breadcrumbs.push(currentBreadcrumb);
+            currentBreadcrumb = currentBreadcrumb.parentBreadcrumb;
+        }
+
+        return (entity: ControllerServiceEntity): string => {
+            const entityBreadcrumb = breadcrumbs.find((bc) => bc.id === entity.parentGroupId);
+            if (entityBreadcrumb) {
+                if (entityBreadcrumb.permissions.canRead) {
+                    return entityBreadcrumb.breadcrumb.name;
+                }
+                return entityBreadcrumb.id;
+            }
+            return '';
+        };
+    }
+
+    definedByCurrentGroup(breadcrumb: BreadcrumbEntity | null): (entity: ControllerServiceEntity) => boolean {
+        if (!breadcrumb) {
+            return () => true;
+        }
+        return (entity: ControllerServiceEntity): boolean => breadcrumb.id === entity.parentGroupId;
+    }
+
+    /**
+     * Connector controller services are strictly read-only -- the table should
+     * never offer mutating actions regardless of the underlying parent group's
+     * permissions.
+     */
+    canModifyParent(): (entity: ControllerServiceEntity) => boolean {
+        return () => false;
+    }
+
+    selectControllerService(entity: ControllerServiceEntity): void {
+        this.store.dispatch(
+            selectConnectorControllerService({
+                request: {
+                    connectorId: this.currentConnectorId,
+                    processGroupId: this.currentProcessGroupId,
+                    serviceId: entity.id
+                }
+            })
+        );
+    }
+
+    viewControllerServiceDocumentation(entity: ControllerServiceEntity): void {
+        const request: DocumentationRequest = {
+            parameters: {
+                componentType: ComponentType.ControllerService,
+                type: entity.component.type,
+                group: entity.component.bundle.group,
+                artifact: entity.component.bundle.artifact,
+                version: entity.component.bundle.version
+            },
+            backNavigation: {
+                route: [
+                    '/connectors',
+                    this.currentConnectorId,
+                    'canvas',
+                    this.currentProcessGroupId,
+                    'controller-services',
+                    entity.id
+                ],
+                routeBoundary: ['/documentation'],
+                context: 'Controller Service'
+            }
+        };
+
+        this.store.dispatch(navigateToComponentDocumentation({ request }));
+    }
+
+    configureControllerService(entity: ControllerServiceEntity): void {
+        this.store.dispatch(openViewControllerServiceDialog({ controllerService: entity }));
+    }
+
+    /**
+     * View component state for a stateful controller service. The connector
+     * canvas dispatches with connectorId so the component-state effect targets
+     * the connector-scoped state endpoint instead of the framework endpoint.
+     */
+    viewStateControllerService(entity: ControllerServiceEntity): void {
+        this.store.dispatch(
+            getComponentStateAndOpenDialog({
+                request: {
+                    componentName: entity.component.name,
+                    componentId: entity.id,
+                    componentType: ComponentType.ControllerService,
+                    canClear: entity.component.state === 'DISABLED',
+                    connectorId: this.currentConnectorId
+                }
+            })
+        );
+    }
+
+    /**
+     * Generate a route generator for breadcrumb navigation back into the
+     * connector canvas.
+     */
+    getBreadcrumbRouteGenerator(): BreadcrumbRouteGenerator {
+        const connectorId = this.currentConnectorId;
+        return (processGroupId: string) => ['/connectors', connectorId, 'canvas', processGroupId];
+    }
+
+    toggleFilter(): void {
+        this.showCurrentScopeOnly.set(!this.showCurrentScopeOnly());
+    }
+
+    getFilterTooltip(breadcrumb: BreadcrumbEntity | null): string {
+        const processGroupName =
+            breadcrumb?.permissions.canRead && breadcrumb?.breadcrumb.name ? breadcrumb.breadcrumb.name : 'this group';
+        return `Only show the Controller Services defined in the current Process Group: '${processGroupName}'`;
+    }
+}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-controller-services/connector-controller-services.module.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-controller-services/connector-controller-services.module.ts
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+import { NifiTooltipDirective } from '@nifi/shared';
+import { ControllerServiceTable } from '../../../../ui/common/controller-service/controller-service-table/controller-service-table.component';
+import { Breadcrumbs } from '../../../../ui/common/breadcrumbs/breadcrumbs.component';
+import { Navigation } from '../../../../ui/common/navigation/navigation.component';
+import { ContextErrorBanner } from '../../../../ui/common/context-error-banner/context-error-banner.component';
+import { connectorControllerServicesFeatureKey } from '../../state/connector-controller-services';
+import { connectorControllerServicesReducer } from '../../state/connector-controller-services/connector-controller-services.reducer';
+import { ConnectorControllerServicesEffects } from '../../state/connector-controller-services/connector-controller-services.effects';
+import { ConnectorControllerServicesComponent } from './connector-controller-services.component';
+
+const routes: Routes = [
+    {
+        path: '',
+        component: ConnectorControllerServicesComponent,
+        children: [
+            {
+                path: ':serviceId',
+                component: ConnectorControllerServicesComponent
+            }
+        ]
+    }
+];
+
+@NgModule({
+    declarations: [ConnectorControllerServicesComponent],
+    exports: [ConnectorControllerServicesComponent],
+    imports: [
+        CommonModule,
+        FormsModule,
+        RouterModule.forChild(routes),
+        StoreModule.forFeature(connectorControllerServicesFeatureKey, connectorControllerServicesReducer),
+        EffectsModule.forFeature(ConnectorControllerServicesEffects),
+        MatButtonModule,
+        MatCheckboxModule,
+        NgxSkeletonLoaderModule,
+        NifiTooltipDirective,
+        Breadcrumbs,
+        ContextErrorBanner,
+        ControllerServiceTable,
+        Navigation
+    ]
+})
+export class ConnectorControllerServicesModule {}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/feature/flow-designer.module.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/feature/flow-designer.module.ts
@@ -27,7 +27,6 @@ import { canvasFeatureKey, reducers } from '../state';
 import { MatDialogModule } from '@angular/material/dialog';
 import { ControllerServicesEffects } from '../state/controller-services/controller-services.effects';
 import { ParameterEffects } from '../state/parameter/parameter.effects';
-import { QueueEffects } from '../state/queue/queue.effects';
 import { BannerText } from '../../../ui/common/banner-text/banner-text.component';
 import { FlowAnalysisEffects } from '../state/flow-analysis/flow-analysis.effects';
 import { ComponentTypeNamePipe } from '@nifi/shared';
@@ -44,7 +43,6 @@ import { ComponentTypeNamePipe } from '@nifi/shared';
             TransformEffects,
             ControllerServicesEffects,
             ParameterEffects,
-            QueueEffects,
             FlowAnalysisEffects
         ),
         NgOptimizedImage,

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/behavior/connectable-behavior.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/behavior/connectable-behavior.service.spec.ts
@@ -33,8 +33,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
 
@@ -47,7 +45,6 @@ describe('ConnectableBehavior', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/behavior/draggable-behavior.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/behavior/draggable-behavior.service.spec.ts
@@ -34,8 +34,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
 
@@ -48,7 +46,6 @@ describe('DraggableBehavior', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/behavior/editable-behavior.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/behavior/editable-behavior.service.spec.ts
@@ -34,8 +34,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
 
@@ -47,7 +45,6 @@ describe('EditableBehaviorService', () => {
         [transformFeatureKey]: fromTransform.initialState,
         [controllerServicesFeatureKey]: fromControllerServices.initialState,
         [parameterFeatureKey]: fromParameter.initialState,
-        [queueFeatureKey]: fromQueue.initialState,
         [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
     };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/behavior/quick-select-behavior.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/behavior/quick-select-behavior.service.spec.ts
@@ -33,8 +33,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
 
@@ -47,7 +45,6 @@ describe('QuickSelectBehavior', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/behavior/selectable-behavior.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/behavior/selectable-behavior.service.spec.ts
@@ -32,8 +32,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
 
@@ -46,7 +44,6 @@ describe('SelectableBehavior', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/birdseye-view.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/birdseye-view.service.spec.ts
@@ -34,8 +34,6 @@ import { parameterFeatureKey } from '../state/parameter';
 import * as fromParameter from '../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../queue/state';
-import * as fromQueue from '../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../state/flow-analysis';
 import * as fromFlowAnalysis from '../state/flow-analysis/flow-analysis.reducer';
 
@@ -48,7 +46,6 @@ describe('BirdseyeView', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-actions.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-actions.service.spec.ts
@@ -35,8 +35,6 @@ import { controllerServicesFeatureKey } from '../state/controller-services';
 import * as fromControllerServices from '../state/controller-services/controller-services.reducer';
 import { parameterFeatureKey } from '../state/parameter';
 import * as fromParameter from '../state/parameter/parameter.reducer';
-import { queueFeatureKey } from '../../queue/state';
-import * as fromQueue from '../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../state/flow-analysis';
 import * as fromFlowAnalysis from '../state/flow-analysis/flow-analysis.reducer';
 import * as FlowActions from '../state/flow/flow.actions';
@@ -57,7 +55,6 @@ describe('CanvasActionsService', () => {
         [transformFeatureKey]: fromTransform.initialState,
         [controllerServicesFeatureKey]: fromControllerServices.initialState,
         [parameterFeatureKey]: fromParameter.initialState,
-        [queueFeatureKey]: fromQueue.initialState,
         [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
     };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
@@ -64,7 +64,7 @@ import {
     ContextMenuDefinitionProvider,
     ContextMenuItemDefinition
 } from '../../../ui/common/context-menu/context-menu.component';
-import { promptEmptyQueueRequest, promptEmptyQueuesRequest } from '../state/queue/queue.actions';
+import { promptEmptyQueueRequest, promptEmptyQueuesRequest } from '../../../state/empty-queue/empty-queue.actions';
 import { getComponentStateAndOpenDialog } from '../../../state/component-state/component-state.actions';
 import { navigateToComponentDocumentation } from '../../../state/documentation/documentation.actions';
 import * as d3 from 'd3';
@@ -1334,7 +1334,8 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
                     this.store.dispatch(
                         promptEmptyQueueRequest({
                             request: {
-                                connectionId: selectionData.id
+                                connectionId: selectionData.id,
+                                source: 'flow-designer'
                             }
                         })
                     );
@@ -1358,7 +1359,8 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
                     this.store.dispatch(
                         promptEmptyQueuesRequest({
                             request: {
-                                processGroupId
+                                processGroupId,
+                                source: 'flow-designer'
                             }
                         })
                     );

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.spec.ts
@@ -33,8 +33,6 @@ import { parameterFeatureKey } from '../state/parameter';
 import * as fromParameter from '../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../queue/state';
-import * as fromQueue from '../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../state/flow-analysis';
 import * as fromFlowAnalysis from '../state/flow-analysis/flow-analysis.reducer';
 import { ComponentType, BulletinEntity } from '@nifi/shared';
@@ -49,7 +47,6 @@ describe('CanvasUtils', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-view.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-view.service.spec.ts
@@ -34,8 +34,6 @@ import { parameterFeatureKey } from '../state/parameter';
 import * as fromParameter from '../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../queue/state';
-import * as fromQueue from '../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../state/flow-analysis';
 import * as fromFlowAnalysis from '../state/flow-analysis/flow-analysis.reducer';
 
@@ -48,7 +46,6 @@ describe('CanvasView', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/connection-manager.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/connection-manager.service.spec.ts
@@ -34,8 +34,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { ClusterConnectionService } from '../../../../service/cluster-connection.service';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
@@ -49,7 +47,6 @@ describe('ConnectionManager', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/funnel-manager.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/funnel-manager.service.spec.ts
@@ -34,8 +34,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
 
@@ -48,7 +46,6 @@ describe('FunnelManager', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/label-manager.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/label-manager.service.spec.ts
@@ -34,8 +34,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { ClusterConnectionService } from '../../../../service/cluster-connection.service';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
@@ -49,7 +47,6 @@ describe('LabelManager', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/port-manager.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/port-manager.service.spec.ts
@@ -34,8 +34,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
 
@@ -48,7 +46,6 @@ describe('PortManager', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/process-group-manager.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/process-group-manager.service.spec.ts
@@ -34,8 +34,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
 
@@ -48,7 +46,6 @@ describe('ProcessGroupManager', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/processor-manager.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/processor-manager.service.spec.ts
@@ -34,8 +34,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
 
@@ -48,7 +46,6 @@ describe('ProcessorManager', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/remote-process-group-manager.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/remote-process-group-manager.service.spec.ts
@@ -34,8 +34,6 @@ import { parameterFeatureKey } from '../../state/parameter';
 import * as fromParameter from '../../state/parameter/parameter.reducer';
 import { selectFlowConfiguration } from '../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../state/flow-configuration/flow-configuration.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import * as fromFlowAnalysis from '../../state/flow-analysis/flow-analysis.reducer';
 
@@ -48,7 +46,6 @@ describe('RemoteProcessGroupManager', () => {
             [transformFeatureKey]: fromTransform.initialState,
             [controllerServicesFeatureKey]: fromControllerServices.initialState,
             [parameterFeatureKey]: fromParameter.initialState,
-            [queueFeatureKey]: fromQueue.initialState,
             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
         };
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.spec.ts
@@ -75,10 +75,10 @@ import { controllerServicesFeatureKey } from '../controller-services';
 import * as fromControllerServices from '../controller-services/controller-services.reducer';
 import { parameterFeatureKey } from '../parameter';
 import * as fromParameter from '../parameter/parameter.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import * as fromQueue from '../queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../flow-analysis';
 import * as fromFlowAnalysis from '../flow-analysis/flow-analysis.reducer';
+import * as EmptyQueueActions from '../../../../state/empty-queue/empty-queue.actions';
+import { firstValueFrom } from 'rxjs';
 
 describe('FlowEffects', () => {
     let action$: ReplaySubject<Action>;
@@ -801,7 +801,6 @@ describe('FlowEffects', () => {
                             [transformFeatureKey]: fromTransform.initialState,
                             [controllerServicesFeatureKey]: fromControllerServices.initialState,
                             [parameterFeatureKey]: fromParameter.initialState,
-                            [queueFeatureKey]: fromQueue.initialState,
                             [flowAnalysisFeatureKey]: fromFlowAnalysis.initialState
                         }
                     },
@@ -1208,6 +1207,85 @@ describe('FlowEffects', () => {
                     request: { id: childGroupId }
                 })
             );
+        });
+    });
+
+    describe('refreshAfterQueueEmptied$', () => {
+        it('should dispatch loadConnection when the queueEmptied originates from the flow designer with a connectionId', async () => {
+            store.overrideSelector(selectCurrentProcessGroupId, 'pg-current');
+            store.refreshState();
+
+            action$.next(
+                EmptyQueueActions.queueEmptied({
+                    connectionId: 'conn-1',
+                    processGroupId: null,
+                    source: 'flow-designer'
+                })
+            );
+
+            const result = await firstValueFrom(effects.refreshAfterQueueEmptied$.pipe(take(1)));
+
+            expect(result).toEqual(FlowActions.loadConnection({ id: 'conn-1' }));
+        });
+
+        it('should dispatch loadProcessGroup when emptying queues for the currently viewed process group', async () => {
+            store.overrideSelector(selectCurrentProcessGroupId, 'pg-current');
+            store.refreshState();
+
+            action$.next(
+                EmptyQueueActions.queueEmptied({
+                    connectionId: null,
+                    processGroupId: 'pg-current',
+                    source: 'flow-designer'
+                })
+            );
+
+            const result = await firstValueFrom(effects.refreshAfterQueueEmptied$.pipe(take(1)));
+
+            expect(result).toEqual(
+                FlowActions.loadProcessGroup({
+                    request: { id: 'pg-current', transitionRequired: false }
+                })
+            );
+        });
+
+        it('should dispatch loadChildProcessGroup when emptying queues for a non-current process group', async () => {
+            store.overrideSelector(selectCurrentProcessGroupId, 'pg-current');
+            store.refreshState();
+
+            action$.next(
+                EmptyQueueActions.queueEmptied({
+                    connectionId: null,
+                    processGroupId: 'pg-child',
+                    source: 'flow-designer'
+                })
+            );
+
+            const result = await firstValueFrom(effects.refreshAfterQueueEmptied$.pipe(take(1)));
+
+            expect(result).toEqual(FlowActions.loadChildProcessGroup({ request: { id: 'pg-child' } }));
+        });
+
+        it('should ignore queueEmptied actions originating from other sources', async () => {
+            store.overrideSelector(selectCurrentProcessGroupId, 'pg-current');
+            store.refreshState();
+
+            const emissions: Action[] = [];
+            const subscription = effects.refreshAfterQueueEmptied$.subscribe((action) => emissions.push(action));
+
+            action$.next(
+                EmptyQueueActions.queueEmptied({
+                    connectionId: 'conn-1',
+                    processGroupId: null,
+                    source: 'connector-canvas'
+                })
+            );
+
+            await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+            subscription.unsubscribe();
+
+            expect(emissions).toEqual([]);
         });
     });
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -31,6 +31,7 @@ import {
 import * as StatusHistoryActions from '../../../../state/status-history/status-history.actions';
 import * as ErrorActions from '../../../../state/error/error.actions';
 import * as CopyActions from '../../../../state/copy/copy.actions';
+import * as EmptyQueueActions from '../../../../state/empty-queue/empty-queue.actions';
 import {
     asyncScheduler,
     catchError,
@@ -4760,6 +4761,46 @@ export class FlowEffects {
                         })
                     );
                 }
+            })
+        )
+    );
+
+    /**
+     * Refreshes the affected connection or process group after a queue has been emptied
+     * from the flow designer. Listens for the shared queueEmptied event and filters on
+     * source so that connector-canvas-initiated empties do not trigger flow-designer
+     * refreshes.
+     */
+    refreshAfterQueueEmptied$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(EmptyQueueActions.queueEmptied),
+            filter((action) => action.source === 'flow-designer'),
+            concatLatestFrom(() => this.store.select(selectCurrentProcessGroupId)),
+            switchMap(([action, currentProcessGroupId]) => {
+                const refreshActions: Action[] = [];
+
+                if (action.connectionId) {
+                    refreshActions.push(FlowActions.loadConnection({ id: action.connectionId }));
+                } else if (action.processGroupId) {
+                    if (action.processGroupId === currentProcessGroupId) {
+                        refreshActions.push(
+                            FlowActions.loadProcessGroup({
+                                request: {
+                                    id: action.processGroupId,
+                                    transitionRequired: false
+                                }
+                            })
+                        );
+                    } else {
+                        refreshActions.push(
+                            FlowActions.loadChildProcessGroup({
+                                request: { id: action.processGroupId }
+                            })
+                        );
+                    }
+                }
+
+                return from(refreshActions);
             })
         )
     );

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/index.ts
@@ -28,9 +28,6 @@ import { controllerServicesFeatureKey, ControllerServicesState } from './control
 import { controllerServicesReducer } from './controller-services/controller-services.reducer';
 import { parameterFeatureKey, ParameterState } from './parameter';
 import { parameterReducer } from './parameter/parameter.reducer';
-import { queueFeatureKey } from '../../queue/state';
-import { QueueState } from './queue';
-import { queueReducer } from './queue/queue.reducer';
 import { FlowAnalysisState, flowAnalysisFeatureKey } from './flow-analysis';
 import { flowAnalysisReducer } from './flow-analysis/flow-analysis.reducer';
 
@@ -41,7 +38,6 @@ export interface CanvasState {
     [transformFeatureKey]: CanvasTransform;
     [controllerServicesFeatureKey]: ControllerServicesState;
     [parameterFeatureKey]: ParameterState;
-    [queueFeatureKey]: QueueState;
     [flowAnalysisFeatureKey]: FlowAnalysisState;
 }
 
@@ -51,7 +47,6 @@ export function reducers(state: CanvasState | undefined, action: Action) {
         [transformFeatureKey]: transformReducer,
         [controllerServicesFeatureKey]: controllerServicesReducer,
         [parameterFeatureKey]: parameterReducer,
-        [queueFeatureKey]: queueReducer,
         [flowAnalysisFeatureKey]: flowAnalysisReducer
     })(state, action);
 }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.spec.ts
@@ -48,8 +48,6 @@ import { controllerServicesFeatureKey } from '../../state/controller-services';
 import { initialState as initialControllerServicesState } from '../../state/controller-services/controller-services.reducer';
 import { parameterFeatureKey } from '../../state/parameter';
 import { initialState as initialParameterState } from '../../state/parameter/parameter.reducer';
-import { queueFeatureKey } from '../../../queue/state';
-import { initialState as initialQueueState } from '../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../state/flow-analysis';
 import { initialState as initialFlowAnalysisState } from '../../state/flow-analysis/flow-analysis.reducer';
 import { selectUrl } from '@nifi/shared';
@@ -98,7 +96,6 @@ describe('Canvas', () => {
                             [transformFeatureKey]: initialTransformState,
                             [controllerServicesFeatureKey]: initialControllerServicesState,
                             [parameterFeatureKey]: initialParameterState,
-                            [queueFeatureKey]: initialQueueState,
                             [flowAnalysisFeatureKey]: initialFlowAnalysisState
                         }
                     },

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/change-color-dialog/change-color-dialog.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/change-color-dialog/change-color-dialog.component.spec.ts
@@ -33,8 +33,6 @@ import { controllerServicesFeatureKey } from '../../../state/controller-services
 import { initialState as initialControllerServicesState } from '../../../state/controller-services/controller-services.reducer';
 import { parameterFeatureKey } from '../../../state/parameter';
 import { initialState as initialParameterState } from '../../../state/parameter/parameter.reducer';
-import { queueFeatureKey } from '../../../../queue/state';
-import { initialState as initialQueueState } from '../../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../../state/flow-analysis';
 import { initialState as initialFlowAnalysisState } from '../../../state/flow-analysis/flow-analysis.reducer';
 import { selectFlowState } from '../../../state/flow/flow.selectors';
@@ -74,7 +72,6 @@ describe('ChangeColorDialog', () => {
                             [transformFeatureKey]: initialTransformState,
                             [controllerServicesFeatureKey]: initialControllerServicesState,
                             [parameterFeatureKey]: initialParameterState,
-                            [queueFeatureKey]: initialQueueState,
                             [flowAnalysisFeatureKey]: initialFlowAnalysisState
                         }
                     },

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/navigation-control.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/navigation-control.component.spec.ts
@@ -34,8 +34,6 @@ import { controllerServicesFeatureKey } from '../../../../state/controller-servi
 import { initialState as initialControllerServicesState } from '../../../../state/controller-services/controller-services.reducer';
 import { parameterFeatureKey } from '../../../../state/parameter';
 import { initialState as initialParameterState } from '../../../../state/parameter/parameter.reducer';
-import { queueFeatureKey } from '../../../../../queue/state';
-import { initialState as initialQueueState } from '../../../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../../../state/flow-analysis';
 import { initialState as initialFlowAnalysisState } from '../../../../state/flow-analysis/flow-analysis.reducer';
 import { selectFlowState } from '../../../../state/flow/flow.selectors';
@@ -65,7 +63,6 @@ describe('NavigationControl', () => {
                             [transformFeatureKey]: initialTransformState,
                             [controllerServicesFeatureKey]: initialControllerServicesState,
                             [parameterFeatureKey]: initialParameterState,
-                            [queueFeatureKey]: initialQueueState,
                             [flowAnalysisFeatureKey]: initialFlowAnalysisState
                         }
                     },

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/create-connection/create-connection.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/create-connection/create-connection.component.spec.ts
@@ -27,8 +27,6 @@ import { controllerServicesFeatureKey } from '../../../../../state/controller-se
 import { initialState as initialControllerServicesState } from '../../../../../state/controller-services/controller-services.reducer';
 import { parameterFeatureKey } from '../../../../../state/parameter';
 import { initialState as initialParameterState } from '../../../../../state/parameter/parameter.reducer';
-import { queueFeatureKey } from '../../../../../../queue/state';
-import { initialState as initialQueueState } from '../../../../../state/queue/queue.reducer';
 import { flowAnalysisFeatureKey } from '../../../../../state/flow-analysis';
 import { initialState as initialFlowAnalysisState } from '../../../../../state/flow-analysis/flow-analysis.reducer';
 import { flowConfigurationFeatureKey } from '../../../../../../../state/flow-configuration';
@@ -184,7 +182,6 @@ describe('CreateConnection', () => {
                             [transformFeatureKey]: initialTransformState,
                             [controllerServicesFeatureKey]: initialControllerServicesState,
                             [parameterFeatureKey]: initialParameterState,
-                            [queueFeatureKey]: initialQueueState,
                             [flowAnalysisFeatureKey]: initialFlowAnalysisState
                         }
                     }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/service/empty-queue.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/service/empty-queue.service.ts
@@ -23,49 +23,49 @@ import {
     EmptyQueuesRequest,
     SubmitEmptyQueueRequest,
     SubmitEmptyQueuesRequest
-} from '../state/queue';
+} from '../state/empty-queue';
 
 @Injectable({ providedIn: 'root' })
-export class QueueService {
+export class EmptyQueueService {
     private httpClient = inject(HttpClient);
 
     private static readonly API: string = '../nifi-api';
 
     submitEmptyQueueRequest(emptyQueueRequest: SubmitEmptyQueueRequest): Observable<any> {
         return this.httpClient.post(
-            `${QueueService.API}/flowfile-queues/${emptyQueueRequest.connectionId}/drop-requests`,
+            `${EmptyQueueService.API}/flowfile-queues/${emptyQueueRequest.connectionId}/drop-requests`,
             {}
         );
     }
 
     submitEmptyQueuesRequest(emptyQueuesRequest: SubmitEmptyQueuesRequest): Observable<any> {
         return this.httpClient.post(
-            `${QueueService.API}/process-groups/${emptyQueuesRequest.processGroupId}/empty-all-connections-requests`,
+            `${EmptyQueueService.API}/process-groups/${emptyQueuesRequest.processGroupId}/empty-all-connections-requests`,
             {}
         );
     }
 
     pollEmptyQueueRequest(request: EmptyQueueRequest): Observable<any> {
         return this.httpClient.get(
-            `${QueueService.API}/flowfile-queues/${request.connectionId}/drop-requests/${request.dropRequestId}`
+            `${EmptyQueueService.API}/flowfile-queues/${request.connectionId}/drop-requests/${request.dropRequestId}`
         );
     }
 
     deleteEmptyQueueRequest(request: EmptyQueueRequest): Observable<any> {
         return this.httpClient.delete(
-            `${QueueService.API}/flowfile-queues/${request.connectionId}/drop-requests/${request.dropRequestId}`
+            `${EmptyQueueService.API}/flowfile-queues/${request.connectionId}/drop-requests/${request.dropRequestId}`
         );
     }
 
     pollEmptyQueuesRequest(request: EmptyQueuesRequest): Observable<any> {
         return this.httpClient.get(
-            `${QueueService.API}/process-groups/${request.processGroupId}/empty-all-connections-requests/${request.dropRequestId}`
+            `${EmptyQueueService.API}/process-groups/${request.processGroupId}/empty-all-connections-requests/${request.dropRequestId}`
         );
     }
 
     deleteEmptyQueuesRequest(request: EmptyQueuesRequest): Observable<any> {
         return this.httpClient.delete(
-            `${QueueService.API}/process-groups/${request.processGroupId}/empty-all-connections-requests/${request.dropRequestId}`
+            `${EmptyQueueService.API}/process-groups/${request.processGroupId}/empty-all-connections-requests/${request.dropRequestId}`
         );
     }
 }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.actions.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.actions.ts
@@ -22,52 +22,68 @@ import {
     SubmitEmptyQueueRequest,
     SubmitEmptyQueuesRequest
 } from './index';
+import { CanvasActionSource } from '../shared';
 
-const QUEUE_PREFIX = '[Queue]';
+const EMPTY_QUEUE_PREFIX = '[Empty Queue]';
 
-export const queueApiError = createAction(`${QUEUE_PREFIX} Queue Error`, props<{ error: string }>());
+export const emptyQueueApiError = createAction(`${EMPTY_QUEUE_PREFIX} API Error`, props<{ error: string }>());
 
-export const resetQueueState = createAction(`${QUEUE_PREFIX} Reset Queue State`);
+export const resetEmptyQueueState = createAction(`${EMPTY_QUEUE_PREFIX} Reset State`);
 
 export const promptEmptyQueueRequest = createAction(
-    `${QUEUE_PREFIX} Prompt Empty Queue Request`,
+    `${EMPTY_QUEUE_PREFIX} Prompt Empty Queue Request`,
     props<{ request: SubmitEmptyQueueRequest }>()
 );
 
 export const submitEmptyQueueRequest = createAction(
-    `${QUEUE_PREFIX} Submit Empty Queue Request`,
+    `${EMPTY_QUEUE_PREFIX} Submit Empty Queue Request`,
     props<{ request: SubmitEmptyQueueRequest }>()
 );
 
 export const promptEmptyQueuesRequest = createAction(
-    `${QUEUE_PREFIX} Prompt Empty Queues Request`,
+    `${EMPTY_QUEUE_PREFIX} Prompt Empty Queues Request`,
     props<{ request: SubmitEmptyQueuesRequest }>()
 );
 
 export const submitEmptyQueuesRequest = createAction(
-    `${QUEUE_PREFIX} Submit Empty Queues Request`,
+    `${EMPTY_QUEUE_PREFIX} Submit Empty Queues Request`,
     props<{ request: SubmitEmptyQueuesRequest }>()
 );
 
 export const submitEmptyQueueRequestSuccess = createAction(
-    `${QUEUE_PREFIX} Submit Empty Queue Request Success`,
+    `${EMPTY_QUEUE_PREFIX} Submit Empty Queue Request Success`,
     props<{ response: PollEmptyQueueSuccess }>()
 );
 
-export const startPollingEmptyQueueRequest = createAction(`${QUEUE_PREFIX} Start Polling Empty Queue Request`);
+export const submitEmptyQueuesRequestSuccess = createAction(
+    `${EMPTY_QUEUE_PREFIX} Submit Empty Queues Request Success`,
+    props<{ response: PollEmptyQueueSuccess }>()
+);
 
-export const pollEmptyQueueRequest = createAction(`${QUEUE_PREFIX} Poll Empty Queue Request`);
+export const startPollingEmptyQueueRequest = createAction(`${EMPTY_QUEUE_PREFIX} Start Polling Empty Queue Request`);
+
+export const pollEmptyQueueRequest = createAction(`${EMPTY_QUEUE_PREFIX} Poll Empty Queue Request`);
 
 export const pollEmptyQueueRequestSuccess = createAction(
-    `${QUEUE_PREFIX} Poll Empty Queue Request Success`,
+    `${EMPTY_QUEUE_PREFIX} Poll Empty Queue Request Success`,
     props<{ response: PollEmptyQueueSuccess }>()
 );
 
-export const stopPollingEmptyQueueRequest = createAction(`${QUEUE_PREFIX} Stop Polling Empty Queue Request`);
+export const stopPollingEmptyQueueRequest = createAction(`${EMPTY_QUEUE_PREFIX} Stop Polling Empty Queue Request`);
 
-export const deleteEmptyQueueRequest = createAction(`${QUEUE_PREFIX} Delete Empty Queue Request`);
+export const deleteEmptyQueueRequest = createAction(`${EMPTY_QUEUE_PREFIX} Delete Empty Queue Request`);
 
 export const showEmptyQueueResults = createAction(
-    `${QUEUE_PREFIX} Show Empty Queue Results`,
+    `${EMPTY_QUEUE_PREFIX} Show Empty Queue Results`,
     props<{ request: ShowEmptyQueueResults }>()
+);
+
+/**
+ * Event dispatched when a queue (or all queues in a process group) has been emptied.
+ * Page-specific effects (flow-designer, connector-canvas) subscribe to this and filter
+ * on `source` to refresh their respective views.
+ */
+export const queueEmptied = createAction(
+    `${EMPTY_QUEUE_PREFIX} Queue Emptied`,
+    props<{ connectionId: string | null; processGroupId: string | null; source: CanvasActionSource }>()
 );

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.effects.spec.ts
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { Action } from '@ngrx/store';
+import { MatDialog } from '@angular/material/dialog';
+import { firstValueFrom, Observable, of, Subject } from 'rxjs';
+import { EmptyQueueEffects } from './empty-queue.effects';
+import {
+    deleteEmptyQueueRequest,
+    emptyQueueApiError,
+    pollEmptyQueueRequest,
+    queueEmptied,
+    showEmptyQueueResults,
+    submitEmptyQueueRequestSuccess,
+    submitEmptyQueuesRequest,
+    submitEmptyQueuesRequestSuccess
+} from './empty-queue.actions';
+import {
+    selectDropConnectionId,
+    selectDropProcessGroupId,
+    selectDropRequestEntity,
+    selectDropSource
+} from './empty-queue.selectors';
+import { EmptyQueueService } from '../../service/empty-queue.service';
+import { ErrorHelper } from '../../service/error-helper.service';
+import { CanvasActionSource } from '../shared';
+import { DropRequestEntity } from './index';
+
+function createDropEntity(overrides: Partial<DropRequestEntity['dropRequest']> = {}): DropRequestEntity {
+    return {
+        dropRequest: {
+            id: 'drop-1',
+            uri: 'http://example/drop-requests/drop-1',
+            submissionTime: '2023-01-01T00:00:00Z',
+            lastUpdated: '2023-01-01T00:00:01Z',
+            percentCompleted: 100,
+            finished: true,
+            failureReason: '',
+            currentCount: 0,
+            currentSize: 0,
+            current: '0 / 0 bytes',
+            originalCount: 5,
+            originalSize: 100,
+            original: '5 / 100 bytes',
+            droppedCount: 5,
+            droppedSize: 100,
+            dropped: '5 / 100 bytes',
+            state: 'COMPLETE',
+            ...overrides
+        }
+    };
+}
+
+describe('EmptyQueueEffects', () => {
+    async function setup(
+        options: {
+            connectionId?: string | null;
+            processGroupId?: string | null;
+            source?: CanvasActionSource | null;
+            dropEntity?: DropRequestEntity | null;
+            emptyQueueService?: Partial<EmptyQueueService>;
+        } = {}
+    ) {
+        let actions$: Observable<Action>;
+
+        const okDialogClosed$ = new Subject<void>();
+        const mockDialog = {
+            open: vi.fn().mockReturnValue({
+                componentInstance: {
+                    yes: of(),
+                    exit: of()
+                },
+                afterClosed: () => okDialogClosed$
+            }),
+            closeAll: vi.fn()
+        };
+
+        await TestBed.configureTestingModule({
+            providers: [
+                EmptyQueueEffects,
+                provideMockActions(() => actions$),
+                provideMockStore({
+                    initialState: {},
+                    selectors: [
+                        {
+                            selector: selectDropConnectionId,
+                            value: options.connectionId !== undefined ? options.connectionId : null
+                        },
+                        {
+                            selector: selectDropProcessGroupId,
+                            value: options.processGroupId !== undefined ? options.processGroupId : null
+                        },
+                        {
+                            selector: selectDropSource,
+                            value: options.source !== undefined ? options.source : null
+                        },
+                        {
+                            selector: selectDropRequestEntity,
+                            value: options.dropEntity !== undefined ? options.dropEntity : null
+                        }
+                    ]
+                }),
+                { provide: MatDialog, useValue: mockDialog },
+                {
+                    provide: EmptyQueueService,
+                    useValue: { submitEmptyQueueRequest: vi.fn(), ...(options.emptyQueueService ?? {}) }
+                },
+                { provide: ErrorHelper, useValue: { getErrorString: vi.fn() } }
+            ]
+        }).compileComponents();
+
+        const effects = TestBed.inject(EmptyQueueEffects);
+        const store = TestBed.inject(MockStore);
+        const dispatchSpy = vi.spyOn(store, 'dispatch');
+
+        return {
+            effects,
+            store,
+            dispatchSpy,
+            mockDialog,
+            actions$: (stream: Observable<Action>) => {
+                actions$ = stream;
+            }
+        };
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('submitEmptyQueuesRequest$', () => {
+        it('should dispatch submitEmptyQueuesRequestSuccess for the bulk path so success handlers can distinguish single vs bulk submits', async () => {
+            const dropEntity = createDropEntity({ finished: false, percentCompleted: 25 });
+            const { effects, actions$ } = await setup({
+                emptyQueueService: {
+                    submitEmptyQueuesRequest: vi.fn().mockReturnValue(of(dropEntity))
+                }
+            });
+            actions$(
+                of(
+                    submitEmptyQueuesRequest({
+                        request: { processGroupId: 'pg-1', source: 'flow-designer' }
+                    })
+                )
+            );
+
+            const action = await firstValueFrom(effects.submitEmptyQueuesRequest$);
+
+            expect(action).toEqual(submitEmptyQueuesRequestSuccess({ response: { dropEntity } }));
+        });
+    });
+
+    describe('submitEmptyQueueRequestSuccess$', () => {
+        it('should request deletion when the drop request is finished', async () => {
+            const { effects, actions$ } = await setup();
+            actions$(
+                of(
+                    submitEmptyQueueRequestSuccess({
+                        response: { dropEntity: createDropEntity({ finished: true }) }
+                    })
+                )
+            );
+
+            const action = await firstValueFrom(effects.submitEmptyQueueRequestSuccess$);
+
+            expect(action.type).toBe('[Empty Queue] Delete Empty Queue Request');
+        });
+
+        it('should also react to the bulk submitEmptyQueuesRequestSuccess action', async () => {
+            const { effects, actions$ } = await setup();
+            actions$(
+                of(
+                    submitEmptyQueuesRequestSuccess({
+                        response: { dropEntity: createDropEntity({ finished: false, percentCompleted: 50 }) }
+                    })
+                )
+            );
+
+            const action = await firstValueFrom(effects.submitEmptyQueueRequestSuccess$);
+
+            expect(action.type).toBe('[Empty Queue] Start Polling Empty Queue Request');
+        });
+
+        it('should start polling when the drop request is not finished', async () => {
+            const { effects, actions$ } = await setup();
+            actions$(
+                of(
+                    submitEmptyQueueRequestSuccess({
+                        response: { dropEntity: createDropEntity({ finished: false, percentCompleted: 50 }) }
+                    })
+                )
+            );
+
+            const action = await firstValueFrom(effects.submitEmptyQueueRequestSuccess$);
+
+            expect(action.type).toBe('[Empty Queue] Start Polling Empty Queue Request');
+        });
+    });
+
+    describe('showEmptyQueueResults$', () => {
+        async function runShowResults(
+            options: {
+                connectionId?: string | null;
+                processGroupId?: string | null;
+                source?: CanvasActionSource | null;
+            } = {}
+        ) {
+            const ctx = await setup(options);
+            ctx.actions$(
+                of(
+                    showEmptyQueueResults({
+                        request: { dropEntity: createDropEntity() }
+                    })
+                )
+            );
+            await firstValueFrom(ctx.effects.showEmptyQueueResults$);
+            return ctx;
+        }
+
+        it('should dispatch queueEmptied with the captured source for a connector-canvas connection empty', async () => {
+            const { dispatchSpy } = await runShowResults({
+                connectionId: 'conn-1',
+                processGroupId: null,
+                source: 'connector-canvas'
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                queueEmptied({
+                    connectionId: 'conn-1',
+                    processGroupId: null,
+                    source: 'connector-canvas'
+                })
+            );
+        });
+
+        it('should dispatch queueEmptied with the process group id for an empty-all-queues from flow designer', async () => {
+            const { dispatchSpy } = await runShowResults({
+                connectionId: null,
+                processGroupId: 'pg-1',
+                source: 'flow-designer'
+            });
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                queueEmptied({
+                    connectionId: null,
+                    processGroupId: 'pg-1',
+                    source: 'flow-designer'
+                })
+            );
+        });
+
+        it('should not dispatch queueEmptied when no source is captured in state', async () => {
+            const { dispatchSpy } = await runShowResults({
+                connectionId: 'conn-1',
+                processGroupId: null,
+                source: null
+            });
+
+            const queueEmptiedDispatches = dispatchSpy.mock.calls.filter(
+                (call) => (call[0] as { type: string }).type === queueEmptied.type
+            );
+            expect(queueEmptiedDispatches).toHaveLength(0);
+        });
+    });
+
+    describe('pollEmptyQueueRequest$', () => {
+        it('should dispatch emptyQueueApiError when neither connectionId nor processGroupId is set', async () => {
+            const pollEmptyQueueRequestSpy = vi.fn();
+            const pollEmptyQueuesRequestSpy = vi.fn();
+            const { effects, actions$ } = await setup({
+                connectionId: null,
+                processGroupId: null,
+                dropEntity: createDropEntity(),
+                emptyQueueService: {
+                    pollEmptyQueueRequest: pollEmptyQueueRequestSpy,
+                    pollEmptyQueuesRequest: pollEmptyQueuesRequestSpy
+                }
+            });
+            actions$(of(pollEmptyQueueRequest()));
+
+            const action = await firstValueFrom(effects.pollEmptyQueueRequest$);
+
+            expect(action).toEqual(
+                emptyQueueApiError({
+                    error: 'Unable to poll empty queue request: no connection or process group is associated with the active request.'
+                })
+            );
+            expect(pollEmptyQueueRequestSpy).not.toHaveBeenCalled();
+            expect(pollEmptyQueuesRequestSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('deleteEmptyQueueRequest$', () => {
+        it('should dispatch emptyQueueApiError when neither connectionId nor processGroupId is set', async () => {
+            const deleteEmptyQueueRequestSpy = vi.fn();
+            const deleteEmptyQueuesRequestSpy = vi.fn();
+            const { effects, actions$, mockDialog } = await setup({
+                connectionId: null,
+                processGroupId: null,
+                dropEntity: createDropEntity(),
+                emptyQueueService: {
+                    deleteEmptyQueueRequest: deleteEmptyQueueRequestSpy,
+                    deleteEmptyQueuesRequest: deleteEmptyQueuesRequestSpy
+                }
+            });
+            actions$(of(deleteEmptyQueueRequest()));
+
+            const action = await firstValueFrom(effects.deleteEmptyQueueRequest$);
+
+            expect(action).toEqual(
+                emptyQueueApiError({
+                    error: 'Unable to delete empty queue request: no connection or process group is associated with the active request.'
+                })
+            );
+            expect(deleteEmptyQueueRequestSpy).not.toHaveBeenCalled();
+            expect(deleteEmptyQueuesRequestSpy).not.toHaveBeenCalled();
+            expect(mockDialog.closeAll).toHaveBeenCalled();
+        });
+    });
+});

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.effects.ts
@@ -18,35 +18,38 @@
 import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { concatLatestFrom } from '@ngrx/operators';
-import * as QueueActions from './queue.actions';
-import * as ErrorActions from '../../../../state/error/error.actions';
+import * as EmptyQueueActions from './empty-queue.actions';
+import * as ErrorActions from '../error/error.actions';
 import { Store } from '@ngrx/store';
 import { asyncScheduler, catchError, filter, from, interval, map, of, switchMap, take, takeUntil, tap } from 'rxjs';
-import { selectDropConnectionId, selectDropProcessGroupId, selectDropRequestEntity } from './queue.selectors';
-import { QueueService } from '../../service/queue.service';
+import {
+    selectDropConnectionId,
+    selectDropProcessGroupId,
+    selectDropRequestEntity,
+    selectDropSource
+} from './empty-queue.selectors';
+import { EmptyQueueService } from '../../service/empty-queue.service';
 import { DropRequest } from './index';
-import { CancelDialog } from '../../../../ui/common/cancel-dialog/cancel-dialog.component';
+import { CancelDialog } from '../../ui/common/cancel-dialog/cancel-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
 import { isDefinedAndNotNull, SMALL_DIALOG, YesNoDialog } from '@nifi/shared';
-import { OkDialog } from '../../../../ui/common/ok-dialog/ok-dialog.component';
-import { loadChildProcessGroup, loadConnection, loadProcessGroup } from '../flow/flow.actions';
-import { resetQueueState } from './queue.actions';
+import { OkDialog } from '../../ui/common/ok-dialog/ok-dialog.component';
+import { resetEmptyQueueState } from './empty-queue.actions';
 import { HttpErrorResponse } from '@angular/common/http';
-import { ErrorHelper } from '../../../../service/error-helper.service';
-import { selectCurrentProcessGroupId } from '../flow/flow.selectors';
+import { ErrorHelper } from '../../service/error-helper.service';
 
 @Injectable()
-export class QueueEffects {
+export class EmptyQueueEffects {
     private actions$ = inject(Actions);
-    private store = inject<Store<CanvasState>>(Store);
-    private queueService = inject(QueueService);
+    private store = inject(Store);
+    private emptyQueueService = inject(EmptyQueueService);
     private dialog = inject(MatDialog);
     private errorHelper = inject(ErrorHelper);
 
     promptEmptyQueueRequest$ = createEffect(
         () =>
             this.actions$.pipe(
-                ofType(QueueActions.promptEmptyQueueRequest),
+                ofType(EmptyQueueActions.promptEmptyQueueRequest),
                 map((action) => action.request),
                 tap((request) => {
                     const dialogReference = this.dialog.open(YesNoDialog, {
@@ -60,7 +63,7 @@ export class QueueEffects {
 
                     dialogReference.componentInstance.yes.pipe(take(1)).subscribe(() => {
                         this.store.dispatch(
-                            QueueActions.submitEmptyQueueRequest({
+                            EmptyQueueActions.submitEmptyQueueRequest({
                                 request
                             })
                         );
@@ -72,7 +75,7 @@ export class QueueEffects {
 
     submitEmptyQueueRequest$ = createEffect(() =>
         this.actions$.pipe(
-            ofType(QueueActions.submitEmptyQueueRequest),
+            ofType(EmptyQueueActions.submitEmptyQueueRequest),
             map((action) => action.request),
             switchMap((request) => {
                 const dialogReference = this.dialog.open(CancelDialog, {
@@ -84,12 +87,12 @@ export class QueueEffects {
                 });
 
                 dialogReference.componentInstance.exit.pipe(take(1)).subscribe(() => {
-                    this.store.dispatch(QueueActions.stopPollingEmptyQueueRequest());
+                    this.store.dispatch(EmptyQueueActions.stopPollingEmptyQueueRequest());
                 });
 
-                return from(this.queueService.submitEmptyQueueRequest(request)).pipe(
+                return from(this.emptyQueueService.submitEmptyQueueRequest(request)).pipe(
                     map((response) =>
-                        QueueActions.submitEmptyQueueRequestSuccess({
+                        EmptyQueueActions.submitEmptyQueueRequestSuccess({
                             response: {
                                 dropEntity: response
                             }
@@ -97,7 +100,7 @@ export class QueueEffects {
                     ),
                     catchError((errorResponse: HttpErrorResponse) =>
                         of(
-                            QueueActions.queueApiError({
+                            EmptyQueueActions.emptyQueueApiError({
                                 error: this.errorHelper.getErrorString(errorResponse)
                             })
                         )
@@ -110,7 +113,7 @@ export class QueueEffects {
     promptEmptyQueuesRequest$ = createEffect(
         () =>
             this.actions$.pipe(
-                ofType(QueueActions.promptEmptyQueuesRequest),
+                ofType(EmptyQueueActions.promptEmptyQueuesRequest),
                 map((action) => action.request),
                 tap((request) => {
                     const dialogReference = this.dialog.open(YesNoDialog, {
@@ -124,7 +127,7 @@ export class QueueEffects {
 
                     dialogReference.componentInstance.yes.pipe(take(1)).subscribe(() => {
                         this.store.dispatch(
-                            QueueActions.submitEmptyQueuesRequest({
+                            EmptyQueueActions.submitEmptyQueuesRequest({
                                 request
                             })
                         );
@@ -136,7 +139,7 @@ export class QueueEffects {
 
     submitEmptyQueuesRequest$ = createEffect(() =>
         this.actions$.pipe(
-            ofType(QueueActions.submitEmptyQueuesRequest),
+            ofType(EmptyQueueActions.submitEmptyQueuesRequest),
             map((action) => action.request),
             switchMap((request) => {
                 const dialogReference = this.dialog.open(CancelDialog, {
@@ -148,12 +151,12 @@ export class QueueEffects {
                 });
 
                 dialogReference.componentInstance.exit.pipe(take(1)).subscribe(() => {
-                    this.store.dispatch(QueueActions.stopPollingEmptyQueueRequest());
+                    this.store.dispatch(EmptyQueueActions.stopPollingEmptyQueueRequest());
                 });
 
-                return from(this.queueService.submitEmptyQueuesRequest(request)).pipe(
+                return from(this.emptyQueueService.submitEmptyQueuesRequest(request)).pipe(
                     map((response) =>
-                        QueueActions.submitEmptyQueueRequestSuccess({
+                        EmptyQueueActions.submitEmptyQueuesRequestSuccess({
                             response: {
                                 dropEntity: response
                             }
@@ -161,7 +164,7 @@ export class QueueEffects {
                     ),
                     catchError((errorResponse: HttpErrorResponse) =>
                         of(
-                            QueueActions.queueApiError({
+                            EmptyQueueActions.emptyQueueApiError({
                                 error: this.errorHelper.getErrorString(errorResponse)
                             })
                         )
@@ -173,14 +176,14 @@ export class QueueEffects {
 
     submitEmptyQueueRequestSuccess$ = createEffect(() =>
         this.actions$.pipe(
-            ofType(QueueActions.submitEmptyQueueRequestSuccess),
+            ofType(EmptyQueueActions.submitEmptyQueueRequestSuccess, EmptyQueueActions.submitEmptyQueuesRequestSuccess),
             map((action) => action.response),
             switchMap((response) => {
                 const dropRequest: DropRequest = response.dropEntity.dropRequest;
                 if (dropRequest.finished) {
-                    return of(QueueActions.deleteEmptyQueueRequest());
+                    return of(EmptyQueueActions.deleteEmptyQueueRequest());
                 } else {
-                    return of(QueueActions.startPollingEmptyQueueRequest());
+                    return of(EmptyQueueActions.startPollingEmptyQueueRequest());
                 }
             })
         )
@@ -188,38 +191,51 @@ export class QueueEffects {
 
     startPollingEmptyQueueRequest$ = createEffect(() =>
         this.actions$.pipe(
-            ofType(QueueActions.startPollingEmptyQueueRequest),
+            ofType(EmptyQueueActions.startPollingEmptyQueueRequest),
             switchMap(() =>
                 interval(2000, asyncScheduler).pipe(
-                    takeUntil(this.actions$.pipe(ofType(QueueActions.stopPollingEmptyQueueRequest)))
+                    takeUntil(this.actions$.pipe(ofType(EmptyQueueActions.stopPollingEmptyQueueRequest)))
                 )
             ),
-            switchMap(() => of(QueueActions.pollEmptyQueueRequest()))
+            switchMap(() => of(EmptyQueueActions.pollEmptyQueueRequest()))
         )
     );
 
     pollEmptyQueueRequest$ = createEffect(() =>
         this.actions$.pipe(
-            ofType(QueueActions.pollEmptyQueueRequest),
+            ofType(EmptyQueueActions.pollEmptyQueueRequest),
             concatLatestFrom(() => [
                 this.store.select(selectDropRequestEntity).pipe(isDefinedAndNotNull()),
                 this.store.select(selectDropConnectionId),
                 this.store.select(selectDropProcessGroupId)
             ]),
             switchMap(([, dropEntity, connectionId, processGroupId]) => {
-                const poll$ = connectionId
-                    ? this.queueService.pollEmptyQueueRequest({
-                          connectionId,
-                          dropRequestId: dropEntity.dropRequest.id
-                      })
-                    : this.queueService.pollEmptyQueuesRequest({
-                          processGroupId: processGroupId!,
-                          dropRequestId: dropEntity.dropRequest.id
-                      });
+                let poll$;
+                if (connectionId) {
+                    poll$ = this.emptyQueueService.pollEmptyQueueRequest({
+                        connectionId,
+                        dropRequestId: dropEntity.dropRequest.id
+                    });
+                } else if (processGroupId) {
+                    poll$ = this.emptyQueueService.pollEmptyQueuesRequest({
+                        processGroupId,
+                        dropRequestId: dropEntity.dropRequest.id
+                    });
+                } else {
+                    // The state machine should keep one of the identifiers populated for the
+                    // lifetime of an in-flight drop request; if both are missing we cannot
+                    // continue polling and surface an error rather than crashing on a non-null
+                    // assertion.
+                    return of(
+                        EmptyQueueActions.emptyQueueApiError({
+                            error: 'Unable to poll empty queue request: no connection or process group is associated with the active request.'
+                        })
+                    );
+                }
 
                 return from(poll$).pipe(
                     map((response) =>
-                        QueueActions.pollEmptyQueueRequestSuccess({
+                        EmptyQueueActions.pollEmptyQueueRequestSuccess({
                             response: {
                                 dropEntity: response
                             }
@@ -227,7 +243,7 @@ export class QueueEffects {
                     ),
                     catchError((errorResponse: HttpErrorResponse) =>
                         of(
-                            QueueActions.queueApiError({
+                            EmptyQueueActions.emptyQueueApiError({
                                 error: this.errorHelper.getErrorString(errorResponse)
                             })
                         )
@@ -239,23 +255,23 @@ export class QueueEffects {
 
     pollEmptyQueueRequestSuccess$ = createEffect(() =>
         this.actions$.pipe(
-            ofType(QueueActions.pollEmptyQueueRequestSuccess),
+            ofType(EmptyQueueActions.pollEmptyQueueRequestSuccess),
             map((action) => action.response),
             filter((response) => response.dropEntity.dropRequest.finished),
-            switchMap(() => of(QueueActions.stopPollingEmptyQueueRequest()))
+            switchMap(() => of(EmptyQueueActions.stopPollingEmptyQueueRequest()))
         )
     );
 
     stopPollingEmptyQueueRequest$ = createEffect(() =>
         this.actions$.pipe(
-            ofType(QueueActions.stopPollingEmptyQueueRequest),
-            switchMap(() => of(QueueActions.deleteEmptyQueueRequest()))
+            ofType(EmptyQueueActions.stopPollingEmptyQueueRequest),
+            switchMap(() => of(EmptyQueueActions.deleteEmptyQueueRequest()))
         )
     );
 
     deleteEmptyQueueRequest$ = createEffect(() =>
         this.actions$.pipe(
-            ofType(QueueActions.deleteEmptyQueueRequest),
+            ofType(EmptyQueueActions.deleteEmptyQueueRequest),
             concatLatestFrom(() => [
                 this.store.select(selectDropRequestEntity).pipe(isDefinedAndNotNull()),
                 this.store.select(selectDropConnectionId),
@@ -264,19 +280,28 @@ export class QueueEffects {
             switchMap(([, dropEntity, connectionId, processGroupId]) => {
                 this.dialog.closeAll();
 
-                const delete$ = connectionId
-                    ? this.queueService.deleteEmptyQueueRequest({
-                          connectionId,
-                          dropRequestId: dropEntity.dropRequest.id
-                      })
-                    : this.queueService.deleteEmptyQueuesRequest({
-                          processGroupId: processGroupId!,
-                          dropRequestId: dropEntity.dropRequest.id
-                      });
+                let delete$;
+                if (connectionId) {
+                    delete$ = this.emptyQueueService.deleteEmptyQueueRequest({
+                        connectionId,
+                        dropRequestId: dropEntity.dropRequest.id
+                    });
+                } else if (processGroupId) {
+                    delete$ = this.emptyQueueService.deleteEmptyQueuesRequest({
+                        processGroupId,
+                        dropRequestId: dropEntity.dropRequest.id
+                    });
+                } else {
+                    return of(
+                        EmptyQueueActions.emptyQueueApiError({
+                            error: 'Unable to delete empty queue request: no connection or process group is associated with the active request.'
+                        })
+                    );
+                }
 
                 return from(delete$).pipe(
                     map((response) =>
-                        QueueActions.showEmptyQueueResults({
+                        EmptyQueueActions.showEmptyQueueResults({
                             request: {
                                 dropEntity: response
                             }
@@ -284,7 +309,7 @@ export class QueueEffects {
                     ),
                     catchError(() =>
                         of(
-                            QueueActions.showEmptyQueueResults({
+                            EmptyQueueActions.showEmptyQueueResults({
                                 request: {
                                     dropEntity
                                 }
@@ -299,14 +324,14 @@ export class QueueEffects {
     showEmptyQueueResults$ = createEffect(
         () =>
             this.actions$.pipe(
-                ofType(QueueActions.showEmptyQueueResults),
+                ofType(EmptyQueueActions.showEmptyQueueResults),
                 map((action) => action.request),
                 concatLatestFrom(() => [
                     this.store.select(selectDropConnectionId),
                     this.store.select(selectDropProcessGroupId),
-                    this.store.select(selectCurrentProcessGroupId)
+                    this.store.select(selectDropSource)
                 ]),
-                tap(([request, connectionId, processGroupId, currentProcessGroupId]) => {
+                tap(([request, connectionId, processGroupId, source]) => {
                     const dropRequest: DropRequest = request.dropEntity.dropRequest;
                     const droppedTokens: string[] = dropRequest.dropped.split(/ \/ /);
 
@@ -319,37 +344,23 @@ export class QueueEffects {
 
                     if (connectionId) {
                         message = `${message} were removed from the queue.`;
-
-                        this.store.dispatch(
-                            loadConnection({
-                                id: connectionId
-                            })
-                        );
                     } else if (processGroupId) {
                         message = `${message} were removed from the queues.`;
-
-                        if (processGroupId === currentProcessGroupId) {
-                            this.store.dispatch(
-                                loadProcessGroup({
-                                    request: {
-                                        id: processGroupId,
-                                        transitionRequired: false
-                                    }
-                                })
-                            );
-                        } else {
-                            this.store.dispatch(
-                                loadChildProcessGroup({
-                                    request: {
-                                        id: processGroupId
-                                    }
-                                })
-                            );
-                        }
                     }
 
                     if (dropRequest.failureReason) {
                         message = `${message} ${dropRequest.failureReason}`;
+                    }
+
+                    // Page-specific refresh is handled by listeners on queueEmptied (filtered by source).
+                    if (source) {
+                        this.store.dispatch(
+                            EmptyQueueActions.queueEmptied({
+                                connectionId,
+                                processGroupId,
+                                source
+                            })
+                        );
                     }
 
                     const dialogReference = this.dialog.open(OkDialog, {
@@ -361,20 +372,20 @@ export class QueueEffects {
                     });
 
                     dialogReference.afterClosed().subscribe(() => {
-                        this.store.dispatch(resetQueueState());
+                        this.store.dispatch(resetEmptyQueueState());
                     });
                 })
             ),
         { dispatch: false }
     );
 
-    queueApiError$ = createEffect(() =>
+    emptyQueueApiError$ = createEffect(() =>
         this.actions$.pipe(
-            ofType(QueueActions.queueApiError),
+            ofType(EmptyQueueActions.emptyQueueApiError),
             map((action) => action.error),
             tap(() => {
                 this.dialog.closeAll();
-                this.store.dispatch(QueueActions.stopPollingEmptyQueueRequest());
+                this.store.dispatch(EmptyQueueActions.stopPollingEmptyQueueRequest());
             }),
             switchMap((error) => of(ErrorActions.snackBarError({ error })))
         )

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.reducer.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.reducer.spec.ts
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { emptyQueueReducer, initialState } from './empty-queue.reducer';
+import {
+    pollEmptyQueueRequestSuccess,
+    resetEmptyQueueState,
+    submitEmptyQueueRequest,
+    submitEmptyQueueRequestSuccess,
+    submitEmptyQueuesRequest,
+    submitEmptyQueuesRequestSuccess
+} from './empty-queue.actions';
+import { DropRequestEntity } from './index';
+
+function createDropEntity(overrides: Partial<DropRequestEntity['dropRequest']> = {}): DropRequestEntity {
+    return {
+        dropRequest: {
+            id: 'drop-1',
+            uri: 'http://example/drop-requests/drop-1',
+            submissionTime: '2023-01-01T00:00:00Z',
+            lastUpdated: '2023-01-01T00:00:01Z',
+            percentCompleted: 100,
+            finished: true,
+            failureReason: '',
+            currentCount: 0,
+            currentSize: 0,
+            current: '0 / 0 bytes',
+            originalCount: 5,
+            originalSize: 100,
+            original: '5 / 100 bytes',
+            droppedCount: 5,
+            droppedSize: 100,
+            dropped: '5 / 100 bytes',
+            state: 'COMPLETE',
+            ...overrides
+        }
+    };
+}
+
+describe('emptyQueueReducer', () => {
+    it('should record the connectionId and source on submitEmptyQueueRequest', () => {
+        const next = emptyQueueReducer(
+            initialState,
+            submitEmptyQueueRequest({
+                request: { connectionId: 'conn-1', source: 'connector-canvas' }
+            })
+        );
+
+        expect(next.connectionId).toBe('conn-1');
+        expect(next.source).toBe('connector-canvas');
+        expect(next.status).toBe('loading');
+    });
+
+    it('should record the processGroupId and source on submitEmptyQueuesRequest', () => {
+        const next = emptyQueueReducer(
+            initialState,
+            submitEmptyQueuesRequest({
+                request: { processGroupId: 'pg-1', source: 'flow-designer' }
+            })
+        );
+
+        expect(next.processGroupId).toBe('pg-1');
+        expect(next.source).toBe('flow-designer');
+        expect(next.status).toBe('loading');
+    });
+
+    it('should set status to success and persist the loadedTimestamp on submitEmptyQueueRequestSuccess', () => {
+        const dropEntity = createDropEntity({ lastUpdated: '2023-02-01T12:00:00Z' });
+
+        const next = emptyQueueReducer(initialState, submitEmptyQueueRequestSuccess({ response: { dropEntity } }));
+
+        expect(next.status).toBe('success');
+        expect(next.dropEntity).toEqual(dropEntity);
+        expect(next.loadedTimestamp).toBe('2023-02-01T12:00:00Z');
+    });
+
+    it('should set status to success and persist the loadedTimestamp on submitEmptyQueuesRequestSuccess', () => {
+        const dropEntity = createDropEntity({ lastUpdated: '2023-02-15T08:00:00Z' });
+
+        const next = emptyQueueReducer(initialState, submitEmptyQueuesRequestSuccess({ response: { dropEntity } }));
+
+        expect(next.status).toBe('success');
+        expect(next.dropEntity).toEqual(dropEntity);
+        expect(next.loadedTimestamp).toBe('2023-02-15T08:00:00Z');
+    });
+
+    it('should preserve the source through the request lifecycle', () => {
+        const submitted = emptyQueueReducer(
+            initialState,
+            submitEmptyQueueRequest({
+                request: { connectionId: 'conn-1', source: 'connector-canvas' }
+            })
+        );
+
+        const polled = emptyQueueReducer(
+            submitted,
+            pollEmptyQueueRequestSuccess({ response: { dropEntity: createDropEntity() } })
+        );
+
+        expect(polled.source).toBe('connector-canvas');
+    });
+
+    it('should clear a previously set processGroupId when starting a new single-connection request', () => {
+        const afterBulk = emptyQueueReducer(
+            initialState,
+            submitEmptyQueuesRequest({
+                request: { processGroupId: 'pg-1', source: 'flow-designer' }
+            })
+        );
+
+        const next = emptyQueueReducer(
+            afterBulk,
+            submitEmptyQueueRequest({
+                request: { connectionId: 'conn-1', source: 'connector-canvas' }
+            })
+        );
+
+        expect(next.connectionId).toBe('conn-1');
+        expect(next.processGroupId).toBeNull();
+        expect(next.source).toBe('connector-canvas');
+        expect(next.status).toBe('loading');
+    });
+
+    it('should clear a previously set connectionId when starting a new bulk request', () => {
+        const afterSingle = emptyQueueReducer(
+            initialState,
+            submitEmptyQueueRequest({
+                request: { connectionId: 'conn-1', source: 'connector-canvas' }
+            })
+        );
+
+        const next = emptyQueueReducer(
+            afterSingle,
+            submitEmptyQueuesRequest({
+                request: { processGroupId: 'pg-1', source: 'flow-designer' }
+            })
+        );
+
+        expect(next.processGroupId).toBe('pg-1');
+        expect(next.connectionId).toBeNull();
+        expect(next.source).toBe('flow-designer');
+        expect(next.status).toBe('loading');
+    });
+
+    it('should reset to the initial state on resetEmptyQueueState', () => {
+        const submitted = emptyQueueReducer(
+            initialState,
+            submitEmptyQueuesRequest({
+                request: { processGroupId: 'pg-1', source: 'flow-designer' }
+            })
+        );
+
+        const reset = emptyQueueReducer(submitted, resetEmptyQueueState());
+
+        expect(reset).toEqual(initialState);
+        expect(reset.source).toBeNull();
+    });
+});

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.reducer.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.reducer.ts
@@ -16,42 +16,56 @@
  */
 
 import { createReducer, on } from '@ngrx/store';
-import { QueueState } from './index';
+import { EmptyQueueState } from './index';
 import {
     pollEmptyQueueRequestSuccess,
     submitEmptyQueueRequest,
     submitEmptyQueueRequestSuccess,
-    resetQueueState,
+    submitEmptyQueuesRequestSuccess,
+    resetEmptyQueueState,
     submitEmptyQueuesRequest
-} from './queue.actions';
+} from './empty-queue.actions';
 
-export const initialState: QueueState = {
+export const initialState: EmptyQueueState = {
     dropEntity: null,
     processGroupId: null,
     connectionId: null,
+    source: null,
     loadedTimestamp: 'N/A',
     status: 'pending'
 };
 
-export const queueReducer = createReducer(
+export const emptyQueueReducer = createReducer(
     initialState,
+    // Explicitly null the unused identifier on each submit so the two
+    // identifier fields remain mutually exclusive even if a prior request was
+    // not explicitly reset.
     on(submitEmptyQueueRequest, (state, { request }) => ({
         ...state,
         connectionId: request.connectionId,
+        processGroupId: null,
+        source: request.source,
         status: 'loading' as const
     })),
     on(submitEmptyQueuesRequest, (state, { request }) => ({
         ...state,
+        connectionId: null,
         processGroupId: request.processGroupId,
+        source: request.source,
         status: 'loading' as const
     })),
-    on(submitEmptyQueueRequestSuccess, pollEmptyQueueRequestSuccess, (state, { response }) => ({
-        ...state,
-        dropEntity: response.dropEntity,
-        loadedTimestamp: response.dropEntity.dropRequest.lastUpdated,
-        status: 'success' as const
-    })),
-    on(resetQueueState, () => ({
+    on(
+        submitEmptyQueueRequestSuccess,
+        submitEmptyQueuesRequestSuccess,
+        pollEmptyQueueRequestSuccess,
+        (state, { response }) => ({
+            ...state,
+            dropEntity: response.dropEntity,
+            loadedTimestamp: response.dropEntity.dropRequest.lastUpdated,
+            status: 'success' as const
+        })
+    ),
+    on(resetEmptyQueueState, () => ({
         ...initialState
     }))
 );

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.selectors.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/empty-queue.selectors.ts
@@ -15,25 +15,24 @@
  * limitations under the License.
  */
 
-import { DropRequestEntity } from '../../../../state/empty-queue';
-import { ConnectorEntity } from '@nifi/shared';
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { EmptyQueueState, emptyQueueFeatureKey } from './index';
 
-export const purgeConnectorFeatureKey = 'purgeConnector';
+export const selectEmptyQueueState = createFeatureSelector<EmptyQueueState>(emptyQueueFeatureKey);
 
-export interface PurgeConnectorState {
-    connectorId: string | null;
-    dropEntity: DropRequestEntity | null;
-    status: 'pending' | 'loading' | 'success';
-}
+export const selectDropRequestEntity = createSelector(
+    selectEmptyQueueState,
+    (state: EmptyQueueState) => state.dropEntity
+);
 
-export interface PurgeConnectorRequest {
-    connector: ConnectorEntity;
-}
+export const selectDropConnectionId = createSelector(
+    selectEmptyQueueState,
+    (state: EmptyQueueState) => state.connectionId
+);
 
-export interface PollPurgeConnectorSuccess {
-    dropEntity: DropRequestEntity;
-}
+export const selectDropProcessGroupId = createSelector(
+    selectEmptyQueueState,
+    (state: EmptyQueueState) => state.processGroupId
+);
 
-export interface ShowPurgeConnectorResults {
-    dropEntity: DropRequestEntity;
-}
+export const selectDropSource = createSelector(selectEmptyQueueState, (state: EmptyQueueState) => state.source);

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/empty-queue/index.ts
@@ -15,6 +15,10 @@
  * limitations under the License.
  */
 
+import { CanvasActionSource } from '../shared';
+
+export const emptyQueueFeatureKey = 'emptyQueue';
+
 export interface DropRequest {
     id: string;
     uri: string;
@@ -41,6 +45,7 @@ export interface DropRequestEntity {
 
 export interface SubmitEmptyQueueRequest {
     connectionId: string;
+    source: CanvasActionSource;
 }
 
 export interface EmptyQueueRequest {
@@ -50,6 +55,7 @@ export interface EmptyQueueRequest {
 
 export interface SubmitEmptyQueuesRequest {
     processGroupId: string;
+    source: CanvasActionSource;
 }
 
 export interface EmptyQueuesRequest {
@@ -65,10 +71,11 @@ export interface ShowEmptyQueueResults {
     dropEntity: DropRequestEntity;
 }
 
-export interface QueueState {
+export interface EmptyQueueState {
     dropEntity: DropRequestEntity | null;
     connectionId: string | null;
     processGroupId: string | null;
+    source: CanvasActionSource | null;
     loadedTimestamp: string;
     status: 'pending' | 'loading' | 'success';
 }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/index.ts
@@ -51,6 +51,8 @@ import { copyFeatureKey, CopyState } from './copy';
 import { copyReducer } from './copy/copy.reducer';
 import { canvasUiFeatureKey, CanvasUiState } from './canvas-ui';
 import { canvasUiReducer } from './canvas-ui/canvas-ui.reducer';
+import { emptyQueueFeatureKey, EmptyQueueState } from './empty-queue';
+import { emptyQueueReducer } from './empty-queue/empty-queue.reducer';
 
 export interface NiFiState {
     [DEFAULT_ROUTER_FEATURENAME]: RouterReducerState;
@@ -71,6 +73,7 @@ export interface NiFiState {
     [propertyVerificationFeatureKey]: PropertyVerificationState;
     [copyFeatureKey]: CopyState;
     [canvasUiFeatureKey]: CanvasUiState;
+    [emptyQueueFeatureKey]: EmptyQueueState;
 }
 
 export const rootReducers: ActionReducerMap<NiFiState> = {
@@ -91,5 +94,6 @@ export const rootReducers: ActionReducerMap<NiFiState> = {
     [clusterSummaryFeatureKey]: clusterSummaryReducer,
     [propertyVerificationFeatureKey]: propertyVerificationReducer,
     [copyFeatureKey]: copyReducer,
-    [canvasUiFeatureKey]: canvasUiReducer
+    [canvasUiFeatureKey]: canvasUiReducer,
+    [emptyQueueFeatureKey]: emptyQueueReducer
 };

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/shared/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/shared/index.ts
@@ -31,6 +31,8 @@ import {
 } from '@nifi/shared';
 import { VersionControlInformation } from '../../ui/common/tooltips/version-control-tip/version-control-tip.component';
 
+export type CanvasActionSource = 'flow-designer' | 'connector-canvas';
+
 export interface OkDialogRequest {
     title: string;
     message: string;
@@ -128,6 +130,12 @@ export interface EditControllerServiceDialogRequest {
     id: string;
     controllerService: ControllerServiceEntity;
     history?: ComponentHistory;
+    /**
+     * When true, forces the dialog to be read-only regardless of the
+     * underlying controller service permissions or run status. Used by the
+     * connector canvas controller services view.
+     */
+    readonly?: boolean;
 }
 
 export interface EditComponentDialogRequest {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.html
@@ -121,7 +121,24 @@
                             <i class="fa fa-ellipsis-v"></i>
                         </button>
                         <mat-menu #actionMenu="matMenu" xPosition="before">
-                            @if (definedByCurrentGroup(item)) {
+                            @if (readOnly) {
+                                @if (canRead(item)) {
+                                    <button mat-menu-item (click)="configureClicked(item)">
+                                        <i class="fa fa-cog primary-color mr-2"></i>
+                                        View Configuration
+                                    </button>
+                                    @if (canViewState(item)) {
+                                        <button mat-menu-item (click)="viewStateClicked(item)">
+                                            <i class="fa fa-tasks primary-color mr-2"></i>
+                                            View State
+                                        </button>
+                                    }
+                                    <button mat-menu-item (click)="viewDocumentationClicked(item)">
+                                        <i class="fa fa-book primary-color mr-2"></i>
+                                        View Documentation
+                                    </button>
+                                }
+                            } @else if (definedByCurrentGroup(item)) {
                                 <button mat-menu-item (click)="configureClicked(item)">
                                     <i class="fa fa-cog primary-color mr-2"></i>
                                     {{ canConfigure(item) ? 'Edit' : 'View Configuration' }}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.spec.ts
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ControllerServiceTable } from './controller-service-table.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ControllerServiceEntity } from '../../../../state/shared';
 import { BulletinEntity } from '@nifi/shared';
+import { CurrentUser } from '../../../../state/current-user';
+import { FlowConfiguration } from '../../../../state/flow-configuration';
 
 describe('ControllerServiceTable', () => {
     // Mock data factories
@@ -100,6 +102,50 @@ describe('ControllerServiceTable', () => {
         fixture.detectChanges();
 
         return { component, fixture };
+    }
+
+    interface TableSetupOptions {
+        readOnly?: boolean;
+        controllerServices?: ControllerServiceEntity[];
+        canModifyParent?: (entity: ControllerServiceEntity) => boolean;
+        canManageAccessPolicies?: boolean;
+    }
+
+    async function setupTable(options: TableSetupOptions = {}): Promise<{
+        fixture: ComponentFixture<ControllerServiceTable>;
+        component: ControllerServiceTable;
+    }> {
+        const { fixture, component } = await setup();
+
+        component.readOnly = options.readOnly ?? false;
+        component.canModifyParent = options.canModifyParent ?? (() => false);
+        component.formatScope = () => '';
+        component.definedByCurrentGroup = () => true;
+        component.flowConfiguration = {
+            supportsManagedAuthorizer: options.canManageAccessPolicies ?? true
+        } as FlowConfiguration;
+        component.currentUser = {
+            tenantsPermissions: { canRead: options.canManageAccessPolicies ?? true }
+        } as CurrentUser;
+        component.controllerServices = options.controllerServices ?? [createMockControllerServiceEntity()];
+
+        fixture.detectChanges();
+        return { fixture, component };
+    }
+
+    function getMenuItemTexts(fixture: ComponentFixture<ControllerServiceTable>): string[] {
+        const trigger = fixture.nativeElement.querySelector('button.global-menu') as HTMLElement | null;
+        trigger?.click();
+        fixture.detectChanges();
+
+        const items = document.querySelectorAll('.mat-mdc-menu-item');
+        return Array.from(items).map((el) => (el.textContent ?? '').trim().replace(/\s+/g, ' '));
+    }
+
+    function closeAllMenus(): void {
+        document.querySelectorAll('.cdk-overlay-backdrop').forEach((backdrop) => {
+            (backdrop as HTMLElement).click();
+        });
     }
 
     it('should create', async () => {
@@ -222,6 +268,75 @@ describe('ControllerServiceTable', () => {
 
             // Assert
             expect(result).toBe(true);
+        });
+    });
+
+    describe('readOnly mode', () => {
+        afterEach(() => {
+            closeAllMenus();
+        });
+
+        it('should default readOnly to false', async () => {
+            const { component } = await setup();
+            expect(component.readOnly).toBe(false);
+        });
+
+        it('should restrict the action menu to view-only entries when readOnly is true', async () => {
+            const entity = createMockControllerServiceEntity();
+            entity.status.runStatus = 'DISABLED';
+            entity.component.persistsState = true;
+            entity.bulletins = [createTestBulletin(1, '12:00:00 UTC')];
+            entity.component.customUiUrl = 'https://example.com/advanced';
+            entity.component.multipleVersionsAvailable = true;
+
+            const { fixture } = await setupTable({
+                readOnly: true,
+                controllerServices: [entity]
+            });
+
+            const labels = getMenuItemTexts(fixture);
+            expect(labels).toEqual(['View Configuration', 'View State', 'View Documentation']);
+        });
+
+        it('should omit View State when persistsState is false even in readOnly mode', async () => {
+            const entity = createMockControllerServiceEntity();
+            entity.status.runStatus = 'DISABLED';
+            entity.component.persistsState = false;
+
+            const { fixture } = await setupTable({
+                readOnly: true,
+                controllerServices: [entity]
+            });
+
+            const labels = getMenuItemTexts(fixture);
+            expect(labels).toEqual(['View Configuration', 'View Documentation']);
+        });
+
+        it('should render no menu items in readOnly mode when the user cannot read the entity', async () => {
+            const entity = createMockControllerServiceEntity();
+            entity.permissions.canRead = false;
+
+            const { fixture } = await setupTable({
+                readOnly: true,
+                controllerServices: [entity]
+            });
+
+            expect(getMenuItemTexts(fixture)).toEqual([]);
+        });
+
+        it('should render the full mutating action menu when readOnly is false', async () => {
+            const entity = createMockControllerServiceEntity();
+            entity.status.runStatus = 'DISABLED';
+
+            const { fixture } = await setupTable({
+                readOnly: false,
+                controllerServices: [entity]
+            });
+
+            const labels = getMenuItemTexts(fixture);
+            expect(labels).toContain('Edit');
+            expect(labels).toContain('Enable');
+            expect(labels).toContain('View Documentation');
         });
     });
 });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.ts
@@ -66,6 +66,16 @@ export class ControllerServiceTable {
     @Input() currentUser!: CurrentUser;
     @Input() canModifyParent!: (entity: ControllerServiceEntity) => boolean;
 
+    /**
+     * When true, the row action menu is restricted to view-only entries
+     * (View Configuration, View State, View Documentation). Mutating actions
+     * such as Edit, Enable, Disable, Change Version, Delete, Clear Bulletins,
+     * Advanced UI, and Manage Access Policies are suppressed regardless of
+     * the underlying entity permissions. Used by the connector canvas
+     * controller services view.
+     */
+    @Input() readOnly = false;
+
     @Output() selectControllerService: EventEmitter<ControllerServiceEntity> =
         new EventEmitter<ControllerServiceEntity>();
     @Output() viewControllerServiceDocumentation: EventEmitter<ControllerServiceEntity> =

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/edit-controller-service/edit-controller-service.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/edit-controller-service/edit-controller-service.component.spec.ts
@@ -620,4 +620,81 @@ describe('EditControllerService', () => {
             }
         });
     });
+
+    describe('readonly derivation', () => {
+        function buildRequest(overrides: {
+            readonly?: boolean;
+            canWrite?: boolean;
+            runStatus?: string;
+        }): EditControllerServiceDialogRequest {
+            return {
+                ...data,
+                ...(overrides.readonly !== undefined ? { readonly: overrides.readonly } : {}),
+                controllerService: {
+                    ...data.controllerService,
+                    permissions: {
+                        ...data.controllerService.permissions,
+                        canWrite: overrides.canWrite ?? data.controllerService.permissions.canWrite
+                    },
+                    status: {
+                        ...data.controllerService.status,
+                        runStatus: overrides.runStatus ?? data.controllerService.status.runStatus
+                    }
+                }
+            };
+        }
+
+        function createWith(request: EditControllerServiceDialogRequest): EditControllerService {
+            TestBed.resetTestingModule();
+            TestBed.configureTestingModule({
+                imports: [EditControllerService, MockComponent(ContextErrorBanner), NoopAnimationsModule],
+                providers: [
+                    provideMockStore({
+                        initialState: {
+                            [errorFeatureKey]: initialErrorState
+                        }
+                    }),
+                    { provide: MAT_DIALOG_DATA, useValue: request },
+                    { provide: MatDialogRef, useValue: null },
+                    { provide: Client, useValue: { getRevision: () => mockRevision } },
+                    {
+                        provide: ClusterConnectionService,
+                        useValue: { isDisconnectionAcknowledged: () => true }
+                    }
+                ]
+            });
+
+            const newFixture = TestBed.createComponent(EditControllerService);
+            newFixture.detectChanges();
+            return newFixture.componentInstance;
+        }
+
+        it('forces readonly mode when the request explicitly opts in, regardless of permissions or run status', () => {
+            const editable = createWith(buildRequest({ readonly: true, canWrite: true, runStatus: 'DISABLED' }));
+
+            expect(editable.readonly).toBe(true);
+            expect(editable.editControllerServiceForm.get('properties')?.disabled).toBe(true);
+        });
+
+        it('forces readonly mode when the user lacks write permission', () => {
+            const noWrite = createWith(buildRequest({ canWrite: false, runStatus: 'DISABLED' }));
+
+            expect(noWrite.readonly).toBe(true);
+            expect(noWrite.editControllerServiceForm.get('properties')?.disabled).toBe(true);
+        });
+
+        it('forces readonly mode when the controller service is not DISABLED', () => {
+            const enabled = createWith(buildRequest({ canWrite: true, runStatus: 'ENABLED' }));
+
+            expect(enabled.readonly).toBe(true);
+            expect(enabled.editControllerServiceForm.get('properties')?.disabled).toBe(true);
+        });
+
+        it('allows editing when the user can write, the service is DISABLED, and the readonly flag is unset', () => {
+            const editable = createWith(buildRequest({ canWrite: true, runStatus: 'DISABLED' }));
+
+            expect(editable.readonly).toBe(false);
+            expect(editable.editControllerServiceForm.get('properties')?.enabled).toBe(true);
+        });
+    });
 });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/edit-controller-service/edit-controller-service.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/controller-service/edit-controller-service/edit-controller-service.component.ts
@@ -148,6 +148,7 @@ export class EditControllerService extends TabbedDialog {
         const request = this.request;
 
         this.readonly =
+            request.readonly === true ||
             !request.controllerService.permissions.canWrite ||
             request.controllerService.status.runStatus !== 'DISABLED';
 


### PR DESCRIPTION
# Summary

Adds support for working with controller services and performing queue operations from the connector canvas in the NiFi UI. Promotes the empty-queue NgRx state slice to a location shared by the flow designer and the connector canvas so both surfaces drive the same drop-request flow.

# Changes

## Connector canvas — context menu

- **Canvas-background menu** gains `Controller Services`, `Empty All Queues`, `Drain`, and `Cancel Drain` (alongside the existing `Refresh` and `Leave Group`).
- **Component menu** gains `Controller Services` and `Empty All Queues` for process groups, and `List Queue` and `Empty Queue` for connections.
- Icons aligned with the flow designer (e.g. `fa fa-list` for Controller Services).
- `Drain` and `Cancel Drain` are gated on connector permissions and the runtime's `allowedActions` set, and disable while the connector is being saved.

## Controller services view (read-only)

- New `ConnectorControllerServicesComponent` rooted at `/connectors/{connectorId}/canvas/{processGroupId}/controller-services`, deep-linkable to a specific service.
- Reuses the shared `controller-service-table`. To support a read-only entry point without mutating entity permissions:
  - Added a `readOnly` input on `controller-service-table` that gates the row action menu down to `View Configuration`, `View State`, and `View Documentation`.
  - Added a `readonly?: boolean` flag on `EditControllerServiceDialogRequest`. When set, `EditControllerService` enters view-only mode regardless of the user's permissions or the service's run status.
- New NgRx slice (`connector-controller-services` — actions, reducer, effects, selectors) handles loading, selection, and dialog wiring.
- Navigation is dispatched as `navigateToControllerServices({ processGroupId })` and uses `BackNavigation` to return to the originating canvas.

## Queue operations — shared empty-queue state

- Promoted the previous `flow-designer/state/queue` slice to `state/empty-queue`. The flow designer and the connector canvas now dispatch the same actions through a single shared slice.
- A new `queueEmptied` action carries a `CanvasActionSource` so each surface filters on the source and only refreshes its own view.
- Bulk drains have their own success action (`submitEmptyQueuesRequestSuccess`); the shared success effect listens to both the singular and bulk forms and routes to either `deleteEmptyQueueRequest` or `startPollingEmptyQueueRequest` depending on whether the drop request is finished.
- Connector-canvas actions for `Empty Queue`, `Empty All Queues`, `List Queue`, `Drain`, and `Cancel Drain` are wired through this slice.

## Cleanup and hardening (second commit)

A follow-up commit addresses minor items grouped by theme:

- **Correctness**
  - `EmptyQueueState` clears the unused identifier on submit so subsequent polling/deletion can never run against a stale `connectionId` or `processGroupId`.
  - Replaced `processGroupId!` non-null assertions in `pollEmptyQueueRequest$` and `deleteEmptyQueueRequest$` with explicit guards that dispatch `emptyQueueApiError` if neither id is present.
  - Added `hasAttemptedLoad` to `ConnectorControllerServicesState` so the controller services skeleton is only shown on the very first load — retries after a failed initial load no longer re-flash the skeleton.
- **Design**
  - Tightened `navigateToControllerServices` to require `processGroupId` and dropped the unreachable route fallback in the effect.
- **Cleanup**
  - Pruned ten unused selectors from `connector-controller-services`.
  - Removed an unused `navigateBackToConnectorCanvas` action and effect.
- **Tests**
  - Added reducer and effect coverage for the new bulk-success action and for the cleared-identifier and null-id guard paths in `EmptyQueueEffects`.
  - Added a `readonly`-derivation spec for `EditControllerService` covering the explicit flag, missing write permission, and non-DISABLED run status.
  - Updated controller-services component and reducer tests for `hasAttemptedLoad`.

# Follow-ups

The connector canvas's `List Queue` action navigates to the existing `/queue/{connectionId}` page. That page's queue listing relies on the standard `nifi-api/flowfile-queues/{id}/...` endpoints; full functionality for connections inside a connector's runtime depends on those endpoints resolving in the connector context and is tracked separately.