### PR TITLE
NIFI-15920 improve accesibility around connector state text in listing

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.html
@@ -76,9 +76,10 @@
                     <div class="inline-flex items-center gap-x-2">
                         <span [title]="formatState(item)">{{ formatState(item) }}</span>
                         @if (canRead(item) && canDiscardConfig(item)) {
-                            <span class="caution-color text-xs font-medium" data-qa="edits-not-applied-badge"
-                                >(Edits not applied)</span
-                            >
+                            <i
+                                class="neutral-color fa fa-asterisk"
+                                matTooltip="Edits not applied"
+                                matTooltipPosition="after"></i>
                         }
                     </div>
                 </td>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.html
@@ -77,7 +77,7 @@
                         @if (canRead(item)) {
                             <status-badge
                                 [label]="formatState(item)"
-                                [variant]="getStateVariant(item)"
+                                [variant]="getConnectorStateVariant(item.component.state)"
                                 data-qa="connector-state">
                             </status-badge>
                         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.html
@@ -74,12 +74,16 @@
                 <th mat-header-cell *matHeaderCellDef mat-sort-header>State</th>
                 <td mat-cell *matCellDef="let item" data-qa="connector-state-cell">
                     <div class="inline-flex items-center gap-x-2">
-                        <span [title]="formatState(item)">{{ formatState(item) }}</span>
+                        @if (canRead(item)) {
+                            <status-badge
+                                [label]="formatState(item)"
+                                [variant]="getStateVariant(item)"
+                                data-qa="connector-state">
+                            </status-badge>
+                        }
                         @if (canRead(item) && canDiscardConfig(item)) {
-                            <i
-                                class="neutral-color fa fa-asterisk"
-                                matTooltip="Edits not applied"
-                                matTooltipPosition="after"></i>
+                            <status-badge label="Edits not applied" variant="caution" data-qa="edits-not-applied-badge">
+                            </status-badge>
                         }
                     </div>
                 </td>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.scss
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.scss
@@ -14,3 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+.connector-table {
+    .listing-table {
+        table {
+            .mat-column-moreDetails {
+                width: 74px;
+            }
+        }
+    }
+}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.ts
@@ -24,8 +24,11 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import {
     ConnectorEntity,
     ConnectorActionName,
+    ConnectorState,
+    StatusVariant,
     NifiTooltipDirective,
     NiFiCommon,
+    StatusBadge,
     canReadConnector,
     canModifyConnector,
     canOperateConnector,
@@ -48,7 +51,7 @@ import { ValidationErrorsTip } from '../../../../ui/common/tooltips/validation-e
         MatMenuModule,
         MatTooltipModule,
         NifiTooltipDirective,
-        MatTooltipModule
+        StatusBadge
     ],
     styleUrls: ['./connector-table.component.scss']
 })
