### PR TITLE
NIFI-15907 - PROPERTY_PARAMETERIZATION_REMOVED showing as local change

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
@@ -588,7 +588,9 @@ public class FlowDifferenceFilters {
      * Determines whether a property difference is caused by a statically defined property being removed from the component definition.
      * When a processor or controller service drops a property (for example, as part of a version upgrade that invokes {@code removeProperty}
      * during migration), the reconciled component in NiFi should not report a "local change" so long as the component does not support
-     * dynamic properties.
+     * dynamic properties. This applies whether the registry-side value was a literal value (yielding {@link DifferenceType#PROPERTY_REMOVED})
+     * or a parameter reference (yielding {@link DifferenceType#PROPERTY_PARAMETERIZATION_REMOVED}); both represent the same underlying
+     * scenario of a property no longer exposed by the component definition.
      *
      * @param difference the flow difference under evaluation
      * @param flowManager the flow manager used to resolve instantiated components
@@ -597,7 +599,7 @@ public class FlowDifferenceFilters {
      */
     public static boolean isStaticPropertyRemoved(final FlowDifference difference, final FlowManager flowManager) {
         final DifferenceType differenceType = difference.getDifferenceType();
-        if (differenceType != DifferenceType.PROPERTY_REMOVED) {
+        if (differenceType != DifferenceType.PROPERTY_REMOVED && differenceType != DifferenceType.PROPERTY_PARAMETERIZATION_REMOVED) {
             return false;
         }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
@@ -205,6 +205,17 @@ public class TestFlowDifferenceFilters {
                 "Property removed in component definition");
 
         assertTrue(FlowDifferenceFilters.isStaticPropertyRemoved(difference, flowManager));
+
+        final FlowDifference parameterizationRemovedDifference = new StandardFlowDifference(
+                DifferenceType.PROPERTY_PARAMETERIZATION_REMOVED,
+                localProcessor,
+                localProcessor,
+                propertyName,
+                "#{SomeParam}",
+                null,
+                "Property parameterization removed in component definition");
+
+        assertTrue(FlowDifferenceFilters.isStaticPropertyRemoved(parameterizationRemovedDifference, flowManager));
     }
 
     @Test
@@ -231,6 +242,17 @@ public class TestFlowDifferenceFilters {
                 "Property still defined");
 
         assertFalse(FlowDifferenceFilters.isStaticPropertyRemoved(difference, flowManager));
+
+        final FlowDifference parameterizationRemovedDifference = new StandardFlowDifference(
+                DifferenceType.PROPERTY_PARAMETERIZATION_REMOVED,
+                localProcessor,
+                localProcessor,
+                propertyName,
+                "#{SomeParam}",
+                null,
+                "Parameterization removed but property still defined");
+
+        assertFalse(FlowDifferenceFilters.isStaticPropertyRemoved(parameterizationRemovedDifference, flowManager));
     }
 
     @Test
@@ -255,6 +277,16 @@ public class TestFlowDifferenceFilters {
                 null,
                 "Dynamic property removed");
         assertFalse(FlowDifferenceFilters.isStaticPropertyRemoved(difference, flowManager));
+
+        final FlowDifference parameterizationRemovedDifference = new StandardFlowDifference(
+                DifferenceType.PROPERTY_PARAMETERIZATION_REMOVED,
+                localProcessor,
+                localProcessor,
+                propertyName,
+                "#{SomeParam}",
+                null,
+                "Dynamic property parameterization removed");
+        assertFalse(FlowDifferenceFilters.isStaticPropertyRemoved(parameterizationRemovedDifference, flowManager));
     }
 
     @Test


### PR DESCRIPTION
# Summary

NIFI-15907 - PROPERTY_PARAMETERIZATION_REMOVED showing as local change

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
