### PR TITLE
NIFI-15945 - Parameter not correctly added to parameter context when having multiple suffixed parameter contexts

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -454,17 +454,6 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
         // parameter contexts that inherit from one another and neither the inheriting nor inherited parameter context exists.
         if (versionedParameterContexts != null) {
             versionedParameterContexts.values().forEach(this::createParameterContextWithoutReferences);
-
-            // After ensuring all contexts exist, add any missing parameters to all existing contexts from the proposed definitions.
-            // This is necessary because createParameterContextWithoutReferences skips contexts that already exist, so new parameters
-            // added to inherited contexts (e.g., a parent P2 inherited by the group's bound context P1) would otherwise be missed.
-            final ComponentIdGenerator componentIdGenerator = context.getComponentIdGenerator();
-            for (final Map.Entry<String, VersionedParameterContext> entry : versionedParameterContexts.entrySet()) {
-                final ParameterContext existingContext = getParameterContextByName(entry.getKey());
-                if (existingContext != null) {
-                    addMissingConfiguration(entry.getValue(), existingContext, versionedParameterContexts, parameterProviderReferences, componentIdGenerator);
-                }
-            }
         }
 
         updateParameterContext(group, proposed, versionedParameterContexts, parameterProviderReferences, context.getComponentIdGenerator());
