### PR TITLE
NIFI-15934 Handle oversized FlowFiles and empty header keys in PublishAMQP

### DIFF
--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -33,6 +33,7 @@ import org.apache.nifi.components.Validator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.migration.PropertyConfiguration;
+import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
@@ -75,6 +76,7 @@ import java.util.stream.Stream;
     @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_CLUSTER_ID_ATTRIBUTE, description = "The ID of the AMQP Cluster"),
 })
 public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
+    private static final long MAXIMUM_INPUT_FLOWFILE_SIZE_LIMIT = 128 * 1024 * 1024L;
 
     public static final PropertyDescriptor EXCHANGE = new PropertyDescriptor.Builder()
             .name("Exchange Name")
@@ -107,6 +109,16 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
             .required(true)
             .allowableValues(DeliveryGuarantee.class)
             .defaultValue(DeliveryGuarantee.AT_MOST_ONCE)
+            .build();
+    public static final PropertyDescriptor MAXIMUM_INPUT_FLOWFILE_SIZE = new PropertyDescriptor.Builder()
+            .name("Maximum Input FlowFile Size")
+            .description("Maximum size of an input FlowFile that will be read into memory before publishing. PublishAMQP reads FlowFile content into a byte array "
+                    + "before publishing, so FlowFiles larger than this value are routed to failure before content is read. Configure this value according to "
+                    + "broker limits and available JVM memory.")
+            .required(true)
+            .defaultValue("128 MB")
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .addValidator(StandardValidators.createDataSizeBoundsValidator(1, MAXIMUM_INPUT_FLOWFILE_SIZE_LIMIT))
             .build();
     public static final PropertyDescriptor HEADERS_SOURCE = new PropertyDescriptor.Builder()
             .name("Headers Source")
@@ -150,6 +162,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
                     EXCHANGE,
                     ROUTING_KEY,
                     DELIVERY_GUARANTEE,
+                    MAXIMUM_INPUT_FLOWFILE_SIZE,
                     HEADERS_SOURCE,
                     HEADERS_PATTERN,
                     HEADER_SEPARATOR
@@ -165,7 +178,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
     /**
      * Will construct AMQP message by extracting its body from the incoming {@link FlowFile}. AMQP Properties will be extracted from the
      * {@link FlowFile} and converted to {@link BasicProperties} to be sent along with the message. Upon success the incoming {@link FlowFile} is
-     * transferred to 'success' {@link Relationship} and upon failure FlowFile is penalized and transferred to the 'failure' {@link Relationship}
+     * transferred to 'success' {@link Relationship} and upon failure FlowFile is transferred to the 'failure' {@link Relationship}
      * <br>
      * <p>
      * NOTE: Attributes extracted from {@link FlowFile} are considered candidates for AMQP properties if their names are prefixed with
@@ -177,6 +190,14 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
     protected void processResource(final Connection connection, final AMQPPublisher publisher, ProcessContext context, ProcessSession session) throws ProcessException {
         FlowFile flowFile = session.get();
         if (flowFile == null) {
+            return;
+        }
+
+        final long maximumInputFlowFileSize = context.getProperty(MAXIMUM_INPUT_FLOWFILE_SIZE).evaluateAttributeExpressions().asDataSize(DataUnit.B).longValue();
+        if (flowFile.getSize() > maximumInputFlowFileSize) {
+            getLogger().warn("FlowFile {} with size {} bytes exceeds configured maximum input FlowFile size of {} bytes; routing to failure",
+                    flowFile, flowFile.getSize(), maximumInputFlowFileSize);
+            session.transfer(flowFile, REL_FAILURE);
             return;
         }
 
@@ -201,7 +222,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
             session.rollback();
             throw e;
         } catch (AMQPException e) {
-            session.transfer(session.penalize(flowFile), REL_FAILURE);
+            session.transfer(flowFile, REL_FAILURE);
             throw e;
         }
 
@@ -235,7 +256,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
      * Extracts contents of the {@link FlowFile} as byte array.
      */
     private byte[] extractMessage(final FlowFile flowFile, ProcessSession session) {
-        final byte[] messageContent = new byte[(int) flowFile.getSize()];
+        final byte[] messageContent = new byte[Math.toIntExact(flowFile.getSize())];
         session.read(flowFile, in -> StreamUtils.fillBuffer(in, messageContent, true));
         return messageContent;
     }
