### PR TITLE
NIFI-15902: Ensure subject is included in merged clustered response f…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ConfigVerificationResultMerger.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ConfigVerificationResultMerger.java
@@ -105,6 +105,7 @@ public class ConfigVerificationResultMerger {
             resultDto.setVerificationStepName(stepName);
             resultDto.setOutcome(selected.result().getOutcome());
             resultDto.setExplanation(aggregateExplanation);
+            resultDto.setSubject(selected.result().getSubject());
 
             aggregateResults.add(resultDto);
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ConfigVerificationResultMergerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ConfigVerificationResultMergerTest.java
@@ -188,11 +188,55 @@ class ConfigVerificationResultMergerTest {
         assertEquals("OK", results.get(0).getExplanation());
     }
 
+    @Test
+    void testSingleNodeSubjectPreserved() {
+        final ConfigVerificationResultMerger merger = new ConfigVerificationResultMerger();
+        merger.addNodeResults(NODE_1, List.of(createResult("Step 1", Outcome.FAILED, "Connection refused", "Hostname")));
+
+        final List<ConfigVerificationResultDTO> results = merger.computeAggregateResults();
+
+        assertNotNull(results);
+        assertEquals(1, results.size());
+        assertEquals("Hostname", results.get(0).getSubject());
+    }
+
+    @Test
+    void testMultiNodeAgreeSubjectPreserved() {
+        final ConfigVerificationResultMerger merger = new ConfigVerificationResultMerger();
+        merger.addNodeResults(NODE_1, List.of(createResult("Step 1", Outcome.SUCCESSFUL, "Connected", "Hostname")));
+        merger.addNodeResults(NODE_2, List.of(createResult("Step 1", Outcome.SUCCESSFUL, "Connected", "Hostname")));
+
+        final List<ConfigVerificationResultDTO> results = merger.computeAggregateResults();
+
+        assertNotNull(results);
+        assertEquals(1, results.size());
+        assertEquals("Hostname", results.get(0).getSubject());
+    }
+
+    @Test
+    void testMultiNodeDisagreeSubjectFromSelectedResult() {
+        final ConfigVerificationResultMerger merger = new ConfigVerificationResultMerger();
+        merger.addNodeResults(NODE_1, List.of(createResult("Step 1", Outcome.SUCCESSFUL, "Connected", "Hostname")));
+        merger.addNodeResults(NODE_2, List.of(createResult("Step 1", Outcome.FAILED, "Connection refused", "Port")));
+
+        final List<ConfigVerificationResultDTO> results = merger.computeAggregateResults();
+
+        assertNotNull(results);
+        assertEquals(1, results.size());
+        assertEquals(Outcome.FAILED.name(), results.get(0).getOutcome());
+        assertEquals("Port", results.get(0).getSubject());
+    }
+
     private static ConfigVerificationResultDTO createResult(final String stepName, final Outcome outcome, final String explanation) {
+        return createResult(stepName, outcome, explanation, null);
+    }
+
+    private static ConfigVerificationResultDTO createResult(final String stepName, final Outcome outcome, final String explanation, final String subject) {
         final ConfigVerificationResultDTO dto = new ConfigVerificationResultDTO();
         dto.setVerificationStepName(stepName);
         dto.setOutcome(outcome.name());
         dto.setExplanation(explanation);
+        dto.setSubject(subject);
         return dto;
     }
 }


### PR DESCRIPTION
…or connector verification.

# Summary

[NIFI-15902](https://issues.apache.org/jira/browse/NIFI-15902)

When a connector configuration step is verified on a clustered NiFi, the
`subject` field on each `ConfigVerificationResultDTO` is dropped during
cluster aggregation. As a result, clients receive verification results
with a populated step name, outcome, and explanation but a `null`
subject, even though every node produced a subject for the failing
property.

The cause is in `ConfigVerificationResultMerger.computeAggregateResults()`,
which constructs a brand new aggregate DTO and copies only
`verificationStepName`, `outcome`, and `explanation` from the selected
node result. The `subject` is silently lost.

This change copies the `subject` from the selected node result onto the
aggregate DTO so it is returned to the client unchanged. The "selected"
result is already chosen as the worst-outcome result (FAILED > SKIPPED >
SUCCESSFUL), which means the surfaced subject corresponds to the
verification result the user actually needs to act on.

The same `ConfigVerificationResultMerger` is also used by
`VerifyConfigEndpointMerger` (processors, controller services,
reporting tasks, parameter providers, flow analysis rules), so any of
those endpoints whose upstream DTOs include a subject will now also
preserve it through cluster aggregation. Today their per-DAO DTO
converters do not set `subject`, so there is no behavior change for
those endpoints; only the connector verification path observes a
visible difference.

## Behavior

- Single-node responses: explanation, outcome, step name, and subject
  are all preserved (unchanged).
- Multi-node clusters where all nodes agree: the agreed subject is
  returned (unchanged step name/outcome/explanation handling).
- Multi-node clusters where nodes disagree: the subject from the
  worst-outcome (selected) result is returned, consistent with how
  the explanation prefix is already chosen.

## Tests

`ConfigVerificationResultMergerTest` adds three cases covering the new
behavior:

- `testSingleNodeSubjectPreserved` - single-node failed result keeps
  its subject through the merge.
- `testMultiNodeAgreeSubjectPreserved` - two nodes agreeing on a
  successful result keep the shared subject.
- `testMultiNodeDisagreeSubjectFromSelectedResult` - when one node
  succeeds and another fails, the merged result carries the failing
  node's subject, matching the worst-outcome selection that already
  governs the merged outcome and explanation.
