### PR TITLE
NIFI-15954 Honor property overrides when verifying Kafka Topics step

### DIFF
--- a/nifi-connectors/nifi-kafka-to-s3-bundle/nifi-kafka-to-s3-connector/src/main/java/org/apache/nifi/connectors/kafkas3/KafkaToS3.java
+++ b/nifi-connectors/nifi-kafka-to-s3-bundle/nifi-kafka-to-s3-connector/src/main/java/org/apache/nifi/connectors/kafkas3/KafkaToS3.java
@@ -130,7 +130,7 @@ public class KafkaToS3 extends AbstractConnector {
         }
         if (stepName.equals(KafkaTopicsStep.STEP_NAME)) {
             final List<ConfigVerificationResult> results = new ArrayList<>();
-            results.addAll(verifyTopicsExists(workingFlowContext));
+            results.addAll(verifyTopicsExists(workingFlowContext, configurationContext));
             results.addAll(verifyKafkaParsability(workingFlowContext, flow));
             return results;
         }
@@ -179,7 +179,7 @@ public class KafkaToS3 extends AbstractConnector {
     }
 
 
-    private List<ConfigVerificationResult> verifyTopicsExists(final FlowContext workingFlowContext) {
+    List<ConfigVerificationResult> verifyTopicsExists(final FlowContext workingFlowContext, final ConnectorConfigurationContext configurationContext) {
         final List<String> topicsAvailable;
         try {
             topicsAvailable = getAvailableTopics(workingFlowContext);
@@ -192,25 +192,25 @@ public class KafkaToS3 extends AbstractConnector {
         }
 
         final Set<String> topicNames = new HashSet<>(topicsAvailable);
-        final List<String> specifiedTopics = workingFlowContext.getConfigurationContext().getProperty(KafkaTopicsStep.STEP_NAME,
+        final List<String> specifiedTopics = configurationContext.getProperty(KafkaTopicsStep.STEP_NAME,
             KafkaTopicsStep.TOPIC_NAMES.getName()).asList();
         final String missingTopics = specifiedTopics.stream()
             .filter(topic -> !topicNames.contains(topic))
             .collect(Collectors.joining(", "));
 
-        if (!missingTopics.isEmpty()) {
-            return List.of(new ConfigVerificationResult.Builder()
-                .verificationStepName("Verify Kafka topics exist")
-                .outcome(Outcome.FAILED)
-                .explanation("The following topics do not exist in the Kafka cluster: " + missingTopics)
-                .build());
-        } else {
+        if (missingTopics.isEmpty()) {
             return List.of(new ConfigVerificationResult.Builder()
                 .verificationStepName("Verify Kafka topics exist")
                 .outcome(Outcome.SUCCESSFUL)
                 .explanation("All specified topics exist in the Kafka cluster")
                 .build());
         }
+
+        return List.of(new ConfigVerificationResult.Builder()
+            .verificationStepName("Verify Kafka topics exist")
+            .outcome(Outcome.FAILED)
+            .explanation("The following topics do not exist in the Kafka cluster: " + missingTopics)
+            .build());
     }
 
     private List<ConfigVerificationResult> verifyKafkaConnectivity(final FlowContext workingFlowContext, final VersionedExternalFlow flow) {
@@ -256,7 +256,7 @@ public class KafkaToS3 extends AbstractConnector {
     }
 
     @SuppressWarnings("unchecked")
-    private List<String> getAvailableTopics(final FlowContext flowContext) {
+    List<String> getAvailableTopics(final FlowContext flowContext) {
         // If Kafka Brokers not yet set, return empty list
         final ConnectorConfigurationContext config = flowContext.getConfigurationContext();
         if (!config.getProperty(KafkaConnectionStep.KAFKA_CONNECTION_STEP, KafkaConnectionStep.KAFKA_BROKERS).isSet()) {

--- a/nifi-connectors/nifi-kafka-to-s3-bundle/nifi-kafka-to-s3-connector/src/test/java/org/apache/nifi/connectors/kafkas3/KafkaToS3Test.java
+++ b/nifi-connectors/nifi-kafka-to-s3-bundle/nifi-kafka-to-s3-connector/src/test/java/org/apache/nifi/connectors/kafkas3/KafkaToS3Test.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.connectors.kafkas3;
+
+import org.apache.nifi.components.ConfigVerificationResult;
+import org.apache.nifi.components.ConfigVerificationResult.Outcome;
+import org.apache.nifi.components.connector.ConnectorConfigurationContext;
+import org.apache.nifi.components.connector.ConnectorPropertyValue;
+import org.apache.nifi.components.connector.components.FlowContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link KafkaToS3}.
+ *
+ * <p>Tests use Mockito to stub the {@link FlowContext} and {@link ConnectorConfigurationContext}
+ * surface that the connector consumes. The heavier {@code StandardConnectorTestRunner} harness
+ * is not used here because it requires a packaged NAR and a running broker, which is the
+ * province of the {@code nifi-kafka-to-s3-integration-tests} module.
+ */
+public class KafkaToS3Test {
+
+    private ConnectorConfigurationContext overriddenContext;
+    private FlowContext flowContext;
+
+    @BeforeEach
+    public void setUp() {
+        overriddenContext = mock(ConnectorConfigurationContext.class);
+        flowContext = mock(FlowContext.class);
+    }
+
+    /**
+     * The specified-topic list passed to the topic-existence check must come from the overridden
+     * {@link ConnectorConfigurationContext} supplied with the verification request, not from the
+     * persisted flow configuration. This guards against silently verifying a stale topic list when
+     * the request narrows the selection (for example, when the UI has dropped a topic that no
+     * longer exists in the broker).
+     */
+    @Test
+    public void verifyTopicsExistsUsesOverriddenTopicList() {
+        stubSpecifiedTopics(overriddenContext, List.of("demo-topic"));
+
+        final KafkaToS3 connector = new KafkaToS3WithAvailableTopics(List.of("demo-topic"));
+        final List<ConfigVerificationResult> results = connector.verifyTopicsExists(flowContext, overriddenContext);
+
+        assertEquals(1, results.size());
+        final ConfigVerificationResult result = results.getFirst();
+        assertEquals(Outcome.SUCCESSFUL, result.getOutcome());
+        assertEquals("Verify Kafka topics exist", result.getVerificationStepName());
+        assertTrue(result.getExplanation().contains("All specified topics exist"),
+                "Explanation should indicate success, but was: " + result.getExplanation());
+    }
+
+    /**
+     * A topic specified by the override that is absent from the broker must still be reported as
+     * missing, ensuring the failure path is preserved for genuine misconfigurations.
+     */
+    @Test
+    public void verifyTopicsExistsReportsTopicMissingFromBroker() {
+        stubSpecifiedTopics(overriddenContext, List.of("demo-topic", "brand-new-topic"));
+
+        final KafkaToS3 connector = new KafkaToS3WithAvailableTopics(List.of("demo-topic"));
+        final List<ConfigVerificationResult> results = connector.verifyTopicsExists(flowContext, overriddenContext);
+
+        assertEquals(1, results.size());
+        final ConfigVerificationResult result = results.getFirst();
+        assertEquals(Outcome.FAILED, result.getOutcome());
+        assertTrue(result.getExplanation().contains("brand-new-topic"),
+                "Explanation should reference the missing topic, but was: " + result.getExplanation());
+    }
+
+    /**
+     * If the broker cannot be queried for available topics, the verification step is reported as
+     * SKIPPED rather than FAILED, since the connector cannot determine whether the specified
+     * topics exist.
+     */
+    @Test
+    public void verifyTopicsExistsReturnsSkippedWhenAvailableTopicsLookupFails() {
+        stubSpecifiedTopics(overriddenContext, List.of("demo-topic"));
+
+        final KafkaToS3 connector = new KafkaToS3WithFailingAvailableTopics(new RuntimeException("broker unreachable"));
+        final List<ConfigVerificationResult> results = connector.verifyTopicsExists(flowContext, overriddenContext);
+
+        assertEquals(1, results.size());
+        final ConfigVerificationResult result = results.getFirst();
+        assertEquals(Outcome.SKIPPED, result.getOutcome());
+        assertTrue(result.getExplanation().contains("broker unreachable"),
+                "Explanation should propagate the lookup failure, but was: " + result.getExplanation());
+    }
+
+    private static void stubSpecifiedTopics(final ConnectorConfigurationContext context, final List<String> topics) {
+        final ConnectorPropertyValue propertyValue = mock(ConnectorPropertyValue.class);
+        when(propertyValue.asList()).thenReturn(topics);
+        when(context.getProperty(KafkaTopicsStep.STEP_NAME,
+                KafkaTopicsStep.TOPIC_NAMES.getName())).thenReturn(propertyValue);
+    }
+
+    /**
+     * Test subclass that bypasses the Kafka connection service lookup and returns a canned list
+     * of topics that the broker reports as available.
+     */
+    private static class KafkaToS3WithAvailableTopics extends KafkaToS3 {
+        private final List<String> availableTopics;
+
+        KafkaToS3WithAvailableTopics(final List<String> availableTopics) {
+            this.availableTopics = availableTopics;
+        }
+
+        @Override
+        List<String> getAvailableTopics(final FlowContext flowContext) {
+            return availableTopics;
+        }
+    }
+
+    /**
+     * Test subclass that simulates a broker lookup failure so the SKIPPED outcome path is
+     * exercised.
+     */
+    private static class KafkaToS3WithFailingAvailableTopics extends KafkaToS3 {
+        private final RuntimeException failure;
+
+        KafkaToS3WithFailingAvailableTopics(final RuntimeException failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        List<String> getAvailableTopics(final FlowContext flowContext) {
+            throw failure;
+        }
+    }
+}


### PR DESCRIPTION
KafkaToS3.verifyTopicsExists now reads the specified Topic Names list from the overridden ConnectorConfigurationContext built from the verify request, rather than from the persisted FlowContext, so a verification request that narrows the selection is no longer evaluated against stale persisted state.
# NIFI-15954 Honor property overrides when verifying Kafka Topics step

# Summary

[NIFI-15954](https://issues.apache.org/jira/browse/NIFI-15954)

This is a **bug fix** for the `KafkaToS3` connector's `Verify Kafka topics exist` step.

## Motivation

`KafkaToS3.verifyConfigurationStep(...)` (`nifi-connectors/nifi-kafka-to-s3-bundle/nifi-kafka-to-s3-connector/src/main/java/org/apache/nifi/connectors/kafkas3/KafkaToS3.java`) already constructs an overridden `ConnectorConfigurationContext` from the verification request's property overrides via `workingFlowContext.getConfigurationContext().createWithOverrides(stepName, propertyValueOverrides)`, and feeds that overridden context into the `VersionedExternalFlow` it builds for verification.

The `verifyTopicsExists(...)` helper, however, was reading the `Topic Names` list directly from `workingFlowContext.getConfigurationContext()` — i.e. from the *persisted* `FlowContext` rather than from the overridden context. As a result, a verify request that narrowed (or otherwise altered) the topic selection was evaluated against stale persisted state instead of the request's own values. The companion `verifyKafkaParsability(...)` was already correct because it operates on the `flow` argument, which is built from the overridden context.

## Changes

`nifi-connectors/nifi-kafka-to-s3-bundle/nifi-kafka-to-s3-connector/src/main/java/org/apache/nifi/connectors/kafkas3/KafkaToS3.java`

- `verifyTopicsExists(...)` now accepts the overridden `ConnectorConfigurationContext` as a second argument and reads `KafkaTopicsStep.TOPIC_NAMES` from it, so the list of specified topics matches what the verification request asked to verify.
- The single call site in `verifyConfigurationStep(...)` was updated to pass the already-built overridden `configurationContext` through to `verifyTopicsExists(...)`.
- Visibility of `verifyTopicsExists(...)` and `getAvailableTopics(...)` was relaxed from `private` to package-private to allow unit-test subclasses to stub the broker lookup. No external visibility changed.
- Inside `verifyTopicsExists(...)`, the if/else order was flipped so the success branch is handled first and the failure branch second. This is purely stylistic; the produced `ConfigVerificationResult` values and outcomes are unchanged.

`nifi-connectors/nifi-kafka-to-s3-bundle/nifi-kafka-to-s3-connector/src/test/java/org/apache/nifi/connectors/kafkas3/KafkaToS3Test.java` (new)

- New unit test class targeting `verifyTopicsExists(...)`. Uses Mockito to stub `FlowContext`, `ConnectorConfigurationContext`, and `ConnectorPropertyValue`, and uses two small private subclasses of `KafkaToS3` to stub `getAvailableTopics(FlowContext)` so the test can drive both the success path and a broker-lookup failure without standing up a real connection service.
- The class JavaDoc notes that the heavier `StandardConnectorTestRunner` harness is intentionally not used here because it requires a packaged NAR and a running broker, which is the responsibility of the `nifi-kafka-to-s3-integration-tests` module.

## Verification

Three unit tests were added in `KafkaToS3Test`:

1. `verifyTopicsExistsUsesOverriddenTopicList` — the specified-topic list read by the step comes from the overridden `ConnectorConfigurationContext`, and a topic present in the broker passes (`Outcome.SUCCESSFUL`).
2. `verifyTopicsExistsReportsTopicMissingFromBroker` — a topic supplied via the override that is absent from the broker is reported as `Outcome.FAILED`, and the explanation references the missing topic.
3. `verifyTopicsExistsReturnsSkippedWhenAvailableTopicsLookupFails` — when the broker lookup throws, the step is reported as `Outcome.SKIPPED` and the explanation propagates the underlying failure message.


## Risk & Scope

- Scope is limited to the `nifi-kafka-to-s3-connector` module; no public API surfaces outside this module are touched.
- The behavioral change is restricted to which `ConnectorConfigurationContext` `verifyTopicsExists(...)` reads `Topic Names` from. Outcome values, step name, and explanation strings on the success and failure paths are unchanged.
- The visibility relaxations (`private` → package-private) are confined to two internal helpers used only within the connector package; no new constructors, fields, or types are exposed.