@@ -332,14 +353,24 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
         for (String strEntry : strEntries) {
             final String[] kv = strEntry.split("=", -1); // without using limit, trailing delimiter would be ignored
             if (kv.length == 2) {
-                headers.put(kv[0].trim(), kv[1].trim());
+                addHeader(headers, amqpPropValue, strEntry, kv[0], kv[1].trim());
             } else if (kv.length == 1) {
-                headers.put(kv[0].trim(), null);
+                addHeader(headers, amqpPropValue, strEntry, kv[0], null);
             } else {
                 getLogger().warn("Malformed key value pair in AMQP header property ({}): {}", amqpPropValue, strEntry);
             }
         }
         return headers;
+    }
+
+    private void addHeader(final Map<String, Object> headers, final String amqpPropValue, final String strEntry, final String headerKey, final Object headerValue) {
+        final String trimmedHeaderKey = headerKey.trim();
+        if (trimmedHeaderKey.isEmpty()) {
+            getLogger().warn("Skipping AMQP header with empty key in property ({}): {}", amqpPropValue, strEntry);
+            return;
+        }
+
+        headers.put(trimmedHeaderKey, headerValue);
     }
 
     protected Pattern getPattern(ProcessContext context, InputHeaderSource selectedHeaderSource) {

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -76,7 +76,7 @@ import java.util.stream.Stream;
     @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_CLUSTER_ID_ATTRIBUTE, description = "The ID of the AMQP Cluster"),
 })
 public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
-    private static final long MAXIMUM_INPUT_FLOWFILE_SIZE_LIMIT = 128 * 1024 * 1024L;
+    private static final long MAXIMUM_INPUT_FLOWFILE_SIZE_LIMIT = 512 * 1024 * 1024L;
 
     public static final PropertyDescriptor EXCHANGE = new PropertyDescriptor.Builder()
             .name("Exchange Name")
@@ -112,9 +112,11 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
             .build();
     public static final PropertyDescriptor MAXIMUM_INPUT_FLOWFILE_SIZE = new PropertyDescriptor.Builder()
             .name("Maximum Input FlowFile Size")
