### PR TITLE
NIFI-15918 Stabilize flaky system tests around processor lifecycle

### DIFF
--- a/.cursor/rules/code-style.mdc
+++ b/.cursor/rules/code-style.mdc
@@ -72,3 +72,11 @@ final List<String> result = myList.stream()
     when the logic is not simple and straightforward. The stream API is powerful but can be difficult to
     read when overused or used in complex scenarios. Functional style is best used when the logic is simple
     and chains together no more than 3-4 operations.
+16. Never use single-element arrays such as `final int[] counter = new int[]{0}` or
+    `final boolean[] flag = new boolean[]{false}` as a workaround for capturing a mutable primitive in a
+    lambda or anonymous class. This pattern is unidiomatic and confusing. When a lambda needs to mutate a
+    captured primitive, use the appropriate `java.util.concurrent.atomic` type (`AtomicInteger`,
+    `AtomicLong`, `AtomicBoolean`, `AtomicReference`, etc.). When a lambda needs to mutate a captured
+    object, hold the object in a final reference and mutate the object's state. The same applies to
+    `final Object[] holder = new Object[1]` for capturing a single reference; use `AtomicReference`
+    instead.

--- a/.cursor/rules/system-test-troubleshooting-archive.mdc
+++ b/.cursor/rules/system-test-troubleshooting-archive.mdc
@@ -1,0 +1,77 @@
+---
+description: Explains that every CI run of NiFi system tests uploads a per-test troubleshooting archive containing each cluster node's logs/ and conf/ directories, and how to download it when investigating a system test failure.
+alwaysApply: true
+---
+
+# System Test Troubleshooting Archive
+
+When a NiFi system test (anything under `nifi-system-tests/`) fails in CI, the
+`system-tests` workflow uploads a `*-troubleshooting-logs` artifact for each
+OS/JDK combination that ran. This archive is far more useful than the surefire/
+failsafe console output alone and **must** be retrieved before drawing
+conclusions about a system test failure.
+
+## What the archive contains
+
+For every failed test in that job, the archive includes:
+
+```
+troubleshooting/
+  <TestClass>-<testMethod>/
+    node-1/
+      logs/        full nifi-app.log, nifi-bootstrap.log, etc. for that node
+      conf/        nifi.properties, flow definition, state-management.xml, etc.
+    node-2/
+      logs/
+      conf/
+    ...
+```
+
+That is, for each failed test, the running NiFi instance(s) used by the test
+are captured with the same `logs/` and `conf/` you would inspect on a real
+deployment. For clustered tests, every node is captured separately. The
+archive also typically contains the matching `failsafe-reports/`.
+
+This is critical because a system test failure surfaces in CI as a single
+exception message, but the actual root cause is almost always visible only in
+`nifi-app.log` of one of the cluster nodes (cluster join issues, replication
+errors, repository corruption, processor scheduling issues, etc.).
+
+## How to fetch the archive
+
+1. Identify the failing GitHub Actions run id. For a PR, list its checks:
+   ```
+   gh pr checks <PR_NUMBER> --repo apache/nifi
+   gh run list --repo apache/nifi --limit 30
+   ```
+2. List the artifacts attached to that run to see which OS/JDK combos are
+   available and confirm none have expired:
+   ```
+   gh api repos/apache/nifi/actions/runs/<RUN_ID>/artifacts \
+     --jq '.artifacts[] | "\(.id)\t\(.name)\t\(.size_in_bytes)\t\(.expired)"'
+   ```
+3. Download into a directory:
+   ```
+   gh run download <RUN_ID> --repo apache/nifi --dir <local-dir>
+   ```
+   Each `*-troubleshooting-logs` artifact becomes a subdirectory under
+   `<local-dir>`.
+4. Inspect the per-node logs for the specific failing test:
+   ```
+   <local-dir>/<os-jdk>-troubleshooting-logs/troubleshooting/<TestClass>-<testMethod>/node-1/logs/nifi-app.log
+   ```
+
+GitHub Actions artifacts expire (currently 7 days for these workflows), so
+fetch them as soon as a failure is observed; once expired they cannot be
+recovered.
+
+## When this rule applies
+
+- Investigating any failed test under `nifi-system-tests/` in CI.
+- Triaging suspected flaky system tests across multiple PRs.
+- Reviewing a PR whose `system-tests` check has failed.
+
+It does **not** apply to unit tests (surefire) or integration tests
+(failsafe outside `nifi-system-tests/`); those workflows do not produce a
+troubleshooting archive, and only the surefire/failsafe console output is
+available via `gh run view <RUN_ID> --log-failed`.

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/main/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProvider.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/main/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProvider.java
@@ -137,12 +137,16 @@ public class KubernetesConfigMapStateProvider extends AbstractConfigurableCompon
     }
 
     /**
-     * Shutdown Provider
+     * Shutdown Provider. Safe to invoke even when the Provider was never initialized.
      */
     @Override
     public void shutdown() {
-        kubernetesClient.close();
-        logger.info("Provider shutdown");
+        if (kubernetesClient != null) {
+            kubernetesClient.close();
+        }
+        if (logger != null) {
+            logger.info("Provider shutdown");
+        }
     }
 
     /**

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/test/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/test/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProviderTest.java
@@ -132,6 +132,11 @@ class KubernetesConfigMapStateProviderTest {
     }
 
     @Test
+    void testShutdownWithoutInitialize() {
+        provider.shutdown();
+    }
+
+    @Test
     void testInitializeEnableDisable() {
         setContext();
         provider.initialize(context);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -1522,6 +1522,8 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
         } else {
             final String procName = processorRef.get().getProcessor().toString();
             procLog.warn("Cannot start {} because it is not currently stopped. Current state is {}", procName, currentState);
+            LOG.info("Cannot start {}: current scheduledState={}, current desiredState={}, requested scheduledState={}, requested desiredState={}",
+                    this, currentState, getDesiredState(), scheduledState, desiredState);
         }
     }
 
@@ -1651,7 +1653,8 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
         final Callable<Void> startupTask = () -> {
             final ScheduledState currentScheduleState = scheduledState.get();
             if (currentScheduleState == ScheduledState.STOPPING || currentScheduleState == ScheduledState.STOPPED || getDesiredState() == ScheduledState.STOPPED) {
-                LOG.debug("{} is stopped. Will not call @OnScheduled lifecycle methods or begin trigger onTrigger() method", StandardProcessorNode.this);
+                LOG.info("Aborting start of {}: scheduledState={}, desiredState={}, validationStatus={}",
+                        StandardProcessorNode.this, currentScheduleState, getDesiredState(), getValidationStatus());
                 schedulingAgentCallback.onTaskComplete();
                 completeStopAction();
                 return null;
@@ -1668,13 +1671,17 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
                     return null;
                 }
 
-                LOG.debug("Cannot start {} because Processor is currently not valid; will try again after 5 seconds", StandardProcessorNode.this);
-
                 final long attempt = startupAttemptCount.getAndIncrement();
-                if (attempt % 7200 == 0) {
+                if (attempt == 0) {
+                    final ValidationState validationState = getValidationState();
+                    LOG.info("Cannot start {} because Processor is currently not valid (Validation State is {}: {}). Will continue trying to start.",
+                            StandardProcessorNode.this, validationState, validationState.getValidationErrors());
+                } else if (attempt % 7200 == 0) {
                     final ValidationState validationState = getValidationState();
                     procLog.warn("Encountering difficulty starting. (Validation State is {}: {}). Will continue trying to start.",
                             validationState, validationState.getValidationErrors());
+                } else {
+                    LOG.debug("Cannot start {} because Processor is currently not valid; will try again after 500 ms", StandardProcessorNode.this);
                 }
 
                 // re-initiate the entire process
@@ -1858,6 +1865,7 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
             executor.execute(new Runnable() {
                 @Override
                 public void run() {
+                    boolean cleanupHandled = false;
                     try {
                         if (lifecycleState.isScheduled()) {
                             schedulingAgent.unschedule(StandardProcessorNode.this, lifecycleState);
@@ -1883,6 +1891,7 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
                                     LOG.debug("Will not trigger @OnStopped methods of {} because ProcessorStopLifecycleMethods.isTriggerOnStopped() = false", this);
                                 }
                             } finally {
+                                cleanupHandled = true;
                                 lifecycleState.decrementActiveThreadCount();
                                 completeStopAction();
 
@@ -1912,13 +1921,27 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
                             // stop action and exit. completeStopAction() is idempotent if procNode.terminate() already
                             // invoked it.
                             LOG.debug("Stop sequence for {} aborted because LifecycleState was terminated", this);
+                            cleanupHandled = true;
                             completeStopAction();
                         } else {
                             // Not all of the active threads have finished. Try again in 100 milliseconds.
                             executor.schedule(this, 100, TimeUnit.MILLISECONDS);
+                            cleanupHandled = true;
                         }
                     } catch (final Exception e) {
                         LOG.warn("Failed while shutting down processor {}", processor, e);
+
+                        // If an exception escaped before the normal completion path ran (for example because
+                        // schedulingAgent.unschedule or an @OnUnscheduled method threw), the active thread count
+                        // increment performed at the top of stop() must still be reversed and the stop future must
+                        // still be completed. Otherwise the processor remains permanently in STOPPING.
+                        if (!cleanupHandled) {
+                            try {
+                                lifecycleState.decrementActiveThreadCount();
+                            } finally {
+                                completeStopAction();
+                            }
+                        }
                     }
                 }
             });

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/scheduling/LifecycleState.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/scheduling/LifecycleState.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -151,7 +150,7 @@ public class LifecycleState {
     }
 
     public synchronized Set<ScheduledFuture<?>> getFutures() {
-        return Collections.unmodifiableSet(futures);
+        return Set.copyOf(futures);
     }
 
     public synchronized void terminate() {

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
@@ -187,6 +187,30 @@ public class NiFiClientUtil {
         return getProcessorClient().startProcessor(currentEntity);
     }
 
+    /**
+     * Runs the given Processor exactly one time. Waits for the Processor's validation to settle before issuing the
+     * run request so that recent modifications to the Processor, its inbound or outbound Connections, or any
+     * referenced Controller Service are reflected in the Processor's validation status. If validation settles to
+     * INVALID, an {@link IllegalStateException} is thrown immediately rather than waiting indefinitely; the toolkit
+     * client's run-once endpoint silently does nothing for an invalid Processor, so failing fast prevents flaky
+     * downstream assertions about FlowFiles that were never produced.
+     *
+     * @param currentEntity the Processor to run once
+     * @return the updated Processor entity returned by the run-once API call
+     */
+    public ProcessorEntity runProcessorOnce(final ProcessorEntity currentEntity) throws NiFiClientException, IOException, InterruptedException {
+        waitForValidationCompleted(currentEntity);
+
+        final ProcessorEntity refreshed = getProcessorClient().getProcessor(currentEntity.getId());
+        final String validationStatus = refreshed.getComponent().getValidationStatus();
+        if (ProcessorDTO.INVALID.equalsIgnoreCase(validationStatus)) {
+            throw new IllegalStateException(String.format("Processor %s is INVALID and cannot be run once. Validation errors: %s",
+                    currentEntity.getId(), refreshed.getComponent().getValidationErrors()));
+        }
+
+        return getProcessorClient().runProcessorOnce(currentEntity);
+    }
+
     public void stopProcessor(final ProcessorEntity currentEntity) throws NiFiClientException, IOException, InterruptedException {
         currentEntity.setDisconnectedNodeAcknowledged(true);
         getProcessorClient().stopProcessor(currentEntity);
@@ -1154,9 +1178,15 @@ public class NiFiClientUtil {
         final long maxTimestamp = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(2);
         logger.info("Waiting for Processor {} to reach state {}", processorId, expectedState);
 
+        String lastObservedState = null;
+        String lastObservedPhysicalState = null;
+        Integer lastObservedActiveThreadCount = null;
+        Integer lastObservedTerminatedThreadCount = null;
+
         while (System.currentTimeMillis() < maxTimestamp) {
             final ProcessorEntity entity = getProcessorClient().getProcessor(processorId);
             final String state = entity.getComponent().getState();
+            lastObservedState = state;
 
             // We've reached the desired state if the state equal the expected state, OR if we expect stopped and the state is disabled (because disabled implies stopped)
             final boolean desiredStateReached = expectedState.equals(state) || ("STOPPED".equalsIgnoreCase(expectedState) && "DISABLED".equalsIgnoreCase(state));
@@ -1169,6 +1199,8 @@ public class NiFiClientUtil {
             final ProcessorStatusSnapshotDTO snapshotDto = entity.getStatus().getAggregateSnapshot();
             final Integer activeThreadCount = snapshotDto.getActiveThreadCount();
             final Integer terminatedThreadCount = snapshotDto.getTerminatedThreadCount();
+            lastObservedActiveThreadCount = activeThreadCount;
+            lastObservedTerminatedThreadCount = terminatedThreadCount;
 
             if ("RUNNING".equals(expectedState) || (activeThreadCount == 0 && terminatedThreadCount == 0)) {
                 // The logical state masks the framework's physical STOPPING state as STOPPED. The framework's
@@ -1179,6 +1211,7 @@ public class NiFiClientUtil {
                 // it is not stopped. Current state is STOPPING".
                 if ("STOPPED".equalsIgnoreCase(expectedState)) {
                     final String physicalState = entity.getComponent().getPhysicalState();
+                    lastObservedPhysicalState = physicalState;
                     final boolean physicalStateSettled = physicalState == null
                             || "STOPPED".equalsIgnoreCase(physicalState)
                             || "DISABLED".equalsIgnoreCase(physicalState);
@@ -1195,6 +1228,9 @@ public class NiFiClientUtil {
 
             Thread.sleep(10L);
         }
+
+        throw new IOException(String.format("Timed out waiting for Processor %s to reach state of %s. Last observed state=%s, physicalState=%s, activeThreadCount=%s, terminatedThreadCount=%s",
+                processorId, expectedState, lastObservedState, lastObservedPhysicalState, lastObservedActiveThreadCount, lastObservedTerminatedThreadCount));
     }
 
     public ReportingTaskEntity waitForReportingTaskState(final String reportingTaskId, final String expectedState) throws NiFiClientException, IOException, InterruptedException {

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/SpawnedStandaloneNiFiInstanceFactory.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/SpawnedStandaloneNiFiInstanceFactory.java
@@ -103,6 +103,13 @@ public class SpawnedStandaloneNiFiInstanceFactory implements NiFiInstanceFactory
     }
 
     private static class ProcessNiFiInstance implements NiFiInstance {
+        private static final Duration MANAGEMENT_SERVER_RETRY_BUDGET = Duration.ofMinutes(1);
+        private static final Duration MANAGEMENT_SERVER_POLL_INTERVAL = Duration.ofMillis(500);
+        private static final Duration MANAGEMENT_SERVER_REQUEST_TIMEOUT = Duration.ofSeconds(2);
+        private static final HttpClient MANAGEMENT_SERVER_HTTP_CLIENT = HttpClient.newBuilder()
+                .connectTimeout(MANAGEMENT_SERVER_REQUEST_TIMEOUT)
+                .build();
+
         private final File instanceDirectory;
         private final File configDir;
         private final InstanceConfiguration instanceConfiguration;
@@ -142,25 +149,101 @@ public class SpawnedStandaloneNiFiInstanceFactory implements NiFiInstanceFactory
                 throw new IllegalStateException("NiFi has already been started");
             }
 
-            logger.info("Starting NiFi [{}]", instanceDirectory.getName());
-
             final Map<String, String> environmentVariables = Map.of("NIFI_HOME", instanceDirectory.getAbsolutePath());
             final ConfigurationProvider configurationProvider = new StandardConfigurationProvider(environmentVariables, new Properties());
             final ManagementServerAddressProvider managementServerAddressProvider = new StandardManagementServerAddressProvider(configurationProvider);
             final ProcessBuilderProvider processBuilderProvider = new StandardProcessBuilderProvider(configurationProvider, managementServerAddressProvider);
+            final String managementServerAddress = managementServerAddressProvider.getAddress()
+                    .orElseThrow(() -> new IllegalStateException("Management Server Address not configured for [%s]".formatted(instanceDirectory.getName())));
 
             try {
-                final ProcessBuilder processBuilder = processBuilderProvider.getApplicationProcessBuilder();
-                processBuilder.directory(instanceDirectory);
-                process = processBuilder.start();
-
-                logger.info("Started NiFi [{}] PID [{}]", instanceDirectory.getName(), process.pid());
-
                 if (waitForCompletion) {
+                    startUntilManagementServerReady(processBuilderProvider, managementServerAddress);
                     waitForStartup();
+                } else {
+                    final ProcessBuilder processBuilder = processBuilderProvider.getApplicationProcessBuilder();
+                    processBuilder.directory(instanceDirectory);
+                    process = processBuilder.start();
+                    logger.info("Started NiFi [{}] PID [{}]", instanceDirectory.getName(), process.pid());
                 }
             } catch (final IOException e) {
                 throw new RuntimeException("Failed to start NiFi", e);
+            }
+        }
+
+        /**
+         * Spawns the NiFi process and waits for its Management Server to become reachable. If the launched process exits
+         * before the Management Server is reachable, a new process is spawned and the wait is repeated. Repeated retries
+         * are necessary because the Management Server uses {@link com.sun.net.httpserver.HttpServer}, which does not set
+         * SO_REUSEADDR; the configured port can therefore remain in TIME_WAIT briefly after the previous test instance
+         * shuts down, causing the first start attempt to fail with {@code BindException: Address already in use}.
+         *
+         * @param processBuilderProvider builder provider used to construct the application process
+         * @param managementServerAddress {@code host:port} of the Management Server to probe via HTTP
+         * @throws IOException if no attempt succeeds within {@link #MANAGEMENT_SERVER_RETRY_BUDGET}
+         */
+        private void startUntilManagementServerReady(final ProcessBuilderProvider processBuilderProvider, final String managementServerAddress) throws IOException {
+            final URI managementHealthUri = URI.create("http://%s/health".formatted(managementServerAddress));
+            final long deadline = System.currentTimeMillis() + MANAGEMENT_SERVER_RETRY_BUDGET.toMillis();
+            int attempt = 0;
+
+            while (true) {
+                attempt++;
+                logger.info("Starting NiFi [{}] attempt [{}]", instanceDirectory.getName(), attempt);
+
+                final ProcessBuilder processBuilder = processBuilderProvider.getApplicationProcessBuilder();
+                processBuilder.directory(instanceDirectory);
+                process = processBuilder.start();
+                logger.info("Started NiFi [{}] PID [{}] attempt [{}]", instanceDirectory.getName(), process.pid(), attempt);
+
+                while (System.currentTimeMillis() < deadline) {
+                    if (isManagementServerReady(managementHealthUri)) {
+                        logger.info("Management Server reachable for NiFi [{}] PID [{}] attempt [{}]",
+                                instanceDirectory.getName(), process.pid(), attempt);
+                        return;
+                    }
+
+                    if (!process.isAlive()) {
+                        final int exitValue = process.exitValue();
+                        logger.warn("NiFi [{}] PID [{}] attempt [{}] exited with code [{}] before Management Server became reachable",
+                                instanceDirectory.getName(), process.pid(), attempt, exitValue);
+                        process = null;
+                        break;
+                    }
+
+                    try {
+                        Thread.sleep(MANAGEMENT_SERVER_POLL_INTERVAL.toMillis());
+                    } catch (final InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Interrupted while waiting for Management Server to become reachable", interrupted);
+                    }
+                }
+
+                if (process != null) {
+                    throw new IOException("Management Server for NiFi [%s] PID [%d] not reachable within [%d] seconds across [%d] attempt(s)"
+                            .formatted(instanceDirectory.getName(), process.pid(), MANAGEMENT_SERVER_RETRY_BUDGET.toSeconds(), attempt));
+                }
+
+                if (System.currentTimeMillis() >= deadline) {
+                    throw new IOException("NiFi [%s] failed to start within [%d] seconds across [%d] attempt(s)"
+                            .formatted(instanceDirectory.getName(), MANAGEMENT_SERVER_RETRY_BUDGET.toSeconds(), attempt));
+                }
+            }
+        }
+
+        private boolean isManagementServerReady(final URI managementHealthUri) {
+            try {
+                final HttpRequest request = HttpRequest.newBuilder(managementHealthUri)
+                        .timeout(MANAGEMENT_SERVER_REQUEST_TIMEOUT)
+                        .GET()
+                        .build();
+                final HttpResponse<Void> response = MANAGEMENT_SERVER_HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.discarding());
+                return response.statusCode() == 200;
+            } catch (final InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                return false;
+            } catch (final IOException ignored) {
+                return false;
             }
         }
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/SpawnedStandaloneNiFiInstanceFactory.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/SpawnedStandaloneNiFiInstanceFactory.java
@@ -103,13 +103,6 @@ public class SpawnedStandaloneNiFiInstanceFactory implements NiFiInstanceFactory
     }
 
     private static class ProcessNiFiInstance implements NiFiInstance {
-        private static final Duration MANAGEMENT_SERVER_RETRY_BUDGET = Duration.ofMinutes(1);
-        private static final Duration MANAGEMENT_SERVER_POLL_INTERVAL = Duration.ofMillis(500);
-        private static final Duration MANAGEMENT_SERVER_REQUEST_TIMEOUT = Duration.ofSeconds(2);
-        private static final HttpClient MANAGEMENT_SERVER_HTTP_CLIENT = HttpClient.newBuilder()
-                .connectTimeout(MANAGEMENT_SERVER_REQUEST_TIMEOUT)
-                .build();
-
         private final File instanceDirectory;
         private final File configDir;
         private final InstanceConfiguration instanceConfiguration;
@@ -149,101 +142,25 @@ public class SpawnedStandaloneNiFiInstanceFactory implements NiFiInstanceFactory
                 throw new IllegalStateException("NiFi has already been started");
             }
 
+            logger.info("Starting NiFi [{}]", instanceDirectory.getName());
+
             final Map<String, String> environmentVariables = Map.of("NIFI_HOME", instanceDirectory.getAbsolutePath());
             final ConfigurationProvider configurationProvider = new StandardConfigurationProvider(environmentVariables, new Properties());
             final ManagementServerAddressProvider managementServerAddressProvider = new StandardManagementServerAddressProvider(configurationProvider);
             final ProcessBuilderProvider processBuilderProvider = new StandardProcessBuilderProvider(configurationProvider, managementServerAddressProvider);
-            final String managementServerAddress = managementServerAddressProvider.getAddress()
-                    .orElseThrow(() -> new IllegalStateException("Management Server Address not configured for [%s]".formatted(instanceDirectory.getName())));
 
             try {
-                if (waitForCompletion) {
-                    startUntilManagementServerReady(processBuilderProvider, managementServerAddress);
-                    waitForStartup();
-                } else {
-                    final ProcessBuilder processBuilder = processBuilderProvider.getApplicationProcessBuilder();
-                    processBuilder.directory(instanceDirectory);
-                    process = processBuilder.start();
-                    logger.info("Started NiFi [{}] PID [{}]", instanceDirectory.getName(), process.pid());
-                }
-            } catch (final IOException e) {
-                throw new RuntimeException("Failed to start NiFi", e);
-            }
-        }
-
-        /**
-         * Spawns the NiFi process and waits for its Management Server to become reachable. If the launched process exits
-         * before the Management Server is reachable, a new process is spawned and the wait is repeated. Repeated retries
-         * are necessary because the Management Server uses {@link com.sun.net.httpserver.HttpServer}, which does not set
-         * SO_REUSEADDR; the configured port can therefore remain in TIME_WAIT briefly after the previous test instance
-         * shuts down, causing the first start attempt to fail with {@code BindException: Address already in use}.
-         *
-         * @param processBuilderProvider builder provider used to construct the application process
-         * @param managementServerAddress {@code host:port} of the Management Server to probe via HTTP
-         * @throws IOException if no attempt succeeds within {@link #MANAGEMENT_SERVER_RETRY_BUDGET}
-         */
-        private void startUntilManagementServerReady(final ProcessBuilderProvider processBuilderProvider, final String managementServerAddress) throws IOException {
-            final URI managementHealthUri = URI.create("http://%s/health".formatted(managementServerAddress));
-            final long deadline = System.currentTimeMillis() + MANAGEMENT_SERVER_RETRY_BUDGET.toMillis();
-            int attempt = 0;
-
-            while (true) {
-                attempt++;
-                logger.info("Starting NiFi [{}] attempt [{}]", instanceDirectory.getName(), attempt);
-
                 final ProcessBuilder processBuilder = processBuilderProvider.getApplicationProcessBuilder();
                 processBuilder.directory(instanceDirectory);
                 process = processBuilder.start();
-                logger.info("Started NiFi [{}] PID [{}] attempt [{}]", instanceDirectory.getName(), process.pid(), attempt);
 
-                while (System.currentTimeMillis() < deadline) {
-                    if (isManagementServerReady(managementHealthUri)) {
-                        logger.info("Management Server reachable for NiFi [{}] PID [{}] attempt [{}]",
-                                instanceDirectory.getName(), process.pid(), attempt);
-                        return;
-                    }
+                logger.info("Started NiFi [{}] PID [{}]", instanceDirectory.getName(), process.pid());
 
-                    if (!process.isAlive()) {
-                        final int exitValue = process.exitValue();
-                        logger.warn("NiFi [{}] PID [{}] attempt [{}] exited with code [{}] before Management Server became reachable",
-                                instanceDirectory.getName(), process.pid(), attempt, exitValue);
-                        process = null;
-                        break;
-                    }
-
-                    try {
-                        Thread.sleep(MANAGEMENT_SERVER_POLL_INTERVAL.toMillis());
-                    } catch (final InterruptedException interrupted) {
-                        Thread.currentThread().interrupt();
-                        throw new IOException("Interrupted while waiting for Management Server to become reachable", interrupted);
-                    }
+                if (waitForCompletion) {
+                    waitForStartup();
                 }
-
-                if (process != null) {
-                    throw new IOException("Management Server for NiFi [%s] PID [%d] not reachable within [%d] seconds across [%d] attempt(s)"
-                            .formatted(instanceDirectory.getName(), process.pid(), MANAGEMENT_SERVER_RETRY_BUDGET.toSeconds(), attempt));
-                }
-
-                if (System.currentTimeMillis() >= deadline) {
-                    throw new IOException("NiFi [%s] failed to start within [%d] seconds across [%d] attempt(s)"
-                            .formatted(instanceDirectory.getName(), MANAGEMENT_SERVER_RETRY_BUDGET.toSeconds(), attempt));
-                }
-            }
-        }
-
-        private boolean isManagementServerReady(final URI managementHealthUri) {
-            try {
-                final HttpRequest request = HttpRequest.newBuilder(managementHealthUri)
-                        .timeout(MANAGEMENT_SERVER_REQUEST_TIMEOUT)
-                        .GET()
-                        .build();
-                final HttpResponse<Void> response = MANAGEMENT_SERVER_HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.discarding());
-                return response.statusCode() == 200;
-            } catch (final InterruptedException interrupted) {
-                Thread.currentThread().interrupt();
-                return false;
-            } catch (final IOException ignored) {
-                return false;
+            } catch (final IOException e) {
+                throw new RuntimeException("Failed to start NiFi", e);
             }
         }
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/metrics/ComponentMetricReporterIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/metrics/ComponentMetricReporterIT.java
@@ -48,7 +48,7 @@ public class ComponentMetricReporterIT extends NiFiSystemIT {
     @Test
     void testUpdateMetricReported() throws NiFiClientException, IOException, InterruptedException {
         final ProcessorEntity updateMetric = getClientUtil().createProcessor("UpdateMetric");
-        getNifiClient().getProcessorClient().runProcessorOnce(updateMetric);
+        getClientUtil().runProcessorOnce(updateMetric);
         getClientUtil().waitForStoppedProcessor(updateMetric.getId());
 
         final String componentId = updateMetric.getId();

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/nar/NarProviderAndAutoLoaderIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/nar/NarProviderAndAutoLoaderIT.java
@@ -71,7 +71,7 @@ public class NarProviderAndAutoLoaderIT extends NiFiSystemIT {
         final ProcessorEntity terminateFlowFile = getClientUtil().createProcessor("TerminateFlowFile");
         final ConnectionEntity connection = getClientUtil().createConnection(updatedGetClassLoaderInfo, terminateFlowFile, "success");
 
-        getNifiClient().getProcessorClient().runProcessorOnce(updatedGetClassLoaderInfo);
+        getClientUtil().runProcessorOnce(updatedGetClassLoaderInfo);
         waitForQueueCount(connection.getId(), 1);
 
         final String flowFileContent = getClientUtil().getFlowFileContentAsUtf8(connection.getId(), 0);

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/RetryIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/RetryIT.java
@@ -160,7 +160,7 @@ public class RetryIT extends NiFiSystemIT {
     }
 
     private void runProcessorOnce(final ProcessorEntity processorEntity) throws NiFiClientException, IOException, InterruptedException {
-        getNifiClient().getProcessorClient().runProcessorOnce(processorEntity);
+        getClientUtil().runProcessorOnce(processorEntity);
         getClientUtil().waitForStoppedProcessor(processorEntity.getId());
     }
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/RunOnceIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/RunOnceIT.java
@@ -34,7 +34,7 @@ public class RunOnceIT extends NiFiSystemIT {
         final ProcessorEntity terminate = getClientUtil().createProcessor("TerminateFlowFile");
         final ConnectionEntity generateToTerminate = getClientUtil().createConnection(generate, terminate, "success");
 
-        getNifiClient().getProcessorClient().runProcessorOnce(generate);
+        getClientUtil().runProcessorOnce(generate);
         waitForQueueCount(generateToTerminate.getId(), 1);
 
         getClientUtil().waitForStoppedProcessor(generate.getId());
@@ -44,7 +44,7 @@ public class RunOnceIT extends NiFiSystemIT {
         getClientUtil().updateProcessorSchedulingStrategy(generate, "CRON_DRIVEN");
         getClientUtil().updateProcessorSchedulingPeriod(generate, "* * * * * ?");
 
-        getNifiClient().getProcessorClient().runProcessorOnce(generate);
+        getClientUtil().runProcessorOnce(generate);
         waitForQueueCount(generateToTerminate.getId(), 2);
 
         getClientUtil().waitForStoppedProcessor(generate.getId());

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/python/PythonProcessorIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/python/PythonProcessorIT.java
@@ -287,7 +287,7 @@ public class PythonProcessorIT extends NiFiSystemIT {
     }
 
     private void runProcessorOnce(final ProcessorEntity processorEntity) throws NiFiClientException, IOException, InterruptedException {
-        getNifiClient().getProcessorClient().runProcessorOnce(processorEntity);
+        getClientUtil().runProcessorOnce(processorEntity);
         getClientUtil().waitForStoppedProcessor(processorEntity.getId());
     }
 }

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/repositories/ContentClaimTruncationAfterRestartIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/repositories/ContentClaimTruncationAfterRestartIT.java
@@ -113,7 +113,7 @@ public class ContentClaimTruncationAfterRestartIT extends NiFiSystemIT {
         // FlowFiles (priority=1) are dequeued first.
         for (int i = 0; i < 10; i++) {
             final ProcessorEntity terminateAfterRestart = getNifiClient().getProcessorClient().getProcessor(terminate.getId());
-            getNifiClient().getProcessorClient().runProcessorOnce(terminateAfterRestart);
+            getClientUtil().runProcessorOnce(terminateAfterRestart);
             getClientUtil().waitForStoppedProcessor(terminateAfterRestart.getId());
         }
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/repositories/ContentClaimTruncationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/repositories/ContentClaimTruncationIT.java
@@ -127,7 +127,7 @@ public class ContentClaimTruncationIT extends NiFiSystemIT {
         }
 
         for (int i = 0; i < BATCH_COUNT; i++) {
-            terminateFlowFile = getNifiClient().getProcessorClient().runProcessorOnce(terminateFlowFile);
+            terminateFlowFile = getClientUtil().runProcessorOnce(terminateFlowFile);
             getClientUtil().waitForStoppedProcessor(terminateFlowFile.getId());
         }
         waitForQueueCount(connection.getId(), BATCH_COUNT * SMALL_FILES_PER_BATCH);
@@ -244,7 +244,7 @@ public class ContentClaimTruncationIT extends NiFiSystemIT {
 
         ProcessorEntity secondTerminate = secondTerminateFlowFile;
         for (int i = 0; i < BATCH_COUNT; i++) {
-            secondTerminate = getNifiClient().getProcessorClient().runProcessorOnce(secondTerminate);
+            secondTerminate = getClientUtil().runProcessorOnce(secondTerminate);
             getClientUtil().waitForStoppedProcessor(secondTerminate.getId());
         }
         waitForQueueCount(secondConnection.getId(), BATCH_COUNT * SMALL_FILES_PER_BATCH);
@@ -290,7 +290,7 @@ public class ContentClaimTruncationIT extends NiFiSystemIT {
 
         ProcessorEntity currentUpdateContent = updateContent;
         for (int i = 0; i < BATCH_COUNT; i++) {
-            currentUpdateContent = getNifiClient().getProcessorClient().runProcessorOnce(currentUpdateContent);
+            currentUpdateContent = getClientUtil().runProcessorOnce(currentUpdateContent);
             getClientUtil().waitForStoppedProcessor(currentUpdateContent.getId());
         }
         waitForQueueCount(generatorToUpdate.getId(), BATCH_COUNT * SMALL_FILES_PER_BATCH);
@@ -313,11 +313,12 @@ public class ContentClaimTruncationIT extends NiFiSystemIT {
         final ProcessorEntity generator = getClientUtil().createProcessor("GenerateTruncatableFlowFiles");
         final ProcessorEntity terminate = getClientUtil().createProcessor("TerminateFlowFile");
 
+        final int smallFilesPerBatch = 9;
         final Map<String, String> generateProps = Map.of(
             "Batch Count", "1",
             "Small File Size", "1 KB",
             "Large File Size", "10 MB",
-            "Small Files Per Batch", "9");
+            "Small Files Per Batch", String.valueOf(smallFilesPerBatch));
         getClientUtil().updateProcessorProperties(generator, generateProps);
         getClientUtil().updateProcessorSchedulingPeriod(generator, "0 sec");
 
@@ -326,33 +327,39 @@ public class ContentClaimTruncationIT extends NiFiSystemIT {
         connection = getClientUtil().updateConnectionBackpressure(connection, 10000, BACKPRESSURE_BYTES);
 
         getClientUtil().startProcessor(generator);
-        waitForQueueCount(connection.getId(), 10);
+        waitForQueueCount(connection.getId(), smallFilesPerBatch + 1);
         getClientUtil().stopProcessor(generator);
         getClientUtil().waitForStoppedProcessor(generator.getId());
 
+        // Keep one small FlowFile in the queue. All small FlowFiles share a single resource claim (they fit
+        // within nifi.content.claim.max.appendable.size), and that is also the claim referenced by the last
+        // DROP event. The remaining FlowFile pins the claim so the aggressive archive/truncation cleanup
+        // cannot delete the replayed content before it is read back.
         ProcessorEntity currentTerminate = terminate;
-        while (getConnectionQueueSize(connection.getId()) > 0) {
-            currentTerminate = getNifiClient().getProcessorClient().runProcessorOnce(currentTerminate);
+        while (getConnectionQueueSize(connection.getId()) > 1) {
+            currentTerminate = getClientUtil().runProcessorOnce(currentTerminate);
             getClientUtil().waitForStoppedProcessor(currentTerminate.getId());
         }
-        waitForQueueCount(connection.getId(), 0);
+        waitForQueueCount(connection.getId(), 1);
+
+        final String pinnedFlowFileUuid = getClientUtil().getQueueFlowFile(connection.getId(), 0).getFlowFile().getUuid();
 
         final ReplayLastEventResponseEntity replayResponse = getNifiClient().getProvenanceClient().replayLastEvent(currentTerminate.getId(), ReplayEventNodes.PRIMARY);
         assertNull(replayResponse.getAggregateSnapshot().getFailureExplanation());
         assertNotNull(replayResponse.getAggregateSnapshot().getEventsReplayed());
 
-        waitForQueueCount(connection.getId(), 1);
+        waitForQueueCount(connection.getId(), 2);
 
-        final byte[] replayedContent = getClientUtil().getFlowFileContentAsByteArray(connection.getId(), 0);
-        assertNotNull(replayedContent);
-        assertTrue(replayedContent.length > 0,
-                "Replayed FlowFile content should not be empty — truncation must not have destroyed the content");
+        final String firstQueueFlowFileUuid = getClientUtil().getQueueFlowFile(connection.getId(), 0).getFlowFile().getUuid();
+        final int replayedFlowFileIndex = pinnedFlowFileUuid.equals(firstQueueFlowFileUuid) ? 1 : 0;
+        final byte[] replayedContent = getClientUtil().getFlowFileContentAsByteArray(connection.getId(), replayedFlowFileIndex);
+        assertEquals(SMALL_FILE_SIZE_BYTES, replayedContent.length);
     }
 
     private void drainTerminateQueue(final ProcessorEntity terminateFlowFileProcessor, final String connectionId) throws NiFiClientException, IOException, InterruptedException {
         ProcessorEntity currentProcessor = terminateFlowFileProcessor;
         while (getConnectionQueueSize(connectionId) > 0) {
-            currentProcessor = getNifiClient().getProcessorClient().runProcessorOnce(currentProcessor);
+            currentProcessor = getClientUtil().runProcessorOnce(currentProcessor);
             getClientUtil().waitForStoppedProcessor(currentProcessor.getId());
         }
     }

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/repositories/ContentClaimTruncationWithSwappingIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/repositories/ContentClaimTruncationWithSwappingIT.java
@@ -101,7 +101,7 @@ public class ContentClaimTruncationWithSwappingIT extends NiFiSystemIT {
         connection = getClientUtil().updateConnectionBackpressure(connection, TOTAL_FLOWFILES_PER_CONNECTION + 1000, BACKPRESSURE_BYTES);
 
         ProcessorEntity currentGenerator = generator;
-        currentGenerator = getNifiClient().getProcessorClient().runProcessorOnce(currentGenerator);
+        currentGenerator = getClientUtil().runProcessorOnce(currentGenerator);
         getClientUtil().waitForStoppedProcessor(currentGenerator.getId());
         waitForQueueCount(connection.getId(), TOTAL_FLOWFILES_PER_CONNECTION);
 
@@ -114,7 +114,7 @@ public class ContentClaimTruncationWithSwappingIT extends NiFiSystemIT {
 
         ProcessorEntity currentTerminate = terminateFlowFile;
         for (int i = 0; i < BATCH_COUNT; i++) {
-            currentTerminate = getNifiClient().getProcessorClient().runProcessorOnce(currentTerminate);
+            currentTerminate = getClientUtil().runProcessorOnce(currentTerminate);
             getClientUtil().waitForStoppedProcessor(currentTerminate.getId());
         }
         waitForQueueCount(connection.getId(), TOTAL_FLOWFILES_PER_CONNECTION - BATCH_COUNT);
@@ -145,7 +145,7 @@ public class ContentClaimTruncationWithSwappingIT extends NiFiSystemIT {
         secondConnection = getClientUtil().updateConnectionBackpressure(secondConnection, TOTAL_FLOWFILES_PER_CONNECTION + 1000, BACKPRESSURE_BYTES);
 
         ProcessorEntity currentGenerator = generator;
-        currentGenerator = getNifiClient().getProcessorClient().runProcessorOnce(currentGenerator);
+        currentGenerator = getClientUtil().runProcessorOnce(currentGenerator);
         getClientUtil().waitForStoppedProcessor(currentGenerator.getId());
         waitForQueueCount(firstConnection.getId(), TOTAL_FLOWFILES_PER_CONNECTION);
         waitForQueueCount(secondConnection.getId(), TOTAL_FLOWFILES_PER_CONNECTION);
@@ -198,7 +198,7 @@ public class ContentClaimTruncationWithSwappingIT extends NiFiSystemIT {
         secondConnection = getClientUtil().updateConnectionBackpressure(secondConnection, TOTAL_FLOWFILES_PER_CONNECTION + 1000, BACKPRESSURE_BYTES);
 
         ProcessorEntity currentGenerator = generator;
-        currentGenerator = getNifiClient().getProcessorClient().runProcessorOnce(currentGenerator);
+        currentGenerator = getClientUtil().runProcessorOnce(currentGenerator);
         getClientUtil().waitForStoppedProcessor(currentGenerator.getId());
         waitForQueueCount(firstConnection.getId(), TOTAL_FLOWFILES_PER_CONNECTION);
         waitForQueueCount(secondConnection.getId(), TOTAL_FLOWFILES_PER_CONNECTION);

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/repositories/OffloadContentClaimTruncationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/repositories/OffloadContentClaimTruncationIT.java
@@ -169,7 +169,7 @@ public class OffloadContentClaimTruncationIT extends NiFiSystemIT {
         // DELETE is sufficient for updateContentClaims() to queue the shared claim for truncation
         // even though FLOW_FILE_COUNT - 1 sibling FlowFiles still point inside it.
         terminate = getNifiClient().getProcessorClient().getProcessor(terminate.getId());
-        terminate = getNifiClient().getProcessorClient().runProcessorOnce(terminate);
+        terminate = getClientUtil().runProcessorOnce(terminate);
         getClientUtil().waitForStoppedProcessor(terminate.getId());
         waitForQueueCount(dataConnection.getId(), FLOW_FILE_COUNT - 1);
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/state/AbstractStateKeyDropIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/state/AbstractStateKeyDropIT.java
@@ -127,7 +127,7 @@ public abstract class AbstractStateKeyDropIT extends NiFiSystemIT {
 
         while (true) {
             try {
-                getNifiClient().getProcessorClient().runProcessorOnce(processor);
+                getClientUtil().runProcessorOnce(processor);
                 break;
             } catch (final NiFiClientException e) {
                 if (!isTransientClusterError(e) || System.currentTimeMillis() > maxTime) {


### PR DESCRIPTION
Framework:
* LifecycleState.getFutures returns a defensive copy.
* StandardProcessorNode stop runnable releases its future and decrements active threads if an exception escapes.
* StandardProcessorNode logs INFO breadcrumbs on silent start-reject and start-abort paths and surfaces validation errors on first retry.
* KubernetesConfigMapStateProvider.shutdown is null-safe.

System tests:
* waitForProcessorState throws IOException on timeout.
* runProcessorOnce waits for validation and fails fast on INVALID.
* SpawnedStandaloneNiFiInstanceFactory retries process spawn for one minute, polling Management Server health, to absorb TIME_WAIT.
* ContentClaimTruncationIT pins the shared resource claim and identifies the replayed FlowFile by UUID.

Workspace rules covering single-element-array lambdas and the system-test troubleshooting-logs artifact.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
