### PR TITLE
NIFI-15891: Connector Asset Sync on Create and Restore

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorRepository.java
@@ -96,13 +96,25 @@ public class StandardConnectorRepository implements ConnectorRepository {
 
     @Override
     public void addConnector(final ConnectorNode connector) {
-        syncFromProvider(connector);
+        syncAssetsFromProvider(connector);
         connectors.put(connector.getIdentifier(), connector);
     }
 
     @Override
     public void restoreConnector(final ConnectorNode connector) {
         connectors.put(connector.getIdentifier(), connector);
+
+        // Reconcile asset binaries and working configuration with the provider so that connectors
+        // restored from the persisted flow do not require an explicit applyUpdate to download
+        // assets that are missing locally or whose digests are unknown. Provider failures during
+        // restore must not prevent the connector from being added to the repository, since the
+        // provider may be temporarily unavailable at startup.
+        try {
+            syncAssetsFromProvider(connector);
+        } catch (final Exception e) {
+            logger.warn("Failed to synchronize assets from provider for restored {}; continuing without sync", connector, e);
+        }
+
         logger.debug("Successfully restored {}", connector);
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorRepository.java
@@ -51,6 +51,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -696,10 +698,49 @@ public class TestStandardConnectorRepository {
 
         repository.syncAssetsFromProvider(connector);
 
-        // Step 1: provider.syncAssets() called
-        verify(provider).syncAssets("connector-1");
+        // Step 1: provider.syncAssets() called (also invoked by addConnector, so happens at least twice)
+        verify(provider, atLeast(2)).syncAssets("connector-1");
         // Step 2: provider.load() called to reload updated config (may also have been called during addConnector)
-        verify(provider, org.mockito.Mockito.atLeastOnce()).load("connector-1");
+        verify(provider, atLeastOnce()).load("connector-1");
+    }
+
+    @Test
+    public void testAddConnectorSyncsAssetsFromProvider() {
+        final ConnectorConfigurationProvider provider = mock(ConnectorConfigurationProvider.class);
+        when(provider.load("connector-1")).thenReturn(Optional.empty());
+        final StandardConnectorRepository repository = createRepositoryWithProvider(provider);
+
+        final ConnectorNode connector = createSimpleConnectorNode("connector-1", "Test");
+        repository.addConnector(connector);
+
+        verify(provider).syncAssets("connector-1");
+        verify(provider).load("connector-1");
+    }
+
+    @Test
+    public void testRestoreConnectorSyncsAssetsFromProvider() {
+        final ConnectorConfigurationProvider provider = mock(ConnectorConfigurationProvider.class);
+        when(provider.load("connector-1")).thenReturn(Optional.empty());
+        final StandardConnectorRepository repository = createRepositoryWithProvider(provider);
+
+        final ConnectorNode connector = createSimpleConnectorNode("connector-1", "Test");
+        repository.restoreConnector(connector);
+
+        assertEquals(1, repository.getConnectors().size());
+        verify(provider).syncAssets("connector-1");
+    }
+
+    @Test
+    public void testRestoreConnectorTolerantOfProviderFailure() {
+        final ConnectorConfigurationProvider provider = mock(ConnectorConfigurationProvider.class);
+        doThrow(new ConnectorConfigurationProviderException("Provider unavailable"))
+                .when(provider).syncAssets("connector-1");
+        final StandardConnectorRepository repository = createRepositoryWithProvider(provider);
+
+        final ConnectorNode connector = createSimpleConnectorNode("connector-1", "Test");
+        repository.restoreConnector(connector);
+
+        assertEquals(1, repository.getConnectors().size(), "Restore must succeed even if provider sync fails");
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15891](https://issues.apache.org/jira/browse/NIFI-15891)


addConnector calls syncFromProvider, which only invokes configurationProvider.load(connectorId) 
The only paths that actually call configurationProvider.syncAssets(connectorId) (which is the method that downloads binaries) are:

StandardConnectorRepository.syncAssetsFromProvider (line 771–784), which is invoked from
applyUpdate (line 523), and
StandardConnectorDAO.syncAssetsFromProvider (web layer) — i.e., an explicit REST call.
So on a NiFi restart, when the connector node is restored from flow.json.gz, syncAssets is never called and no binary will be (re-)downloaded just by virtue of NiFi starting. 

This change allows asset sync to happen at those points.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
