### PR TITLE
NIFI-15912 - PutSplunk Processor runs countinously and causes high load

### DIFF
--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunk.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunk.java
@@ -101,11 +101,13 @@ public class PutSplunk extends AbstractPutEventProcessor<byte[]> {
     }
 
     @Override
-    public void onTrigger(ProcessContext context, ProcessSessionFactory sessionFactory) throws ProcessException {
+    public void onTrigger(final ProcessContext context, final ProcessSessionFactory sessionFactory) throws ProcessException {
         // first complete any batches from previous executions
+        boolean completedAny = false;
         FlowFileMessageBatch batch;
         while ((batch = completeBatches.poll()) != null) {
             batch.completeSession();
+            completedAny = true;
         }
 
         // create a session and try to get a FlowFile, if none available then close any idle senders
@@ -113,6 +115,12 @@ public class PutSplunk extends AbstractPutEventProcessor<byte[]> {
         final FlowFile flowFile = session.get();
 
         if (flowFile == null) {
+            // The processor is annotated with @TriggerWhenEmpty so onTrigger is invoked even with no input,
+            // allowing async send callbacks to drain completeBatches. Yield when nothing was drained to avoid
+            // a busy scheduling loop on an idle processor.
+            if (!completedAny) {
+                context.yield();
+            }
             return;
         }
 

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestPutSplunk.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestPutSplunk.java
@@ -42,8 +42,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestPutSplunk {
 
@@ -259,6 +261,31 @@ public class TestPutSplunk {
         mockFlowFile.assertContentEquals(message);
 
         checkReceivedAllData(message);
+    }
+
+    @Test
+    @Timeout(value = DEFAULT_TEST_TIMEOUT_PERIOD, unit = TimeUnit.MILLISECONDS)
+    public void testYieldsWhenIdle() throws Exception {
+        createTestServer(TransportProtocol.TCP);
+
+        runner.run(1);
+
+        assertTrue(runner.isYieldCalled(), "Processor should yield when no FlowFile is available to avoid busy scheduling");
+    }
+
+    @Test
+    @Timeout(value = DEFAULT_TEST_TIMEOUT_PERIOD, unit = TimeUnit.MILLISECONDS)
+    public void testDoesNotYieldWhenFlowFileProcessed() throws Exception {
+        createTestServer(TransportProtocol.TCP);
+        final String message = "This is one message, should send the whole FlowFile";
+
+        runner.enqueue(message);
+        runner.run(1);
+        runner.assertAllFlowFilesTransferred(PutSplunk.REL_SUCCESS, 1);
+
+        checkReceivedAllData(message);
+
+        assertFalse(runner.isYieldCalled(), "Processor should not yield after successfully processing a FlowFile");
     }
 
     @Test


### PR DESCRIPTION
# Summary

NIFI-15912 - PutSplunk Processor runs countinously and causes high load

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
