### PR TITLE
NIFI-15922 Removed the use of the word JSON from those properties YamTreeReader inherits from JsonTreeReader.

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
@@ -56,7 +56,7 @@ public abstract class AbstractJsonRowRecordReader implements RecordReader {
 
     public static final PropertyDescriptor MAX_STRING_LENGTH = new PropertyDescriptor.Builder()
             .name("Max String Length")
-            .description("The maximum allowed length of a string value when parsing the JSON document")
+            .description("The maximum allowed length of a string value when parsing the document")
             .required(true)
             .defaultValue(DEFAULT_MAX_STRING_LENGTH)
             .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/StartingFieldStrategy.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/StartingFieldStrategy.java
@@ -25,7 +25,7 @@ public enum StartingFieldStrategy implements DescribedValue {
     ),
     NESTED_FIELD(
             "Nested Field",
-            "Skips forward to the given nested JSON field (array or object) to begin processing."
+            "Skips forward to the given nested field (array or object) to begin processing."
     );
 
     private final String displayName;

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonTreeReader.java
@@ -89,7 +89,7 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
 
     public static final PropertyDescriptor STARTING_FIELD_NAME = new PropertyDescriptor.Builder()
             .name("Starting Field Name")
-            .description("Skips forward to the given nested JSON field (array or object) to begin processing.")
+            .description("Skips forward to the given nested field (array or object) to begin processing.")
             .required(false)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .dependsOn(STARTING_FIELD_STRATEGY, StartingFieldStrategy.NESTED_FIELD.name())
@@ -97,7 +97,7 @@ public class JsonTreeReader extends SchemaRegistryService implements RecordReade
 
     public static final PropertyDescriptor SCHEMA_APPLICATION_STRATEGY = new PropertyDescriptor.Builder()
             .name("Schema Application Strategy")
-            .description("Specifies whether the schema is defined for the whole JSON or for the selected part starting from \"Starting Field Name\".")
+            .description("Specifies whether the schema is defined for the whole document or for the selected part starting from \"Starting Field Name\".")
             .required(true)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .defaultValue(SchemaApplicationStrategy.SELECTED_PART.getValue())


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15922](https://issues.apache.org/jira/browse/NIFI-15922)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
