### PR TITLE
NIFI-15957 - Do not resolve parameter references when displaying parameter contexts

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -1882,14 +1882,14 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
     }
 
     private void collectValueAndReferences(final ParameterContext parameterContext, final Map<String, ParameterValueAndReferences> valueAndRef) {
-        parameterContext.getEffectiveParameters()
+        parameterContext.getRawEffectiveParameters()
                 .forEach((pd, param) -> valueAndRef.put(pd.getName(), getValueAndReferences(param)));
     }
 
     protected Set<String> getUpdatedParameterNames(final ParameterContext parameterContext, final VersionedParameterContext proposed) {
         final Map<String, ParameterValueAndReferences> originalValues = new HashMap<>();
         collectValueAndReferences(parameterContext, originalValues);
-        parameterContext.getEffectiveParameters().forEach((pd, param) -> originalValues.put(pd.getName(), getValueAndReferences(param)));
+        parameterContext.getRawEffectiveParameters().forEach((pd, param) -> originalValues.put(pd.getName(), getValueAndReferences(param)));
 
         final Map<String, ParameterValueAndReferences> proposedValues = new HashMap<>();
         if (proposed != null) {
@@ -1899,7 +1899,7 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                     final ParameterContext inheritedContext = getParameterContextByName(name);
                     if (inheritedContext != null) {
                         collectValueAndReferences(inheritedContext, proposedValues);
-                        inheritedContext.getEffectiveParameters().forEach((pd, param) -> proposedValues.put(pd.getName(), getValueAndReferences(param)));
+                        inheritedContext.getRawEffectiveParameters().forEach((pd, param) -> proposedValues.put(pd.getName(), getValueAndReferences(param)));
                     }
                 }
             }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -1889,7 +1889,6 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
     protected Set<String> getUpdatedParameterNames(final ParameterContext parameterContext, final VersionedParameterContext proposed) {
         final Map<String, ParameterValueAndReferences> originalValues = new HashMap<>();
         collectValueAndReferences(parameterContext, originalValues);
-        parameterContext.getRawEffectiveParameters().forEach((pd, param) -> originalValues.put(pd.getName(), getValueAndReferences(param)));
 
         final Map<String, ParameterValueAndReferences> proposedValues = new HashMap<>();
         if (proposed != null) {
@@ -1899,7 +1898,6 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                     final ParameterContext inheritedContext = getParameterContextByName(name);
                     if (inheritedContext != null) {
                         collectValueAndReferences(inheritedContext, proposedValues);
-                        inheritedContext.getRawEffectiveParameters().forEach((pd, param) -> proposedValues.put(pd.getName(), getValueAndReferences(param)));
                     }
                 }
             }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContext.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContext.java
@@ -355,6 +355,11 @@ public class StandardParameterContext implements ParameterContext {
     }
 
     @Override
