### PR TITLE
NIFI-15972 - Bump Netty to 4.2.14.Final, Azure to 1.3.7, Kafka to 4.3.0

### DIFF
--- a/nifi-extension-bom/pom.xml
+++ b/nifi-extension-bom/pom.xml
@@ -189,19 +189,19 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.10</version>
+                <version>9.10.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-commons</artifactId>
-                <version>9.10</version>
+                <version>9.10.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-tree</artifactId>
-                <version>9.10</version>
+                <version>9.10.1</version>
                 <scope>provided</scope>
             </dependency>
             <!-- Jetty EE11 Apache JSP and deps -->

--- a/nifi-extension-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.box</groupId>
                 <artifactId>box-java-sdk</artifactId>
-                <version>5.10.0</version>
+                <version>5.11.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-standard-services/pom.xml
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-standard-services/pom.xml
@@ -27,7 +27,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <couchbase.version>3.11.2</couchbase.version>
+        <couchbase.version>3.11.3</couchbase.version>
     </properties>
 
     <dependencies>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>4.0.6</spring.boot.version>
-        <flyway.version>12.6.1</flyway.version>
+        <flyway.version>12.6.2</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.6.0.202603022253-r</jgit.version>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <jline.version>4.1.0</jline.version>
+        <jline.version>4.1.2</jline.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -122,9 +122,9 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.44.9</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.44.12</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
-        <azure.sdk.bom.version>1.3.6</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
+        <azure.sdk.bom.version>1.3.7</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
         <!-- Apache Commons -->
         <org.apache.commons.cli.version>1.11.0</org.apache.commons.cli.version>
@@ -150,9 +150,9 @@
         <hsqldb.version>2.7.4</hsqldb.version>
 
         <!-- Data formats and serialization -->
-        <kafka-clients.version>4.2.0</kafka-clients.version>
+        <kafka-clients.version>4.3.0</kafka-clients.version>
         <avro.version>1.12.1</avro.version>
-        <com.github.luben.zstd-jni.version>1.5.7-8</com.github.luben.zstd-jni.version>
+        <com.github.luben.zstd-jni.version>1.5.7-9</com.github.luben.zstd-jni.version>
         <com.jayway.jsonpath.version>3.0.0</com.jayway.jsonpath.version>
         <gson.version>2.14.0</gson.version>
         <jackson.annotations.version>2.21</jackson.annotations.version>
@@ -174,7 +174,7 @@
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
 
         <!-- Networking and transport -->
-        <netty.4.version>4.2.13.Final</netty.4.version>
+        <netty.4.version>4.2.14.Final</netty.4.version>
         <okhttp.version>5.3.2</okhttp.version>
         <okio.version>3.17.0</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>


### PR DESCRIPTION
# Summary

NIFI-15972 - Bump Netty to 4.2.14.Final, Azure to 1.3.7, Kafka to 4.3.0

- ASM from 9.10 to 9.10.1 - https://asm.ow2.io/versions.html
- Box Java SDK from 5.10.0 to 5.11.0 - https://github.com/box/box-java-sdk/releases/tag/v5.11.0
- Couchbase from 3.11.2 to 3.11.3 - https://github.com/couchbase/couchbase-jvm-clients/releases/tag/3.11.3
- FlywayDB from 12.6.1 to 12.6.2 - https://github.com/flyway/flyway/releases/tag/flyway-12.6.2
- JLine from 4.1.0 to 4.1.2 - https://github.com/jline/jline3/releases/tag/4.1.2
- AWS SDK BOM from 2.44.9 to 2.44.12 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Azure SDK BOM from 1.3.6 to 1.3.7 - https://github.com/Azure/azure-sdk-for-java/releases/tag/com.azure%2Bazure-sdk-bom_1.3.7
- Kafka from 4.2.0 to 4.3.0 - https://kafka.apache.org/blog/2026/05/22/apache-kafka-4.3.0-release-announcement/
- zstd jni from 1.5.7-8 to 1.5.7-9 - https://github.com/luben/zstd-jni/releases/tag/v1.5.7-9
- Netty from 4.2.13.Final to 4.2.14.Final - https://github.com/netty/netty/releases/tag/netty-4.2.14.Final

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
