### PR TITLE
NIFI-15921 - Bump Log4J2 to 2.26.0, Snowflake JDBC to 4.2.0, and others

### DIFF
--- a/nifi-extension-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.box</groupId>
                 <artifactId>box-java-sdk</artifactId>
-                <version>5.9.0</version>
+                <version>5.10.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.80.0</google.libraries.version>
+        <google.libraries.version>26.81.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -24,7 +24,7 @@
         <guava.version>33.6.0-jre</guava.version>
         <protobuf.version>4.34.1</protobuf.version>
         <grpc.version>1.81.0</grpc.version>
-        <snowflake-jdbc-thin.version>4.1.0</snowflake-jdbc-thin.version>
+        <snowflake-jdbc-thin.version>4.2.0</snowflake-jdbc-thin.version>
     </properties>
 
     <modules>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>4.0.6</spring.boot.version>
-        <flyway.version>12.5.0</flyway.version>
+        <flyway.version>12.6.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.6.0.202603022253-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.44.3</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.44.4</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.6</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -167,7 +167,7 @@
         <kotlin.version>2.3.21</kotlin.version>
 
         <!-- Logging and observability -->
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.0</log4j2.version>
         <logback.version>1.5.32</logback.version>
         <org.slf4j.version>2.0.17</org.slf4j.version>
         <prometheus.version>0.16.0</prometheus.version>


### PR DESCRIPTION
# Summary

NIFI-15921 - Bump Log4J2 to 2.26.0, Snowflake JDBC to 4.2.0, and others

- Box SDK from 5.9.0 to 5.10.0 - https://github.com/box/box-java-sdk/releases/tag/v5.10.0
- Google Cloud BOM from 26.80.0 to 26.81.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.81.0
- Snowflake JDBC from 4.1.0 to 4.2.0 - https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc-2026#version-420-may-06-2026
- FlywayDB from 12.5.0 to 12.6.0 - https://github.com/flyway/flyway/releases/tag/flyway-12.6.0
- AWS SDK BOM from 2.44.3 to 2.44.4 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Log4j2 from 2.25.4 to 2.26.0 - https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.26.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
