### PR TITLE
NIFI-15908: Disabling the Apply button in the Connector wizard when t…

### DIFF
--- a/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
@@ -793,4 +793,10 @@
             )
         );
     }
+
+    // buttons
+    .mdc-button:disabled {
+        pointer-events: auto;
+        cursor: not-allowed;
+    }
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-configuration-summary-step/connector-configuration-summary-step.component.html
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-configuration-summary-step/connector-configuration-summary-step.component.html
@@ -185,6 +185,7 @@
                 [disabled]="applyDisabled()"
                 [matTooltipDisabled]="applyTooltip() === ''"
                 [matTooltip]="applyTooltip()"
+                [matTooltipShowDelay]="500"
                 matTooltipPosition="left"
                 (click)="onConfirm()"
                 data-qa="apply-button"

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-configuration-summary-step/connector-configuration-summary-step.component.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-configuration-summary-step/connector-configuration-summary-step.component.scss
@@ -20,8 +20,3 @@
     line-height: 1;
     vertical-align: middle;
 }
-
-button[disabled] {
-    pointer-events: auto;
-    cursor: not-allowed;
-}

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-configuration-summary-step/connector-configuration-summary-step.component.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-configuration-summary-step/connector-configuration-summary-step.component.scss
@@ -20,3 +20,8 @@
     line-height: 1;
     vertical-align: middle;
 }
+
+button[disabled] {
+    pointer-events: auto;
+    cursor: not-allowed;
+}

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-configuration-summary-step/connector-configuration-summary-step.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-configuration-summary-step/connector-configuration-summary-step.component.spec.ts
@@ -1045,6 +1045,48 @@ describe('ConnectorConfigurationSummaryStep', () => {
                 const applyButton = fixture.debugElement.query(By.css('[data-qa="apply-button"]'));
                 expect(applyButton.nativeElement.disabled).toBe(true);
             });
