### PR TITLE
NIFI-15949 - Bump Apache Maven to 3.9.16, ASM to 9.10, Wire to 6.4.0 and others

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/nifi-extension-bom/pom.xml
+++ b/nifi-extension-bom/pom.xml
@@ -189,19 +189,19 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.9.1</version>
+                <version>9.10</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-commons</artifactId>
-                <version>9.9.1</version>
+                <version>9.10</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-tree</artifactId>
-                <version>9.9.1</version>
+                <version>9.10</version>
                 <scope>provided</scope>
             </dependency>
             <!-- Jetty EE11 Apache JSP and deps -->
@@ -224,13 +224,13 @@
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-jsp</artifactId>
-                <version>11.0.10.1</version>
+                <version>11.0.22</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-el</artifactId>
-                <version>11.0.10.1</version>
+                <version>11.0.22</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/pom.xml
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.9.15</version>
+            <version>3.9.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <protobuf.version>4.34.1</protobuf.version>
-        <wire.version>6.3.0</wire.version>
+        <wire.version>6.4.0</wire.version>
     </properties>
 
     <dependencies>

--- a/nifi-registry/nifi-registry-core/nifi-registry-jetty/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-jetty/pom.xml
@@ -101,13 +101,13 @@
         <dependency>
             <groupId>org.mortbay.jasper</groupId>
             <artifactId>mortbay-apache-jsp</artifactId>
-            <version>11.0.10.1</version>
+            <version>11.0.22</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mortbay.jasper</groupId>
             <artifactId>mortbay-apache-el</artifactId>
-            <version>11.0.10.1</version>
+            <version>11.0.22</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -118,13 +118,13 @@
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-jsp</artifactId>
-                <version>11.0.10.1</version>
+                <version>11.0.22</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-el</artifactId>
-                <version>11.0.10.1</version>
+                <version>11.0.22</version>
                 <scope>compile</scope>
                 <exclusions>
                     <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.44.5</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.44.7</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.6</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -913,7 +913,7 @@
                                     </plugins>
                                 </requireSameVersions>
                                 <requireMavenVersion>
-                                    <version>3.9.15</version>
+                                    <version>3.9.16</version>
                                 </requireMavenVersion>
                                 <requireReleaseDeps>
                                     <message>Dependencies outside of Apache NiFi must not use SNAPSHOT versions</message>


### PR DESCRIPTION
# Summary

NIFI-15949 - Bump Apache Maven to 3.9.16, ASM to 9.10, Wire to 6.4.0 and others

- ASM from 9.9.1 to 9.10 - https://asm.ow2.io/versions.html
- Jetty Jasper JSP from 11.0.10.1 to 11.0.22 - https://github.com/jetty-project/jasper-jsp/releases/tag/jasper-jsp-11.0.22
- Apache Maven from 3.9.15 to 3.9.16 - https://maven.apache.org/docs/3.9.16/release-notes.html
- Wire from 6.3.0 to 6.4.0 - https://github.com/square/wire/releases/tag/6.4.0
- AWS SDK BOM from 2.44.5 to 2.44.7 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
