### PR TITLE
NIFI-14855 fix AttributesToJSON Attributes Regular Expression property initialization

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToJSON.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToJSON.java
@@ -272,6 +272,8 @@ public class AttributesToJSON extends AbstractProcessor {
 
         if (context.getProperty(ATTRIBUTES_REGEX).isSet()) {
             pattern = Pattern.compile(context.getProperty(ATTRIBUTES_REGEX).evaluateAttributeExpressions().getValue());
+        } else {
+            pattern = null;
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestAttributesToJSON.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestAttributesToJSON.java
@@ -441,6 +441,26 @@ public class TestAttributesToJSON {
         assertFalse(val.containsKey("delimited.footer.column.1"));
         assertTrue(val.containsKey("test"));
         assertTrue(val.containsKey("test1"));
+
+        // Now remove ATTRIBUTES_REGEX property, verify JSON attribute does not contain ATTRIBUTES_REGEX matches
+        runner.removeProperty(AttributesToJSON.ATTRIBUTES_REGEX);
+        runner.enqueue("".getBytes(), attributes);
+
+        runner.run();
+
+        runner.assertTransferCount(AttributesToJSON.REL_FAILURE, 0);
+        runner.assertTransferCount(AttributesToJSON.REL_SUCCESS, 2);
+
+        flowFile = runner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS).get(1);
+
+        val = MAPPER.readValue(flowFile.getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME), new TypeReference<>() { });
+        assertFalse(val.containsKey("delimited.header.column.1"));
+        assertFalse(val.containsKey("delimited.header.column.2"));
+        assertFalse(val.containsKey("delimited.header.column.3"));
+        assertFalse(val.containsKey("delimited.header.column.4"));
+        assertFalse(val.containsKey("delimited.footer.column.1"));
+        assertTrue(val.containsKey("test"));
+        assertTrue(val.containsKey("test1"));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
# Summary

[NIFI-14855](https://issues.apache.org/jira/browse/NIFI-14855)

Fix AttributesToJSON onScheduled method handing of the Attributes Regular Expression property, if a user clears that property's value.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
