### PR TITLE
NIFI-15890 Add Token Request Endpoint property to AwsRdsIamDatabasePasswordProvider

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/rds/AwsRdsIamDatabasePasswordProvider.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/rds/AwsRdsIamDatabasePasswordProvider.java
@@ -29,6 +29,7 @@ import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.dbcp.api.DatabasePasswordProvider;
 import org.apache.nifi.dbcp.api.DatabasePasswordRequestContext;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.aws.credentials.provider.AwsCredentialsProviderService;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -60,15 +61,24 @@ public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService
             .required(true)
             .build();
 
+    static final PropertyDescriptor RDS_ENDPOINT = new PropertyDescriptor.Builder()
+            .name("RDS Endpoint")
+            .description("RDS endpoint in hostname:port format used for IAM token signing, overriding the hostname and port from the JDBC URL.")
+            .required(false)
+            .addValidator(StandardValidators.HOSTNAME_PORT_LIST_VALIDATOR)
+            .build();
+
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             AWS_CREDENTIALS_PROVIDER_SERVICE,
             REGION,
-            CUSTOM_REGION
+            CUSTOM_REGION,
+            RDS_ENDPOINT
     );
 
     private volatile AwsCredentialsProvider awsCredentialsProvider;
     private volatile RdsUtilities rdsUtilities;
     private volatile Region awsRegion;
+    private volatile ParsedEndpoint rdsEndpoint;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -95,6 +105,7 @@ public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService
         awsCredentialsProvider = credentialsService.getAwsCredentialsProvider();
         awsRegion = getRegion(context);
         rdsUtilities = createRdsUtilities(awsRegion, awsCredentialsProvider);
+        rdsEndpoint = getRdsEndpoint(context);
     }
 
     @OnDisabled
@@ -102,15 +113,23 @@ public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService
         awsCredentialsProvider = null;
         rdsUtilities = null;
         awsRegion = null;
+        rdsEndpoint = null;
     }
 
     @Override
     public char[] getPassword(final DatabasePasswordRequestContext requestContext) {
         Objects.requireNonNull(requestContext, "Database Password Request Context required");
 
-        final ParsedEndpoint parsedEndpoint = parseEndpoint(requestContext.getJdbcUrl());
-        final String hostname = resolveHostname(parsedEndpoint, requestContext.getJdbcUrl());
-        final int port = resolvePort(parsedEndpoint);
+        final String hostname;
+        final int port;
+        if (rdsEndpoint != null) {
+            hostname = rdsEndpoint.hostname();
+            port = rdsEndpoint.port();
+        } else {
+            final ParsedEndpoint jdbcEndpoint = parseEndpoint(requestContext.getJdbcUrl());
+            hostname = resolveHostname(jdbcEndpoint, requestContext.getJdbcUrl());
+            port = resolvePort(jdbcEndpoint);
+        }
         final String username = resolveUsername(requestContext.getDatabaseUser());
 
         final GenerateAuthenticationTokenRequest tokenRequest = GenerateAuthenticationTokenRequest.builder()
@@ -158,6 +177,22 @@ public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService
             throw new ProcessException("Database Username not configured and referencing DBCP service did not provide a username");
         }
         return username;
