### PR TITLE
NIFI-15916 Log dropped FlowFiles when content is missing

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -3751,13 +3751,14 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
         if (missingClaim == registeredClaim) {
             suspectRecord.markForAbort();
+            LOG.warn("Unable to find content for {}; dropping FlowFile", suspectRecord.getCurrent(), nfe);
             rollback();
-            throw new MissingFlowFileException("Unable to find content for FlowFile", nfe);
+            throw new MissingFlowFileException("Unable to find content for " + suspectRecord.getCurrent() + "; dropping FlowFile", nfe);
         }
 
         if (missingClaim == transientClaim) {
             rollback();
-            throw new MissingFlowFileException("Unable to find content for FlowFile", nfe);
+            throw new MissingFlowFileException("Unable to find in-flight content for " + suspectRecord.getCurrent() + "; rolling back", nfe);
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/StandardProcessSessionIT.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/StandardProcessSessionIT.java
@@ -1601,7 +1601,10 @@ public class StandardProcessSessionIT {
 
         // attempt to read the data.
         final FlowFile ff1 = session.get();
-        assertThrows(MissingFlowFileException.class, () -> session.read(ff1, InputStream::read));
+        final MissingFlowFileException ex = assertThrows(MissingFlowFileException.class,
+                () -> session.read(ff1, InputStream::read));
+        assertTrue(ex.getMessage().contains("12345678-1234-1234-1234-123456789012"));
+        assertTrue(ex.getMessage().contains("rolling back"));
     }
 
     @Test
@@ -1775,7 +1778,10 @@ public class StandardProcessSessionIT {
         session.get();
         final FlowFile ff2 = session.get();
 
-        assertThrows(MissingFlowFileException.class, () -> session.read(ff2, InputStream::read));
+        final MissingFlowFileException ex = assertThrows(MissingFlowFileException.class,
+                () -> session.read(ff2, InputStream::read));
+        assertTrue(ex.getMessage().contains("12345678-1234-1234-1234-123456789012"));
+        assertTrue(ex.getMessage().contains("rolling back"));
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15916](https://issues.apache.org/jira/browse/NIFI-15916)

In `handleContentNotFound` both branches threw `MissingFlowFileException` with the same generic "Unable to find content for FlowFile" message, giving operators no FlowFile identity and no way to distinguish an unrecoverable drop from a recoverable rollback.

Registered-claim branch (`markForAbort` + drop): enrich the exception message with the FlowFile identity and emit a WARN log so the drop is recorded even if the caller swallows the exception.

Transient-claim branch (rollback returns the FlowFile to its queue): enrich the message only - name the in-flight content and signal the session is rolling back so callers can tell this is recoverable.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
