### PR TITLE
NIFI-15905 Switch to qualified Table Names in CaptureChangeMySQL

### DIFF
--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
@@ -1222,14 +1222,14 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
         if (jdbcConnectionHolder != null) {
 
             try (Statement s = getJdbcConnection().createStatement()) {
-                s.execute("USE `" + key.getDatabaseName() + "`");
-                ResultSet rs = s.executeQuery("SELECT * FROM `" + key.getTableName() + "` LIMIT 0");
-                ResultSetMetaData rsmd = rs.getMetaData();
-                int numCols = rsmd.getColumnCount();
-                List<ColumnDefinition> columnDefinitions = new ArrayList<>();
-                for (int i = 1; i <= numCols; i++) {
+                final String tableInfoQuery = getTableInfoQuery(s, key);
+                final ResultSet rs = s.executeQuery(tableInfoQuery);
+                final ResultSetMetaData rsmd = rs.getMetaData();
+                final int columnCount = rsmd.getColumnCount();
+                final List<ColumnDefinition> columnDefinitions = new ArrayList<>();
+                for (int i = 1; i <= columnCount; i++) {
                     // Use the column label if it exists, otherwise use the column name. We're not doing aliasing here, but it's better practice.
-                    String columnLabel = rsmd.getColumnLabel(i);
+                    final String columnLabel = rsmd.getColumnLabel(i);
                     columnDefinitions.add(new ColumnDefinition(rsmd.getColumnType(i), columnLabel != null ? columnLabel : rsmd.getColumnName(i)));
                 }
 
@@ -1238,6 +1238,12 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
         }
 
         return tableInfo;
+    }
+
+    protected String getTableInfoQuery(final Statement statement, final TableInfoCacheKey tableInfoCacheKey) throws SQLException {
+        final String databaseNameQuoted = statement.enquoteIdentifier(tableInfoCacheKey.getDatabaseName(), true);
+        final String tableNameQuoted = statement.enquoteIdentifier(tableInfoCacheKey.getTableName(), true);
+        return "SELECT * FROM %s.%s LIMIT 0".formatted(databaseNameQuoted, tableNameQuoted);
     }
 
     protected Connection getJdbcConnection() throws SQLException {

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/test/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQLTest.java
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/test/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQLTest.java
@@ -62,6 +62,8 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -71,6 +73,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 import javax.net.ssl.SSLContext;
@@ -80,7 +83,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -122,7 +127,7 @@ public class CaptureChangeMySQLTest {
     private static final String TEN = "10";
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private CaptureChangeMySQL processor;
+    private MockCaptureChangeMySQL processor;
     private TestRunner testRunner;
     private MockBinlogClient client;
 
@@ -1296,6 +1301,22 @@ public class CaptureChangeMySQLTest {
     }
 
     @Test
+    public void testGetTableInfoQuery() throws SQLException {
+        final Statement statement = mock(Statement.class, CALLS_REAL_METHODS);
+
+        final String prefix = UUID.randomUUID().toString();
+        final long tableId = 0;
+
+        final String databaseName = "NiFi 'Quoted' Repository";
+        final String tableName = "FlowFile";
+
+        final TableInfoCacheKey cacheKey = new TableInfoCacheKey(prefix, databaseName, tableName, tableId);
+        final String tableInfoQuery = processor.getTableInfoQuery(statement, cacheKey);
+
+        assertEquals("SELECT * FROM \"NiFi 'Quoted' Repository\".\"FlowFile\" LIMIT 0", tableInfoQuery);
+    }
+
+    @Test
     void testMigration() {
         final Map<String, String> expectedRenamed = Map.ofEntries(
                 Map.entry("capture-change-mysql-db-name-pattern", CaptureChangeMySQL.DATABASE_NAME_PATTERN.getName()),
@@ -1349,9 +1370,8 @@ public class CaptureChangeMySQLTest {
 
         @Override
         protected TableInfo loadTableInfo(TableInfoCacheKey key) {
-            TableInfo tableInfo = cache.computeIfAbsent(key, k -> new TableInfo(k.getDatabaseName(), k.getTableName(), k.getTableId(),
+            return cache.computeIfAbsent(key, k -> new TableInfo(k.getDatabaseName(), k.getTableName(), k.getTableId(),
                     Collections.singletonList(new ColumnDefinition((byte) -4, "string1"))));
-            return tableInfo;
         }
 
         @Override


### PR DESCRIPTION
# Summary

[NIFI-15905](https://issues.apache.org/jira/browse/NIFI-15905) Refactors the table information query in the `CaptureChangeMySQL` Processor to use qualified table names instead of two separate queries.

Changes include a separate method for standardized quoting of identifiers and constructing the query, as well as a unit test for the new method.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
