### PR TITLE
NIFI-15935 Clean up AMQP resources after processor failures

### DIFF
--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -285,8 +285,9 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
 
     private AMQPResource<T> createResource(final ProcessContext context) {
         Connection connection = null;
+        ExecutorService executor = null;
         try {
-            final ExecutorService executor = Executors.newSingleThreadExecutor(BasicThreadFactory.builder()
+            executor = Executors.newSingleThreadExecutor(BasicThreadFactory.builder()
                     .namingPattern("AMQP Client: " + getIdentifier() + "-%d")
                     .build());
             connection = createConnection(context, executor);
@@ -298,6 +299,14 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
                     connection.close();
                 } catch (Exception closingEx) {
                     getLogger().error("Failed to close AMQP Connection", closingEx);
+                }
+            }
+            if (executor != null) {
+                try {
+                    executor.shutdown();
+                } catch (Exception closingEx) {
+                    getLogger().error("Failed to shut down AMQP Executor", closingEx);
+                    e.addSuppressed(closingEx);
                 }
             }
             throw e;

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -244,8 +244,10 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
             context.yield();
             closeResource(resource);
         } catch (Exception e) {
-            getLogger().error("Processor failure", e);
+            getLogger().error("Processor failure, dropping the client", e);
+            session.rollback();
             context.yield();
+            closeResource(resource);
         }
     }
 
@@ -284,8 +286,8 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
     private AMQPResource<T> createResource(final ProcessContext context) {
         Connection connection = null;
         try {
-            ExecutorService executor = Executors.newSingleThreadExecutor(BasicThreadFactory.builder()
-                    .namingPattern("AMQP Consumer: " + getIdentifier())
+            final ExecutorService executor = Executors.newSingleThreadExecutor(BasicThreadFactory.builder()
+                    .namingPattern("AMQP Client: " + getIdentifier() + "-%d")
                     .build());
             connection = createConnection(context, executor);
             T worker = createAMQPWorker(context, connection);

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessorTest.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessorTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.nifi.amqp.processors;
 
+import com.rabbitmq.client.Connection;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.ssl.SSLContextProvider;
 import org.apache.nifi.util.TestRunner;
@@ -23,7 +26,11 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -88,6 +95,21 @@ public class AbstractAMQPProcessorTest {
         testRunner.assertNotValid();
     }
 
+    @Test
+    public void testExecutorShutdownWhenResourceCreationFails() throws Exception {
+        final FailingWorkerCreationConsumeAMQP processor = new FailingWorkerCreationConsumeAMQP();
+        final TestRunner runner = TestRunners.newTestRunner(processor);
+        runner.setProperty(ConsumeAMQP.QUEUE, "queue");
+        runner.setProperty(AbstractAMQPProcessor.BROKERS, "localhost:5672");
+        runner.setProperty(AbstractAMQPProcessor.USER, "user");
+        runner.setProperty(AbstractAMQPProcessor.PASSWORD, "password");
+
+        runner.run();
+
+        assertTrue(processor.getExecutor().isShutdown());
+        verify(processor.getConnection()).close();
+    }
+
     private void configureSSLContextService() throws InitializationException {
         SSLContextProvider sslContextProvider = mock(SSLContextProvider.class);
         when(sslContextProvider.getIdentifier()).thenReturn("ssl-context");
@@ -95,5 +117,33 @@ public class AbstractAMQPProcessorTest {
         testRunner.enableControllerService(sslContextProvider);
 
         testRunner.setProperty(AbstractAMQPProcessor.SSL_CONTEXT_SERVICE, "ssl-context");
+    }
+
+    private static class FailingWorkerCreationConsumeAMQP extends ConsumeAMQP {
+        private final Connection connection = mock(Connection.class);
+        private ExecutorService executor;
+
+        private FailingWorkerCreationConsumeAMQP() {
+            when(connection.isOpen()).thenReturn(true);
+        }
+
+        @Override
+        protected Connection createConnection(final ProcessContext context, final ExecutorService executor) {
+            this.executor = executor;
+            return connection;
+        }
+
+        @Override
+        protected AMQPConsumer createAMQPWorker(final ProcessContext context, final Connection connection) {
+            throw new ProcessException("Worker creation failed");
+        }
+
+        private Connection getConnection() {
+            return connection;
+        }
+
+        private ExecutorService getExecutor() {
+            return executor;
+        }
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-15935](https://issues.apache.org/jira/browse/NIFI-15935)

This pull request updates `AbstractAMQPProcessor` to clean up AMQP resources more consistently after unexpected processor failures.

When `processResource()` throws an unexpected exception, the processor currently logs the failure and yields the context. This change also rolls back the `ProcessSession` and closes the AMQP resource, ensuring that the client is dropped and recreated instead of potentially remaining in an inconsistent state.

This change also ensures that the AMQP executor service is shut down when resource creation fails after the executor has been created.

## Changes

- Rolls back the `ProcessSession` after unexpected processor failures
- Closes the AMQP resource after unexpected processor failures
- Shuts down the AMQP executor service when resource creation fails
- Updates AMQP client executor thread naming to use a generic client name

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-15935) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [x] Pull request contains commits signed with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

Module-level verification performed:

`.\mvnw.cmd -pl :nifi-amqp-processors -am test`

Additional verification performed:

`.\mvnw.cmd -pl :nifi-amqp-processors -am -P contrib-check install -DskipTests`

### Licensing

- [x] New dependencies are compatible with the Apache License 2.0
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

No new dependencies were added.

### Documentation

- [x] Documentation formatting appears as expected in rendered files

No user-facing documentation files were changed.