@@ -119,6 +122,26 @@ export class ConnectorTable {
 
     getActionDisabledReason(entity: ConnectorEntity, actionName: ConnectorActionName): string {
         return getConnectorActionDisabledReason(entity, actionName);
+    }
+
+    getStateVariant(entity: ConnectorEntity): StatusVariant {
+        switch (entity.component.state) {
+            case ConnectorState.RUNNING:
+                return 'success';
+            case ConnectorState.STOPPED:
+            case ConnectorState.DISABLED:
+                return 'neutral';
+            case ConnectorState.STARTING:
+            case ConnectorState.UPDATING:
+            case ConnectorState.STOPPING:
+            case ConnectorState.DRAINING:
+            case ConnectorState.PREPARING_FOR_UPDATE:
+                return 'info';
+            case ConnectorState.UPDATE_FAILED:
+                return 'critical';
+            default:
+                return 'neutral';
+        }
     }
 
     canConfigure(entity: ConnectorEntity): boolean {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.ts
@@ -24,8 +24,6 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import {
     ConnectorEntity,
     ConnectorActionName,
-    ConnectorState,
-    StatusVariant,
     NifiTooltipDirective,
     NiFiCommon,
     StatusBadge,
@@ -33,7 +31,8 @@ import {
     canModifyConnector,
     canOperateConnector,
     isConnectorActionAllowed,
-    getConnectorActionDisabledReason
+    getConnectorActionDisabledReason,
+    getConnectorStateVariant
 } from '@nifi/shared';
 import { ValidationErrorsTipInput } from '../../../../state/shared';
 import { FlowConfiguration } from '../../../../state/flow-configuration';
@@ -124,25 +123,7 @@ export class ConnectorTable {
         return getConnectorActionDisabledReason(entity, actionName);
     }
 
-    getStateVariant(entity: ConnectorEntity): StatusVariant {
-        switch (entity.component.state) {
-            case ConnectorState.RUNNING:
-                return 'success';
-            case ConnectorState.STOPPED:
-            case ConnectorState.DISABLED:
-                return 'neutral';
-            case ConnectorState.STARTING:
-            case ConnectorState.UPDATING:
-            case ConnectorState.STOPPING:
-            case ConnectorState.DRAINING:
-            case ConnectorState.PREPARING_FOR_UPDATE:
-                return 'info';
-            case ConnectorState.UPDATE_FAILED:
-                return 'critical';
-            default:
-                return 'neutral';
-        }
-    }
+    protected readonly getConnectorStateVariant = getConnectorStateVariant;
 
     canConfigure(entity: ConnectorEntity): boolean {
         return isConnectorActionAllowed(entity, 'CONFIGURE');

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/ui/connector-table/connector-table.component.ts
@@ -41,7 +41,15 @@ import { ValidationErrorsTip } from '../../../../ui/common/tooltips/validation-e
     selector: 'connector-table',
     standalone: true,
     templateUrl: './connector-table.component.html',
-    imports: [MatButtonModule, MatTableModule, MatSortModule, MatMenuModule, MatTooltipModule, NifiTooltipDirective],
+    imports: [
+        MatButtonModule,
+        MatTableModule,
+        MatSortModule,
+        MatMenuModule,
+        MatTooltipModule,
+        NifiTooltipDirective,
+        MatTooltipModule
+    ],
     styleUrls: ['./connector-table.component.scss']
 })
 export class ConnectorTable {

--- a/nifi-frontend/src/main/frontend/libs/shared/src/assets/themes/material.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/assets/themes/material.scss
@@ -361,6 +361,30 @@
             )
         );
     }
+
+    // NOTE: The following styles are for the status badge and status banner components. The `.status-variant` class should only be applied to a div or span element that should adhear to the variant color and background.
+    .status-variant {
+        &.neutral {
+            color: var(--mat-sys-on-surface);
+            background-color: var(--mat-sys-surface-dim);
+        }
+        &.critical {
+            color: var(--mat-sys-on-error);
+            background-color: var(--mat-sys-error);
+        }
+        &.caution {
+            color: var(--nf-caution-contrast);
+            background-color: var(--nf-caution-default);
+        }
+        &.success {
+            color: var(--nf-success-contrast);
+            background-color: var(--nf-success-default);
+        }
+        &.info {
+            color: var(--nf-success-contrast);
+            background-color: var(--nf-success-variant);
+        }
+    }
 }
 
 // Note: Color palettes are generated from primary: #6750a4
@@ -853,5 +877,29 @@ html {
                 active-indicator-color: var(--md-ref-palette-tertiary-70)
             )
         );
+    }
+
+    // NOTE: The following styles are for the status badge and status banner components. The `.status-variant` class should only be applied to a div or span element that should adhear to the variant color and background.
+    .status-variant {
+        &.neutral {
+            color: var(--mat-sys-on-surface);
+            background-color: var(--mat-sys-surface-dim);
+        }
+        &.critical {
+            color: var(--mat-sys-on-error);
+            background-color: var(--mat-sys-error);
+        }
+        &.caution {
+            color: var(--nf-caution-contrast);
+            background-color: var(--nf-caution-default);
+        }
+        &.success {
+            color: var(--nf-success-contrast);
+            background-color: var(--nf-success-default);
+        }
+        &.info {
+            color: var(--nf-success-contrast);
+            background-color: var(--nf-success-variant);
+        }
     }
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-detail-header/connector-detail-header.component.html
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-detail-header/connector-detail-header.component.html
@@ -16,16 +16,13 @@
   -->
 
 <ng-template #badges>
