### PR TITLE
NIFI-15956 - Bump Protobuf to 4.35.0, Iceberg to 1.11.0, JUnit to 6.1.0, and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -122,7 +122,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>4.34.1</version>
+                <version>4.35.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-commons/nifi-calcite-utils/pom.xml
+++ b/nifi-commons/nifi-calcite-utils/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>4.34.1</version>
+            <version>4.35.0</version>
         </dependency>
     </dependencies>
 

--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <guava.version>33.6.0-jre</guava.version>
-        <protobuf.version>4.34.1</protobuf.version>
+        <protobuf.version>4.35.0</protobuf.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.81.0</google.libraries.version>
+        <google.libraries.version>26.83.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>nifi-graph-test-clients</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <janusgraph.version>1.2.0-20260424-225650.346f5a4</janusgraph.version>
+        <janusgraph.version>1.2.0-20260518-231441.3ed2758</janusgraph.version>
         <guava.version>33.6.0-jre</guava.version>
         <amqp-client.version>5.30.0</amqp-client.version>
     </properties>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-parquet-writer/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-parquet-writer/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
-            <version>7.1.1</version>
+            <version>7.2.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>org.apache.iceberg</groupId>
                 <artifactId>iceberg-bom</artifactId>
-                <version>1.10.1</version>
+                <version>1.11.0</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
@@ -32,7 +32,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
-                <version>4.34.1</version>
+                <version>4.35.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>nifi-protobuf-services</artifactId>
 
     <properties>
-        <protobuf.version>4.34.1</protobuf.version>
+        <protobuf.version>4.35.0</protobuf.version>
         <wire.version>6.4.0</wire.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.slack.api</groupId>
             <artifactId>bolt-socket-mode</artifactId>
-            <version>1.48.1</version>
+            <version>1.49.0</version>
         </dependency>
         <!-- Required by bolt-socket-mode but the library itself doesn't have the dependency. -->
         <dependency>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <guava.version>33.6.0-jre</guava.version>
-        <protobuf.version>4.34.1</protobuf.version>
+        <protobuf.version>4.35.0</protobuf.version>
         <grpc.version>1.81.0</grpc.version>
         <snowflake-jdbc-thin.version>4.2.0</snowflake-jdbc-thin.version>
     </properties>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>de.siegmar</groupId>
             <artifactId>fastcsv</artifactId>
-            <version>4.2.0</version>
+            <version>4.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.palindromicity</groupId>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.questdb</groupId>
             <artifactId>questdb</artifactId>
-            <version>9.4.0</version>
+            <version>9.3.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.questdb</groupId>
             <artifactId>questdb</artifactId>
-            <version>9.3.5</version>
+            <version>9.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.44.7</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.44.9</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.6</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -183,7 +183,7 @@
 
         <!-- Security -->
         <nimbus-jose-jwt.version>10.9</nimbus-jose-jwt.version>
-        <nimbus-oauth2-oidc.version>11.37.1</nimbus-oauth2-oidc.version>
+        <nimbus-oauth2-oidc.version>11.37.2</nimbus-oauth2-oidc.version>
         <org.bouncycastle.version>1.84</org.bouncycastle.version>
 
         <!-- Utilities -->
@@ -205,7 +205,7 @@
         <swagger.annotations.version>2.2.50</swagger.annotations.version>
 
         <!-- Testing and quality -->
-        <junit.version>6.0.3</junit.version>
+        <junit.version>6.1.0</junit.version>
         <mockito.version>5.23.0</mockito.version>
         <pmd.version>7.24.0</pmd.version>
         <checkstyle.version>13.4.2</checkstyle.version>
@@ -843,7 +843,7 @@
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>3.0.80</version>
+                    <version>3.0.81</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
# Summary

NIFI-15956 - Bump Protobuf to 4.35.0, Iceberg to 1.11.0, JUnit to 6.1.0, and others

- Protobuf from 4.34.1 to 4.35.0 - https://github.com/protocolbuffers/protobuf/releases/tag/v35.0
- GCP SDK BOM from 26.81.0 to 26.83.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.83.0
- JanusGraph from 1.2.0-20260424-225650.346f5a4 to 1.2.0-20260518-231441.3ed2758 - https://github.com/JanusGraph/janusgraph
- Woodstox from 7.1.1 to 7.2.0 - https://github.com/FasterXML/woodstox/releases/tag/woodstox-core-7.2.0
- Apache Iceberg from 1.10.1 to 1.11.0 - https://github.com/apache/iceberg/releases/tag/apache-iceberg-1.11.0
- Slack Bolt from 1.48.1 to 1.49.0 - https://github.com/slackapi/java-slack-sdk/releases/tag/v1.49.0
- FastCSV from 4.2.0 to 4.3.0 - https://github.com/osiegmar/FastCSV/releases/tag/v4.3.0
- ~~QuestDB from 9.3.5 to 9.4.0 - https://github.com/questdb/questdb/releases/tag/9.4.0~~
- AWS SDK BOM from 2.44.7 to 2.44.9 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Nimbus OAuth2 OIDC from 11.37.1 to 11.37.2 - https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/master/CHANGELOG.txt
- JUnit from 6.0.3 to 6.1.0 - https://docs.junit.org/6.1.0/release-notes.html
- Swagger Maven Plugin from 3.0.80 to 3.0.81 - https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.81

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
