### PR TITLE
NIFI-15904 Fix Lineage Start Index in Session.create()

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -2069,8 +2069,13 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         attrs.put(CoreAttributes.PATH.key(), DEFAULT_FLOWFILE_PATH);
         attrs.put(CoreAttributes.UUID.key(), uuid);
 
-        final FlowFileRecord fFile = new StandardFlowFileRecord.Builder().id(context.getNextFlowFileSequence())
+        final long entryDate = System.currentTimeMillis();
+        final long id = context.getNextFlowFileSequence();
+        final FlowFileRecord fFile = new StandardFlowFileRecord.Builder().id(id)
             .addAttributes(attrs)
+            // Set Lineage Start to Entry Date and use Identifier as Lineage Start Index for unambiguous ordering
+            .entryDate(entryDate)
+            .lineageStart(entryDate, id)
             .build();
         final StandardRepositoryRecord record = new StandardRepositoryRecord((FlowFileQueue) null);
         record.setWorking(fFile, attrs, false);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/controller/repository/StandardProcessSessionTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/controller/repository/StandardProcessSessionTest.java
@@ -45,6 +45,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -189,6 +191,26 @@ class StandardProcessSessionTest {
 
         assertEquals(GAUGE_NAME, gaugeRecord.name());
         assertEquals(GAUGE_VALUE, gaugeRecord.value());
+    }
+
+    @Test
+    void testCreateLineage() {
+        final long firstFlowFileId = 1;
+        final long secondFlowFileId = 2;
+        when(repositoryContext.getNextFlowFileSequence()).thenReturn(firstFlowFileId, secondFlowFileId);
+
+        final FlowFile firstFlowFile = session.create();
+
+        assertNotNull(firstFlowFile);
+        assertNotEquals(0, firstFlowFile.getLineageStartDate());
+        assertEquals(firstFlowFile.getEntryDate(), firstFlowFile.getLineageStartDate());
+        assertEquals(firstFlowFileId, firstFlowFile.getId());
+        assertEquals(firstFlowFileId, firstFlowFile.getLineageStartIndex());
+
+        final FlowFile secondFlowFile = session.create();
+        assertNotNull(secondFlowFile);
+        assertEquals(secondFlowFileId, secondFlowFile.getId());
+        assertEquals(secondFlowFileId, secondFlowFile.getLineageStartIndex());
     }
 
     private void assertFlowFileEventMatched(final long bytesRead, final long bytesWritten) throws IOException {


### PR DESCRIPTION
# Summary

[NIFI-15904](https://issues.apache.org/jira/browse/NIFI-15904) Corrects the value of Lineage Start Index on FlowFiles created using the `StandardProcessSession.create()` method, setting the value using the number provided as the FlowFile ID from the FlowFile Repository. Using the FlowFile ID avoids introducing a separate variable for tracking the index, while providing an increasing number.

Other `create()` methods set the Lineage Start Index from parent FlowFiles, but the current implementation always uses the default value of `0`, leading the potential ambiguity when the framework creates multiple FlowFiles with the same Lineage Start Date.

The changes include a new unit test method to check the expected value of the Lineage Start Index.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
