### PR TITLE
NIFI-15967 Adjust Proxy Header Validation for Replicated Requests

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ReplicationHeaderUtils.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ReplicationHeaderUtils.java
@@ -18,6 +18,7 @@ package org.apache.nifi.cluster.coordination.http.replication;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.authorization.user.NiFiUser;
+import org.apache.nifi.cluster.coordination.http.ReplicationHeader;
 import org.apache.nifi.web.security.ProxiedEntitiesUtils;
 import org.apache.nifi.web.security.http.SecurityCookieName;
 import org.apache.nifi.web.security.http.SecurityHeader;
@@ -96,11 +97,14 @@ public final class ReplicationHeaderUtils {
     }
 
     /**
-     * Removes all {@link RequestReplicationHeader} names from the map (case-insensitive) so
+     * Removes all request replication header names from the map (case-insensitive) so
      * that inbound client requests cannot spoof replication protocol headers.
      */
     public static void stripRequestReplicationHeaders(final Map<String, String> headers) {
         for (final RequestReplicationHeader rh : RequestReplicationHeader.values()) {
+            removeHeader(headers, rh.getHeader());
+        }
+        for (final ReplicationHeader rh : ReplicationHeader.values()) {
             removeHeader(headers, rh.getHeader());
         }
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/RequestReplicationHeader.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/RequestReplicationHeader.java
@@ -45,16 +45,6 @@ public enum RequestReplicationHeader {
     REPLICATION_TARGET_ID("replication-target-id"),
 
     /**
-     * When we replicate a request across the cluster, we replicate it only from the cluster coordinator.
-     * If the request needs to be replicated by another node, it first replicates the request to the coordinator,
-     * which then replicates the request on the node's behalf. This header name and value are used to denote
-     * that the request has already been to the cluster coordinator, and the cluster coordinator is the one replicating
-     * the request. This allows us to know that the request should be serviced, rather than proxied back to the
-     * cluster coordinator.
-     */
-    REQUEST_REPLICATED("request-replicated"),
-
-    /**
      * Transaction Identifier for replicated requests
      */
     REQUEST_TRANSACTION_ID("request-transaction-id"),

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/StandardUploadRequestReplicator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/StandardUploadRequestReplicator.java
@@ -20,6 +20,7 @@ package org.apache.nifi.cluster.coordination.http.replication;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.apache.nifi.cluster.coordination.ClusterCoordinator;
+import org.apache.nifi.cluster.coordination.http.ReplicationHeader;
 import org.apache.nifi.cluster.protocol.NodeIdentifier;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.util.file.FileUtils;
@@ -191,7 +192,7 @@ public class StandardUploadRequestReplicator implements UploadRequestReplicator 
         ReplicationHeaderUtils.applyUserProxyAndStripCredentials(headers, uploadRequest.getUser());
 
         headers.put(RequestReplicationHeader.EXECUTION_CONTINUE.getHeader(), Boolean.TRUE.toString());
-        headers.put(RequestReplicationHeader.REQUEST_REPLICATED.getHeader(), Boolean.TRUE.toString());
+        headers.put(ReplicationHeader.REQUEST_REPLICATED.getHeader(), Boolean.TRUE.toString());
 
         return headers;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ThreadPoolRequestReplicator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ThreadPoolRequestReplicator.java
@@ -25,6 +25,7 @@ import org.apache.nifi.authorization.user.NiFiUser;
 import org.apache.nifi.authorization.user.NiFiUserUtils;
 import org.apache.nifi.cluster.coordination.ClusterCoordinator;
 import org.apache.nifi.cluster.coordination.http.HttpResponseMapper;
+import org.apache.nifi.cluster.coordination.http.ReplicationHeader;
 import org.apache.nifi.cluster.coordination.http.StandardHttpResponseMapper;
 import org.apache.nifi.cluster.coordination.http.endpoints.ConnectionEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.ConnectorEndpointMerger;
@@ -257,7 +258,7 @@ public class ThreadPoolRequestReplicator implements RequestReplicator, Closeable
 
         updatedHeaders.put(RequestReplicationHeader.CLUSTER_ID_GENERATION_SEED.getHeader(), ComponentIdGenerator.generateId().toString());
         if (indicateReplicated) {
-            updatedHeaders.put(RequestReplicationHeader.REQUEST_REPLICATED.getHeader(), Boolean.TRUE.toString());
+            updatedHeaders.put(ReplicationHeader.REQUEST_REPLICATED.getHeader(), Boolean.TRUE.toString());
         }
 
         // include the proxied entities header and strip untrusted headers

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestStandardUploadRequestReplicatorHeaders.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestStandardUploadRequestReplicatorHeaders.java
@@ -18,6 +18,7 @@ package org.apache.nifi.cluster.coordination.http.replication;
 
 import org.apache.nifi.authorization.user.StandardNiFiUser;
 import org.apache.nifi.cluster.coordination.ClusterCoordinator;
+import org.apache.nifi.cluster.coordination.http.ReplicationHeader;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.web.client.api.WebClientService;
 import org.apache.nifi.web.security.ProxiedEntitiesUtils;
@@ -111,14 +112,14 @@ class TestStandardUploadRequestReplicatorHeaders {
     @Test
     void testReplicationHeadersFromForwardedInputAreStripped() {
         final Map<String, String> forwarded = new HashMap<>();
-        forwarded.put(RequestReplicationHeader.REQUEST_REPLICATED.getHeader(), SPOOFED_VALUE);
+        forwarded.put(ReplicationHeader.REQUEST_REPLICATED.getHeader(), SPOOFED_VALUE);
         forwarded.put(RequestReplicationHeader.EXECUTION_CONTINUE.getHeader(), SPOOFED_VALUE);
         forwarded.put(RequestReplicationHeader.REQUEST_TRANSACTION_ID.getHeader(), SPOOFED_TX_VALUE);
 
         final UploadRequest<String> request = buildUploadRequest(forwarded);
         final Map<String, String> result = replicator.buildOutboundHeaders(request);
 
-        assertEquals(Boolean.TRUE.toString(), result.get(RequestReplicationHeader.REQUEST_REPLICATED.getHeader()));
+        assertEquals(Boolean.TRUE.toString(), result.get(ReplicationHeader.REQUEST_REPLICATED.getHeader()));
         assertEquals(Boolean.TRUE.toString(), result.get(RequestReplicationHeader.EXECUTION_CONTINUE.getHeader()));
         assertNull(result.get(RequestReplicationHeader.REQUEST_TRANSACTION_ID.getHeader()));
     }
@@ -198,7 +199,7 @@ class TestStandardUploadRequestReplicatorHeaders {
         final UploadRequest<String> request = buildUploadRequest(new HashMap<>());
         final Map<String, String> result = replicator.buildOutboundHeaders(request);
 
-        assertEquals(Boolean.TRUE.toString(), result.get(RequestReplicationHeader.REQUEST_REPLICATED.getHeader()));
+        assertEquals(Boolean.TRUE.toString(), result.get(ReplicationHeader.REQUEST_REPLICATED.getHeader()));
         assertEquals(Boolean.TRUE.toString(), result.get(RequestReplicationHeader.EXECUTION_CONTINUE.getHeader()));
     }
 
@@ -218,7 +219,7 @@ class TestStandardUploadRequestReplicatorHeaders {
         final Map<String, String> result = replicator.buildOutboundHeaders(request);
 
         assertEquals(TEST_FILENAME, result.get(FILENAME_HEADER));
-        assertEquals(Boolean.TRUE.toString(), result.get(RequestReplicationHeader.REQUEST_REPLICATED.getHeader()));
+        assertEquals(Boolean.TRUE.toString(), result.get(ReplicationHeader.REQUEST_REPLICATED.getHeader()));
         assertNotNull(result.get(ProxiedEntitiesUtils.PROXY_ENTITIES_CHAIN));
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/cluster/coordination/http/ReplicationHeader.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/cluster/coordination/http/ReplicationHeader.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cluster.coordination.http;
+
+/**
+ * Enumeration of HTTP headers for Cluster Request Replication with lowercasing for compatibility with HTTP/2
+ */
+public enum ReplicationHeader {
+    /** Boolean indicator that the Cluster Coordinator is initiating the replicated request to other nodes */
+    REQUEST_REPLICATED("request-replicated");
+
+    private final String header;
+
+    ReplicationHeader(final String header) {
+        this.header = header;
+    }
+
+    public String getHeader() {
+        return header;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/ProxyHeaderValidatorCustomizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/ProxyHeaderValidatorCustomizer.java
@@ -21,9 +21,13 @@ import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.server.ConnectionMetaData;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
 
+import java.security.cert.X509Certificate;
 import java.util.Objects;
 import java.util.Set;
 
@@ -32,6 +36,8 @@ import java.util.Set;
  */
 public class ProxyHeaderValidatorCustomizer implements HttpConfiguration.Customizer {
     private static final String MISDIRECTED_REQUEST_REASON = "Invalid Proxy Host Requested";
+
+    private static final String REQUEST_REPLICATED_HEADER = "request-replicated";
 
     private static final Set<String> SUPPORTED_PROXY_HOST_HEADERS = Set.of(
             ProxyHeader.PROXY_HOST.getHeader(),
@@ -65,6 +71,24 @@ public class ProxyHeaderValidatorCustomizer implements HttpConfiguration.Customi
     }
 
     private Request customizeSecureRequest(final Request request) {
+        final X509Certificate peerCertificate = findPeerCertificate(request);
+
+        // Requests not authenticated with Client Certificates require header validation
+        if (peerCertificate == null) {
+            processProxyHostHeaders(request);
+        } else {
+            // Requests authenticated with Client Certificates but not indicated as replicated require header validation
+            final HttpFields requestHeaders = request.getHeaders();
+            final String requestReplicated = requestHeaders.get(REQUEST_REPLICATED_HEADER);
+            if (requestReplicated == null) {
+                processProxyHostHeaders(request);
+            }
+        }
+
+        return request;
+    }
+
+    private void processProxyHostHeaders(final Request request) {
         final HttpURI requestUri = request.getHttpURI();
         final String requestHost = requestUri.getHost();
 
@@ -85,7 +109,24 @@ public class ProxyHeaderValidatorCustomizer implements HttpConfiguration.Customi
 
             throw new HttpException.RuntimeException(HttpStatus.MISDIRECTED_REQUEST_421, MISDIRECTED_REQUEST_REASON);
         }
+    }
 
-        return request;
+    private X509Certificate findPeerCertificate(final Request request) {
+        final X509Certificate peerCertificate;
+        final ConnectionMetaData connectionMetaData = request.getConnectionMetaData();
+        final Connection connection = connectionMetaData.getConnection();
+        final EndPoint endPoint = connection.getEndPoint();
+        final EndPoint.SslSessionData sslSessionData = endPoint.getSslSessionData();
+        if (sslSessionData == null) {
+            peerCertificate = null;
+        } else {
+            final X509Certificate[] peerCertificates = sslSessionData.peerCertificates();
+            if (peerCertificates == null || peerCertificates.length == 0) {
+                peerCertificate = null;
+            } else {
+                peerCertificate = peerCertificates[0];
+            }
+        }
+        return peerCertificate;
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/ProxyHeaderValidatorCustomizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/ProxyHeaderValidatorCustomizer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.web.server.connector;
 
+import org.apache.nifi.cluster.coordination.http.ReplicationHeader;
 import org.apache.nifi.web.servlet.shared.ProxyHeader;
 import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpFields;
@@ -36,8 +37,6 @@ import java.util.Set;
  */
 public class ProxyHeaderValidatorCustomizer implements HttpConfiguration.Customizer {
     private static final String MISDIRECTED_REQUEST_REASON = "Invalid Proxy Host Requested";
-
-    private static final String REQUEST_REPLICATED_HEADER = "request-replicated";
 
     private static final Set<String> SUPPORTED_PROXY_HOST_HEADERS = Set.of(
             ProxyHeader.PROXY_HOST.getHeader(),
@@ -79,7 +78,7 @@ public class ProxyHeaderValidatorCustomizer implements HttpConfiguration.Customi
         } else {
             // Requests authenticated with Client Certificates but not indicated as replicated require header validation
             final HttpFields requestHeaders = request.getHeaders();
-            final String requestReplicated = requestHeaders.get(REQUEST_REPLICATED_HEADER);
+            final String requestReplicated = requestHeaders.get(ReplicationHeader.REQUEST_REPLICATED.getHeader());
             if (requestReplicated == null) {
                 processProxyHostHeaders(request);
             }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
@@ -82,6 +82,8 @@ class StandardServerProviderTest {
 
     private static final String HOST_HEADER = "Host";
 
+    private static final String REQUEST_REPLICATED_HEADER = "request-replicated";
+
     private static final String PUBLIC_HOST = "nifi.apache.org";
 
     private static final String PUBLIC_STAGED_HOST = "nifi.staged.apache.org";
@@ -106,6 +108,8 @@ class StandardServerProviderTest {
 
     private static SSLContext sslContext;
 
+    private static SSLContext sslContextWithoutClientCertificates;
+
     @BeforeAll
     static void setConfiguration() throws Exception {
         final KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
@@ -118,6 +122,10 @@ class StandardServerProviderTest {
                 .keyStore(keyStore)
                 .trustStore(keyStore)
                 .keyPassword(PROTECTION_PARAMETER)
+                .build();
+
+        sslContextWithoutClientCertificates = new StandardSslContextBuilder()
+                .trustStore(keyStore)
                 .build();
 
         // Allow Restricted Headers for testing TLS SNI
@@ -190,20 +198,64 @@ class StandardServerProviderTest {
         assertHttpsConnectorFound(server);
 
         try {
-            server.start();
-
-            assertFalse(server.isFailed());
-
-            while (server.isStarting()) {
-                TimeUnit.MILLISECONDS.sleep(250);
-            }
-
-            assertTrue(server.isStarted());
-
+            startServer(server);
             final URI uri = server.getURI();
             assertHttpsRequestsCompleted(uri);
         } finally {
             server.stop();
+        }
+    }
+
+    @Timeout(15)
+    @Test
+    void testGetServerHttpsWithoutClientCertificates() throws Exception {
+        final Properties applicationProperties = new Properties();
+        applicationProperties.setProperty(NiFiProperties.WEB_HTTPS_PORT, RANDOM_PORT);
+        // Set placeholder property to disable requiring Client Certificates
+        applicationProperties.setProperty(NiFiProperties.SECURITY_USER_LOGIN_IDENTITY_PROVIDER, Boolean.TRUE.toString());
+        final NiFiProperties properties = NiFiProperties.createBasicNiFiProperties((String) null, applicationProperties);
+
+        final StandardServerProvider provider = new StandardServerProvider(sslContext);
+
+        final Server server = provider.getServer(properties);
+
+        assertStandardConfigurationFound(server);
+        assertHttpsConnectorFound(server);
+
+        try {
+            startServer(server);
+            final URI uri = server.getURI();
+            assertHttpsRequestsWithoutClientCertificates(uri);
+        } finally {
+            server.stop();
+        }
+    }
+
+    private void startServer(final Server server) throws Exception {
+        server.start();
+
+        assertFalse(server.isFailed());
+
+        while (server.isStarting()) {
+            TimeUnit.MILLISECONDS.sleep(250);
+        }
+
+        assertTrue(server.isStarted());
+    }
+
+    void assertHttpsRequestsWithoutClientCertificates(final URI serverUri) throws IOException, InterruptedException {
+        try (HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(TIMEOUT)
+                .sslContext(sslContextWithoutClientCertificates)
+                .build()
+        ) {
+            final URI localhostUri = UriComponentsBuilder.fromUri(serverUri).host(LOCALHOST_NAME).build().toUri();
+
+            assertFrontendRedirectRequestsCompleted(httpClient, localhostUri);
+            assertBadRequestsCompleted(httpClient, localhostUri);
+            assertMisdirectedRequestsCompleted(httpClient, localhostUri);
+
+            assertReplicatedRequestCompleted(httpClient, localhostUri, HttpStatus.MISDIRECTED_REQUEST_421);
         }
     }
 
@@ -219,7 +271,18 @@ class StandardServerProviderTest {
             assertRedirectRequestsCompleted(httpClient, localhostUri);
             assertBadRequestsCompleted(httpClient, localhostUri);
             assertMisdirectedRequestsCompleted(httpClient, localhostUri);
+
+            assertReplicatedRequestCompleted(httpClient, localhostUri, HttpStatus.MOVED_TEMPORARILY_302);
         }
+    }
+
+    void assertReplicatedRequestCompleted(final HttpClient httpClient, final URI localhostUri, final int statusCodeExpected) throws IOException, InterruptedException {
+        final HttpRequest proxyHostRequestReplicatedRequest = HttpRequest.newBuilder(localhostUri)
+                .version(HttpClient.Version.HTTP_1_1)
+                .header(ProxyHeader.PROXY_HOST.getHeader(), PUBLIC_UNKNOWN_HOST)
+                .header(REQUEST_REPLICATED_HEADER, Boolean.TRUE.toString())
+                .build();
+        assertResponseStatusCode(httpClient, proxyHostRequestReplicatedRequest, statusCodeExpected);
     }
 
     void assertFrontendRedirectRequestsCompleted(final HttpClient httpClient, final URI localhostUri) throws IOException, InterruptedException {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.web.server;
 
+import org.apache.nifi.cluster.coordination.http.ReplicationHeader;
 import org.apache.nifi.jetty.configuration.connector.ApplicationLayerProtocol;
 import org.apache.nifi.security.cert.builder.StandardCertificateBuilder;
 import org.apache.nifi.security.ssl.EphemeralKeyStoreBuilder;
@@ -81,8 +82,6 @@ class StandardServerProviderTest {
     private static final String LOCALHOST_HTTP_PORT = "localhost:80";
 
     private static final String HOST_HEADER = "Host";
-
-    private static final String REQUEST_REPLICATED_HEADER = "request-replicated";
 
     private static final String PUBLIC_HOST = "nifi.apache.org";
 
@@ -280,7 +279,7 @@ class StandardServerProviderTest {
         final HttpRequest proxyHostRequestReplicatedRequest = HttpRequest.newBuilder(localhostUri)
                 .version(HttpClient.Version.HTTP_1_1)
                 .header(ProxyHeader.PROXY_HOST.getHeader(), PUBLIC_UNKNOWN_HOST)
-                .header(REQUEST_REPLICATED_HEADER, Boolean.TRUE.toString())
+                .header(ReplicationHeader.REQUEST_REPLICATED.getHeader(), Boolean.TRUE.toString())
                 .build();
         assertResponseStatusCode(httpClient, proxyHostRequestReplicatedRequest, statusCodeExpected);
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
@@ -42,6 +42,7 @@ import org.apache.nifi.authorization.resource.Authorizable;
 import org.apache.nifi.authorization.user.NiFiUser;
 import org.apache.nifi.authorization.user.NiFiUserUtils;
 import org.apache.nifi.cluster.coordination.ClusterCoordinator;
+import org.apache.nifi.cluster.coordination.http.ReplicationHeader;
 import org.apache.nifi.cluster.coordination.http.replication.RequestReplicationHeader;
 import org.apache.nifi.cluster.coordination.http.replication.RequestReplicator;
 import org.apache.nifi.cluster.coordination.node.NodeConnectionState;
@@ -388,7 +389,7 @@ public abstract class ApplicationResource {
 
         // Check if the replicated header is set. If so, the request has already been replicated,
         // so we need to service the request locally. If not, then replicate the request to the entire cluster.
-        final String header = httpServletRequest.getHeader(RequestReplicationHeader.REQUEST_REPLICATED.getHeader());
+        final String header = httpServletRequest.getHeader(ReplicationHeader.REQUEST_REPLICATED.getHeader());
         return header == null;
     }
 


### PR DESCRIPTION
# Summary

[NIFI-15967](https://issues.apache.org/jira/browse/NIFI-15967) Adjusts the implementation of proxy header validation to support authenticated and replicated requests between NiFi cluster nodes.

Proxy host header validation applies only when the application is enabled for HTTPS, so the implementation checks for the presence of X509 Peer Certificates in the TLS Session. This occurs after a successful TLS handshake, and the presence of the client certificates in the TLS Session indicates that mutual TLS authentication completed as expected. To differentiate requests, the implementation looks for the presence of the custom `request-replicated` header, which the application sets when constructing forwarded requests. Without both of these qualifiers, standard proxy host header validation occurs, checking the values configured in the `nifi.web.proxy.host` property, as implemented in [NIFI-15953](https://issues.apache.org/jira/browse/NIFI-15953). 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