+
+            it('should disable apply when applyAllowed is false even with verificationPassed=true', () => {
+                fixture.componentRef.setInput('verificationPassed', true);
+                fixture.componentRef.setInput('applyAllowed', false);
+                fixture.componentRef.setInput('applyDisabledReason', 'No pending changes');
+                fixture.detectChanges();
+
+                const applyButton = fixture.debugElement.query(By.css('[data-qa="apply-button"]'));
+                expect(applyButton.nativeElement.disabled).toBe(true);
+            });
+
+            it('should surface the applyDisabledReason as the apply tooltip when not allowed', () => {
+                fixture.componentRef.setInput('verificationPassed', true);
+                fixture.componentRef.setInput('applyAllowed', false);
+                fixture.componentRef.setInput('applyDisabledReason', 'No pending changes');
+                fixture.detectChanges();
+
+                expect(component.applyTooltip()).toBe('No pending changes');
+            });
+
+            it('should keep the verify-required tooltip when apply is allowed but verification has not passed', () => {
+                fixture.componentRef.setInput('verificationPassed', null);
+                fixture.componentRef.setInput('applyAllowed', true);
+                fixture.componentRef.setInput('applyDisabledReason', '');
+                fixture.detectChanges();
+
+                expect(component.applyTooltip()).toBe('Run verification before applying');
+            });
+
+            it('should fall through to the verify-required tooltip when applyAllowed=false but no reason is provided', () => {
+                fixture.componentRef.setInput('verificationPassed', null);
+                fixture.componentRef.setInput('applyAllowed', false);
+                fixture.componentRef.setInput('applyDisabledReason', '');
+                fixture.detectChanges();
+
+                expect(component.applyTooltip()).toBe('Run verification before applying');
+            });
+
+            it('should default applyAllowed to true so existing callers are unaffected', () => {
+                expect(component.applyAllowed()).toBe(true);
+                expect(component.applyDisabledReason()).toBe('');
+            });
         });
 
         describe('Step verification status icons', () => {

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-configuration-summary-step/connector-configuration-summary-step.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-configuration-summary-step/connector-configuration-summary-step.component.ts
@@ -58,6 +58,18 @@ export class ConnectorConfigurationSummaryStep {
     stepVerificationResults = input<{ [stepName: string]: ConfigVerificationResult[] }>({});
     stepNameMapping = input<{ [displayName: string]: string[] }>({});
     verifyAllError = input<string | null>(null);
+    /**
+     * Whether the backend permits applying updates. Defaults to true so callers that
+     * have not yet adopted the input continue to behave as before. When false (e.g. the
+     * connector reports `APPLY_UPDATES` as not allowed because there are no pending
+     * changes or the connector is mid-update), the Apply button is disabled.
+     */
+    applyAllowed = input(true);
+    /**
+     * Backend-supplied reason describing why apply is not allowed. Surfaced verbatim as
+     * the Apply button tooltip when {@link applyAllowed} is false. May be empty.
+     */
+    applyDisabledReason = input('');
 
     // Signal outputs
     confirm = output<void>();
@@ -66,10 +78,27 @@ export class ConnectorConfigurationSummaryStep {
     verify = output<void>();
 
     applyDisabled = computed(() => {
-        return this.loading() || this.applying() || this.verifying() || this.verificationPassed() !== true;
+        return (
+            this.loading() ||
+            this.applying() ||
+            this.verifying() ||
+            this.verificationPassed() !== true ||
+            !this.applyAllowed()
+        );
     });
 
+    /**
+     * The Apply button's tooltip. Returns one of:
+     *  - the backend-supplied {@link applyDisabledReason} verbatim when apply is not
+     *    allowed; takes precedence so the user sees the authoritative reason
+     *    (e.g. "No pending changes", "Connector is updating");
+     *  - the verify-required hint when verification has not succeeded;
+     *  - empty string otherwise.
+     */
     applyTooltip = computed(() => {
+        if (!this.applyAllowed() && this.applyDisabledReason()) {
+            return this.applyDisabledReason();
+        }
         if (this.verificationPassed() !== true) {
             return 'Run verification before applying';
         }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-wizard.component.html
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-wizard.component.html
@@ -81,6 +81,8 @@
                                     [stepVerificationResults]="wizardStore.stepVerificationResults()"
                                     [verifyAllError]="wizardStore.verifyAllError()"
                                     [stepNameMapping]="stepNameMapping()"
+                                    [applyAllowed]="wizardStore.applyUpdatesAllowed()"
+                                    [applyDisabledReason]="wizardStore.applyUpdatesDisabledReason()"
                                     (confirm)="onApplyConfiguration()"
                                     (dismiss)="navigateBack.emit()"
                                     (previous)="onPreviousStep()"

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-wizard.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-wizard.component.spec.ts
@@ -53,6 +53,8 @@ function createMockStore(state: MockStoreState = {}) {
         currentVerifyingStepName: signal<string | null>(null),
         stepVerificationResults: signal<Record<string, unknown>>({}),
         verifyAllError: signal<string | null>(null),
+        applyUpdatesAllowed: signal<boolean>(false),
+        applyUpdatesDisabledReason: signal<string>(''),
         bannerErrors: signal<string[]>([]),
         initializeWithConnector: vi.fn(),
         loadSecrets: vi.fn(),

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-wizard.store.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-wizard.store.spec.ts
@@ -264,6 +264,63 @@ describe('StandardConnectorWizardStore', () => {
     });
 
     // ═══════════════════════════════════════════════════════
+    // applyUpdatesAllowed / applyUpdatesDisabledReason
+    // ═══════════════════════════════════════════════════════
+
+    describe('applyUpdatesAllowed / applyUpdatesDisabledReason', () => {
+        it('returns false with empty reason when no connector is set', () => {
+            const { store } = setup();
+            expect(store.applyUpdatesAllowed()).toBe(false);
+            expect(store.applyUpdatesDisabledReason()).toBe('');
+        });
+
+        it('returns false with empty reason when APPLY_UPDATES action is missing', () => {
+            const { store } = setup();
+            store.initializeWithConnector(makeConnector());
+            expect(store.applyUpdatesAllowed()).toBe(false);
+            expect(store.applyUpdatesDisabledReason()).toBe('');
+        });
+
+        it('reflects allowed=true when backend permits APPLY_UPDATES', () => {
+            const { store } = setup();
+            const connector = makeConnector();
+            connector.component.availableActions = [
+                { name: 'APPLY_UPDATES', description: 'Apply updates', allowed: true }
+            ];
+            store.initializeWithConnector(connector);
+            expect(store.applyUpdatesAllowed()).toBe(true);
+            expect(store.applyUpdatesDisabledReason()).toBe('');
+        });
+
+        it('surfaces the backend reason when APPLY_UPDATES is not allowed', () => {
+            const { store } = setup();
+            const connector = makeConnector();
+            connector.component.availableActions = [
+                {
+                    name: 'APPLY_UPDATES',
+                    description: 'Apply updates',
+                    allowed: false,
+                    reasonNotAllowed: 'No pending changes'
+                }
+            ];
+            store.initializeWithConnector(connector);
+            expect(store.applyUpdatesAllowed()).toBe(false);
+            expect(store.applyUpdatesDisabledReason()).toBe('No pending changes');
+        });
+
+        it('returns empty reason when APPLY_UPDATES is not allowed but no reason is provided', () => {
+            const { store } = setup();
+            const connector = makeConnector();
+            connector.component.availableActions = [
+                { name: 'APPLY_UPDATES', description: 'Apply updates', allowed: false }
+            ];
+            store.initializeWithConnector(connector);
+            expect(store.applyUpdatesAllowed()).toBe(false);
+            expect(store.applyUpdatesDisabledReason()).toBe('');
+        });
+    });
+
+    // ═══════════════════════════════════════════════════════
     // Per-step signal factories
     // ═══════════════════════════════════════════════════════
 

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-wizard.store.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-wizard.store.ts
@@ -69,6 +69,8 @@ export abstract class ConnectorWizardStore {
     abstract readonly verificationPassed: Signal<boolean | null>;
     abstract readonly currentVerifyingStepName: Signal<string | null>;
     abstract readonly verifyAllError: Signal<string | null>;
+    abstract readonly applyUpdatesAllowed: Signal<boolean>;
+    abstract readonly applyUpdatesDisabledReason: Signal<string>;
 
     // --------------- Per-step signal factories ---------------
     abstract stepConfiguration(stepName: string): Signal<ConfigurationStepConfiguration | null>;

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/with-connector-wizard.feature.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/with-connector-wizard.feature.ts
@@ -68,6 +68,7 @@ import {
     initialConnectorWizardState
 } from './connector-wizard.types';
 import { getVisibleStepNames } from './step-dependency.utils';
+import { getConnectorAction } from '../../utils/connector-permissions.utils';
 
 /**
  * Reusable SignalStore feature encapsulating all shared connector wizard logic.
@@ -90,7 +91,28 @@ export function withConnectorWizard() {
                 allStepsVerifying: computed(() => allStepsVerification().verifying),
                 verificationPassed: computed(() => allStepsVerification().passed),
                 currentVerifyingStepName: computed(() => allStepsVerification().currentStepName),
-                verifyAllError: computed(() => allStepsVerification().error)
+                verifyAllError: computed(() => allStepsVerification().error),
+                /**
+                 * Whether the backend currently permits applying the connector's working
+                 * configuration. Derived from the `APPLY_UPDATES` action on the connector
+                 * entity. The backend reports `allowed: false` with reason
+                 * `"No pending changes"` when there is nothing to apply, and with reason
+                 * `"Connector is updating"` while a previous apply is still in progress.
+                 */
+                applyUpdatesAllowed: computed(() => {
+                    const c = connector();
+                    if (!c) return false;
+                    return getConnectorAction(c, 'APPLY_UPDATES')?.allowed ?? false;
+                }),
+                /**
+                 * Backend-supplied reason describing why apply is not allowed. Empty when
+                 * apply is allowed or the action is missing entirely.
+                 */
+                applyUpdatesDisabledReason: computed(() => {
+                    const c = connector();
+                    if (!c) return '';
+                    return getConnectorAction(c, 'APPLY_UPDATES')?.reasonNotAllowed ?? '';
+                })
             })
         ),
 


### PR DESCRIPTION
…here are no pending edits.

# Summary

[NIFI-15908](https://issues.apache.org/jira/browse/NIFI-15908)

Disables the Connector wizard's **Apply** button when the backend reports there
is nothing to apply (e.g. no pending working-configuration changes, or a prior
apply still in progress) and surfaces the backend-supplied reason as a tooltip
on hover so the user can discover *why* the action is unavailable.

## Background

The connector entity exposes an `availableActions` array; the `APPLY_UPDATES`
action carries `allowed: boolean` and `reasonNotAllowed: string`. The framework
already populates these correctly:

- `"No pending changes"` when the working configuration matches the active
  configuration.
- `"Connector is updating"` while a previous apply is `PREPARING_FOR_UPDATE` or
  `UPDATING`.

Until now the wizard ignored the action and only gated Apply on local UI state
(loading / applying / verifying / verification-passed). This PR threads the
backend signal through the wizard store into the summary step, then surfaces
the reason as a tooltip on the disabled button.

## Changes

### Wizard state plumbing

- `with-connector-wizard.feature.ts` — derives `applyUpdatesAllowed` and
  `applyUpdatesDisabledReason` `computed` signals from the connector's
  `APPLY_UPDATES` action via the existing `getConnectorAction()` helper.
- `connector-wizard.store.ts` — adds the two new signals to the abstract
  `ConnectorWizardStore` contract.
- `connector-wizard.component.html` — passes the signals down to the summary
  step as `[applyAllowed]` / `[applyDisabledReason]` inputs.

### Summary step UI

- `connector-configuration-summary-step.component.ts` — adds `applyAllowed`
  (default `true`, preserving existing callers) and `applyDisabledReason`
  signal inputs; updates `applyDisabled` and `applyTooltip` computed signals
  so the backend reason takes precedence over the verify-required hint.
- `connector-configuration-summary-step.component.html` — binds
  `[matTooltip]="applyTooltip()"` plus a local `[matTooltipShowDelay]="500"`.
  The tooltip lives directly on the `<button>` rather than on a wrapping
  `<span>`, made possible by the SCSS rule below.
- `connector-configuration-summary-step.component.scss` — re-enables
  `pointer-events: auto` on `button[disabled]` inside this component so the
  Material tooltip directive receives the hover events the browser would
  otherwise suppress on a native disabled button. Adds
  `cursor: not-allowed` for visual affordance.

### Test coverage

- `connector-configuration-summary-step.component.spec.ts` — 5 new tests
  covering: disable state when `applyAllowed=false` overrides
  `verificationPassed=true`; tooltip surfacing the backend reason verbatim;
  the verify-required hint still wins when no backend reason is present;
  default values preserve existing-caller behavior.
- `connector-wizard.store.spec.ts` — 5 new tests against the
  `applyUpdatesAllowed` / `applyUpdatesDisabledReason` selectors covering:
  no connector / missing action / `allowed=true` / `allowed=false` with
  reason / `allowed=false` without reason (verifies the `?? ''` fallback).
- `connector-wizard.component.spec.ts` — `createMockStore` factory updated
  to expose the two new signals so the mock continues to fully implement
  the abstract `ConnectorWizardStore` contract (prevents a future
  "is not a function" failure in tests that render the summary step).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-15908) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number `NIFI-15908`
- Pull Request commit message starts with Apache NiFi Jira issue number `NIFI-15908`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25
- [x] Frontend verified with `nx test shared` (725/725 passing) and
      `nx lint shared` (clean) from `nifi-frontend/src/main/frontend`

### Licensing

- [x] No new dependencies introduced
- [x] N/A — no `LICENSE`/`NOTICE` updates required

### Documentation

- [x] N/A — UI behavior change with no user-facing documentation impact
