### PR TITLE
NIFI-15940: Ensure that when a ConnectorConfigurationProviderExceptio…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiResourceConfig.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiResourceConfig.java
@@ -24,6 +24,7 @@ import org.apache.nifi.web.api.config.AuthenticationCredentialsNotFoundException
 import org.apache.nifi.web.api.config.AuthenticationNotSupportedExceptionMapper;
 import org.apache.nifi.web.api.config.AuthorizationAccessExceptionMapper;
 import org.apache.nifi.web.api.config.ClusterExceptionMapper;
+import org.apache.nifi.web.api.config.ConnectorConfigurationProviderExceptionMapper;
 import org.apache.nifi.web.api.config.IllegalArgumentExceptionMapper;
 import org.apache.nifi.web.api.config.IllegalClusterResourceRequestExceptionMapper;
 import org.apache.nifi.web.api.config.IllegalClusterStateExceptionMapper;
@@ -114,6 +115,7 @@ public class NiFiWebApiResourceConfig extends ResourceConfig {
         register(AuthenticationCredentialsNotFoundExceptionMapper.class);
         register(AdministrationExceptionMapper.class);
         register(ClusterExceptionMapper.class);
+        register(ConnectorConfigurationProviderExceptionMapper.class);
         register(IllegalArgumentExceptionMapper.class);
         register(IllegalClusterResourceRequestExceptionMapper.class);
         register(IllegalClusterStateExceptionMapper.class);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/config/ConnectorConfigurationProviderExceptionMapper.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/config/ConnectorConfigurationProviderExceptionMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.api.config;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.apache.nifi.components.connector.ConnectorConfigurationProviderException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Maps connector configuration provider exceptions into client responses. Provider implementations
+ * raise this exception for any failure of an external configuration operation (load, save, discard,
+ * delete, asset management, etc.). The framework cannot classify the failure further without
+ * coupling to a specific provider implementation, so a generic Internal Server Error response is
+ * returned with the provider-supplied message in the response body so callers can surface it
+ * directly.
+ */
+@Provider
+public class ConnectorConfigurationProviderExceptionMapper implements ExceptionMapper<ConnectorConfigurationProviderException> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConnectorConfigurationProviderExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final ConnectorConfigurationProviderException exception) {
+        logger.warn("{}. Returning {} response.", exception, Response.Status.INTERNAL_SERVER_ERROR, exception);
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(exception.getMessage()).type("text/plain").build();
+    }
+
+}


### PR DESCRIPTION
…n is thrown during a web request it doesn't fall through to the ThrowableMapper.

# Summary

[NIFI-15940](https://issues.apache.org/jira/browse/NIFI-15940)

Adds a dedicated JAX-RS `ExceptionMapper` for `ConnectorConfigurationProviderException` so failures originating from a `ConnectorConfigurationProvider` no longer fall through to the generic `ThrowableMapper`.

Previously, any exception raised by a provider implementation (during configuration load, save, discard, delete, asset management, etc.) was caught by `ThrowableMapper` and translated into a `500 Internal Server Error` with a canned "An unexpected error has occurred…" body. This obscured the provider's own diagnostic message and prevented clients from surfacing the underlying cause to the user.

With this change, `ConnectorConfigurationProviderException` is mapped to `500 Internal Server Error` with the provider-supplied message returned in the `text/plain` response body. The framework cannot classify the failure further without coupling to a specific provider implementation, so a generic 5xx status is appropriate while still preserving the original message for callers to display. This mirrors the precedent set by `AdministrationExceptionMapper`, which handles analogous failures from pluggable framework subsystems.

### Changes

- New `ConnectorConfigurationProviderExceptionMapper` in `nifi-web-api`, registered in `NiFiWebApiResourceConfig` alongside the other framework exception mappers.
- The mapper logs the exception at `WARN` and returns the exception message verbatim in the response body so clients can render it directly.
