### PR TITLE
NIFI-7686: Support multiple key columns in database lookup services

### DIFF
--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/AbstractDatabaseLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/AbstractDatabaseLookupService.java
@@ -23,16 +23,15 @@ import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.util.StandardValidators;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class AbstractDatabaseLookupService extends AbstractControllerService {
 
     static final String KEY = "key";
-
-    static final Set<String> REQUIRED_KEYS = Set.of(
-        KEY
-    );
 
     static final PropertyDescriptor DBCP_SERVICE = new PropertyDescriptor.Builder()
             .name("Database Connection Pooling Service")
@@ -51,8 +50,11 @@ public class AbstractDatabaseLookupService extends AbstractControllerService {
 
     static final PropertyDescriptor LOOKUP_KEY_COLUMN = new PropertyDescriptor.Builder()
             .name("Lookup Key Column")
-            .description("The column in the table that will serve as the lookup key. This is the column that will be matched against "
-                    + "the property specified in the lookup processor. Note that this may be case-sensitive depending on the database.")
+            .description("The column(s) in the table that will serve as the lookup key. For composite key lookups, "
+                    + "specify a comma-separated list of column names (e.g. 'col1, col2'). When a single column is specified, "
+                    + "the lookup processor should pass a coordinate named 'key'. When multiple columns are specified, "
+                    + "the lookup processor should pass coordinates whose names match the column names. "
+                    + "Note that this may be case-sensitive depending on the database.")
             .required(true)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -92,6 +94,22 @@ public class AbstractDatabaseLookupService extends AbstractControllerService {
     DBCPService dbcpService;
 
     volatile String lookupKeyColumn;
+
+    volatile List<String> lookupKeyColumns;
+
+    static List<String> parseKeyColumns(final String value) {
+        if (value == null || value.isBlank()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    boolean isCompositeKey() {
+        return lookupKeyColumns != null && lookupKeyColumns.size() > 1;
+    }
 
     @Override
     public void migrateProperties(PropertyConfiguration config) {

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
@@ -34,7 +34,6 @@ import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.ResultSetRecordSet;
-import org.apache.nifi.util.Tuple;
 import org.apache.nifi.util.db.JdbcProperties;
 
 import java.io.IOException;
@@ -42,6 +41,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -49,6 +50,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.nifi.util.db.JdbcProperties.DEFAULT_PRECISION;
@@ -56,11 +58,14 @@ import static org.apache.nifi.util.db.JdbcProperties.DEFAULT_SCALE;
 
 @Tags({"lookup", "cache", "enrich", "join", "rdbms", "database", "reloadable", "key", "value", "record"})
 @CapabilityDescription("A relational-database-based lookup service. When the lookup key is found in the database, "
-        + "the specified columns (or all if Lookup Value Columns are not specified) are returned as a Record. Only one row "
+        + "the specified columns (or all if Lookup Value Columns are not specified) are returned as a Record. "
+        + "Supports composite (multi-column) primary key lookups by specifying a comma-separated list of column names "
+        + "in the Lookup Key Column property. When multiple key columns are configured, the lookup processor should "
+        + "pass coordinates whose names match the column names. Only one row "
         + "will be returned for each lookup, duplicate database entries are ignored.")
 public class DatabaseRecordLookupService extends AbstractDatabaseLookupService implements RecordLookupService {
 
-    private volatile Cache<Tuple<String, Object>, Record> cache;
+    private volatile Cache<List<Object>, Record> cache;
 
     static final PropertyDescriptor LOOKUP_VALUE_COLUMNS = new PropertyDescriptor.Builder()
             .name("Lookup Value Columns")
@@ -91,6 +96,7 @@ public class DatabaseRecordLookupService extends AbstractDatabaseLookupService i
     public void onEnabled(final ConfigurationContext context) {
         this.dbcpService = context.getProperty(DBCP_SERVICE).asControllerService(DBCPService.class);
         this.lookupKeyColumn = context.getProperty(LOOKUP_KEY_COLUMN).evaluateAttributeExpressions().getValue();
+        this.lookupKeyColumns = parseKeyColumns(this.lookupKeyColumn);
         final int cacheSize = context.getProperty(CACHE_SIZE).evaluateAttributeExpressions().asInteger();
         final boolean clearCache = context.getProperty(CLEAR_CACHE_ON_ENABLED).asBoolean();
         final long durationNanos = context.getProperty(CACHE_EXPIRATION).isSet() ? context.getProperty(CACHE_EXPIRATION).evaluateAttributeExpressions().asTimePeriod(TimeUnit.NANOSECONDS) : 0L;
@@ -98,19 +104,19 @@ public class DatabaseRecordLookupService extends AbstractDatabaseLookupService i
             if (durationNanos > 0) {
                 this.cache = Caffeine.newBuilder()
                         .maximumSize(cacheSize)
-                        .expireAfter(new Expiry<Tuple<String, Object>, Record>() {
+                        .expireAfter(new Expiry<List<Object>, Record>() {
                             @Override
-                            public long expireAfterCreate(Tuple<String, Object> stringObjectTuple, Record record, long currentTime) {
+                            public long expireAfterCreate(List<Object> key, Record record, long currentTime) {
                                 return durationNanos;
                             }
 
                             @Override
-                            public long expireAfterUpdate(Tuple<String, Object> stringObjectTuple, Record record, long currentTime, long currentDuration) {
+                            public long expireAfterUpdate(List<Object> key, Record record, long currentTime, long currentDuration) {
                                 return currentDuration;
                             }
 
                             @Override
-                            public long expireAfterRead(Tuple<String, Object> stringObjectTuple, Record record, long currentTime, long currentDuration) {
+                            public long expireAfterRead(List<Object> key, Record record, long currentTime, long currentDuration) {
                                 return currentDuration;
                             }
                         })
@@ -134,9 +140,22 @@ public class DatabaseRecordLookupService extends AbstractDatabaseLookupService i
             return Optional.empty();
         }
 
-        final Object key = coordinates.get(KEY);
-        if (StringUtils.isBlank(key.toString())) {
-            return Optional.empty();
+        // Build ordered list of key values from coordinates
+        final List<Object> keyValues = new ArrayList<>(lookupKeyColumns.size());
+        if (isCompositeKey()) {
+            for (final String col : lookupKeyColumns) {
+                final Object val = coordinates.get(col);
+                if (val == null || StringUtils.isBlank(val.toString())) {
+                    return Optional.empty();
+                }
+                keyValues.add(val);
+            }
+        } else {
+            final Object key = coordinates.get(KEY);
+            if (key == null || StringUtils.isBlank(key.toString())) {
+                return Optional.empty();
+            }
+            keyValues.add(key);
         }
 
         final String tableName = getProperty(TABLE_NAME).evaluateAttributeExpressions(context).getValue();
@@ -155,36 +174,91 @@ public class DatabaseRecordLookupService extends AbstractDatabaseLookupService i
 
         final String lookupValueColumns = lookupValueColumnsSet.isEmpty() ? "*" : String.join(",", lookupValueColumnsSet);
 
-        Tuple<String, Object> cacheLookupKey = new Tuple<>(tableName, key);
+        // Cache key includes table name and all key values
+        final List<Object> cacheKey = new ArrayList<>(keyValues.size() + 1);
+        cacheKey.add(tableName);
+        cacheKey.addAll(keyValues);
 
         // Not using the function param of cache.get so we can catch and handle the checked exceptions
-        Record foundRecord = cache.get(cacheLookupKey, k -> null);
+        Record foundRecord = cache.get(cacheKey, k -> null);
 
         if (foundRecord == null) {
-            final String selectQuery = "SELECT " + lookupValueColumns + " FROM " + tableName + " WHERE " + lookupKeyColumn + " = ?";
+            final String whereClause = lookupKeyColumns.stream()
+                    .map(col -> col + " = ?")
+                    .collect(Collectors.joining(" AND "));
+            final String selectQuery = "SELECT " + lookupValueColumns + " FROM " + tableName + " WHERE " + whereClause;
             try (final Connection con = dbcpService.getConnection(context);
                  final PreparedStatement st = con.prepareStatement(selectQuery)) {
 
-                st.setObject(1, key);
-                ResultSet resultSet = st.executeQuery();
-                ResultSetRecordSet resultSetRecordSet = new ResultSetRecordSet(resultSet, null, defaultPrecision, defaultScale);
-                foundRecord = resultSetRecordSet.next();
+                for (int i = 0; i < keyValues.size(); i++) {
+                    Object value = keyValues.get(i);
+                    try {
+                        final int sqlType = st.getParameterMetaData().getParameterType(i + 1);
+                        if (value instanceof String) {
+                            value = coerceValue((String) value, sqlType);
+                        }
+                        st.setObject(i + 1, value, sqlType);
+                    } catch (final SQLException | NullPointerException e) {
+                        if (value instanceof String) {
+                            value = coerceStringValue((String) value);
+                        }
+                        st.setObject(i + 1, value);
+                    }
+                }
+
+                final ResultSet resultSet = st.executeQuery();
+                try (final ResultSetRecordSet resultSetRecordSet = new ResultSetRecordSet(resultSet, null, defaultPrecision, defaultScale)) {
+                    foundRecord = resultSetRecordSet.next();
+                }
 
                 // Populate the cache if the record is present
                 if (foundRecord != null) {
-                    cache.put(cacheLookupKey, foundRecord);
+                    cache.put(cacheKey, foundRecord);
                 }
 
-            } catch (SQLException se) {
-                throw new LookupFailureException("Error executing SQL statement: " + selectQuery + "for value " + key.toString()
+            } catch (final SQLException se) {
+                throw new LookupFailureException("Error executing SQL statement: " + selectQuery + " for values " + keyValues
                         + " : " + (se.getCause() == null ? se.getMessage() : se.getCause().getMessage()), se);
-            } catch (IOException ioe) {
-                throw new LookupFailureException("Error retrieving result set for SQL statement: " + selectQuery + "for value " + key.toString()
+            } catch (final IOException ioe) {
+                throw new LookupFailureException("Error retrieving result set for SQL statement: " + selectQuery + " for values " + keyValues
                         + " : " + (ioe.getCause() == null ? ioe.getMessage() : ioe.getCause().getMessage()), ioe);
             }
         }
 
         return Optional.ofNullable(foundRecord);
+    }
+
+    static Object coerceValue(final String value, final int sqlType) {
+        switch (sqlType) {
+            case Types.INTEGER:
+            case Types.SMALLINT:
+            case Types.TINYINT:
+                return Integer.valueOf(value);
+            case Types.BIGINT:
+                return Long.valueOf(value);
+            case Types.FLOAT:
+            case Types.REAL:
+                return Float.valueOf(value);
+            case Types.DOUBLE:
+                return Double.valueOf(value);
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return new java.math.BigDecimal(value);
+            default:
+                return value;
+        }
+    }
+
+    static Object coerceStringValue(final String value) {
+        try {
+            return Integer.valueOf(value);
+        } catch (final NumberFormatException e) {
+            try {
+                return Long.valueOf(value);
+            } catch (final NumberFormatException e2) {
+                return value;
+            }
+        }
     }
 
     private static boolean isNotBlank(final String value) {
@@ -193,7 +267,10 @@ public class DatabaseRecordLookupService extends AbstractDatabaseLookupService i
 
     @Override
     public Set<String> getRequiredKeys() {
-        return REQUIRED_KEYS;
+        if (isCompositeKey()) {
+            return new LinkedHashSet<>(lookupKeyColumns);
+        }
+        return Set.of(KEY);
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/SimpleDatabaseLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/SimpleDatabaseLookupService.java
@@ -32,24 +32,29 @@ import org.apache.nifi.lookup.LookupFailureException;
 import org.apache.nifi.lookup.StringLookupService;
 import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.util.Tuple;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Tags({"lookup", "cache", "enrich", "join", "rdbms", "database", "reloadable", "key", "value"})
 @CapabilityDescription("A relational-database-based lookup service. When the lookup key is found in the database, " +
-        "the specified lookup value column is returned. Only one value will be returned for each lookup, duplicate database entries are ignored.")
+        "the specified lookup value column is returned. Supports composite (multi-column) primary key lookups by " +
+        "specifying a comma-separated list of column names in the Lookup Key Column property. " +
+        "Only one value will be returned for each lookup, duplicate database entries are ignored.")
 public class SimpleDatabaseLookupService extends AbstractDatabaseLookupService implements StringLookupService {
 
-    private volatile Cache<Tuple<String, Object>, String> cache;
+    private volatile Cache<List<Object>, String> cache;
 
     static final PropertyDescriptor LOOKUP_VALUE_COLUMN =
             new PropertyDescriptor.Builder()
@@ -79,6 +84,7 @@ public class SimpleDatabaseLookupService extends AbstractDatabaseLookupService i
     public void onEnabled(final ConfigurationContext context) {
         this.dbcpService = context.getProperty(DBCP_SERVICE).asControllerService(DBCPService.class);
         this.lookupKeyColumn = context.getProperty(LOOKUP_KEY_COLUMN).evaluateAttributeExpressions().getValue();
+        this.lookupKeyColumns = parseKeyColumns(this.lookupKeyColumn);
         int cacheSize = context.getProperty(CACHE_SIZE).evaluateAttributeExpressions().asInteger();
         boolean clearCache = context.getProperty(CLEAR_CACHE_ON_ENABLED).asBoolean();
         final long durationNanos = context.getProperty(CACHE_EXPIRATION).isSet() ? context.getProperty(CACHE_EXPIRATION).evaluateAttributeExpressions().asTimePeriod(TimeUnit.NANOSECONDS) : 0L;
@@ -86,19 +92,19 @@ public class SimpleDatabaseLookupService extends AbstractDatabaseLookupService i
             if (durationNanos > 0) {
                 this.cache = Caffeine.newBuilder()
                         .maximumSize(cacheSize)
-                        .expireAfter(new Expiry<Tuple<String, Object>, Object>() {
+                        .expireAfter(new Expiry<List<Object>, String>() {
                             @Override
-                            public long expireAfterCreate(Tuple<String, Object> stringObjectTuple, Object value, long currentTime) {
+                            public long expireAfterCreate(List<Object> key, String value, long currentTime) {
                                 return durationNanos;
                             }
 
                             @Override
-                            public long expireAfterUpdate(Tuple<String, Object> stringObjectTuple, Object value, long currentTime, long currentDuration) {
+                            public long expireAfterUpdate(List<Object> key, String value, long currentTime, long currentDuration) {
                                 return currentDuration;
                             }
 
                             @Override
-                            public long expireAfterRead(Tuple<String, Object> stringObjectTuple, Object value, long currentTime, long currentDuration) {
+                            public long expireAfterRead(List<Object> key, String value, long currentTime, long currentDuration) {
                                 return currentDuration;
                             }
                         })
@@ -122,25 +128,59 @@ public class SimpleDatabaseLookupService extends AbstractDatabaseLookupService i
             return Optional.empty();
         }
 
-        final Object key = coordinates.get(KEY);
-        if (StringUtils.isBlank(key.toString())) {
-            return Optional.empty();
+        // Build ordered list of key values from coordinates
+        final List<Object> keyValues = new ArrayList<>(lookupKeyColumns.size());
+        if (isCompositeKey()) {
+            for (final String col : lookupKeyColumns) {
+                final Object val = coordinates.get(col);
+                if (val == null || StringUtils.isBlank(val.toString())) {
+                    return Optional.empty();
+                }
+                keyValues.add(val);
+            }
+        } else {
+            final Object key = coordinates.get(KEY);
+            if (key == null || StringUtils.isBlank(key.toString())) {
+                return Optional.empty();
+            }
+            keyValues.add(key);
         }
 
         final String tableName = getProperty(TABLE_NAME).evaluateAttributeExpressions(context).getValue();
         final String lookupValueColumn = getProperty(LOOKUP_VALUE_COLUMN).evaluateAttributeExpressions(context).getValue();
 
-        Tuple<String, Object> cacheLookupKey = new Tuple<>(tableName, key);
+        // Cache key includes table name and all key values
+        final List<Object> cacheKey = new ArrayList<>(keyValues.size() + 1);
+        cacheKey.add(tableName);
+        cacheKey.addAll(keyValues);
 
         // Not using the function param of cache.get so we can catch and handle the checked exceptions
-        String foundRecord = cache.get(cacheLookupKey, k -> null);
+        String foundRecord = cache.get(cacheKey, k -> null);
 
         if (foundRecord == null) {
-            final String selectQuery = "SELECT " + lookupValueColumn + " FROM " + tableName + " WHERE " + lookupKeyColumn + " = ?";
+            final String whereClause = lookupKeyColumns.stream()
+                    .map(col -> col + " = ?")
+                    .collect(Collectors.joining(" AND "));
+            final String selectQuery = "SELECT " + lookupValueColumn + " FROM " + tableName + " WHERE " + whereClause;
             try (final Connection con = dbcpService.getConnection(context);
                  final PreparedStatement st = con.prepareStatement(selectQuery)) {
 
-                st.setObject(1, key);
+                for (int i = 0; i < keyValues.size(); i++) {
+                    Object value = keyValues.get(i);
+                    try {
+                        final int sqlType = st.getParameterMetaData().getParameterType(i + 1);
+                        if (value instanceof String) {
+                            value = coerceValue((String) value, sqlType);
+                        }
+                        st.setObject(i + 1, value, sqlType);
+                    } catch (final SQLException | NullPointerException e) {
+                        if (value instanceof String) {
+                            value = coerceStringValue((String) value);
+                        }
+                        st.setObject(i + 1, value);
+                    }
+                }
+
                 ResultSet resultSet = st.executeQuery();
 
                 if (!resultSet.next()) {
@@ -155,11 +195,11 @@ public class SimpleDatabaseLookupService extends AbstractDatabaseLookupService i
 
                 // Populate the cache if the record is present
                 if (foundRecord != null) {
-                    cache.put(cacheLookupKey, foundRecord);
+                    cache.put(cacheKey, foundRecord);
                 }
 
             } catch (SQLException se) {
-                throw new LookupFailureException("Error executing SQL statement: " + selectQuery + "for value " + key.toString()
+                throw new LookupFailureException("Error executing SQL statement: " + selectQuery + " for values " + keyValues
                         + " : " + (se.getCause() == null ? se.getMessage() : se.getCause().getMessage()), se);
             }
         }
@@ -167,9 +207,45 @@ public class SimpleDatabaseLookupService extends AbstractDatabaseLookupService i
         return Optional.ofNullable(foundRecord);
     }
 
+    static Object coerceValue(final String value, final int sqlType) {
+        switch (sqlType) {
+            case Types.INTEGER:
+            case Types.SMALLINT:
+            case Types.TINYINT:
+                return Integer.valueOf(value);
+            case Types.BIGINT:
+                return Long.valueOf(value);
+            case Types.FLOAT:
+            case Types.REAL:
+                return Float.valueOf(value);
+            case Types.DOUBLE:
+                return Double.valueOf(value);
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return new java.math.BigDecimal(value);
+            default:
+                return value;
+        }
+    }
+
+    static Object coerceStringValue(final String value) {
+        try {
+            return Integer.valueOf(value);
+        } catch (final NumberFormatException e) {
+            try {
+                return Long.valueOf(value);
+            } catch (final NumberFormatException e2) {
+                return value;
+            }
+        }
+    }
+
     @Override
     public Set<String> getRequiredKeys() {
-        return REQUIRED_KEYS;
+        if (isCompositeKey()) {
+            return new LinkedHashSet<>(lookupKeyColumns);
+        }
+        return Set.of(KEY);
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/db/TestDatabaseRecordLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/db/TestDatabaseRecordLookupService.java
@@ -41,8 +41,10 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.apache.nifi.util.db.JdbcProperties.DEFAULT_PRECISION;
 import static org.apache.nifi.util.db.JdbcProperties.DEFAULT_SCALE;
@@ -185,5 +187,85 @@ class TestDatabaseRecordLookupService {
         verify(connection).prepareStatement(statementCaptor.capture());
         final String statement = statementCaptor.getValue();
         assertEquals(EXPECTED_STATEMENT, statement);
+    }
+
+    // --- Composite key tests ---
+
+    private static final String COMPOSITE_KEY_COLUMN_1 = "system_id";
+    private static final String COMPOSITE_KEY_COLUMN_2 = "fund_code";
+    private static final String COMPOSITE_KEY_COLUMNS = COMPOSITE_KEY_COLUMN_1 + ", " + COMPOSITE_KEY_COLUMN_2;
+    private static final String COMPOSITE_KEY_VALUE_1 = "PML";
+    private static final int COMPOSITE_KEY_VALUE_2 = 13128;
+    private static final String COMPOSITE_EXPECTED_STATEMENT = String.format(
+            "SELECT %s FROM %s WHERE %s = ? AND %s = ?",
+            LOOKUP_VALUE_COLUMN, TABLE_NAME, COMPOSITE_KEY_COLUMN_1, COMPOSITE_KEY_COLUMN_2);
+
+    private void setUpCompositeKey() {
+        runner.setProperty(lookupService, DatabaseRecordLookupService.LOOKUP_KEY_COLUMN, COMPOSITE_KEY_COLUMNS);
+    }
+
+    @Test
+    void testCompositeKeyLookupEmpty() throws LookupFailureException, SQLException {
+        setUpCompositeKey();
+        runner.enableControllerService(lookupService);
+
+        setConnection();
+
+        final Map<String, Object> coordinates = Map.of(
+                COMPOSITE_KEY_COLUMN_1, COMPOSITE_KEY_VALUE_1,
+                COMPOSITE_KEY_COLUMN_2, COMPOSITE_KEY_VALUE_2);
+        final Optional<Record> lookupFound = lookupService.lookup(coordinates);
+
+        assertFalse(lookupFound.isPresent());
+        verify(connection).prepareStatement(statementCaptor.capture());
+        assertEquals(COMPOSITE_EXPECTED_STATEMENT, statementCaptor.getValue());
+    }
+
+    @Test
+    void testCompositeKeyLookupFound() throws LookupFailureException, SQLException {
+        setUpCompositeKey();
+        runner.enableControllerService(lookupService);
+
+        setConnection();
+        setResultSetMetaData();
+
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getObject(eq(LOOKUP_VALUE_COLUMN))).thenReturn(LOOKUP_VALUE);
+
+        final Map<String, Object> coordinates = Map.of(
+                COMPOSITE_KEY_COLUMN_1, COMPOSITE_KEY_VALUE_1,
+                COMPOSITE_KEY_COLUMN_2, COMPOSITE_KEY_VALUE_2);
+        final Optional<Record> lookupFound = lookupService.lookup(coordinates);
+
+        assertTrue(lookupFound.isPresent());
+    }
+
+    @Test
+    void testCompositeKeyLookupMissingCoordinate() throws LookupFailureException, SQLException {
+        setUpCompositeKey();
+        runner.enableControllerService(lookupService);
+
+        // Only provide one of the two required keys
+        final Map<String, Object> coordinates = Map.of(COMPOSITE_KEY_COLUMN_1, COMPOSITE_KEY_VALUE_1);
+        final Optional<Record> lookupFound = lookupService.lookup(coordinates);
+
+        assertFalse(lookupFound.isPresent());
+    }
+
+    @Test
+    void testCompositeKeyGetRequiredKeys() {
+        setUpCompositeKey();
+        runner.enableControllerService(lookupService);
+
+        final Set<String> requiredKeys = lookupService.getRequiredKeys();
+        assertEquals(new LinkedHashSet<>(java.util.List.of(COMPOSITE_KEY_COLUMN_1, COMPOSITE_KEY_COLUMN_2)), requiredKeys);
+    }
+
+    @Test
+    void testSingleKeyGetRequiredKeys() {
+        runner.enableControllerService(lookupService);
+
+        final Set<String> requiredKeys = lookupService.getRequiredKeys();
+        assertEquals(Set.of("key"), requiredKeys);
     }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/db/TestSimpleDatabaseLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/db/TestSimpleDatabaseLookupService.java
@@ -37,8 +37,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -165,5 +167,86 @@ class TestSimpleDatabaseLookupService {
         verify(connection).prepareStatement(statementCaptor.capture());
         final String statement = statementCaptor.getValue();
         assertEquals(EXPECTED_STATEMENT, statement);
+    }
+
+    // --- Composite key tests ---
+
+    private static final String COMPOSITE_KEY_COLUMN_1 = "system_id";
+    private static final String COMPOSITE_KEY_COLUMN_2 = "fund_code";
+    private static final String COMPOSITE_KEY_COLUMNS = COMPOSITE_KEY_COLUMN_1 + ", " + COMPOSITE_KEY_COLUMN_2;
+    private static final String COMPOSITE_KEY_VALUE_1 = "PML";
+    private static final int COMPOSITE_KEY_VALUE_2 = 13128;
+    private static final String COMPOSITE_EXPECTED_STATEMENT = String.format(
+            "SELECT %s FROM %s WHERE %s = ? AND %s = ?",
+            LOOKUP_VALUE_COLUMN, TABLE_NAME, COMPOSITE_KEY_COLUMN_1, COMPOSITE_KEY_COLUMN_2);
+
+    private void setUpCompositeKey() {
+        runner.setProperty(lookupService, SimpleDatabaseLookupService.LOOKUP_KEY_COLUMN, COMPOSITE_KEY_COLUMNS);
+    }
+
+    @Test
+    void testCompositeKeyLookupEmpty() throws LookupFailureException, SQLException {
+        setUpCompositeKey();
+        runner.enableControllerService(lookupService);
+
+        setConnection();
+
+        final Map<String, Object> coordinates = Map.of(
+                COMPOSITE_KEY_COLUMN_1, COMPOSITE_KEY_VALUE_1,
+                COMPOSITE_KEY_COLUMN_2, COMPOSITE_KEY_VALUE_2);
+        final Optional<String> lookupFound = lookupService.lookup(coordinates);
+
+        assertFalse(lookupFound.isPresent());
+        verify(connection).prepareStatement(statementCaptor.capture());
+        assertEquals(COMPOSITE_EXPECTED_STATEMENT, statementCaptor.getValue());
+    }
+
+    @Test
+    void testCompositeKeyLookupFound() throws LookupFailureException, SQLException {
+        setUpCompositeKey();
+        runner.enableControllerService(lookupService);
+
+        setConnection();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getObject(eq(LOOKUP_VALUE_COLUMN))).thenReturn(LOOKUP_VALUE);
+
+        final Map<String, Object> coordinates = Map.of(
+                COMPOSITE_KEY_COLUMN_1, COMPOSITE_KEY_VALUE_1,
+                COMPOSITE_KEY_COLUMN_2, COMPOSITE_KEY_VALUE_2);
+        final Optional<String> lookupFound = lookupService.lookup(coordinates);
+
+        assertTrue(lookupFound.isPresent());
+        assertEquals(LOOKUP_VALUE, lookupFound.get());
+        verify(connection).prepareStatement(statementCaptor.capture());
+        assertEquals(COMPOSITE_EXPECTED_STATEMENT, statementCaptor.getValue());
+    }
+
+    @Test
+    void testCompositeKeyLookupMissingCoordinate() throws LookupFailureException, SQLException {
+        setUpCompositeKey();
+        runner.enableControllerService(lookupService);
+
+        // Only provide one of the two required keys
+        final Map<String, Object> coordinates = Map.of(COMPOSITE_KEY_COLUMN_1, COMPOSITE_KEY_VALUE_1);
+        final Optional<String> lookupFound = lookupService.lookup(coordinates);
+
+        assertFalse(lookupFound.isPresent());
+    }
+
+    @Test
+    void testCompositeKeyGetRequiredKeys() {
+        setUpCompositeKey();
+        runner.enableControllerService(lookupService);
+
+        final Set<String> requiredKeys = lookupService.getRequiredKeys();
+        assertEquals(new LinkedHashSet<>(java.util.List.of(COMPOSITE_KEY_COLUMN_1, COMPOSITE_KEY_COLUMN_2)), requiredKeys);
+    }
+
+    @Test
+    void testSingleKeyGetRequiredKeys() {
+        runner.enableControllerService(lookupService);
+
+        final Set<String> requiredKeys = lookupService.getRequiredKeys();
+        assertEquals(Set.of("key"), requiredKeys);
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-7686](https://issues.apache.org/jira/browse/NIFI-7686)

Added composite key support to DatabaseRecordLookupService and SimpleDatabaseLookupService. When LOOKUP_KEY_COLUMN contains a comma-separated list of column names, the services build a composite WHERE clause and expect coordinates keyed by column name instead of the single 'key' coordinate.

Includes type coercion so String values from LookupRecord are converted to the correct SQL types based on ParameterMetaData.

Backward compatible: single-key behavior is unchanged.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
