### PR TITLE
NIFI-15969 Fixed PutS3Object multipart upload data corruption for concurrent FlowFiles with same S3 key

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -394,6 +394,10 @@ public class PutS3Object extends AbstractS3Processor {
         return new File(this.tempDirMultipart + File.separator + getIdentifier());
     }
 
+    protected String buildCacheKey(final String bucket, final String key, final String uuid) {
+        return getIdentifier() + "/" + bucket + "/" + key + "/" + uuid;
+    }
+
     protected boolean localUploadExistsInS3(final S3Client client, final String bucket, final MultipartState localState) {
         final ListMultipartUploadsRequest listRequest = ListMultipartUploadsRequest.builder()
                 .bucket(bucket)
@@ -546,7 +550,7 @@ public class PutS3Object extends AbstractS3Processor {
 
         final String bucket = context.getProperty(BUCKET_WITH_DEFAULT_VALUE).evaluateAttributeExpressions(flowFile).getValue();
         final String key = context.getProperty(KEY).evaluateAttributeExpressions(flowFile).getValue();
-        final String cacheKey = getIdentifier() + "/" + bucket + "/" + key;
+        final String cacheKey = buildCacheKey(bucket, key, flowFile.getAttribute(CoreAttributes.UUID.key()));
 
         final Map<String, String> attributes = new HashMap<>();
         final String ffFilename = flowFile.getAttributes().get(CoreAttributes.FILENAME.key());

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
@@ -51,11 +51,13 @@ import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.nifi.processors.transfer.ResourceTransferProperties.FILE_RESOURCE_SERVICE;
 import static org.apache.nifi.processors.transfer.ResourceTransferProperties.RESOURCE_TRANSFER_SOURCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -291,4 +293,22 @@ public class TestPutS3Object {
 
         expectedRenamed.forEach((key, value) -> assertEquals(value, propertyMigrationResult.getPropertiesRenamed().get(key)));
     }
+
+    @Test
+    void testBuildCacheKeyIncludesFlowFileUUID() {
+        final String bucket = "test-bucket";
+        final String key = "data/file.csv";
+        final String uuid1 = UUID.randomUUID().toString();
+        final String uuid2 = UUID.randomUUID().toString();
+
+        final String cacheKey1 = putS3Object.buildCacheKey(bucket, key, uuid1);
+        final String cacheKey2 = putS3Object.buildCacheKey(bucket, key, uuid2);
+        final String cacheKey1Retry = putS3Object.buildCacheKey(bucket, key, uuid1);
+
+        assertNotEquals(cacheKey1, cacheKey2,
+                "FlowFiles with different UUIDs sharing the same bucket and key must use distinct cache keys to prevent multipart state collision");
+        assertEquals(cacheKey1, cacheKey1Retry,
+                "Same FlowFile UUID must produce the same cache key so interrupted uploads can be resumed");
+    }
+
 }


### PR DESCRIPTION
NIFI-15969 Fixed PutS3Object multipart upload data corruption for concurrent FlowFiles with same S3 key.

Previously the multipart upload state was tracked using only the processor identifier, bucket name, and object key. When two FlowFiles with the same name were uploaded concurrently to the same bucket, they shared the same state tracking key, causing parts from different uploads to be interleaved and resulting in a corrupt S3 object.

**Fix:**

Included the FlowFile UUID in the state tracking key so each FlowFile maintains its own independent multipart upload state. Retries of the same FlowFile retain the same UUID and continue to benefit from state resumption. A FlowFile with a new UUID starts a fresh upload rather than inheriting stale state.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15969](https://issues.apache.org/jira/browse/NIFI-15969)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