+    }
+
+    private ParsedEndpoint getRdsEndpoint(final ConfigurationContext context) {
+        return context.getProperty(RDS_ENDPOINT).isSet()
+                ? parseRdsEndpoint(context.getProperty(RDS_ENDPOINT).getValue())
+                : null;
+    }
+
+    private ParsedEndpoint parseRdsEndpoint(final String endpoint) {
+        try {
+            // Prepend a dummy scheme to delegate host and port parsing to the standard URI parser
+            final URI uri = URI.create("tcp://" + endpoint);
+            return new ParsedEndpoint(uri.getHost(), uri.getPort() >= 0 ? uri.getPort() : null);
+        } catch (final IllegalArgumentException e) {
+            throw new ProcessException("Failed to parse RDS Endpoint [%s] as hostname:port".formatted(endpoint), e);
+        }
     }
 
     private ParsedEndpoint parseEndpoint(final String jdbcUrl) {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/rds/AwsRdsIamDatabasePasswordProvider.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/rds/AwsRdsIamDatabasePasswordProvider.java
@@ -54,6 +54,8 @@ import static org.apache.nifi.processors.aws.region.RegionUtil.isDynamicRegion;
         """)
 public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService implements DatabasePasswordProvider {
 
+    private static final String URI_ENDPOINT_FORMAT = "tcp://%s";
+
     static final PropertyDescriptor AWS_CREDENTIALS_PROVIDER_SERVICE = new PropertyDescriptor.Builder()
             .name("AWS Credentials Provider Service")
             .description("Controller Service that provides the AWS credentials used to sign IAM authentication requests.")
@@ -61,9 +63,9 @@ public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService
             .required(true)
             .build();
 
-    static final PropertyDescriptor RDS_ENDPOINT = new PropertyDescriptor.Builder()
-            .name("RDS Endpoint")
-            .description("RDS endpoint in hostname:port format used for IAM token signing, overriding the hostname and port from the JDBC URL.")
+    static final PropertyDescriptor TOKEN_REQUEST_ENDPOINT = new PropertyDescriptor.Builder()
+            .name("Token Request Endpoint")
+            .description("Token Request Endpoint in hostname:port format used for IAM token signing, overriding the hostname and port from the JDBC URL.")
             .required(false)
             .addValidator(StandardValidators.HOSTNAME_PORT_LIST_VALIDATOR)
             .build();
@@ -72,13 +74,13 @@ public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService
             AWS_CREDENTIALS_PROVIDER_SERVICE,
             REGION,
             CUSTOM_REGION,
-            RDS_ENDPOINT
+            TOKEN_REQUEST_ENDPOINT
     );
 
     private volatile AwsCredentialsProvider awsCredentialsProvider;
     private volatile RdsUtilities rdsUtilities;
     private volatile Region awsRegion;
-    private volatile ParsedEndpoint rdsEndpoint;
+    private volatile ParsedEndpoint tokenRequestEndpoint;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -105,7 +107,7 @@ public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService
         awsCredentialsProvider = credentialsService.getAwsCredentialsProvider();
         awsRegion = getRegion(context);
         rdsUtilities = createRdsUtilities(awsRegion, awsCredentialsProvider);
-        rdsEndpoint = getRdsEndpoint(context);
+        tokenRequestEndpoint = getTokenRequestEndpoint(context);
     }
 
     @OnDisabled
@@ -113,7 +115,7 @@ public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService
         awsCredentialsProvider = null;
         rdsUtilities = null;
         awsRegion = null;
-        rdsEndpoint = null;
+        tokenRequestEndpoint = null;
     }
 
     @Override
@@ -122,13 +124,13 @@ public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService
 
         final String hostname;
         final int port;
-        if (rdsEndpoint != null) {
-            hostname = rdsEndpoint.hostname();
-            port = rdsEndpoint.port();
-        } else {
+        if (tokenRequestEndpoint == null) {
             final ParsedEndpoint jdbcEndpoint = parseEndpoint(requestContext.getJdbcUrl());
             hostname = resolveHostname(jdbcEndpoint, requestContext.getJdbcUrl());
             port = resolvePort(jdbcEndpoint);
+        } else {
+            hostname = tokenRequestEndpoint.hostname();
+            port = tokenRequestEndpoint.port();
         }
         final String username = resolveUsername(requestContext.getDatabaseUser());
 
@@ -179,19 +181,18 @@ public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService
         return username;
     }
 
-    private ParsedEndpoint getRdsEndpoint(final ConfigurationContext context) {
-        return context.getProperty(RDS_ENDPOINT).isSet()
-                ? parseRdsEndpoint(context.getProperty(RDS_ENDPOINT).getValue())
+    private ParsedEndpoint getTokenRequestEndpoint(final ConfigurationContext context) {
+        return context.getProperty(TOKEN_REQUEST_ENDPOINT).isSet()
+                ? parseTokenRequestEndpoint(context.getProperty(TOKEN_REQUEST_ENDPOINT).getValue())
                 : null;
     }
 
-    private ParsedEndpoint parseRdsEndpoint(final String endpoint) {
+    private ParsedEndpoint parseTokenRequestEndpoint(final String endpoint) {
         try {
-            // Prepend a dummy scheme to delegate host and port parsing to the standard URI parser
-            final URI uri = URI.create("tcp://" + endpoint);
-            return new ParsedEndpoint(uri.getHost(), uri.getPort() >= 0 ? uri.getPort() : null);
+            final URI uri = URI.create(URI_ENDPOINT_FORMAT.formatted(endpoint));
+            return new ParsedEndpoint(uri.getHost(), uri.getPort());
         } catch (final IllegalArgumentException e) {
-            throw new ProcessException("Failed to parse RDS Endpoint [%s] as hostname:port".formatted(endpoint), e);
+            throw new ProcessException("Failed to parse Token Request Endpoint [%s] as hostname:port".formatted(endpoint), e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/docs/org.apache.nifi.processors.aws.rds.AwsRdsIamDatabasePasswordProvider/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/docs/org.apache.nifi.processors.aws.rds.AwsRdsIamDatabasePasswordProvider/additionalDetails.md
@@ -90,3 +90,31 @@ When that works, configure NiFi’s DBCP service with:
 - `Database Password Provider`: `AwsRdsIamDatabasePasswordProvider`
 
 NiFi will then mint IAM tokens automatically for each new JDBC connection.
+
+## Connecting Through a Network Load Balancer in Front of an RDS Proxy
+
+When connecting through a Network Load Balancer (NLB) placed in front of an RDS Proxy, the JDBC URL must point to the NLB endpoint, but the IAM token must be signed for the RDS Proxy endpoint. By default, the token is generated using the hostname extracted from the JDBC URL, which causes authentication to fail.
+
+Use the optional **RDS Endpoint** property to specify the RDS Proxy endpoint (`hostname:port`) for token signing while keeping the NLB endpoint in the JDBC URL for the actual TCP connection.
+
+### CLI verification
+
+```bash
+NLB_ENDPOINT="nlb-example.elb.us-east-1.amazonaws.com"
+RDS_PROXY_ENDPOINT="my-proxy.proxy-example.us-east-1.rds.amazonaws.com"
+
+TOKEN=$(aws rds generate-db-auth-token \
+  --hostname "$RDS_PROXY_ENDPOINT" \
+  --port 3306 \
+  --region us-east-1 \
+  --username nifi_app)
+
+mysql -h "$NLB_ENDPOINT" -P 3306 -u nifi_app --password="$TOKEN"
+```
+
+When that works, configure NiFi's DBCP service with:
+
+- `Database Connection URL`: `jdbc:mysql://nlb-example.elb.us-east-1.amazonaws.com:3306/mydb`
+- `Database User`: `nifi_app`
+- `Database Password Provider`: `AwsRdsIamDatabasePasswordProvider`
+- `RDS Endpoint`: `my-proxy.proxy-example.us-east-1.rds.amazonaws.com:3306`

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/docs/org.apache.nifi.processors.aws.rds.AwsRdsIamDatabasePasswordProvider/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/docs/org.apache.nifi.processors.aws.rds.AwsRdsIamDatabasePasswordProvider/additionalDetails.md
@@ -95,7 +95,7 @@ NiFi will then mint IAM tokens automatically for each new JDBC connection.
 
 When connecting through a Network Load Balancer (NLB) placed in front of an RDS Proxy, the JDBC URL must point to the NLB endpoint, but the IAM token must be signed for the RDS Proxy endpoint. By default, the token is generated using the hostname extracted from the JDBC URL, which causes authentication to fail.
 
-Use the optional **RDS Endpoint** property to specify the RDS Proxy endpoint (`hostname:port`) for token signing while keeping the NLB endpoint in the JDBC URL for the actual TCP connection.
+Use the optional **Token Request Endpoint** property to specify the RDS Proxy endpoint (`hostname:port`) for token signing while keeping the NLB endpoint in the JDBC URL for the actual TCP connection.
 
 ### CLI verification
 
@@ -117,4 +117,4 @@ When that works, configure NiFi's DBCP service with:
 - `Database Connection URL`: `jdbc:mysql://nlb-example.elb.us-east-1.amazonaws.com:3306/mydb`
 - `Database User`: `nifi_app`
 - `Database Password Provider`: `AwsRdsIamDatabasePasswordProvider`
-- `RDS Endpoint`: `my-proxy.proxy-example.us-east-1.rds.amazonaws.com:3306`
+- `Token Request Endpoint`: `my-proxy.proxy-example.us-east-1.rds.amazonaws.com:3306`

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/rds/AwsRdsIamDatabasePasswordProviderTest.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/rds/AwsRdsIamDatabasePasswordProviderTest.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.regions.Region;
 import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.ACCESS_KEY_ID;
 import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.SECRET_KEY;
 import static org.apache.nifi.processors.aws.rds.AwsRdsIamDatabasePasswordProvider.AWS_CREDENTIALS_PROVIDER_SERVICE;
+import static org.apache.nifi.processors.aws.rds.AwsRdsIamDatabasePasswordProvider.RDS_ENDPOINT;
 import static org.apache.nifi.processors.aws.region.RegionUtil.REGION;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,6 +44,7 @@ class AwsRdsIamDatabasePasswordProviderTest {
     private static final String POSTGRES_DRIVER_CLASS = "org.postgresql.Driver";
     private static final String DB_USER = "dbuser";
     private static final String HOSTNAME = "example.us-west-2.rds.amazonaws.com";
+    private static final String RDS_PROXY_HOSTNAME = "my-proxy.proxy-example.us-west-2.rds.amazonaws.com";
     private static final String JDBC_PREFIX = "jdbc:postgresql://";
     private static final String DATABASE = "dev";
     private static final int PORT = 5432;
@@ -79,7 +81,11 @@ class AwsRdsIamDatabasePasswordProviderTest {
     }
 
     @Test
-    void testGeneratesTokenWithDefaultPort() {
+    void testGeneratesTokenUsingRdsEndpointOverride() {
+        runner.disableControllerService(passwordProvider);
+        runner.setProperty(passwordProvider, RDS_ENDPOINT, "%s:%d".formatted(RDS_PROXY_HOSTNAME, PORT));
+        runner.enableControllerService(passwordProvider);
+
         final DatabasePasswordProvider service = getService();
         final DatabasePasswordRequestContext context = DatabasePasswordRequestContext.builder()
                 .jdbcUrl("%s%s:%d/%s".formatted(JDBC_PREFIX, HOSTNAME, PORT, DATABASE))
@@ -88,7 +94,7 @@ class AwsRdsIamDatabasePasswordProviderTest {
                 .build();
 
         final String token = new String(service.getPassword(context));
-        assertTrue(token.startsWith("%s:%d/".formatted(HOSTNAME, PORT)));
+        assertTrue(token.startsWith("%s:%d/".formatted(RDS_PROXY_HOSTNAME, PORT)));
         assertTrue(token.contains("DBUser=" + DB_USER));
     }
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/rds/AwsRdsIamDatabasePasswordProviderTest.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/rds/AwsRdsIamDatabasePasswordProviderTest.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.regions.Region;
 import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.ACCESS_KEY_ID;
 import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.SECRET_KEY;
 import static org.apache.nifi.processors.aws.rds.AwsRdsIamDatabasePasswordProvider.AWS_CREDENTIALS_PROVIDER_SERVICE;
-import static org.apache.nifi.processors.aws.rds.AwsRdsIamDatabasePasswordProvider.RDS_ENDPOINT;
+import static org.apache.nifi.processors.aws.rds.AwsRdsIamDatabasePasswordProvider.TOKEN_REQUEST_ENDPOINT;
 import static org.apache.nifi.processors.aws.region.RegionUtil.REGION;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -81,9 +81,9 @@ class AwsRdsIamDatabasePasswordProviderTest {
     }
 
     @Test
-    void testGeneratesTokenUsingRdsEndpointOverride() {
+    void testGeneratesTokenUsingTokenRequestEndpointOverride() {
         runner.disableControllerService(passwordProvider);
-        runner.setProperty(passwordProvider, RDS_ENDPOINT, "%s:%d".formatted(RDS_PROXY_HOSTNAME, PORT));
+        runner.setProperty(passwordProvider, TOKEN_REQUEST_ENDPOINT, "%s:%d".formatted(RDS_PROXY_HOSTNAME, PORT));
         runner.enableControllerService(passwordProvider);
 
         final DatabasePasswordProvider service = getService();


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15890](https://issues.apache.org/jira/browse/NIFI-15890)

Added an optional `Token Request Endpoint` property to `AwsRdsIamDatabasePasswordProvider` to support architectures where the JDBC URL points to an intermediary such as a Network Load Balancer in front of an RDS Proxy.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [x] JDK 25

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
