### PR TITLE
NIFI-12456 Enabled JsonTreeReader and JsonPathReader to parse JSON leniently.

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
@@ -52,6 +52,8 @@ import java.util.Optional;
 import java.util.function.BiPredicate;
 
 public abstract class AbstractJsonRowRecordReader implements RecordReader {
+    public static final String OBSOLETE_ALLOW_COMMENTS = "Allow Comments";
+
     public static final String DEFAULT_MAX_STRING_LENGTH = "20 MB";
 
     public static final PropertyDescriptor MAX_STRING_LENGTH = new PropertyDescriptor.Builder()
@@ -69,6 +71,14 @@ public abstract class AbstractJsonRowRecordReader implements RecordReader {
             .allowableValues("true", "false")
             .defaultValue("false")
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor JSON_PARSE_MODE = new PropertyDescriptor.Builder()
+            .name("JSON Parse Mode")
+            .description("Specifies whether to parse the incoming JSON per the JSON specification or allow for lenient parsing")
+            .required(true)
+            .allowableValues(JsonParseMode.class)
+            .defaultValue(JsonParseMode.STANDARD)
             .build();
 
     private final ComponentLog logger;

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
@@ -64,21 +64,12 @@ public abstract class AbstractJsonRowRecordReader implements RecordReader {
             .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
             .build();
 
-    public static final PropertyDescriptor ALLOW_COMMENTS = new PropertyDescriptor.Builder()
-            .name("Allow Comments")
-            .description("Whether to allow comments when parsing the JSON document")
+    public static final PropertyDescriptor PARSING_STRATEGY = new PropertyDescriptor.Builder()
+            .name("Parsing Strategy")
+            .description("Set the strategy for the level of JSON specification conformity required")
             .required(true)
-            .allowableValues("true", "false")
-            .defaultValue("false")
-            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
-            .build();
-
-    public static final PropertyDescriptor JSON_PARSE_MODE = new PropertyDescriptor.Builder()
-            .name("JSON Parse Mode")
-            .description("Specifies whether to parse the incoming JSON per the JSON specification or allow for lenient parsing")
-            .required(true)
-            .allowableValues(JsonParseMode.class)
-            .defaultValue(JsonParseMode.STANDARD)
+            .allowableValues(ParsingStrategy.class)
+            .defaultValue(ParsingStrategy.STANDARD)
             .build();
 
     private final ComponentLog logger;

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonParseMode.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonParseMode.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.json;
+
+import org.apache.nifi.components.DescribedValue;
+
+enum JsonParseMode implements DescribedValue {
+    STANDARD("Standard", "Parse JSON per the JSON specification"),
+    LENIENT("Lenient", """
+            Parse JSON leniently allowing Java comments (/**/ and //), Yaml comments (start of line begins with #)
+            , leading plus sign in numbers (e.g. +123), leading zeros in numbers (e.g. 0001),
+            "missing" decimal numbers to end with a decimal point (e.g. 123.),
+            "missing value" in an array (i.e. sequence of two commas, without value in-between e.g. ["A",,"C"]),
+            trailing comma in an array or member in an object, use of single quotes for quoting strings (i.e. use of an apostrophe)
+            and use of unquoted field names.""");
+
+    private final String displayName;
+    private final String description;
+
+    JsonParseMode(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonParserFactory.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonParserFactory.java
@@ -42,14 +42,22 @@ public class JsonParserFactory implements TokenParserFactory {
      * JSON Parser Factory constructor with configurable constraints
      *
      * @param streamReadConstraints Stream Read Constraints
-     * @param allowComments Allow Comments during parsing
+     * @param lenient Allow for parsing JSON leniently
      */
-    public JsonParserFactory(final StreamReadConstraints streamReadConstraints, final boolean allowComments) {
+    public JsonParserFactory(final StreamReadConstraints streamReadConstraints, final boolean lenient) {
         Objects.requireNonNull(streamReadConstraints, "Stream Read Constraints required");
 
         final ObjectMapper objectMapper = new ObjectMapper();
-        if (allowComments) {
+        if (lenient) {
             objectMapper.enable(JsonReadFeature.ALLOW_JAVA_COMMENTS.mappedFeature());
+            objectMapper.enable(JsonReadFeature.ALLOW_YAML_COMMENTS.mappedFeature());
+            objectMapper.enable(JsonReadFeature.ALLOW_SINGLE_QUOTES.mappedFeature());
+            objectMapper.enable(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES.mappedFeature());
+            objectMapper.enable(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS.mappedFeature());
+            objectMapper.enable(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS.mappedFeature());
+            objectMapper.enable(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature());
+            objectMapper.enable(JsonReadFeature.ALLOW_TRAILING_COMMA.mappedFeature());
+            objectMapper.enable(JsonReadFeature.ALLOW_MISSING_VALUES.mappedFeature());
         }
         jsonFactory = objectMapper.getFactory();
         jsonFactory.setStreamReadConstraints(streamReadConstraints);

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonParserFactory.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonParserFactory.java
@@ -42,13 +42,13 @@ public class JsonParserFactory implements TokenParserFactory {
      * JSON Parser Factory constructor with configurable constraints
      *
      * @param streamReadConstraints Stream Read Constraints
-     * @param lenient Allow for parsing JSON leniently
+     * @param parsingStrategy Parsing strategy which determines how the JSON should be parsed.
      */
-    public JsonParserFactory(final StreamReadConstraints streamReadConstraints, final boolean lenient) {
+    public JsonParserFactory(final StreamReadConstraints streamReadConstraints, final ParsingStrategy parsingStrategy) {
         Objects.requireNonNull(streamReadConstraints, "Stream Read Constraints required");
 
         final ObjectMapper objectMapper = new ObjectMapper();
-        if (lenient) {
+        if (ParsingStrategy.LENIENT == parsingStrategy) {
             objectMapper.enable(JsonReadFeature.ALLOW_JAVA_COMMENTS.mappedFeature());
             objectMapper.enable(JsonReadFeature.ALLOW_YAML_COMMENTS.mappedFeature());
             objectMapper.enable(JsonReadFeature.ALLOW_SINGLE_QUOTES.mappedFeature());

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonParserFactory.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonParserFactory.java
@@ -58,6 +58,7 @@ public class JsonParserFactory implements TokenParserFactory {
             objectMapper.enable(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature());
             objectMapper.enable(JsonReadFeature.ALLOW_TRAILING_COMMA.mappedFeature());
             objectMapper.enable(JsonReadFeature.ALLOW_MISSING_VALUES.mappedFeature());
+            objectMapper.enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature());
         }
         jsonFactory = objectMapper.getFactory();
         jsonFactory.setStreamReadConstraints(streamReadConstraints);

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonRecordSource.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonRecordSource.java
@@ -33,15 +33,15 @@ public class JsonRecordSource implements RecordSource<JsonNode> {
 
     private static final StreamReadConstraints DEFAULT_STREAM_READ_CONSTRAINTS = StreamReadConstraints.defaults();
 
-    private static final boolean ALLOW_COMMENTS_ENABLED = true;
+    private static final boolean ALLOW_LENIENT_JSON = true;
 
-    private static final TokenParserFactory defaultTokenParserFactory = new JsonParserFactory(DEFAULT_STREAM_READ_CONSTRAINTS, ALLOW_COMMENTS_ENABLED);
+    private static final TokenParserFactory DEFAULT_TOKEN_PARSER_FACTORY = new JsonParserFactory(DEFAULT_STREAM_READ_CONSTRAINTS, ALLOW_LENIENT_JSON);
 
     private final JsonParser jsonParser;
     private final StartingFieldStrategy strategy;
 
     public JsonRecordSource(final InputStream in) throws IOException {
-        this(in, null, null, defaultTokenParserFactory);
+        this(in, null, null, DEFAULT_TOKEN_PARSER_FACTORY);
     }
 
     public JsonRecordSource(final InputStream in, final StartingFieldStrategy strategy, final String startingFieldName, final TokenParserFactory tokenParserFactory) throws IOException {

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonRecordSource.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonRecordSource.java
@@ -33,9 +33,7 @@ public class JsonRecordSource implements RecordSource<JsonNode> {
 
     private static final StreamReadConstraints DEFAULT_STREAM_READ_CONSTRAINTS = StreamReadConstraints.defaults();
 
-    private static final boolean ALLOW_LENIENT_JSON = true;
-
-    private static final TokenParserFactory DEFAULT_TOKEN_PARSER_FACTORY = new JsonParserFactory(DEFAULT_STREAM_READ_CONSTRAINTS, ALLOW_LENIENT_JSON);
+    private static final TokenParserFactory DEFAULT_TOKEN_PARSER_FACTORY = new JsonParserFactory(DEFAULT_STREAM_READ_CONSTRAINTS, ParsingStrategy.LENIENT);
 
     private final JsonParser jsonParser;
     private final StartingFieldStrategy strategy;

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/ParsingStrategy.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/ParsingStrategy.java
@@ -18,7 +18,7 @@ package org.apache.nifi.json;
 
 import org.apache.nifi.components.DescribedValue;
 
-enum JsonParseMode implements DescribedValue {
+public enum ParsingStrategy implements DescribedValue {
     STANDARD("Standard", "Parse JSON per the JSON specification"),
     LENIENT("Lenient", """
             Parse JSON leniently allowing Java comments (/**/ and //), Yaml comments (start of line begins with #)
@@ -31,7 +31,7 @@ enum JsonParseMode implements DescribedValue {
     private final String displayName;
     private final String description;
 
-    JsonParseMode(String displayName, String description) {
+    ParsingStrategy(String displayName, String description) {
         this.displayName = displayName;
         this.description = description;
     }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/ParsingStrategy.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/ParsingStrategy.java
@@ -26,7 +26,7 @@ public enum ParsingStrategy implements DescribedValue {
             "missing" decimal numbers to end with a decimal point (e.g. 123.),
             "missing value" in an array (i.e. sequence of two commas, without value in-between e.g. ["A",,"C"]),
             trailing comma in an array or member in an object, use of single quotes for quoting strings (i.e. use of an apostrophe)
-            and use of unquoted field names.""");
+            use of unquoted field names and use of unescaped control characters (ASCII characters with value less than 32).""");
 
     private final String displayName;
     private final String description;

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/test/java/org/apache/nifi/json/TestJsonParserFactory.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/test/java/org/apache/nifi/json/TestJsonParserFactory.java
@@ -60,7 +60,7 @@ public class TestJsonParserFactory {
     @ParameterizedTest
     @MethodSource("jsonParsing")
     void testJsonParsing(ParsingStrategy parsingStrategy) throws Exception {
-        StreamReadConstraints streamReadConstraints = StreamReadConstraints.builder().build();
+        final StreamReadConstraints streamReadConstraints = StreamReadConstraints.builder().build();
         final JsonParserFactory jsonParserFactory = new JsonParserFactory(streamReadConstraints, parsingStrategy);
         final InputStream inputStream = new ByteArrayInputStream(LENIENT_JSON.getBytes(StandardCharsets.UTF_8));
         final JsonParser jsonParser = jsonParserFactory.getJsonParser(inputStream);

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/test/java/org/apache/nifi/json/TestJsonParserFactory.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/test/java/org/apache/nifi/json/TestJsonParserFactory.java
@@ -59,13 +59,13 @@ public class TestJsonParserFactory {
 
     @ParameterizedTest
     @MethodSource("jsonParsing")
-    void testJsonParsing(boolean lenient) throws Exception {
+    void testJsonParsing(ParsingStrategy parsingStrategy) throws Exception {
         StreamReadConstraints streamReadConstraints = StreamReadConstraints.builder().build();
-        final JsonParserFactory jsonParserFactory = new JsonParserFactory(streamReadConstraints, lenient);
+        final JsonParserFactory jsonParserFactory = new JsonParserFactory(streamReadConstraints, parsingStrategy);
         final InputStream inputStream = new ByteArrayInputStream(LENIENT_JSON.getBytes(StandardCharsets.UTF_8));
         final JsonParser jsonParser = jsonParserFactory.getJsonParser(inputStream);
 
-        if (lenient) {
+        if (ParsingStrategy.LENIENT == parsingStrategy) {
             assertDoesNotThrow(() -> jsonParser.readValueAsTree());
         } else {
             assertThrows(JsonParseException.class, jsonParser::readValueAsTree);
@@ -74,8 +74,8 @@ public class TestJsonParserFactory {
 
     private static Stream<Arguments> jsonParsing() {
         return Stream.of(
-                Arguments.argumentSet("Standard", false),
-                Arguments.argumentSet("Lenient", true)
+                Arguments.argumentSet("Standard", ParsingStrategy.STANDARD),
+                Arguments.argumentSet("Lenient", ParsingStrategy.LENIENT)
         );
     }
 }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/test/java/org/apache/nifi/json/TestJsonParserFactory.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/test/java/org/apache/nifi/json/TestJsonParserFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.json;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestJsonParserFactory {
+    private static final String LENIENT_JSON = """
+            {
+              // Java-style single line comment
+              /* C-style multi-line
+                 comment */
+              "numbers": {
+                "leadingZero": 00042,
+                "leadingPlus": +123,
+                "missingDecimal": 10.
+              },
+              "quotes": {
+                'singleQuotedKey': 'value',
+                unquotedKey: "value"
+              },
+              "arrayMissingValue": [
+                "first",
+                ,
+                "third",
+              ],
+              "objectTrailing": {
+                "key": "value",
+              }
+            }
+            """;
+
+    @ParameterizedTest
+    @MethodSource("jsonParsing")
+    void testJsonParsing(boolean lenient) throws Exception {
+        StreamReadConstraints streamReadConstraints = StreamReadConstraints.builder().build();
+        final JsonParserFactory jsonParserFactory = new JsonParserFactory(streamReadConstraints, lenient);
+        final InputStream inputStream = new ByteArrayInputStream(LENIENT_JSON.getBytes(StandardCharsets.UTF_8));
+        final JsonParser jsonParser = jsonParserFactory.getJsonParser(inputStream);
+
+        if (lenient) {
+            assertDoesNotThrow(() -> jsonParser.readValueAsTree());
+        } else {
+            assertThrows(JsonParseException.class, jsonParser::readValueAsTree);
+        }
+    }
+
+    private static Stream<Arguments> jsonParsing() {
+        return Stream.of(
+                Arguments.argumentSet("Standard", false),
+                Arguments.argumentSet("Lenient", true)
+        );
+    }
+}

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-yaml-record-utils/src/main/java/org/apache/nifi/yaml/YamlParserFactory.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-yaml-record-utils/src/main/java/org/apache/nifi/yaml/YamlParserFactory.java
@@ -45,14 +45,12 @@ public class YamlParserFactory implements TokenParserFactory {
      * YAML Parser Factory constructor with configurable parsing constraints
      *
      * @param streamReadConstraints Stream Read Constraints required
-     * @param allowComments Allow Comments during parsing
      */
-    public YamlParserFactory(final StreamReadConstraints streamReadConstraints, final boolean allowComments) {
+    public YamlParserFactory(final StreamReadConstraints streamReadConstraints) {
         Objects.requireNonNull(streamReadConstraints, "Stream Read Constraints required");
 
         final LoaderOptions loaderOptions = new LoaderOptions();
         loaderOptions.setCodePointLimit(streamReadConstraints.getMaxStringLength());
-        loaderOptions.setProcessComments(allowComments);
 
         yamlFactory = YAMLFactory.builder().loaderOptions(loaderOptions).build();
         yamlFactory.setCodec(yamlMapper);

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonPathReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonPathReader.java
@@ -159,7 +159,7 @@ public class JsonPathReader extends SchemaRegistryService implements RecordReade
         super.migrateProperties(config);
 
         if (config.isPropertySet(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS)) {
-            final String allowCommentsRawValue = config.getRawPropertyValue(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS).orElse("");
+            final String allowCommentsRawValue = config.getRawPropertyValue(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS).orElse(Boolean.FALSE.toString());
             final boolean allowComments = Boolean.parseBoolean(allowCommentsRawValue);
             if (allowComments) {
                 config.setProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY, ParsingStrategy.LENIENT.getValue());

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonPathReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonPathReader.java
@@ -34,6 +34,7 @@ import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.schema.access.SchemaAccessStrategy;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
@@ -83,7 +84,7 @@ public class JsonPathReader extends SchemaRegistryService implements RecordReade
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         final List<PropertyDescriptor> properties = new ArrayList<>(super.getSupportedPropertyDescriptors());
         properties.add(AbstractJsonRowRecordReader.MAX_STRING_LENGTH);
-        properties.add(AbstractJsonRowRecordReader.ALLOW_COMMENTS);
+        properties.add(AbstractJsonRowRecordReader.JSON_PARSE_MODE);
         properties.add(DateTimeUtils.DATE_FORMAT);
         properties.add(DateTimeUtils.TIME_FORMAT);
         properties.add(DateTimeUtils.TIMESTAMP_FORMAT);
@@ -113,8 +114,10 @@ public class JsonPathReader extends SchemaRegistryService implements RecordReade
         this.objectMapper = new ObjectMapper();
         objectMapper.getFactory().setStreamReadConstraints(streamReadConstraints);
 
-        final boolean allowComments = context.getProperty(AbstractJsonRowRecordReader.ALLOW_COMMENTS).asBoolean();
-        this.tokenParserFactory = new JsonParserFactory(streamReadConstraints, allowComments);
+        final JsonParseMode jsonParseMode =
+                context.getProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE).asAllowableValue(JsonParseMode.class);
+        final boolean lenientEnabled = JsonParseMode.LENIENT == jsonParseMode;
+        this.tokenParserFactory = new JsonParserFactory(streamReadConstraints, lenientEnabled);
 
         final Map<String, JsonPath> compiled = new LinkedHashMap<>();
         for (final PropertyDescriptor descriptor : context.getProperties().keySet()) {
@@ -150,6 +153,23 @@ public class JsonPathReader extends SchemaRegistryService implements RecordReade
             .valid(false)
             .explanation("No JSON Paths were specified")
             .build());
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        super.migrateProperties(config);
+
+        if (config.isPropertySet(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS)) {
+            final String allowCommentsRawValue = config.getRawPropertyValue(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS).orElse("");
+            final boolean allowComments = Boolean.parseBoolean(allowCommentsRawValue);
+            if (allowComments) {
+                config.setProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE, JsonParseMode.LENIENT.getValue());
+            } else {
+                config.setProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE, JsonParseMode.STANDARD.getValue());
+            }
+
+            config.removeProperty(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS);
+        }
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonPathReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonPathReader.java
@@ -84,7 +84,7 @@ public class JsonPathReader extends SchemaRegistryService implements RecordReade
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         final List<PropertyDescriptor> properties = new ArrayList<>(super.getSupportedPropertyDescriptors());
         properties.add(AbstractJsonRowRecordReader.MAX_STRING_LENGTH);
-        properties.add(AbstractJsonRowRecordReader.JSON_PARSE_MODE);
+        properties.add(AbstractJsonRowRecordReader.PARSING_STRATEGY);
         properties.add(DateTimeUtils.DATE_FORMAT);
         properties.add(DateTimeUtils.TIME_FORMAT);
         properties.add(DateTimeUtils.TIMESTAMP_FORMAT);
@@ -114,10 +114,9 @@ public class JsonPathReader extends SchemaRegistryService implements RecordReade
         this.objectMapper = new ObjectMapper();
         objectMapper.getFactory().setStreamReadConstraints(streamReadConstraints);
 
-        final JsonParseMode jsonParseMode =
-                context.getProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE).asAllowableValue(JsonParseMode.class);
-        final boolean lenientEnabled = JsonParseMode.LENIENT == jsonParseMode;
-        this.tokenParserFactory = new JsonParserFactory(streamReadConstraints, lenientEnabled);
+        final ParsingStrategy parsingStrategy =
+                context.getProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY).asAllowableValue(ParsingStrategy.class);
+        this.tokenParserFactory = new JsonParserFactory(streamReadConstraints, parsingStrategy);
 
         final Map<String, JsonPath> compiled = new LinkedHashMap<>();
         for (final PropertyDescriptor descriptor : context.getProperties().keySet()) {
@@ -163,9 +162,9 @@ public class JsonPathReader extends SchemaRegistryService implements RecordReade
             final String allowCommentsRawValue = config.getRawPropertyValue(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS).orElse("");
             final boolean allowComments = Boolean.parseBoolean(allowCommentsRawValue);
             if (allowComments) {
-                config.setProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE, JsonParseMode.LENIENT.getValue());
+                config.setProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY, ParsingStrategy.LENIENT.getValue());
             } else {
-                config.setProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE, JsonParseMode.STANDARD.getValue());
+                config.setProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY, ParsingStrategy.STANDARD.getValue());
             }
 
             config.removeProperty(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS);

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeReader.java
@@ -144,7 +144,7 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
         config.renameProperty(OBSOLETE_SCHEMA_CACHE, SCHEMA_CACHE.getName());
 
         if (config.isPropertySet(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS)) {
-            final String allowCommentsRawValue = config.getRawPropertyValue(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS).orElse("");
+            final String allowCommentsRawValue = config.getRawPropertyValue(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS).orElse(Boolean.FALSE.toString());
             final boolean allowComments = Boolean.parseBoolean(allowCommentsRawValue);
             if (allowComments) {
                 config.setProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY, ParsingStrategy.LENIENT.getValue());

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeReader.java
@@ -117,7 +117,7 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
         properties.add(STARTING_FIELD_NAME);
         properties.add(SCHEMA_APPLICATION_STRATEGY);
         properties.add(AbstractJsonRowRecordReader.MAX_STRING_LENGTH);
-        properties.add(AbstractJsonRowRecordReader.JSON_PARSE_MODE);
+        properties.add(AbstractJsonRowRecordReader.PARSING_STRATEGY);
         properties.add(DateTimeUtils.DATE_FORMAT);
         properties.add(DateTimeUtils.TIME_FORMAT);
         properties.add(DateTimeUtils.TIMESTAMP_FORMAT);
@@ -147,9 +147,9 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
             final String allowCommentsRawValue = config.getRawPropertyValue(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS).orElse("");
             final boolean allowComments = Boolean.parseBoolean(allowCommentsRawValue);
             if (allowComments) {
-                config.setProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE, JsonParseMode.LENIENT.getValue());
+                config.setProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY, ParsingStrategy.LENIENT.getValue());
             } else {
-                config.setProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE, JsonParseMode.STANDARD.getValue());
+                config.setProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY, ParsingStrategy.STANDARD.getValue());
             }
 
             config.removeProperty(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS);
@@ -157,7 +157,9 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
     }
 
     protected TokenParserFactory createTokenParserFactory(final ConfigurationContext context) {
-        return new JsonParserFactory(buildStreamReadConstraints(context), isLenientParsingEnabled(context));
+        final ParsingStrategy parsingStrategy =
+                context.getProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY).asAllowableValue(ParsingStrategy.class);
+        return new JsonParserFactory(buildStreamReadConstraints(context), parsingStrategy);
     }
 
     /**
@@ -169,18 +171,6 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
     protected StreamReadConstraints buildStreamReadConstraints(final ConfigurationContext context) {
         final int maxStringLength = context.getProperty(AbstractJsonRowRecordReader.MAX_STRING_LENGTH).asDataSize(DataUnit.B).intValue();
         return StreamReadConstraints.builder().maxStringLength(maxStringLength).build();
-    }
-
-    /**
-     * Determine whether to allow lenient parsing based on available properties
-     *
-     * @param context Configuration Context with property values
-     * @return Allow lenient parsing status
-     */
-    protected boolean isLenientParsingEnabled(final ConfigurationContext context) {
-        final JsonParseMode jsonParseMode =
-                context.getProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE).asAllowableValue(JsonParseMode.class);
-        return JsonParseMode.LENIENT == jsonParseMode;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeReader.java
@@ -117,7 +117,7 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
         properties.add(STARTING_FIELD_NAME);
         properties.add(SCHEMA_APPLICATION_STRATEGY);
         properties.add(AbstractJsonRowRecordReader.MAX_STRING_LENGTH);
-        properties.add(AbstractJsonRowRecordReader.ALLOW_COMMENTS);
+        properties.add(AbstractJsonRowRecordReader.JSON_PARSE_MODE);
         properties.add(DateTimeUtils.DATE_FORMAT);
         properties.add(DateTimeUtils.TIME_FORMAT);
         properties.add(DateTimeUtils.TIMESTAMP_FORMAT);
@@ -142,10 +142,22 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
         config.renameProperty("starting-field-name", STARTING_FIELD_NAME.getName());
         config.renameProperty("schema-application-strategy", SCHEMA_APPLICATION_STRATEGY.getName());
         config.renameProperty(OBSOLETE_SCHEMA_CACHE, SCHEMA_CACHE.getName());
+
+        if (config.isPropertySet(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS)) {
+            final String allowCommentsRawValue = config.getRawPropertyValue(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS).orElse("");
+            final boolean allowComments = Boolean.parseBoolean(allowCommentsRawValue);
+            if (allowComments) {
+                config.setProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE, JsonParseMode.LENIENT.getValue());
+            } else {
+                config.setProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE, JsonParseMode.STANDARD.getValue());
+            }
+
+            config.removeProperty(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS);
+        }
     }
 
     protected TokenParserFactory createTokenParserFactory(final ConfigurationContext context) {
-        return new JsonParserFactory(buildStreamReadConstraints(context), isAllowCommentsEnabled(context));
+        return new JsonParserFactory(buildStreamReadConstraints(context), isLenientParsingEnabled(context));
     }
 
     /**
@@ -160,13 +172,15 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
     }
 
     /**
-     * Determine whether to allow comments when parsing based on available properties
+     * Determine whether to allow lenient parsing based on available properties
      *
      * @param context Configuration Context with property values
-     * @return Allow comments status
+     * @return Allow lenient parsing status
      */
-    protected boolean isAllowCommentsEnabled(final ConfigurationContext context) {
-        return context.getProperty(AbstractJsonRowRecordReader.ALLOW_COMMENTS).asBoolean();
+    protected boolean isLenientParsingEnabled(final ConfigurationContext context) {
+        final JsonParseMode jsonParseMode =
+                context.getProperty(AbstractJsonRowRecordReader.JSON_PARSE_MODE).asAllowableValue(JsonParseMode.class);
+        return JsonParseMode.LENIENT == jsonParseMode;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/yaml/YamlTreeReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/yaml/YamlTreeReader.java
@@ -44,7 +44,7 @@ import java.util.List;
         + "See the Usage of the Controller Service for more information and examples.")
 public class YamlTreeReader extends JsonTreeReader {
 
-    private static final boolean ALLOW_COMMENTS_DISABLED = false;
+    private static final boolean LENIENT_PARSING_DISABLED = false;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -53,7 +53,7 @@ public class YamlTreeReader extends JsonTreeReader {
 
     @Override
     protected TokenParserFactory createTokenParserFactory(final ConfigurationContext context) {
-        return new YamlParserFactory(buildStreamReadConstraints(context), isAllowCommentsEnabled(context));
+        return new YamlParserFactory(buildStreamReadConstraints(context), isLenientParsingEnabled(context));
     }
 
     @Override
@@ -63,7 +63,7 @@ public class YamlTreeReader extends JsonTreeReader {
     }
 
     @Override
-    protected boolean isAllowCommentsEnabled(final ConfigurationContext context) {
-        return ALLOW_COMMENTS_DISABLED;
+    protected boolean isLenientParsingEnabled(final ConfigurationContext context) {
+        return LENIENT_PARSING_DISABLED;
     }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/yaml/YamlTreeReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/yaml/YamlTreeReader.java
@@ -49,6 +49,7 @@ public class YamlTreeReader extends JsonTreeReader {
     @Override
     public void migrateProperties(PropertyConfiguration config) {
         super.migrateProperties(config);
+        // Remove Parsing Strategy from potential addition through the parent JsonTreeReader property migration
         config.removeProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY.getName());
     }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/yaml/YamlTreeReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/yaml/YamlTreeReader.java
@@ -21,8 +21,10 @@ import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.json.AbstractJsonRowRecordReader;
 import org.apache.nifi.json.JsonTreeReader;
 import org.apache.nifi.json.JsonTreeRowRecordReader;
+import org.apache.nifi.json.ParsingStrategy;
 import org.apache.nifi.json.TokenParserFactory;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.serialization.MalformedRecordException;
@@ -44,8 +46,6 @@ import java.util.List;
         + "See the Usage of the Controller Service for more information and examples.")
 public class YamlTreeReader extends JsonTreeReader {
 
-    private static final boolean LENIENT_PARSING_DISABLED = false;
-
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return new ArrayList<>(super.getSupportedPropertyDescriptors());
@@ -53,17 +53,15 @@ public class YamlTreeReader extends JsonTreeReader {
 
     @Override
     protected TokenParserFactory createTokenParserFactory(final ConfigurationContext context) {
-        return new YamlParserFactory(buildStreamReadConstraints(context), isLenientParsingEnabled(context));
+        final ParsingStrategy parsingStrategy =
+                context.getProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY).asAllowableValue(ParsingStrategy.class);
+        final boolean allowComments = ParsingStrategy.LENIENT == parsingStrategy;
+        return new YamlParserFactory(buildStreamReadConstraints(context), allowComments);
     }
 
     @Override
     protected JsonTreeRowRecordReader createJsonTreeRowRecordReader(InputStream in, ComponentLog logger, RecordSchema schema) throws IOException, MalformedRecordException {
         return new YamlTreeRowRecordReader(in, logger, schema, dateFormat, timeFormat, timestampFormat, startingFieldStrategy, startingFieldName,
                 schemaApplicationStrategy, null);
-    }
-
-    @Override
-    protected boolean isLenientParsingEnabled(final ConfigurationContext context) {
-        return LENIENT_PARSING_DISABLED;
     }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/yaml/YamlTreeReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/yaml/YamlTreeReader.java
@@ -24,9 +24,9 @@ import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.json.AbstractJsonRowRecordReader;
 import org.apache.nifi.json.JsonTreeReader;
 import org.apache.nifi.json.JsonTreeRowRecordReader;
-import org.apache.nifi.json.ParsingStrategy;
 import org.apache.nifi.json.TokenParserFactory;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.record.RecordSchema;
 
@@ -47,16 +47,22 @@ import java.util.List;
 public class YamlTreeReader extends JsonTreeReader {
 
     @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        super.migrateProperties(config);
+        config.removeProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY.getName());
+    }
+
+    @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return new ArrayList<>(super.getSupportedPropertyDescriptors());
+        final List<PropertyDescriptor> supportedPropertyDescriptors = new ArrayList<>(super.getSupportedPropertyDescriptors());
+        supportedPropertyDescriptors.remove(AbstractJsonRowRecordReader.PARSING_STRATEGY);
+
+        return  supportedPropertyDescriptors;
     }
 
     @Override
     protected TokenParserFactory createTokenParserFactory(final ConfigurationContext context) {
-        final ParsingStrategy parsingStrategy =
-                context.getProperty(AbstractJsonRowRecordReader.PARSING_STRATEGY).asAllowableValue(ParsingStrategy.class);
-        final boolean allowComments = ParsingStrategy.LENIENT == parsingStrategy;
-        return new YamlParserFactory(buildStreamReadConstraints(context), allowComments);
+        return new YamlParserFactory(buildStreamReadConstraints(context));
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonPathReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonPathReader.java
@@ -34,20 +34,14 @@ import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REFERENCE_R
 import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REGISTRY;
 import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_TEXT;
 import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_VERSION;
-import static org.apache.nifi.schema.inference.SchemaInferenceUtil.OBSOLETE_SCHEMA_CACHE;
-import static org.apache.nifi.schema.inference.SchemaInferenceUtil.SCHEMA_CACHE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TestJsonTreeReader {
+public class TestJsonPathReader {
 
     @ParameterizedTest
     @MethodSource("migrationConfigurations")
     void testMigrateProperties(MockPropertyConfiguration configuration, Set<String> expectedRemoved) {
         final Map<String, String> expectedRenamed = Map.ofEntries(
-                Map.entry("starting-field-strategy", JsonTreeReader.STARTING_FIELD_STRATEGY.getName()),
-                Map.entry("starting-field-name", JsonTreeReader.STARTING_FIELD_NAME.getName()),
-                Map.entry("schema-application-strategy", JsonTreeReader.SCHEMA_APPLICATION_STRATEGY.getName()),
-                Map.entry(OBSOLETE_SCHEMA_CACHE, SCHEMA_CACHE.getName()),
                 Map.entry(SchemaAccessUtils.OLD_SCHEMA_ACCESS_STRATEGY_PROPERTY_NAME, SCHEMA_ACCESS_STRATEGY.getName()),
                 Map.entry(SchemaAccessUtils.OLD_SCHEMA_REGISTRY_PROPERTY_NAME, SCHEMA_REGISTRY.getName()),
                 Map.entry(SchemaAccessUtils.OLD_SCHEMA_NAME_PROPERTY_NAME, SCHEMA_NAME.getName()),
@@ -57,7 +51,7 @@ public class TestJsonTreeReader {
                 Map.entry(SchemaAccessUtils.OLD_SCHEMA_REFERENCE_READER_PROPERTY_NAME, SCHEMA_REFERENCE_READER.getName())
         );
 
-        final JsonTreeReader service = new JsonTreeReader();
+        final JsonPathReader service = new JsonPathReader();
         service.migrateProperties(configuration);
         final PropertyMigrationResult result = configuration.toPropertyMigrationResult();
 
@@ -75,5 +69,4 @@ public class TestJsonTreeReader {
                         new MockPropertyConfiguration(Map.of(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS, "true")), Set.of(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS))
         );
     }
-
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
@@ -307,34 +307,34 @@ class TestJsonTreeRowRecordReader {
 
     @Test
     void testReadMultilineJSON() throws Exception {
-        testReadAccountJson("src/test/resources/json/bank-account-multiline.json", false, null);
+        testReadAccountJson("src/test/resources/json/bank-account-multiline.json", ParsingStrategy.STANDARD, null);
     }
 
     @Test
     void testReadJSONStringTooLong() {
         final StreamConstraintsException mre = assertThrows(StreamConstraintsException.class, () ->
-                testReadAccountJson("src/test/resources/json/bank-account-multiline.json", false, StreamReadConstraints.builder().maxStringLength(2).build()));
+                testReadAccountJson("src/test/resources/json/bank-account-multiline.json", ParsingStrategy.STANDARD, StreamReadConstraints.builder().maxStringLength(2).build()));
         assertTrue(mre.getMessage().contains("maximum"));
         assertTrue(mre.getMessage().contains("2"));
     }
 
     @Test
     void testReadJSONComments() throws Exception {
-        testReadAccountJson("src/test/resources/json/bank-account-comments.jsonc", true, StreamReadConstraints.builder().maxStringLength(20_000).build());
+        testReadAccountJson("src/test/resources/json/bank-account-comments.jsonc", ParsingStrategy.LENIENT, StreamReadConstraints.builder().maxStringLength(20_000).build());
     }
 
     @Test
     void testReadJSONDisallowComments() {
         assertThrows(MalformedRecordException.class, () ->
-            testReadAccountJson("src/test/resources/json/bank-account-comments.jsonc", false, StreamReadConstraints.builder().maxStringLength(20_000).build()));
+            testReadAccountJson("src/test/resources/json/bank-account-comments.jsonc", ParsingStrategy.STANDARD, StreamReadConstraints.builder().maxStringLength(20_000).build()));
     }
 
-    private void testReadAccountJson(final String inputFile, final boolean allowComments, final StreamReadConstraints streamReadConstraints) throws Exception {
+    private void testReadAccountJson(final String inputFile, final ParsingStrategy parsingStrategy, final StreamReadConstraints streamReadConstraints) throws Exception {
         final List<RecordField> fields = getFields(RecordFieldType.DECIMAL.getDecimalDataType(30, 10));
         final RecordSchema schema = new SimpleRecordSchema(fields);
 
         try (final InputStream in = new FileInputStream(inputFile);
-             final JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(in, schema, null, null, null, null, null, null, null, allowComments, streamReadConstraints)) {
+             final JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(in, schema, null, null, null, null, null, null, null, parsingStrategy, streamReadConstraints)) {
 
             final List<String> fieldNames = schema.getFieldNames();
             final List<String> expectedFieldNames = Arrays.asList("id", "name", "balance", "address", "city", "state", "zipCode", "country");
@@ -519,7 +519,7 @@ class TestJsonTreeRowRecordReader {
         final String json = String.format("{ \"%s\": \"%s\" }", dateField, date);
         for (final boolean coerceTypes : new boolean[] {true, false}) {
             try (final InputStream in = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
-                 final JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(in, schema, datePattern, timeFormat, timestampFormat, null, null, null, null, false, null)) {
+                 final JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(in, schema, datePattern, timeFormat, timestampFormat, null, null, null, null, ParsingStrategy.STANDARD, null)) {
 
                 final Record record = reader.nextRecord(coerceTypes, false);
                 final Object value = record.getValue(dateField);
@@ -536,7 +536,8 @@ class TestJsonTreeRowRecordReader {
 
         for (final boolean coerceTypes : new boolean[] {true, false}) {
             try (final InputStream in = new FileInputStream("src/test/resources/json/timestamp.json");
-                 final JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(in, schema, dateFormat, timeFormat, "yyyy/MM/dd HH:mm:ss", null, null, null, null, false, null)) {
+                 final JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(in, schema, dateFormat, timeFormat,
+                         "yyyy/MM/dd HH:mm:ss", null, null, null, null, ParsingStrategy.STANDARD, null)) {
 
                 final Record record = reader.nextRecord(coerceTypes, false);
                 final Object value = record.getValue("timestamp");
@@ -748,7 +749,7 @@ class TestJsonTreeRowRecordReader {
         final List<String> ids = new ArrayList<>();
         try (final InputStream in = new ByteArrayInputStream(inputJson.getBytes(StandardCharsets.UTF_8));
              final JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(in, bookSchema, dateFormat, timeFormat, timestampFormat,
-                     StartingFieldStrategy.NESTED_FIELD, "books", SchemaApplicationStrategy.SELECTED_PART, null, false, null)) {
+                     StartingFieldStrategy.NESTED_FIELD, "books", SchemaApplicationStrategy.SELECTED_PART, null, ParsingStrategy.STANDARD, null)) {
 
             Record record;
             while ((record = reader.nextRecord()) != null) {
@@ -777,7 +778,7 @@ class TestJsonTreeRowRecordReader {
         final StringBuilder labelsRead = new StringBuilder();
         try (final InputStream in = new ByteArrayInputStream(inputJson.getBytes(StandardCharsets.UTF_8));
              final JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(in, recordSchema, dateFormat, timeFormat, timestampFormat,
-                     StartingFieldStrategy.ROOT_NODE, null, SchemaApplicationStrategy.SELECTED_PART, null, false, null)
+                     StartingFieldStrategy.ROOT_NODE, null, SchemaApplicationStrategy.SELECTED_PART, null, ParsingStrategy.STANDARD, null)
         ) {
             final Record record = reader.nextRecord();
             assertNotNull(record, "Record not found");
@@ -806,7 +807,7 @@ class TestJsonTreeRowRecordReader {
         final List<String> ids = new ArrayList<>();
         try (final InputStream in = new ByteArrayInputStream(inputJson.getBytes(StandardCharsets.UTF_8));
              final JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(in, bookSchema, dateFormat, timeFormat, timestampFormat,
-                StartingFieldStrategy.NESTED_FIELD, "book", SchemaApplicationStrategy.SELECTED_PART, null, false, null)) {
+                StartingFieldStrategy.NESTED_FIELD, "book", SchemaApplicationStrategy.SELECTED_PART, null, ParsingStrategy.STANDARD, null)) {
 
             Record record;
             while ((record = reader.nextRecord()) != null) {
@@ -1261,7 +1262,7 @@ class TestJsonTreeRowRecordReader {
         try (InputStream in = new FileInputStream("src/test/resources/json/capture-fields.json")) {
             JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(in, recordSchema, dateFormat, timeFormat, timestampFormat,
                     StartingFieldStrategy.NESTED_FIELD, startingFieldName, SchemaApplicationStrategy.SELECTED_PART,
-                    capturePredicate, false, null);
+                    capturePredicate, ParsingStrategy.STANDARD, null);
 
             while (reader.nextRecord() != null) {
                 // continue reading
@@ -1348,7 +1349,7 @@ class TestJsonTreeRowRecordReader {
             throws Exception {
 
         try (JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(jsonStream, schema, dateFormat, timeFormat, timestampFormat,
-                strategy, startingFieldName, schemaApplicationStrategy, null, false, null)) {
+                strategy, startingFieldName, schemaApplicationStrategy, null, ParsingStrategy.STANDARD, null)) {
             List<Object> actual = new ArrayList<>();
             Record record;
 
@@ -1386,19 +1387,19 @@ class TestJsonTreeRowRecordReader {
     }
 
     private JsonTreeRowRecordReader createJsonTreeRowRecordReader(InputStream inputStream, RecordSchema recordSchema) throws Exception {
-        return createJsonTreeRowRecordReader(inputStream, recordSchema, dateFormat, timeFormat, timestampFormat, null, null, null, null, false, null);
+        return createJsonTreeRowRecordReader(inputStream, recordSchema, dateFormat, timeFormat, timestampFormat, null, null, null, null, ParsingStrategy.STANDARD, null);
     }
 
     private JsonTreeRowRecordReader createJsonTreeRowRecordReader(InputStream inputStream, RecordSchema recordSchema, String dateFormat, String timeFormat, String timestampFormat,
                                                                   StartingFieldStrategy startingFieldStrategy, String startingFieldName, SchemaApplicationStrategy schemaApplicationStrategy,
-                                                                  BiPredicate<String, String> captureFieldPredicate, boolean allowComments, StreamReadConstraints streamReadConstraints)
+                                                                  BiPredicate<String, String> captureFieldPredicate, ParsingStrategy parsingStrategy, StreamReadConstraints streamReadConstraints)
             throws Exception {
 
         final TokenParserFactory tokenParserFactory;
         if (streamReadConstraints == null) {
             tokenParserFactory = new JsonParserFactory();
         } else {
-            tokenParserFactory = new JsonParserFactory(streamReadConstraints, allowComments);
+            tokenParserFactory = new JsonParserFactory(streamReadConstraints, parsingStrategy);
         }
 
         return new JsonTreeRowRecordReader(inputStream, log, recordSchema, dateFormat, timeFormat, timestampFormat, startingFieldStrategy, startingFieldName, schemaApplicationStrategy,

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/yaml/TestYamlTreeReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/yaml/TestYamlTreeReader.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.yaml;
+
+import org.apache.nifi.json.AbstractJsonRowRecordReader;
+import org.apache.nifi.json.JsonTreeReader;
+import org.apache.nifi.schema.access.SchemaAccessUtils;
+import org.apache.nifi.util.MockPropertyConfiguration;
+import org.apache.nifi.util.PropertyMigrationResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY;
+import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_BRANCH_NAME;
+import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_NAME;
+import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REFERENCE_READER;
+import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REGISTRY;
+import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_TEXT;
+import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_VERSION;
+import static org.apache.nifi.schema.inference.SchemaInferenceUtil.OBSOLETE_SCHEMA_CACHE;
+import static org.apache.nifi.schema.inference.SchemaInferenceUtil.SCHEMA_CACHE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class TestYamlTreeReader {
+    @Test
+    void testGetSupportedPropertyDescriptors() {
+        final YamlTreeReader service = new YamlTreeReader();
+        assertFalse(service.getSupportedPropertyDescriptors().contains(AbstractJsonRowRecordReader.PARSING_STRATEGY));
+    }
+
+    @ParameterizedTest
+    @MethodSource("migrationConfigurations")
+    void testMigrateProperties(MockPropertyConfiguration configuration, Set<String> expectedRemoved) {
+        final Map<String, String> expectedRenamed = Map.ofEntries(
+                Map.entry("starting-field-strategy", JsonTreeReader.STARTING_FIELD_STRATEGY.getName()),
+                Map.entry("starting-field-name", JsonTreeReader.STARTING_FIELD_NAME.getName()),
+                Map.entry("schema-application-strategy", JsonTreeReader.SCHEMA_APPLICATION_STRATEGY.getName()),
+                Map.entry(OBSOLETE_SCHEMA_CACHE, SCHEMA_CACHE.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_ACCESS_STRATEGY_PROPERTY_NAME, SCHEMA_ACCESS_STRATEGY.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REGISTRY_PROPERTY_NAME, SCHEMA_REGISTRY.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_NAME_PROPERTY_NAME, SCHEMA_NAME.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_BRANCH_NAME_PROPERTY_NAME, SCHEMA_BRANCH_NAME.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_VERSION_PROPERTY_NAME, SCHEMA_VERSION.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_TEXT_PROPERTY_NAME, SCHEMA_TEXT.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REFERENCE_READER_PROPERTY_NAME, SCHEMA_REFERENCE_READER.getName())
+        );
+
+        final YamlTreeReader service = new YamlTreeReader();
+        service.migrateProperties(configuration);
+        final PropertyMigrationResult result = configuration.toPropertyMigrationResult();
+
+        final Map<String, String> propertiesRenamed = result.getPropertiesRenamed();
+        assertEquals(expectedRenamed, propertiesRenamed);
+
+        final Set<String> propertiesRemoved = result.getPropertiesRemoved();
+        assertEquals(expectedRemoved, propertiesRemoved);
+    }
+
+    private static Stream<Arguments> migrationConfigurations() {
+        return Stream.of(
+                Arguments.argumentSet("Configuration without allow comments",
+                        new MockPropertyConfiguration(Map.of()), Set.of(AbstractJsonRowRecordReader.PARSING_STRATEGY.getName())),
+                Arguments.argumentSet("Configuration with allow comments",
+                        new MockPropertyConfiguration(Map.of(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS, "true")),
+                        Set.of(AbstractJsonRowRecordReader.OBSOLETE_ALLOW_COMMENTS, AbstractJsonRowRecordReader.PARSING_STRATEGY.getName()))
+        );
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12456](https://issues.apache.org/jira/browse/NIFI-12456)
The changes in this PR now allow for  `JsonTreeReader` and `JsonPathReader`  to parse incoming JSON leniently which includes allowing

-  Java comments (/**/ and //)
-  Yaml comments (start of line begins with #)
-  Leading plus sign in numbers (e.g. +123)
-  Leading zeros in numbers (e.g. 0001)
-  "missing" decimal numbers to end with a decimal point (e.g. 123.)
-  "missing value" in an array (i.e. sequence of two commas, without value in-between e.g. ["A",,"C"]),
-  Trailing comma in an array or member in an object
-  Use of single quotes for quoting strings (i.e. use of an apostrophe)
-  Use of unquoted field names
-  Use of unescaped control characters (ASCII characters with value less than 32)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
