### PR TITLE
NIFI-15936: Fixing connector flow uri pattern in cluster response mer…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ConnectorFlowEndpointMerger.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ConnectorFlowEndpointMerger.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 public class ConnectorFlowEndpointMerger extends AbstractSingleDTOEndpoint<ProcessGroupFlowEntity, ProcessGroupFlowDTO> {
-    public static final Pattern CONNECTOR_FLOW_URI_PATTERN = Pattern.compile("/nifi-api/connectors/[a-f0-9\\-]{36}/flow");
+    public static final Pattern CONNECTOR_FLOW_URI_PATTERN = Pattern.compile("/nifi-api/connectors/[a-f0-9\\-]{36}/flow/process-groups/[a-f0-9\\-]{36}");
 
     @Override
     public boolean canHandle(final URI uri, final String method) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ConnectorFlowEndpointMergerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ConnectorFlowEndpointMergerTest.java
@@ -25,58 +25,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConnectorFlowEndpointMergerTest {
 
-    private static final String CONNECTOR_ID = "12345678-1234-1234-1234-123456789012";
-    private static final String PROCESS_GROUP_ID = "abcdef01-2345-6789-abcd-ef0123456789";
-
-    private final ConnectorFlowEndpointMerger merger = new ConnectorFlowEndpointMerger();
-
     @Test
-    public void testCanHandleConnectorProcessGroupFlowUri() {
-        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow/process-groups/" + PROCESS_GROUP_ID);
-        assertTrue(merger.canHandle(uri, "GET"));
-    }
+    public void testCanHandle() {
+        final ConnectorFlowEndpointMerger merger = new ConnectorFlowEndpointMerger();
+        final String connectorId = "12345678-1234-1234-1234-123456789012";
+        final String processGroupId = "abcdef01-2345-6789-abcd-ef0123456789";
+        final String connectorFlowUri = "/nifi-api/connectors/" + connectorId + "/flow/process-groups/" + processGroupId;
 
-    @Test
-    public void testCanHandleIgnoresQueryParameters() {
-        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow/process-groups/" + PROCESS_GROUP_ID + "?uiOnly=true");
-        assertTrue(merger.canHandle(uri, "GET"));
-    }
+        // Test valid URIs
+        assertTrue(merger.canHandle(URI.create(connectorFlowUri), "GET"));
+        assertTrue(merger.canHandle(URI.create(connectorFlowUri + "?uiOnly=true"), "GET"));
 
-    @Test
-    public void testCannotHandleNonGetMethods() {
-        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow/process-groups/" + PROCESS_GROUP_ID);
-        assertFalse(merger.canHandle(uri, "POST"));
-        assertFalse(merger.canHandle(uri, "PUT"));
-        assertFalse(merger.canHandle(uri, "DELETE"));
-    }
-
-    @Test
-    public void testCannotHandleConnectorFlowWithoutProcessGroup() {
-        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow");
-        assertFalse(merger.canHandle(uri, "GET"));
-    }
-
-    @Test
-    public void testCannotHandleControllerServicesSubPath() {
-        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow/process-groups/" + PROCESS_GROUP_ID + "/controller-services");
-        assertFalse(merger.canHandle(uri, "GET"));
-    }
-
-    @Test
-    public void testCannotHandleStandardFlowUri() {
-        final URI uri = URI.create("/nifi-api/flow/process-groups/" + PROCESS_GROUP_ID);
-        assertFalse(merger.canHandle(uri, "GET"));
-    }
-
-    @Test
-    public void testCannotHandleInvalidConnectorId() {
-        final URI uri = URI.create("/nifi-api/connectors/not-a-uuid/flow/process-groups/" + PROCESS_GROUP_ID);
-        assertFalse(merger.canHandle(uri, "GET"));
-    }
-
-    @Test
-    public void testCannotHandleInvalidProcessGroupId() {
-        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow/process-groups/not-a-uuid");
-        assertFalse(merger.canHandle(uri, "GET"));
+        // Test invalid URIs
+        assertFalse(merger.canHandle(URI.create(connectorFlowUri), "POST"));
+        assertFalse(merger.canHandle(URI.create("/nifi-api/connectors/" + connectorId + "/flow"), "GET"));
+        assertFalse(merger.canHandle(URI.create(connectorFlowUri + "/controller-services"), "GET"));
+        assertFalse(merger.canHandle(URI.create("/nifi-api/flow/process-groups/" + processGroupId), "GET"));
+        assertFalse(merger.canHandle(URI.create("/nifi-api/connectors/not-a-uuid/flow/process-groups/" + processGroupId), "GET"));
+        assertFalse(merger.canHandle(URI.create("/nifi-api/connectors/" + connectorId + "/flow/process-groups/not-a-uuid"), "GET"));
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ConnectorFlowEndpointMergerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ConnectorFlowEndpointMergerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cluster.coordination.http.endpoints;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConnectorFlowEndpointMergerTest {
+
+    private static final String CONNECTOR_ID = "12345678-1234-1234-1234-123456789012";
+    private static final String PROCESS_GROUP_ID = "abcdef01-2345-6789-abcd-ef0123456789";
+
+    private final ConnectorFlowEndpointMerger merger = new ConnectorFlowEndpointMerger();
+
+    @Test
+    public void testCanHandleConnectorProcessGroupFlowUri() {
+        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow/process-groups/" + PROCESS_GROUP_ID);
+        assertTrue(merger.canHandle(uri, "GET"));
+    }
+
+    @Test
+    public void testCanHandleIgnoresQueryParameters() {
+        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow/process-groups/" + PROCESS_GROUP_ID + "?uiOnly=true");
+        assertTrue(merger.canHandle(uri, "GET"));
+    }
+
+    @Test
+    public void testCannotHandleNonGetMethods() {
+        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow/process-groups/" + PROCESS_GROUP_ID);
+        assertFalse(merger.canHandle(uri, "POST"));
+        assertFalse(merger.canHandle(uri, "PUT"));
+        assertFalse(merger.canHandle(uri, "DELETE"));
+    }
+
+    @Test
+    public void testCannotHandleConnectorFlowWithoutProcessGroup() {
+        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow");
+        assertFalse(merger.canHandle(uri, "GET"));
+    }
+
+    @Test
+    public void testCannotHandleControllerServicesSubPath() {
+        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow/process-groups/" + PROCESS_GROUP_ID + "/controller-services");
+        assertFalse(merger.canHandle(uri, "GET"));
+    }
+
+    @Test
+    public void testCannotHandleStandardFlowUri() {
+        final URI uri = URI.create("/nifi-api/flow/process-groups/" + PROCESS_GROUP_ID);
+        assertFalse(merger.canHandle(uri, "GET"));
+    }
+
+    @Test
+    public void testCannotHandleInvalidConnectorId() {
+        final URI uri = URI.create("/nifi-api/connectors/not-a-uuid/flow/process-groups/" + PROCESS_GROUP_ID);
+        assertFalse(merger.canHandle(uri, "GET"));
+    }
+
+    @Test
+    public void testCannotHandleInvalidProcessGroupId() {
+        final URI uri = URI.create("/nifi-api/connectors/" + CONNECTOR_ID + "/flow/process-groups/not-a-uuid");
+        assertFalse(merger.canHandle(uri, "GET"));
+    }
+}


### PR DESCRIPTION
…ging.

# Summary

[NIFI-15936](https://issues.apache.org/jira/browse/NIFI-15936)

`ConnectorFlowEndpointMerger.canHandle` was never returning `true` for the actual connector flow endpoint, so cluster responses for `GET /nifi-api/connectors/{id}/flow/process-groups/{pgId}` were not being merged through `FlowMerger.mergeProcessGroupFlowDto`. The result on a multi-node cluster: per-node bulletins/statuses on the connector's flow are not aggregated into the coordinator's response, so bulletins emitted on non-coordinator nodes are not visible on the connector canvas.

The endpoint URI declared by `ConnectorResource` is:

https://github.com/apache/nifi/blob/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ConnectorResource.java#L1755

i.e. `/connectors/{connectorId}/flow/process-groups/{processGroupId}`. The merger's pattern `/nifi-api/connectors/[a-f0-9\-]{36}/flow` was missing the trailing `/process-groups/{pgId}` segment, which under `Matcher#matches()` (whole-string match) meant `canHandle` always returned `false`.

## Change

- Updated `CONNECTOR_FLOW_URI_PATTERN` in `ConnectorFlowEndpointMerger` to `/nifi-api/connectors/[a-f0-9\-]{36}/flow/process-groups/[a-f0-9\-]{36}`, mirroring the shape of `FlowMerger.FLOW_URI_PATTERN`.
- The `mergeResponses` body is unchanged; it already delegates to the package-private `FlowMerger.mergeProcessGroupFlowDto`, which was the intended reuse all along.
- Added `ConnectorFlowEndpointMergerTest` covering `canHandle` for:
  - the real connector flow URI (with and without `?uiOnly=true`),
  - non-`GET` methods on the same URI,
  - the previously-broken `/connectors/{id}/flow` shape (regression guard),
  - adjacent connector sub-paths (`/controller-services`, `/parameter-context`) that must keep being routed to their own mergers,
  - the standard `/nifi-api/flow/process-groups/{pgId}` URI (must remain owned by `FlowMerger`),
  - non-UUID connector and process group ids.

## Scope

- nifi-api: no changes.
- DTO/entity surface: no changes.
- Server-side flow / aggregation logic: no changes — `getProcessGroupBulletins` already walks `findAllProcessGroups()` for descendants on the connector flow path; the bug was strictly in cluster-mode response routing.
- Standalone (non-clustered) NiFi: no behavior change.
- Cluster-mode NiFi: connector flow responses now flow through `FlowMerger.mergeProcessGroupFlowDto`, so per-node bulletins/statuses on the connector's flow are merged into the coordinator's response.