-    <span
-        class="connector-state-badge text-xs font-semibold uppercase"
-        [class]="getStateColorClass(connector().component.state)"
+    <status-badge
+        [label]="connector().component.state"
+        [variant]="getStateVariant(connector().component.state)"
         data-qa="connector-state">
-        {{ connector().component.state }}
-    </span>
+    </status-badge>
     @if (hasUnappliedEdits()) {
-        <span class="caution-color text-xs font-semibold uppercase" data-qa="edits-not-applied-badge">
-            Edits not applied
-        </span>
+        <status-badge label="Edits not applied" variant="caution" data-qa="edits-not-applied-badge"> </status-badge>
     }
 </ng-template>
 

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-detail-header/connector-detail-header.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-detail-header/connector-detail-header.component.spec.ts
@@ -18,6 +18,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ConnectorDetailHeader } from './connector-detail-header.component';
 import { ConnectorEntity, ConnectorState, ConnectorStatus } from '../../types';
+import { getConnectorStateVariant } from '../../utils/connector-permissions.utils';
 
 interface SetupOptions {
     connector?: ConnectorEntity;
@@ -108,56 +109,9 @@ describe('ConnectorDetailHeader', () => {
         expect(stateBadge.textContent.trim()).toBe('RUNNING');
     });
 
-    describe('getStateVariant', () => {
-        it('should return success for RUNNING', async () => {
-            const { component } = await setup();
-            expect(component.getStateVariant(ConnectorState.RUNNING)).toBe('success');
-        });
-
-        it('should return neutral for STOPPED', async () => {
-            const { component } = await setup();
-            expect(component.getStateVariant(ConnectorState.STOPPED)).toBe('neutral');
-        });
-
-        it('should return neutral for DISABLED', async () => {
-            const { component } = await setup();
-            expect(component.getStateVariant(ConnectorState.DISABLED)).toBe('neutral');
-        });
-
-        it('should return info for STARTING', async () => {
-            const { component } = await setup();
-            expect(component.getStateVariant(ConnectorState.STARTING)).toBe('info');
-        });
-
-        it('should return info for UPDATING', async () => {
-            const { component } = await setup();
-            expect(component.getStateVariant(ConnectorState.UPDATING)).toBe('info');
-        });
-
-        it('should return info for STOPPING', async () => {
-            const { component } = await setup();
-            expect(component.getStateVariant(ConnectorState.STOPPING)).toBe('info');
-        });
-
-        it('should return info for DRAINING', async () => {
-            const { component } = await setup();
-            expect(component.getStateVariant(ConnectorState.DRAINING)).toBe('info');
-        });
-
-        it('should return info for PREPARING_FOR_UPDATE', async () => {
-            const { component } = await setup();
-            expect(component.getStateVariant(ConnectorState.PREPARING_FOR_UPDATE)).toBe('info');
-        });
-
-        it('should return critical for UPDATE_FAILED', async () => {
-            const { component } = await setup();
-            expect(component.getStateVariant(ConnectorState.UPDATE_FAILED)).toBe('critical');
-        });
-
-        it('should return neutral for unknown state', async () => {
-            const { component } = await setup();
-            expect(component.getStateVariant('UNKNOWN')).toBe('neutral');
-        });
+    it('should delegate getStateVariant to getConnectorStateVariant', async () => {
+        const { component } = await setup();
+        expect(component.getStateVariant).toBe(getConnectorStateVariant);
     });
 
     describe('hasUnappliedEdits', () => {

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-detail-header/connector-detail-header.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-detail-header/connector-detail-header.component.spec.ts
@@ -160,28 +160,6 @@ describe('ConnectorDetailHeader', () => {
         });
     });
 
-    describe('getStateColorClass', () => {
-        it('should map success variant to success-color-default', async () => {
-            const { component } = await setup();
-            expect(component.getStateColorClass(ConnectorState.RUNNING)).toBe('success-color-default');
-        });
-
-        it('should map neutral variant to neutral-color', async () => {
-            const { component } = await setup();
-            expect(component.getStateColorClass(ConnectorState.STOPPED)).toBe('neutral-color');
-        });
-
-        it('should map info variant to primary-color', async () => {
-            const { component } = await setup();
-            expect(component.getStateColorClass(ConnectorState.STARTING)).toBe('primary-color');
-        });
-
-        it('should map critical variant to error-color', async () => {
-            const { component } = await setup();
-            expect(component.getStateColorClass(ConnectorState.UPDATE_FAILED)).toBe('error-color');
-        });
-    });
-
     describe('hasUnappliedEdits', () => {
         it('should return false when no DISCARD_WORKING_CONFIGURATION action exists', async () => {
             const { component } = await setup();

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-detail-header/connector-detail-header.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-detail-header/connector-detail-header.component.ts
@@ -17,14 +17,13 @@
 
 import { Component, computed, input } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
-import { ConnectorEntity, ConnectorState } from '../../types';
-
-export type ConnectorStateVariant = 'neutral' | 'critical' | 'caution' | 'success' | 'info';
+import { ConnectorEntity, ConnectorState, StatusVariant } from '../../types';
+import { StatusBadge } from '../status-badge/status-badge.component';
 
 @Component({
     selector: 'connector-detail-header',
     standalone: true,
-    imports: [NgTemplateOutlet],
+    imports: [NgTemplateOutlet, StatusBadge],
     templateUrl: './connector-detail-header.component.html',
     styleUrls: ['./connector-detail-header.component.scss']
 })
@@ -48,7 +47,7 @@ export class ConnectorDetailHeader {
         return action?.allowed ?? false;
     });
 
-    getStateVariant(state: string): ConnectorStateVariant {
+    getStateVariant(state: string): StatusVariant {
         switch (state) {
             case ConnectorState.RUNNING:
                 return 'success';
@@ -65,22 +64,6 @@ export class ConnectorDetailHeader {
                 return 'critical';
             default:
                 return 'neutral';
-        }
-    }
-
-    getStateColorClass(state: string): string {
-        switch (this.getStateVariant(state)) {
-            case 'success':
-                return 'success-color-default';
-            case 'critical':
-                return 'error-color';
-            case 'caution':
-                return 'caution-color';
-            case 'info':
-                return 'primary-color';
-            case 'neutral':
-            default:
-                return 'neutral-color';
         }
     }
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-detail-header/connector-detail-header.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-detail-header/connector-detail-header.component.ts
@@ -17,8 +17,9 @@
 
 import { Component, computed, input } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
-import { ConnectorEntity, ConnectorState, StatusVariant } from '../../types';
+import { ConnectorEntity } from '../../types';
 import { StatusBadge } from '../status-badge/status-badge.component';
+import { getConnectorStateVariant } from '../../utils/connector-permissions.utils';
 
 @Component({
     selector: 'connector-detail-header',
@@ -47,23 +48,5 @@ export class ConnectorDetailHeader {
         return action?.allowed ?? false;
     });
 
-    getStateVariant(state: string): StatusVariant {
-        switch (state) {
-            case ConnectorState.RUNNING:
-                return 'success';
-            case ConnectorState.STOPPED:
-            case ConnectorState.DISABLED:
-                return 'neutral';
-            case ConnectorState.STARTING:
-            case ConnectorState.UPDATING:
-            case ConnectorState.STOPPING:
-            case ConnectorState.DRAINING:
-            case ConnectorState.PREPARING_FOR_UPDATE:
-                return 'info';
-            case ConnectorState.UPDATE_FAILED:
-                return 'critical';
-            default:
-                return 'neutral';
-        }
-    }
+    protected readonly getStateVariant = getConnectorStateVariant;
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/index.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/index.ts
@@ -46,5 +46,6 @@ export * from './side-panel-container/side-panel-container.component';
 export * from './connector-property-input/connector-property-input.component';
 export * from './connector-detail-header/connector-detail-header.component';
 export * from './searchable-select/searchable-select.component';
+export * from './status-badge/status-badge.component';
 export * from './multi-select-option/multi-select-option.component';
 export * from './asset-upload/asset-upload.component';

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/status-badge/status-badge.component.html
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/status-badge/status-badge.component.html
@@ -1,0 +1,28 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+@if (label) {
+    <span
+        class="status-badge status-variant py-0.5 px-1.5 rounded-xs items-center inline-flex text-sm font-semibold max-h-fit max-w-fit gap-0.5 cursor-default"
+        [class]="variant"
+        [matTooltip]="message">
+        {{ label }}
+        @if (message && message.length > 0) {
+            <i class="fa fa-info text-[16px]" [class]="variant"></i>
+        }
+    </span>
+}

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/status-badge/status-badge.component.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/status-badge/status-badge.component.scss
@@ -1,4 +1,4 @@
-/*
+/*!
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,3 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+@use '@angular/material' as mat;
+
+.status-badge {
+    .fa {
+        &.neutral {
+            color: var(--mat-sys-on-surface);
+        }
+
+        &.critical {
+            color: var(--mat-sys-on-error);
+        }
+
+        &.caution {
+            color: var(--nf-caution-contrast);
+        }
+
+        &.success {
+            color: var(--nf-success-contrast);
+        }
+
+        &.info {
+            color: var(--nf-success-contrast);
+        }
+    }
+}

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/status-badge/status-badge.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/status-badge/status-badge.component.spec.ts
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,3 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StatusBadge } from './status-badge.component';
+
+describe('StatusBadge', () => {
+    let component: StatusBadge;
+    let fixture: ComponentFixture<StatusBadge>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [StatusBadge]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(StatusBadge);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/status-badge/status-badge.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/status-badge/status-badge.component.ts
@@ -17,12 +17,11 @@
 
 import { Component, Input } from '@angular/core';
 import { StatusVariant } from '../../types';
-import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 
 @Component({
     selector: 'status-badge',
-    imports: [MatIcon, MatTooltip],
+    imports: [MatTooltip],
     templateUrl: './status-badge.component.html',
     styleUrls: ['./status-badge.component.scss']
 })

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/status-badge/status-badge.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/status-badge/status-badge.component.ts
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,3 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { Component, Input } from '@angular/core';
+import { StatusVariant } from '../../types';
+import { MatIcon } from '@angular/material/icon';
+import { MatTooltip } from '@angular/material/tooltip';
+
+@Component({
+    selector: 'status-badge',
+    imports: [MatIcon, MatTooltip],
+    templateUrl: './status-badge.component.html',
+    styleUrls: ['./status-badge.component.scss']
+})
+export class StatusBadge {
+    @Input() label: string | null = null;
+    @Input() variant: StatusVariant = 'neutral';
+    @Input() message: string | null | undefined = null;
+}

--- a/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-permissions.utils.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-permissions.utils.spec.ts
@@ -15,14 +15,15 @@
  * limitations under the License.
  */
 
-import { ConnectorEntity } from '../types';
+import { ConnectorEntity, ConnectorState } from '../types';
 import {
     canReadConnector,
     canModifyConnector,
     canOperateConnector,
     getConnectorAction,
     isConnectorActionAllowed,
-    getConnectorActionDisabledReason
+    getConnectorActionDisabledReason,
+    getConnectorStateVariant
 } from './connector-permissions.utils';
 
 function createMockEntity(overrides: Partial<ConnectorEntity> = {}): ConnectorEntity {
@@ -180,6 +181,48 @@ describe('connector-permissions.utils', () => {
             const entity = createMockEntity();
             (entity.component as any).availableActions = undefined;
             expect(getConnectorActionDisabledReason(entity, 'START')).toBe('');
+        });
+    });
+
+    describe('getConnectorStateVariant', () => {
+        it('should return success for RUNNING', () => {
+            expect(getConnectorStateVariant(ConnectorState.RUNNING)).toBe('success');
+        });
+
+        it('should return neutral for STOPPED', () => {
+            expect(getConnectorStateVariant(ConnectorState.STOPPED)).toBe('neutral');
+        });
+
+        it('should return neutral for DISABLED', () => {
+            expect(getConnectorStateVariant(ConnectorState.DISABLED)).toBe('neutral');
+        });
+
+        it('should return info for STARTING', () => {
+            expect(getConnectorStateVariant(ConnectorState.STARTING)).toBe('info');
+        });
+
+        it('should return info for UPDATING', () => {
+            expect(getConnectorStateVariant(ConnectorState.UPDATING)).toBe('info');
+        });
+
+        it('should return info for STOPPING', () => {
+            expect(getConnectorStateVariant(ConnectorState.STOPPING)).toBe('info');
+        });
+
+        it('should return info for DRAINING', () => {
+            expect(getConnectorStateVariant(ConnectorState.DRAINING)).toBe('info');
+        });
+
+        it('should return info for PREPARING_FOR_UPDATE', () => {
+            expect(getConnectorStateVariant(ConnectorState.PREPARING_FOR_UPDATE)).toBe('info');
+        });
+
+        it('should return critical for UPDATE_FAILED', () => {
+            expect(getConnectorStateVariant(ConnectorState.UPDATE_FAILED)).toBe('critical');
+        });
+
+        it('should return neutral for unknown state', () => {
+            expect(getConnectorStateVariant('UNKNOWN')).toBe('neutral');
         });
     });
 });

--- a/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-permissions.utils.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-permissions.utils.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ConnectorAction, ConnectorActionName, ConnectorEntity } from '../types';
+import { ConnectorAction, ConnectorActionName, ConnectorEntity, ConnectorState, StatusVariant } from '../types';
 
 export function canReadConnector(entity: ConnectorEntity): boolean {
     return entity.permissions.canRead;
@@ -44,4 +44,24 @@ export function isConnectorActionAllowed(entity: ConnectorEntity, actionName: Co
 export function getConnectorActionDisabledReason(entity: ConnectorEntity, actionName: ConnectorActionName): string {
     const action = getConnectorAction(entity, actionName);
     return action?.reasonNotAllowed ?? '';
+}
+
+export function getConnectorStateVariant(state: string): StatusVariant {
+    switch (state) {
+        case ConnectorState.RUNNING:
+            return 'success';
+        case ConnectorState.STOPPED:
+        case ConnectorState.DISABLED:
+            return 'neutral';
+        case ConnectorState.STARTING:
+        case ConnectorState.UPDATING:
+        case ConnectorState.STOPPING:
+        case ConnectorState.DRAINING:
+        case ConnectorState.PREPARING_FOR_UPDATE:
+            return 'info';
+        case ConnectorState.UPDATE_FAILED:
+            return 'critical';
+        default:
+            return 'neutral';
+    }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15920](https://issues.apache.org/jira/browse/NIFI-15920)

Current main has some unreadable text:

<img width="1425" height="1022" alt="Screenshot 2026-05-08 at 5 18 02 PM" src="https://github.com/user-attachments/assets/8612b9aa-2376-42bb-8ec8-2024ea32e7c6" />

<img width="1426" height="1019" alt="Screenshot 2026-05-08 at 5 17 53 PM" src="https://github.com/user-attachments/assets/90e40c96-5e58-4069-bef5-37c6634aa2d0" />

This PR utilized established pattern from nifi to mark the state of the connector as "edits not applied":

<img width="1428" height="600" alt="Screenshot 2026-05-08 at 5 17 19 PM" src="https://github.com/user-attachments/assets/c5b75809-6d54-4cf7-ab23-02d46be8bfa0" />
<img width="1428" height="1016" alt="Screenshot 2026-05-08 at 5 17 37 PM" src="https://github.com/user-attachments/assets/c80801e7-2bec-4fb6-9fbf-d24a5d1a0e01" />

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
