### PR TITLE
NIFI-15950 Remove Grype ignore for GHSA-72hv-8253-57qq

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -13,12 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ignore:
-  # Reason: Referencing libraries bundle shaded version of Jackson
-  # Mitigating Factors: Jackson Async Parser not used
-  # Reference: com.hazelcast:hazelcast:5.6.0
-  # Reference: org.apache.parquet:parquet-jackson:1.17.0
-  - vulnerability: GHSA-72hv-8253-57qq
-    package:
-      name: jackson-core
-      version: 2.19.2


### PR DESCRIPTION
# Summary

[NIFI-15950](https://issues.apache.org/jira/browse/NIFI-15950) Removes the Grype vulnerability scanning ignore reference for GHSA-72hv-8253-57qq. This ignore is no longer needed following recent upgrades to `parquet-jackson` 1.17.1 and `hazelcast` 5.7.0.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
