### PR TITLE
NIFI-15653 Fix DeleteSFTP security check for dot directory path

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteSFTP.java
@@ -211,7 +211,8 @@ public class DeleteSFTP extends AbstractProcessor {
                         filename = context.getProperty(FILENAME).evaluateAttributeExpressions(flowFile).getValue();
                         final Path filePath = directoryPath.resolve(filename).normalize();
 
-                        if (!directoryPath.equals(filePath.getParent())) {
+                        final Path fileParent = filePath.getParent();
+                        if (!directoryPath.equals(fileParent == null ? Paths.get("") : fileParent)) {
                             final String errorMessage = "Attempting to delete file at path '%s' which is not a direct child of the directory '%s'"
                                     .formatted(filePath, directoryPath);
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDeleteSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDeleteSFTP.java
@@ -155,6 +155,18 @@ class TestDeleteSFTP {
     }
 
     @Test
+    void deletesFileWhenDirectoryPathIsDot() throws IOException {
+        final Path fileToDelete = Files.writeString(sshServerRootPath.resolve("test.txt"), "some text");
+        enqueue(".", fileToDelete.getFileName().toString());
+        assertExists(fileToDelete);
+
+        runner.run();
+
+        assertNotExists(fileToDelete);
+        runner.assertAllFlowFilesTransferred(DeleteSFTP.REL_SUCCESS, 1);
+    }
+
+    @Test
     void sendsFlowFileToFailureWhenFileIsNotADirectChildOfTheDirectory() throws IOException {
         final Path directoryPath = Files.createDirectories(sshServerRootPath.resolve("rel/path"));
         final String filename = "../sibling.txt";


### PR DESCRIPTION
### Summary

When the **Remote Path** property is configured as . (dot) — the default produced by **ListSFTP** — DeleteSFTP incorrectly routes every FlowFile to the failure relationship instead of deleting the file.

### Root Cause

`java
final Path directoryPath = Paths.get(directoryPathProperty).normalize(); // "." → ""
final Path filePath = directoryPath.resolve(filename).normalize();        // "" + "test.txt" → "test.txt"

if (!directoryPath.equals(filePath.getParent())) { // "".equals(null) → false ← bug
`

Paths.get(".").normalize() returns an empty Path (""). Resolving a filename against that path yields a single-component relative path whose getParent() returns 
ull. The check Paths.get("").equals(null) is always false, so the security guard fires incorrectly for every valid file.

### Fix

`java
final Path fileParent = filePath.getParent();
if (!directoryPath.equals(fileParent == null ? Paths.get("") : fileParent)) {
`

When fileParent is 
ull (single-component relative path), substitute Paths.get("") — the same empty-path value that directoryPath holds. Both represent the implicit current directory, so the check now passes correctly.

Path-traversal attempts (e.g. ../etc/passwd) still produce a non-empty parent that does not equal the empty directoryPath, so the security guard remains fully intact.

### Testing

Added TestDeleteSFTP.deletesFileWhenDirectoryPathIsDot() using the existing embedded SSH server to confirm that a file in the root of the SFTP server is successfully deleted when the directory property is set to .(dot).