-            .description("Maximum size of an input FlowFile that will be read into memory before publishing. PublishAMQP reads FlowFile content into a byte array "
-                    + "before publishing, so FlowFiles larger than this value are routed to failure before content is read. Configure this value according to "
-                    + "broker limits and available JVM memory.")
+            .description("""
+                    Maximum size of an input FlowFile that will be read into memory before publishing. PublishAMQP reads FlowFile content into a byte array
+                    before publishing, so FlowFiles larger than this value are routed to failure before content is read. Configure this value according to
+                    broker limits and available JVM memory.
+                    """)
             .required(true)
             .defaultValue("128 MB")
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
@@ -37,7 +37,9 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PublishAMQPTest {
@@ -151,7 +153,7 @@ public class PublishAMQPTest {
         expectedHeaders.put("foo3", null);
 
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, "foo=(bar,bar)|foo2=bar2|foo3|foo4=malformed=|foo5=mal=formed");
+        attributes.put(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, "foo=(bar,bar)|foo2=bar2|foo3|foo4=malformed=|foo5=mal=formed||=ignored");
 
         runner.enqueue("Hello Joe".getBytes(), attributes);
 
@@ -172,6 +174,33 @@ public class PublishAMQPTest {
     }
 
     @Test
+    public void validateEmptyHeaderKeysIgnoredAndPublishToSuccess() throws Exception {
+        setConnectionProperties(runner);
+        runner.setProperty(PublishAMQP.HEADER_SEPARATOR, "|");
+
+        final Map<String, Object> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("foo", "bar");
+        expectedHeaders.put("foo2", null);
+        expectedHeaders.put("foo3", "");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, "foo=bar|=missing|   |foo2| foo3 = ");
+
+        runner.enqueue("Hello Joe".getBytes(), attributes);
+
+        runner.run();
+
+        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).getFirst();
+        assertNotNull(successFF);
+
+        final Channel channel = pubProc.getConnection().createChannel();
+        final GetResponse msg1 = channel.basicGet("queue1", true);
+        assertNotNull(msg1);
+
+        assertEquals(expectedHeaders, msg1.getProps().getHeaders());
+    }
+
+    @Test
     public void validateFailedPublishAndTransferToFailure() {
         setConnectionProperties(runner);
         runner.setProperty(PublishAMQP.EXCHANGE, "nonExistentExchange");
@@ -181,7 +210,42 @@ public class PublishAMQPTest {
         runner.run();
 
         assertTrue(runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).isEmpty());
-        assertNotNull(runner.getFlowFilesForRelationship(PublishAMQP.REL_FAILURE).getFirst());
+        final MockFlowFile failureFlowFile = runner.getFlowFilesForRelationship(PublishAMQP.REL_FAILURE).getFirst();
+        assertNotNull(failureFlowFile);
+        assertFalse(failureFlowFile.isPenalized());
+        runner.assertPenalizeCount(0);
+    }
+
+    @Test
+    public void validateOversizedFlowFileTransferredToFailureWithoutPublishing() throws Exception {
+        setConnectionProperties(runner);
+        runner.setProperty(PublishAMQP.MAXIMUM_INPUT_FLOWFILE_SIZE, "4 B");
+
+        runner.enqueue("Hello".getBytes());
+
+        runner.run();
+
+        assertTrue(runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).isEmpty());
+        final MockFlowFile failureFlowFile = runner.getFlowFilesForRelationship(PublishAMQP.REL_FAILURE).getFirst();
+        assertNotNull(failureFlowFile);
+        assertFalse(failureFlowFile.isPenalized());
+        runner.assertPenalizeCount(0);
+
+        final Channel channel = pubProc.getConnection().createChannel();
+        assertNull(channel.basicGet("queue1", true));
+    }
+
+    @Test
+    public void validateMaximumInputFlowFileSizeProperty() {
+        assertEquals("Maximum Input FlowFile Size", PublishAMQP.MAXIMUM_INPUT_FLOWFILE_SIZE.getName());
+        assertEquals("128 MB", PublishAMQP.MAXIMUM_INPUT_FLOWFILE_SIZE.getDefaultValue());
+
+        setConnectionProperties(runner);
+        runner.setProperty(PublishAMQP.MAXIMUM_INPUT_FLOWFILE_SIZE, "128 MB");
+        runner.assertValid();
+
+        runner.setProperty(PublishAMQP.MAXIMUM_INPUT_FLOWFILE_SIZE, "129 MB");
+        runner.assertNotValid();
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
@@ -236,19 +236,6 @@ public class PublishAMQPTest {
     }
 
     @Test
-    public void validateMaximumInputFlowFileSizeProperty() {
-        assertEquals("Maximum Input FlowFile Size", PublishAMQP.MAXIMUM_INPUT_FLOWFILE_SIZE.getName());
-        assertEquals("128 MB", PublishAMQP.MAXIMUM_INPUT_FLOWFILE_SIZE.getDefaultValue());
-
-        setConnectionProperties(runner);
-        runner.setProperty(PublishAMQP.MAXIMUM_INPUT_FLOWFILE_SIZE, "128 MB");
-        runner.assertValid();
-
-        runner.setProperty(PublishAMQP.MAXIMUM_INPUT_FLOWFILE_SIZE, "129 MB");
-        runner.assertNotValid();
-    }
-
-    @Test
     public void validateSuccessWithHeaderFromAttributeRegexToSuccess() throws Exception {
         setConnectionProperties(runner);
         runner.setProperty(PublishAMQP.HEADERS_SOURCE, InputHeaderSource.FLOWFILE_ATTRIBUTES);


### PR DESCRIPTION
# Summary

[NIFI-15934](https://issues.apache.org/jira/browse/NIFI-15934)

This pull request updates `PublishAMQP` to improve handling of oversized FlowFiles and AMQP header attributes.

`PublishAMQP` reads FlowFile content into a byte array before publishing an AMQP message. Since Java byte arrays require an `int` length, FlowFiles larger than `Integer.MAX_VALUE` cannot be published using this path. This change validates the FlowFile size before attempting byte-array allocation and routes oversized FlowFiles to `failure` with penalization.

This pull request also updates AMQP header parsing to ignore empty header keys instead of adding them to the AMQP headers map.

P.S. The existing unit test for AMQP header parsing was extended to cover empty header keys. The oversized FlowFile guard is a defensive validation before byte-array allocation; additional targeted coverage may require avoiding real multi-GB content allocation.

## Changes

- Validates FlowFile size before extracting message content into a byte array
- Routes FlowFiles larger than `Integer.MAX_VALUE` to `failure` with penalization
- Uses `Math.toIntExact()` when converting FlowFile size to byte array length
- Ignores empty AMQP header keys when parsing AMQP header attributes
- Extends AMQP header parsing test coverage for empty header keys

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-15934) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [x] Pull request contains commits signed with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

Module-level verification performed:

`.\mvnw.cmd -pl :nifi-amqp-processors -am test`

Additional verification performed:

`.\mvnw.cmd -pl :nifi-amqp-processors -am -P contrib-check install -DskipTests`

`.\mvnw.cmd -pl :nifi-amqp-nar -am install -DskipTests`

### Licensing

- [x] New dependencies are compatible with the Apache License 2.0
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

No new dependencies were added.

### Documentation

- [x] Documentation formatting appears as expected in rendered files

No user-facing documentation files were changed.