+    public Map<ParameterDescriptor, Parameter> getRawEffectiveParameters() {
+        return getMergedEffectiveParametersReadLocked();
+    }
+
+    @Override
     public Map<String, Parameter> getEffectiveParameterUpdates(final Map<String, Parameter> parameterUpdates, final List<ParameterContext> inheritedParameterContexts) {
         Objects.requireNonNull(parameterUpdates, "Parameter Updates must be specified");
         Objects.requireNonNull(inheritedParameterContexts, "Inherited parameter contexts must be specified");

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/parameter/TestStandardParameterContext.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/parameter/TestStandardParameterContext.java
@@ -963,6 +963,50 @@ public class TestStandardParameterContext {
     }
 
     @Test
+    public void testGetRawEffectiveParametersPreservesAliasValue() {
+        final StandardParameterContextManager parameterContextLookup = new StandardParameterContextManager();
+
+        final ParameterContext s = createParameterContext("s", parameterContextLookup);
+        addProvidedParameter(s, "db_host", "myserver.example.com");
+        addProvidedParameter(s, "db_port", "3306");
+
+        final ParameterContext p = createParameterContext("p", parameterContextLookup);
+        addParameter(p, "host", "#{db_host}");
+        addParameter(p, "port", "#{db_port}");
+        addParameter(p, "plain", "literal_value");
+
+        p.setInheritedParameterContexts(List.of(s));
+
+        final Map<ParameterDescriptor, Parameter> raw = p.getRawEffectiveParameters();
+        assertEquals("#{db_host}", raw.get(new ParameterDescriptor.Builder().name("host").build()).getValue());
+        assertEquals("#{db_port}", raw.get(new ParameterDescriptor.Builder().name("port").build()).getValue());
+        assertEquals("literal_value", raw.get(new ParameterDescriptor.Builder().name("plain").build()).getValue());
+
+        assertEquals("myserver.example.com", raw.get(new ParameterDescriptor.Builder().name("db_host").build()).getValue());
+        assertEquals("3306", raw.get(new ParameterDescriptor.Builder().name("db_port").build()).getValue());
+
+        final Map<ParameterDescriptor, Parameter> effective = p.getEffectiveParameters();
+        assertEquals("myserver.example.com", effective.get(new ParameterDescriptor.Builder().name("host").build()).getValue());
+        assertEquals("3306", effective.get(new ParameterDescriptor.Builder().name("port").build()).getValue());
+    }
+
+    @Test
+    public void testGetRawEffectiveParametersWithNoInheritance() {
+        final StandardParameterContextManager parameterContextLookup = new StandardParameterContextManager();
+
+        final ParameterContext p = createParameterContext("p", parameterContextLookup);
+        addParameter(p, "a", "#{b}");
+        addParameter(p, "b", "concrete");
+
+        final Map<ParameterDescriptor, Parameter> raw = p.getRawEffectiveParameters();
+        assertEquals("#{b}", raw.get(new ParameterDescriptor.Builder().name("a").build()).getValue());
+        assertEquals("concrete", raw.get(new ParameterDescriptor.Builder().name("b").build()).getValue());
+
+        final Map<ParameterDescriptor, Parameter> effective = p.getEffectiveParameters();
+        assertEquals("concrete", effective.get(new ParameterDescriptor.Builder().name("a").build()).getValue());
+    }
+
+    @Test
     public void testParameterValueReferenceResolvesQuotedName() {
         final StandardParameterContextManager parameterContextLookup = new StandardParameterContextManager();
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/parameter/ParameterContext.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/parameter/ParameterContext.java
@@ -100,6 +100,20 @@ public interface ParameterContext extends ParameterLookup, ComponentAuthorizable
     Map<ParameterDescriptor, Parameter> getEffectiveParameters();
 
     /**
+     * Returns the merged effective parameter map -- identical in shape to {@link #getEffectiveParameters()} --
+     * but WITHOUT resolving one-to-one parameter value references. Local aliases retain their literal
+     * <code>#{otherName}</code> values. Use this method for display, persistence comparison, or any other
+     * read-side use where the raw, user-authored value matters. Use {@link #getEffectiveParameters()}
+     * when components require fully-resolved values for runtime substitution.
+     *
+     * @return a Map that contains all Parameters in the context and all nested ParameterContexts, keyed by their
+     *         descriptors, without parameter value reference resolution applied
+     */
+    default Map<ParameterDescriptor, Parameter> getRawEffectiveParameters() {
+        return getEffectiveParameters();
+    }
+
+    /**
      * Returns a map from parameter name to Parameter, representing all parameters that would be effectively
      * updated if the provided configuration was applied.  Only parameters that would be effectively updated or added are
      * included in the map.  A null value for a Parameter represents an effective deletion of that parameter name.

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -1522,7 +1522,7 @@ public final class DtoFactory {
         dto.setBoundProcessGroups(boundGroups);
 
         final Set<ParameterEntity> parameterEntities = new LinkedHashSet<>();
-        final Map<ParameterDescriptor, Parameter> parameters = includeInheritedParameters ? parameterContext.getEffectiveParameters()
+        final Map<ParameterDescriptor, Parameter> parameters = includeInheritedParameters ? parameterContext.getRawEffectiveParameters()
                 : parameterContext.getParameters();
         for (final Parameter parameter : parameters.values()) {
             parameterEntities.add(createParameterEntity(parameterContext, parameter, revisionManager, parameterContextLookup));

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/parameters/ParameterContextIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/parameters/ParameterContextIT.java
@@ -1406,6 +1406,42 @@ public class ParameterContextIT extends NiFiSystemIT {
         }
     }
 
+    @Test
+    public void testParameterAliasDisplayedAsRawValue() throws NiFiClientException, IOException {
+        final Set<ParameterEntity> sParams = new HashSet<>();
+        sParams.add(createParameterEntity("db_host", null, false, "myserver.example.com"));
+        final ParameterContextEntity sContextEntity = createParameterContextEntity("S_RawDisplay", "Inherited context",
+                sParams, Collections.emptyList(), null, null);
+        final ParameterContextEntity createdS = getNifiClient().getParamContextClient().createParamContext(sContextEntity);
+
+        final Set<ParameterEntity> pParams = new HashSet<>();
+        pParams.add(createParameterEntity("host", null, false, "#{db_host}"));
+        final ParameterContextEntity pContextEntity = createParameterContextEntity("P_RawDisplay", "Parent context with alias",
+                pParams, Collections.singletonList(createdS), null, null);
+        final ParameterContextEntity createdP = getNifiClient().getParamContextClient().createParamContext(pContextEntity);
+
+        final ParameterContextEntity fetched = getNifiClient().getParamContextClient().getParamContext(createdP.getId(), true);
+        final Set<ParameterEntity> parameters = fetched.getComponent().getParameters();
+
+        final ParameterDTO hostDto = parameters.stream()
+                .map(ParameterEntity::getParameter)
+                .filter(p -> "host".equals(p.getName()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(hostDto);
+        assertFalse(hostDto.getInherited() != null && hostDto.getInherited());
+        assertEquals("#{db_host}", hostDto.getValue());
+
+        final ParameterDTO dbHostDto = parameters.stream()
+                .map(ParameterEntity::getParameter)
+                .filter(p -> "db_host".equals(p.getName()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(dbHostDto);
+        assertTrue(dbHostDto.getInherited());
+        assertEquals("myserver.example.com", dbHostDto.getValue());
+    }
+
     protected void assertAsset(final AssetEntity asset, final String expectedName) {
         assertNotNull(asset);
         assertNotNull(asset.getAsset());


### PR DESCRIPTION
# Summary

NIFI-15957 - Do not resolve parameter references when displaying parameter contexts

Following changes done in [NIFI-15829](https://issues.apache.org/jira/browse/NIFI-15829) we can now have parameters referencing inherited parameters. However, when showing the parameter contexts in the UI the parameters that are referencing parameters are now showing the resolved value instead of the raw reference. While this is not an issue, it can be confusing and we should display the raw reference.

Example:

```
MyInheritedParameter => MyInheritedValue
MyParameter => #{MyInheritedParameter}
```

Showing the parameter context in the UI, it would show:

```
MyParameter => MyInheritedValue
```

(even though the flow definition does have the reference)

We want to always show:

```
MyParameter => #{MyInheritedParameter}
```

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
