### PR TITLE
NIFI-15906: Fix IllegalStateException during cluster reconnect in StandardConnection

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/connectable/StandardConnection.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/connectable/StandardConnection.java
@@ -292,7 +292,18 @@ public final class StandardConnection implements Connection {
             return;
         }
 
-        if (previousDestination.isRunning() && !(previousDestination instanceof Funnel || previousDestination instanceof LocalPort)) {
+        // Allow destination changes when the current destination is a Funnel, a LocalPort, or a
+        // RemoteGroupPort. Funnels and LocalPorts cannot be stopped/started so they are exempt.
+        // RemoteGroupPort represents an S2S ingress point: re-routing its incoming connections
+        // during cluster reconnect synchronization (e.g., temporarily pointing to a dummy Funnel)
+        // is safe because the RPG does not hold per-FlowFile processing state the way a Processor
+        // does. Without this exemption, StandardVersionedComponentSynchronizer throws
+        // IllegalStateException when a running RPG with versionedComponentId=null is encountered
+        // during updateConnectionDestinations(), leaving the node permanently disconnected.
+        // (NIFI-15906)
+        if (previousDestination.isRunning() && !(previousDestination instanceof Funnel
+                || previousDestination instanceof LocalPort
+                || previousDestination instanceof RemoteGroupPort)) {
             throw new IllegalStateException("Cannot change destination of Connection because the current destination ([%s]) is running".formatted(previousDestination));
         }
 


### PR DESCRIPTION
## Summary

During cluster node reconnection, StandardConnection.setDestination() throws an IllegalStateException ("Cannot change destination while destination is running") when the destination is a RemoteGroupPort. Remote ports are managed by the cluster coordinator and can legally be running during reconnect — they should be exempt from this guard, just like Funnel and NiFiPort.

## Changes

- Added RemoteGroupPort to the instanceof-check exemption list in StandardConnection.setDestination().
- RemoteGroupPort was already imported in the file; no new imports needed.

## Testing

- Reproducer: disconnect a node from a cluster that has a Remote Process Group destination, then reconnect — the ISE no longer fires.
- Existing unit tests pass.

Fixes: https://issues.apache.org/jira/browse/NIFI-15906