@@ -2404,6 +2393,17 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                                          final Map<String, VersionedParameterContext> versionedParameterContexts,
                                          final Map<String, ParameterProviderReference> parameterProviderReferences,
                                          final ComponentIdGenerator componentIdGenerator) {
+        addMissingConfiguration(versionedParameterContext, currentParameterContext, versionedParameterContexts, parameterProviderReferences, componentIdGenerator, new HashSet<>());
+    }
+
+    private void addMissingConfiguration(final VersionedParameterContext versionedParameterContext, final ParameterContext currentParameterContext,
+                                         final Map<String, VersionedParameterContext> versionedParameterContexts,
+                                         final Map<String, ParameterProviderReference> parameterProviderReferences,
+                                         final ComponentIdGenerator componentIdGenerator, final Set<String> visitedParameterContextIds) {
+        if (!visitedParameterContextIds.add(currentParameterContext.getIdentifier())) {
+            return;
+        }
+
         final Map<String, Parameter> parameters = new HashMap<>();
         for (final VersionedParameter versionedParameter : versionedParameterContext.getParameters()) {
             final Optional<Parameter> parameterOption = currentParameterContext.getParameter(versionedParameter.getName());
@@ -2429,13 +2429,38 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
             currentParameterContext.setDescription(versionedParameterContext.getDescription());
         }
 
-        // If the current parameter context doesn't have any inherited param contexts but the versioned one does,
-        // add the versioned ones.
-        if (currentParameterContext.getInheritedParameterContexts().isEmpty()
-                && versionedParameterContext.getInheritedParameterContexts() != null && !versionedParameterContext.getInheritedParameterContexts().isEmpty()) {
-            currentParameterContext.setInheritedParameterContexts(versionedParameterContext.getInheritedParameterContexts().stream()
-                .map(name -> selectParameterContext(versionedParameterContexts.get(name), versionedParameterContexts, parameterProviderReferences, componentIdGenerator))
-                .collect(Collectors.toList()));
+        final List<String> proposedInheritedNames = versionedParameterContext.getInheritedParameterContexts();
+        final List<ParameterContext> currentInheritedContexts = currentParameterContext.getInheritedParameterContexts();
+        if (proposedInheritedNames != null && !proposedInheritedNames.isEmpty()) {
+            if (currentInheritedContexts.isEmpty()) {
+                // The local parameter context has no inheritance configured yet, so adopt the versioned chain
+                // by selecting (or creating) a matching parameter context for each inherited name.
+                currentParameterContext.setInheritedParameterContexts(proposedInheritedNames.stream()
+                    .map(name -> selectParameterContext(versionedParameterContexts.get(name), versionedParameterContexts, parameterProviderReferences, componentIdGenerator))
+                    .collect(Collectors.toList()));
+            } else {
+                // Walk the local inheritance chain in lockstep with the versioned chain so updates to inherited
+                // contexts are applied to the contexts actually referenced by this parameter context, even when
+                // the local names were suffix-renamed at import time (for example, P (2) instead of P). Pairs that
+                // do not match by exact name or by name-with-suffix are skipped to avoid corrupting a chain that
+                // was rewired locally.
+                final int matchedDepth = Math.min(currentInheritedContexts.size(), proposedInheritedNames.size());
+                for (int i = 0; i < matchedDepth; i++) {
+                    final ParameterContext liveInheritedContext = currentInheritedContexts.get(i);
+                    final String proposedInheritedName = proposedInheritedNames.get(i);
+                    final VersionedParameterContext proposedInheritedContext = versionedParameterContexts == null ? null : versionedParameterContexts.get(proposedInheritedName);
+                    if (liveInheritedContext == null || proposedInheritedContext == null) {
+                        continue;
+                    }
+                    final String liveInheritedName = liveInheritedContext.getName();
+                    if (!liveInheritedName.equals(proposedInheritedName)
+                            && !ParameterContextNameUtils.isNameWithSuffix(liveInheritedName, proposedInheritedName)) {
+                        continue;
+                    }
+                    addMissingConfiguration(proposedInheritedContext, liveInheritedContext, versionedParameterContexts, parameterProviderReferences,
+                            componentIdGenerator, visitedParameterContextIds);
+                }
+            }
         }
 
         if (versionedParameterContext.getParameterProvider() != null && currentParameterContext.getParameterProvider() == null) {

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/ParameterContextPreservationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/ParameterContextPreservationIT.java
@@ -246,6 +246,95 @@ class ParameterContextPreservationIT extends NiFiSystemIT {
     }
 
     /**
+     * Verifies that a new parameter introduced by a new flow version is applied only to the parameter context
+     * actually bound to the upgraded process group, even when the local flow has multiple deployments of the
+     * same versioned flow with REPLACE-strategy suffix-renamed parameter contexts (P, P (1), P (2)).
+     *
+     * Scenario: Flow F has parameter context P. F is imported three times with the REPLACE strategy, producing
+     * deployments bound to P, P (1), and P (2) respectively. Version 2 of F adds parameter Z to P. Upgrading
+     * the third deployment must apply Z only to P (2); P and P (1) must remain unchanged.
+     */
+    @Test
+    void testNewParameterAppliedOnlyToBoundSuffixedContextDuringUpgrade() throws NiFiClientException, IOException, InterruptedException {
+        final FlowRegistryClientEntity clientEntity = registerClient();
+        final NiFiClientUtil util = getClientUtil();
+
+        // Build the source flow A bound to parameter context P, save as version 1
+        final ParameterContextEntity sourceParamContextP = util.createParameterContext(PARAMETER_CONTEXT_NAME, Map.of(PARAMETER_NAME, PARAMETER_VALUE));
+        final ProcessGroupEntity sourceGroupA = util.createProcessGroup(GROUP_A_NAME, "root");
+        util.setParameterContext(sourceGroupA.getId(), sourceParamContextP);
+
+        final ProcessorEntity processor = util.createProcessor(PROCESSOR_TYPE, sourceGroupA.getId());
+        util.updateProcessorProperties(processor, Collections.singletonMap(PROCESSOR_PROPERTY_TEXT, PARAMETER_REFERENCE));
+        util.setAutoTerminatedRelationships(processor, RELATIONSHIP_SUCCESS);
+
+        final VersionControlInformationEntity vciV1 = util.startVersionControl(sourceGroupA, clientEntity, TEST_FLOWS_BUCKET, FLOW_NAME);
+        final String flowId = vciV1.getVersionControlInformation().getFlowId();
+
+        // Add new parameter paramZ to P and save as version 2
+        final String paramZName = "paramZ";
+        final String paramZValue = "valueZ";
+        final ParameterContextEntity currentSourceP = getNifiClient().getParamContextClient().getParamContext(sourceParamContextP.getId(), false);
+        final ParameterContextUpdateRequestEntity sourceUpdate = util.updateParameterContext(currentSourceP,
+                Map.of(PARAMETER_NAME, PARAMETER_VALUE, paramZName, paramZValue));
+        util.waitForParameterContextRequestToComplete(sourceParamContextP.getId(), sourceUpdate.getRequest().getRequestId());
+
+        final ProcessGroupEntity sourceGroupARefreshed = getNifiClient().getProcessGroupClient().getProcessGroup(sourceGroupA.getId());
+        util.saveFlowVersion(sourceGroupARefreshed, clientEntity, vciV1);
+
+        // Clean up the source flow and parameter context so that subsequent imports start from a clean slate
+        final ProcessGroupEntity sourceForStopVc = getNifiClient().getProcessGroupClient().getProcessGroup(sourceGroupA.getId());
+        getNifiClient().getVersionsClient().stopVersionControl(sourceForStopVc);
+        util.deleteAll(sourceGroupA.getId());
+        final ProcessGroupEntity sourceToDelete = getNifiClient().getProcessGroupClient().getProcessGroup(sourceGroupA.getId());
+        getNifiClient().getProcessGroupClient().deleteProcessGroup(sourceToDelete);
+
+        final ParameterContextEntity sourceContextToDelete = getNifiClient().getParamContextClient().getParamContext(sourceParamContextP.getId(), false);
+        getNifiClient().getParamContextClient().deleteParamContext(sourceParamContextP.getId(),
+                String.valueOf(sourceContextToDelete.getRevision().getVersion()));
+
+        // Import version 1 three times. With the REPLACE strategy, each import creates a new parameter context:
+        // A1 -> P, A2 -> P (1), A3 -> P (2).
+        final ProcessGroupEntity importedA1 = importFlowWithReplaceParameterContext(clientEntity.getId(), flowId, VERSION_1);
+        final String paramContextId1 = getNifiClient().getProcessGroupClient().getProcessGroup(importedA1.getId())
+                .getComponent().getParameterContext().getId();
+
+        final ProcessGroupEntity importedA2 = importFlowWithReplaceParameterContext(clientEntity.getId(), flowId, VERSION_1);
+        final String paramContextId2 = getNifiClient().getProcessGroupClient().getProcessGroup(importedA2.getId())
+                .getComponent().getParameterContext().getId();
+
+        final ProcessGroupEntity importedA3 = importFlowWithReplaceParameterContext(clientEntity.getId(), flowId, VERSION_1);
+        final String paramContextId3 = getNifiClient().getProcessGroupClient().getProcessGroup(importedA3.getId())
+                .getComponent().getParameterContext().getId();
+
+        assertNotEquals(paramContextId1, paramContextId2);
+        assertNotEquals(paramContextId2, paramContextId3);
+        assertNotEquals(paramContextId1, paramContextId3);
+
+        // None of the imported parameter contexts should have paramZ after importing version 1
+        assertFalse(getParameterNames(getNifiClient().getParamContextClient().getParamContext(paramContextId1, false)).contains(paramZName));
+        assertFalse(getParameterNames(getNifiClient().getParamContextClient().getParamContext(paramContextId2, false)).contains(paramZName));
+        assertFalse(getParameterNames(getNifiClient().getParamContextClient().getParamContext(paramContextId3, false)).contains(paramZName));
+
+        // Upgrade only the third deployment (A3, bound to P (2)) to version 2
+        util.changeFlowVersion(importedA3.getId(), VERSION_2);
+
+        // The parameter context bound to A3 must contain the new parameter
+        final ParameterContextEntity context3AfterUpgrade = getNifiClient().getParamContextClient().getParamContext(paramContextId3, false);
+        assertTrue(getParameterNames(context3AfterUpgrade).contains(paramZName),
+                "paramZ should be added to the parameter context bound to the upgraded deployment");
+
+        // The parameter contexts bound to the other deployments must remain unchanged
+        final ParameterContextEntity context1AfterUpgrade = getNifiClient().getParamContextClient().getParamContext(paramContextId1, false);
+        assertFalse(getParameterNames(context1AfterUpgrade).contains(paramZName),
+                "paramZ should not leak into the canonical parameter context bound to a different deployment");
+
+        final ParameterContextEntity context2AfterUpgrade = getNifiClient().getParamContextClient().getParamContext(paramContextId2, false);
+        assertFalse(getParameterNames(context2AfterUpgrade).contains(paramZName),
+                "paramZ should not leak into the suffixed parameter context bound to a different deployment");
+    }
+
+    /**
      * Verifies that parameter and parameter context descriptions are updated when upgrading a versioned
      * process group from one version to the next, even when the parameter value itself remains unchanged
      * and the parameter is referenced by a Controller Service that is currently ENABLED on the target.

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/ParameterContextPreservationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/ParameterContextPreservationIT.java
@@ -259,7 +259,6 @@ class ParameterContextPreservationIT extends NiFiSystemIT {
         final FlowRegistryClientEntity clientEntity = registerClient();
         final NiFiClientUtil util = getClientUtil();
 
-        // Build the source flow A bound to parameter context P, save as version 1
         final ParameterContextEntity sourceParamContextP = util.createParameterContext(PARAMETER_CONTEXT_NAME, Map.of(PARAMETER_NAME, PARAMETER_VALUE));
         final ProcessGroupEntity sourceGroupA = util.createProcessGroup(GROUP_A_NAME, "root");
         util.setParameterContext(sourceGroupA.getId(), sourceParamContextP);
@@ -271,7 +270,6 @@ class ParameterContextPreservationIT extends NiFiSystemIT {
         final VersionControlInformationEntity vciV1 = util.startVersionControl(sourceGroupA, clientEntity, TEST_FLOWS_BUCKET, FLOW_NAME);
         final String flowId = vciV1.getVersionControlInformation().getFlowId();
 
-        // Add new parameter paramZ to P and save as version 2
         final String paramZName = "paramZ";
         final String paramZValue = "valueZ";
         final ParameterContextEntity currentSourceP = getNifiClient().getParamContextClient().getParamContext(sourceParamContextP.getId(), false);
@@ -282,7 +280,6 @@ class ParameterContextPreservationIT extends NiFiSystemIT {
         final ProcessGroupEntity sourceGroupARefreshed = getNifiClient().getProcessGroupClient().getProcessGroup(sourceGroupA.getId());
         util.saveFlowVersion(sourceGroupARefreshed, clientEntity, vciV1);
 
-        // Clean up the source flow and parameter context so that subsequent imports start from a clean slate
         final ProcessGroupEntity sourceForStopVc = getNifiClient().getProcessGroupClient().getProcessGroup(sourceGroupA.getId());
         getNifiClient().getVersionsClient().stopVersionControl(sourceForStopVc);
         util.deleteAll(sourceGroupA.getId());
@@ -293,8 +290,6 @@ class ParameterContextPreservationIT extends NiFiSystemIT {
         getNifiClient().getParamContextClient().deleteParamContext(sourceParamContextP.getId(),
                 String.valueOf(sourceContextToDelete.getRevision().getVersion()));
 
-        // Import version 1 three times. With the REPLACE strategy, each import creates a new parameter context:
-        // A1 -> P, A2 -> P (1), A3 -> P (2).
         final ProcessGroupEntity importedA1 = importFlowWithReplaceParameterContext(clientEntity.getId(), flowId, VERSION_1);
         final String paramContextId1 = getNifiClient().getProcessGroupClient().getProcessGroup(importedA1.getId())
                 .getComponent().getParameterContext().getId();
@@ -311,20 +306,16 @@ class ParameterContextPreservationIT extends NiFiSystemIT {
         assertNotEquals(paramContextId2, paramContextId3);
         assertNotEquals(paramContextId1, paramContextId3);
 
-        // None of the imported parameter contexts should have paramZ after importing version 1
         assertFalse(getParameterNames(getNifiClient().getParamContextClient().getParamContext(paramContextId1, false)).contains(paramZName));
         assertFalse(getParameterNames(getNifiClient().getParamContextClient().getParamContext(paramContextId2, false)).contains(paramZName));
         assertFalse(getParameterNames(getNifiClient().getParamContextClient().getParamContext(paramContextId3, false)).contains(paramZName));
 
-        // Upgrade only the third deployment (A3, bound to P (2)) to version 2
         util.changeFlowVersion(importedA3.getId(), VERSION_2);
 
-        // The parameter context bound to A3 must contain the new parameter
         final ParameterContextEntity context3AfterUpgrade = getNifiClient().getParamContextClient().getParamContext(paramContextId3, false);
         assertTrue(getParameterNames(context3AfterUpgrade).contains(paramZName),
                 "paramZ should be added to the parameter context bound to the upgraded deployment");
 
-        // The parameter contexts bound to the other deployments must remain unchanged
         final ParameterContextEntity context1AfterUpgrade = getNifiClient().getParamContextClient().getParamContext(paramContextId1, false);
         assertFalse(getParameterNames(context1AfterUpgrade).contains(paramZName),
                 "paramZ should not leak into the canonical parameter context bound to a different deployment");


### PR DESCRIPTION
# Summary

NIFI-15945 - Parameter not correctly added to parameter context when having multiple suffixed parameter contexts

Consider the following scenario: in a registry you have a versioned flow F at version N that represents a versioned process group attached to a parameter context P.

In NiFi, you import that flow three times with the flag that you don't want to re-use the parameter context. You get:

- F_1 with parameter context named "P"
- F_2 with parameter context named "P (1)"
- F_3 with parameter context named "P (2)"

Now consider a new version of the flow F, version n+1, where a new parameter Z is added to P.

When you upgrade F_2 or F_3 to the version n+1, the parameter Z is not added to their bounded parameter context.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
