### PR TITLE
NIFI-14472: Fix potential NPE in PutKinesisFirehose batch accumulation

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/firehose/PutKinesisFirehose.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/firehose/PutKinesisFirehose.java
@@ -134,8 +134,11 @@ public class PutKinesisFirehose extends AbstractAwsSyncProcessor<FirehoseClient,
             for (final FlowFile flowFile : flowFiles) {
                 final String firehoseStreamName = context.getProperty(KINESIS_FIREHOSE_DELIVERY_STREAM_NAME).evaluateAttributeExpressions(flowFile).getValue();
 
-                recordHash.computeIfAbsent(firehoseStreamName, k -> new ArrayList<>());
-                session.read(flowFile, in -> recordHash.get(firehoseStreamName).add(Record.builder().data(SdkBytes.fromInputStream(in)).build()));
+                session.read(flowFile, in ->
+                        recordHash
+                                .computeIfAbsent(firehoseStreamName, k -> new ArrayList<>())
+                                .add(Record.builder().data(SdkBytes.fromInputStream(in)).build())
+                );
 
                 final List<FlowFile> flowFilesForStream = hashFlowFiles.computeIfAbsent(firehoseStreamName, k -> new ArrayList<>());
                 flowFilesForStream.add(flowFile);


### PR DESCRIPTION
## Summary

Fixes a race condition / NPE in PutKinesisFirehose.onTrigger() where a two-step computeIfAbsent() + get() on the batch-accumulation map could return null if the entry was evicted between the two calls.

## Changes

- Collapsed the two-step lookup into a single atomic computeIfAbsent(...).add(record) call in PutKinesisFirehose.java, eliminating the window for a NullPointerException.

## Testing

- Existing unit tests pass.
- The fix is a straightforward atomic-operation replacement with no behavioral change under normal conditions.

Fixes: https://issues.apache.org/jira/browse/NIFI-14472