### PR TITLE
NIFI-15895 Set Apache HttpClient5 version to 5.6.1

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -53,6 +53,12 @@
                 <version>2.10.0-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
+            <!-- Override httpclient 5.6 from apache5-client -->
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>5.6.1</version>
+            </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>sts</artifactId>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
@@ -69,6 +69,12 @@
                 <artifactId>aircompressor</artifactId>
                 <version>2.0.3</version>
             </dependency>
+            <!-- Override httpclient 5.6 from iceberg-core -->
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>5.6.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,6 @@
         <okio.version>3.17.0</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
-        <org.apache.httpcomponents.client5.version>5.6.1</org.apache.httpcomponents.client5.version>
         <org.apache.sshd.version>2.17.1</org.apache.sshd.version>
 
         <!-- Security -->
@@ -367,11 +366,6 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5</artifactId>
-                <version>${org.apache.httpcomponents.client5.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@
         <okio.version>3.17.0</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
+        <org.apache.httpcomponents.client5.version>5.6.1</org.apache.httpcomponents.client5.version>
         <org.apache.sshd.version>2.17.1</org.apache.sshd.version>
 
         <!-- Security -->
@@ -366,6 +367,11 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${org.apache.httpcomponents.client5.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>


### PR DESCRIPTION
# Summary

[NIFI-15895](https://issues.apache.org/jira/browse/NIFI-15895) Sets the Apache HttpClient5 library version to [5.6.1](https://downloads.apache.org/httpcomponents/httpclient/RELEASE_NOTES-5.6.x.txt) mitigating CVE-2026-40542. The library is packaged as a dependency in `nifi-aws-services-api-nar` and `nifi-iceberg-shared-nar`. Applying the dependency management version in the root Maven configuration applies to all modules.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
