### PR TITLE
NIFI-15973 Fix issues caused by the use of deprecated GregorianCalendar

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverter.java
@@ -49,10 +49,6 @@ class ObjectLocalDateFieldConverter implements FieldConverter<Object, LocalDate>
                 return localDate;
             }
             case Date date -> {
-                // Avoid java.sql.Date#toLocalDate which uses deprecated getYear/getMonth/getDate
-                // accessors backed by GregorianCalendar, applying Julian calendar semantics for years
-                // before 1582 and shifting pre-1582 dates by approximately two days. java.sql.Date
-                // does not implement toInstant, so the epoch milliseconds are read explicitly.
                 return ofInstant(Instant.ofEpochMilli(date.getTime()));
             }
             case java.util.Date date -> {

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverter.java
@@ -49,7 +49,11 @@ class ObjectLocalDateFieldConverter implements FieldConverter<Object, LocalDate>
                 return localDate;
             }
             case Date date -> {
-                return date.toLocalDate();
+                // Avoid java.sql.Date#toLocalDate which uses deprecated getYear/getMonth/getDate
+                // accessors backed by GregorianCalendar, applying Julian calendar semantics for years
+                // before 1582 and shifting pre-1582 dates by approximately two days. java.sql.Date
+                // does not implement toInstant, so the epoch milliseconds are read explicitly.
+                return ofInstant(Instant.ofEpochMilli(date.getTime()));
             }
             case java.util.Date date -> {
                 final Instant instant = date.toInstant();

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverter.java
@@ -49,7 +49,11 @@ class ObjectLocalDateFieldConverter implements FieldConverter<Object, LocalDate>
                 return localDate;
             }
             case Date date -> {
-                return ofInstant(Instant.ofEpochMilli(date.getTime()));
+                // java.sql.Date#toInstant throws UnsupportedOperationException
+                final Instant instant = Instant.ofEpochMilli(date.getTime());
+
+                // Create LocalDate from Instant to preserve proleptic Gregorian calendar for pre-1582 dates
+                return ofInstant(instant);
             }
             case java.util.Date date -> {
                 final Instant instant = date.toInstant();

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
@@ -64,9 +64,6 @@ class ObjectLocalDateTimeFieldConverter implements FieldConverter<Object, LocalD
                 return localDateTime;
             }
             case Timestamp timestamp -> {
-                // Avoid Timestamp#toLocalDateTime which routes through deprecated GregorianCalendar
-                // and applies Julian calendar semantics for years before 1582, shifting pre-1582
-                // timestamps by approximately two days.
                 return ofInstant(timestamp.toInstant());
             }
             case Date date -> {

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
@@ -67,8 +67,10 @@ class ObjectLocalDateTimeFieldConverter implements FieldConverter<Object, LocalD
                 return ofInstant(timestamp.toInstant());
             }
             case Date date -> {
-                // java.sql.Date and java.sql.Time do not support the toInstant() method so using getTime() is required
+                // java.sql.Date#toInstant throws UnsupportedOperationException
                 final Instant instant = Instant.ofEpochMilli(date.getTime());
+
+                // Create LocalDateTime from Instant to preserve proleptic Gregorian calendar for pre-1582 dates
                 return ofInstant(instant);
             }
             case final Number number -> {

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
@@ -64,7 +64,10 @@ class ObjectLocalDateTimeFieldConverter implements FieldConverter<Object, LocalD
                 return localDateTime;
             }
             case Timestamp timestamp -> {
-                return timestamp.toLocalDateTime();
+                // Avoid Timestamp#toLocalDateTime which routes through deprecated GregorianCalendar
+                // and applies Julian calendar semantics for years before 1582, shifting pre-1582
+                // timestamps by approximately two days.
+                return ofInstant(timestamp.toInstant());
             }
             case Date date -> {
                 // java.sql.Date and java.sql.Time do not support the toInstant() method so using getTime() is required

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverter.java
@@ -23,7 +23,6 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Clob;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -58,10 +57,9 @@ class ObjectStringFieldConverter implements FieldConverter<Object, String> {
                     return Long.toString(timestamp.getTime());
                 }
                 final DateTimeFormatter formatter = DateTimeFormatterRegistry.getDateTimeFormatter(pattern.get());
-                final LocalDateTime localDateTime = timestamp.toLocalDateTime();
-
-                // Convert LocalDateTime to ZonedDateTime using system default zone to support offsets in Date Time Formatter
-                final ZonedDateTime dateTime = ZonedDateTime.of(localDateTime, ZoneId.systemDefault());
+                // Avoid Timestamp#toLocalDateTime which routes through deprecated GregorianCalendar
+                // and applies Julian calendar semantics for years before 1582.
+                final ZonedDateTime dateTime = timestamp.toInstant().atZone(ZoneId.systemDefault());
                 return formatter.format(dateTime);
             }
             case Date date -> {

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverter.java
@@ -56,8 +56,14 @@ class ObjectStringFieldConverter implements FieldConverter<Object, String> {
                 if (pattern.isEmpty()) {
                     return Long.toString(timestamp.getTime());
                 }
+
+                // Convert via Instant to ZonedDateTime to preserve proleptic Gregorian calendar for pre-1582 dates
+                final Instant instant = timestamp.toInstant();
+
+                // Convert to ZonedDateTime using system default zone to support offsets in Date Time Formatter
+                final ZonedDateTime dateTime = instant.atZone(ZoneId.systemDefault());
+
                 final DateTimeFormatter formatter = DateTimeFormatterRegistry.getDateTimeFormatter(pattern.get());
-                final ZonedDateTime dateTime = timestamp.toInstant().atZone(ZoneId.systemDefault());
                 return formatter.format(dateTime);
             }
             case Date date -> {

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverter.java
@@ -57,8 +57,6 @@ class ObjectStringFieldConverter implements FieldConverter<Object, String> {
                     return Long.toString(timestamp.getTime());
                 }
                 final DateTimeFormatter formatter = DateTimeFormatterRegistry.getDateTimeFormatter(pattern.get());
-                // Avoid Timestamp#toLocalDateTime which routes through deprecated GregorianCalendar
-                // and applies Julian calendar semantics for years before 1582.
                 final ZonedDateTime dateTime = timestamp.toInstant().atZone(ZoneId.systemDefault());
                 return formatter.format(dateTime);
             }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverter.java
@@ -41,9 +41,6 @@ class ObjectTimestampFieldConverter implements FieldConverter<Object, Timestamp>
     @Override
     public Timestamp convertField(final Object field, final Optional<String> pattern, final String name) {
         final LocalDateTime localDateTime = CONVERTER.convertField(field, pattern, name);
-        // Avoid Timestamp.valueOf(LocalDateTime) which routes through deprecated GregorianCalendar
-        // and applies Julian calendar semantics for years before 1582, shifting pre-1582 timestamps
-        // by approximately two days.
         return localDateTime == null ? null : Timestamp.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
     }
 }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverter.java
@@ -21,6 +21,7 @@ import org.apache.nifi.serialization.record.util.IllegalTypeConversionException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 /**
@@ -41,6 +42,11 @@ class ObjectTimestampFieldConverter implements FieldConverter<Object, Timestamp>
     @Override
     public Timestamp convertField(final Object field, final Optional<String> pattern, final String name) {
         final LocalDateTime localDateTime = CONVERTER.convertField(field, pattern, name);
-        return localDateTime == null ? null : Timestamp.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        if (localDateTime == null) {
+            return null;
+        }
+
+        final ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.systemDefault());
+        return Timestamp.from(zonedDateTime.toInstant());
     }
 }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverter.java
@@ -20,6 +20,7 @@ import org.apache.nifi.serialization.record.util.IllegalTypeConversionException;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 /**
@@ -40,6 +41,9 @@ class ObjectTimestampFieldConverter implements FieldConverter<Object, Timestamp>
     @Override
     public Timestamp convertField(final Object field, final Optional<String> pattern, final String name) {
         final LocalDateTime localDateTime = CONVERTER.convertField(field, pattern, name);
-        return localDateTime == null ? null : Timestamp.valueOf(localDateTime);
+        // Avoid Timestamp.valueOf(LocalDateTime) which routes through deprecated GregorianCalendar
+        // and applies Julian calendar semantics for years before 1582, shifting pre-1582 timestamps
+        // by approximately two days.
+        return localDateTime == null ? null : Timestamp.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
     }
 }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverter.java
@@ -46,7 +46,10 @@ class ObjectTimestampFieldConverter implements FieldConverter<Object, Timestamp>
             return null;
         }
 
+        // Convert to ZonedDateTime using system default zone to allow for later conversion to Instant
         final ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.systemDefault());
+
+        // Create Timestamp from Instant to preserve proleptic Gregorian calendar for pre-1582 dates
         return Timestamp.from(zonedDateTime.toInstant());
     }
 }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -200,7 +200,9 @@ public class DataTypeUtils {
             case DATE:
                 final FieldConverter<Object, LocalDate> localDateConverter = StandardFieldConverterRegistry.getRegistry().getFieldConverter(LocalDate.class);
                 final LocalDate localDate = localDateConverter.convertField(value, dateFormat, fieldName);
-                return localDate == null ? null : Date.valueOf(localDate);
+                // Avoid Date.valueOf(LocalDate) which routes through deprecated GregorianCalendar
+                // and applies Julian calendar semantics for years before 1582.
+                return localDate == null ? null : new Date(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
             case DECIMAL:
                 return toBigDecimal(value, fieldName);
             case DOUBLE:

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -200,7 +200,12 @@ public class DataTypeUtils {
             case DATE:
                 final FieldConverter<Object, LocalDate> localDateConverter = StandardFieldConverterRegistry.getRegistry().getFieldConverter(LocalDate.class);
                 final LocalDate localDate = localDateConverter.convertField(value, dateFormat, fieldName);
-                return localDate == null ? null : new Date(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
+                if (localDate == null) {
+                    return null;
+                }
+
+                final ZonedDateTime zonedDate = localDate.atStartOfDay(ZoneId.systemDefault());
+                return new Date(zonedDate.toInstant().toEpochMilli());
             case DECIMAL:
                 return toBigDecimal(value, fieldName);
             case DOUBLE:

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -204,8 +204,12 @@ public class DataTypeUtils {
                     return null;
                 }
 
+                // Convert to ZonedDateTime using system default zone to allow for later conversion to Instant
                 final ZonedDateTime zonedDate = localDate.atStartOfDay(ZoneId.systemDefault());
-                return new Date(zonedDate.toInstant().toEpochMilli());
+
+                // Create Date from Instant epoch millis to preserve proleptic Gregorian calendar for pre-1582 dates
+                final long epochMillis = zonedDate.toInstant().toEpochMilli();
+                return new Date(epochMillis);
             case DECIMAL:
                 return toBigDecimal(value, fieldName);
             case DOUBLE:

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -200,8 +200,6 @@ public class DataTypeUtils {
             case DATE:
                 final FieldConverter<Object, LocalDate> localDateConverter = StandardFieldConverterRegistry.getRegistry().getFieldConverter(LocalDate.class);
                 final LocalDate localDate = localDateConverter.convertField(value, dateFormat, fieldName);
-                // Avoid Date.valueOf(LocalDate) which routes through deprecated GregorianCalendar
-                // and applies Julian calendar semantics for years before 1582.
                 return localDate == null ? null : new Date(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
             case DECIMAL:
                 return toBigDecimal(value, fieldName);

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverterTest.java
@@ -27,8 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ObjectLocalDateFieldConverterTest {
-    private static final ObjectLocalDateFieldConverter CONVERTER = new ObjectLocalDateFieldConverter();
 
+    private static final ObjectLocalDateFieldConverter CONVERTER = new ObjectLocalDateFieldConverter();
     private static final String FIELD_NAME = LocalDate.class.getSimpleName();
 
     @Test
@@ -46,22 +46,15 @@ class ObjectLocalDateFieldConverterTest {
     void testConvertFieldSqlDateModernYear() {
         final LocalDate localDate = LocalDate.of(2025, 5, 25);
         final Date sqlDate = new Date(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
-
         final LocalDate result = CONVERTER.convertField(sqlDate, Optional.empty(), FIELD_NAME);
-
         assertEquals(localDate, result);
     }
 
     @Test
     void testConvertFieldSqlDateYearOneIsProlepticGregorian() {
-        // A java.sql.Date built from a proleptic-Gregorian year-1 epoch must round-trip back
-        // to year 1, not be shifted to year 0 by Julian calendar semantics in
-        // java.sql.Date#toLocalDate (which uses deprecated getYear/getMonth/getDate).
         final LocalDate yearOne = LocalDate.of(1, 1, 1);
         final Date sqlDate = new Date(yearOne.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
-
         final LocalDate result = CONVERTER.convertField(sqlDate, Optional.empty(), FIELD_NAME);
-
         assertEquals(yearOne, result);
     }
 }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.serialization.record.field;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ObjectLocalDateFieldConverterTest {
+    private static final ObjectLocalDateFieldConverter CONVERTER = new ObjectLocalDateFieldConverter();
+
+    private static final String FIELD_NAME = LocalDate.class.getSimpleName();
+
+    @Test
+    void testConvertFieldNull() {
+        assertNull(CONVERTER.convertField(null, Optional.empty(), FIELD_NAME));
+    }
+
+    @Test
+    void testConvertFieldLocalDate() {
+        final LocalDate input = LocalDate.of(2025, 5, 25);
+        assertEquals(input, CONVERTER.convertField(input, Optional.empty(), FIELD_NAME));
+    }
+
+    @Test
+    void testConvertFieldSqlDateModernYear() {
+        final LocalDate localDate = LocalDate.of(2025, 5, 25);
+        final Date sqlDate = new Date(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+        final LocalDate result = CONVERTER.convertField(sqlDate, Optional.empty(), FIELD_NAME);
+
+        assertEquals(localDate, result);
+    }
+
+    @Test
+    void testConvertFieldSqlDateYearOneIsProlepticGregorian() {
+        // A java.sql.Date built from a proleptic-Gregorian year-1 epoch must round-trip back
+        // to year 1, not be shifted to year 0 by Julian calendar semantics in
+        // java.sql.Date#toLocalDate (which uses deprecated getYear/getMonth/getDate).
+        final LocalDate yearOne = LocalDate.of(1, 1, 1);
+        final Date sqlDate = new Date(yearOne.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+        final LocalDate result = CONVERTER.convertField(sqlDate, Optional.empty(), FIELD_NAME);
+
+        assertEquals(yearOne, result);
+    }
+}

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverterTest.java
@@ -59,7 +59,7 @@ class ObjectLocalDateFieldConverterTest {
         final ZonedDateTime zonedDate = yearOne.atStartOfDay(ZoneId.systemDefault());
         final Date sqlDate = new Date(zonedDate.toInstant().toEpochMilli());
         final LocalDate result = CONVERTER.convertField(sqlDate, Optional.empty(), FIELD_NAME);
-        
+
         assertEquals(yearOne, result);
     }
 }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectLocalDateFieldConverterTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.sql.Date;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,16 +46,20 @@ class ObjectLocalDateFieldConverterTest {
     @Test
     void testConvertFieldSqlDateModernYear() {
         final LocalDate localDate = LocalDate.of(2025, 5, 25);
-        final Date sqlDate = new Date(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
+        final ZonedDateTime zonedDate = localDate.atStartOfDay(ZoneId.systemDefault());
+        final Date sqlDate = new Date(zonedDate.toInstant().toEpochMilli());
         final LocalDate result = CONVERTER.convertField(sqlDate, Optional.empty(), FIELD_NAME);
+
         assertEquals(localDate, result);
     }
 
     @Test
     void testConvertFieldSqlDateYearOneIsProlepticGregorian() {
         final LocalDate yearOne = LocalDate.of(1, 1, 1);
-        final Date sqlDate = new Date(yearOne.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
+        final ZonedDateTime zonedDate = yearOne.atStartOfDay(ZoneId.systemDefault());
+        final Date sqlDate = new Date(zonedDate.toInstant().toEpochMilli());
         final LocalDate result = CONVERTER.convertField(sqlDate, Optional.empty(), FIELD_NAME);
+        
         assertEquals(yearOne, result);
     }
 }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverterTest.java
@@ -24,8 +24,10 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.zone.ZoneRules;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -156,6 +158,19 @@ class ObjectStringFieldConverterTest {
 
         final String string = CONVERTER.convertField(objectArray, Optional.empty(), FIELD_NAME);
         assertEquals(EMPTY_ARRAY_STRING, string);
+    }
+
+    @Test
+    void testConvertFieldTimestampYearOneIsProlepticGregorian() {
+        // A Timestamp built from a proleptic-Gregorian year-1 Instant must format with year 1
+        // (not "0000-12-30" produced when Timestamp#toLocalDateTime applies Julian semantics).
+        final LocalDateTime yearOne = LocalDateTime.of(1, 1, 1, 12, 0, 0);
+        final Timestamp timestamp = Timestamp.from(yearOne.atZone(ZoneId.systemDefault()).toInstant());
+
+        final String formatted = CONVERTER.convertField(timestamp, Optional.of(DEFAULT_PATTERN), FIELD_NAME);
+
+        final String expected = DateTimeFormatter.ofPattern(DEFAULT_PATTERN, Locale.ROOT).format(yearOne);
+        assertEquals(expected, formatted);
     }
 
     private String getDateTimeZoneOffset() {

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverterTest.java
@@ -24,6 +24,7 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.zone.ZoneRules;
 import java.util.Date;
@@ -163,9 +164,11 @@ class ObjectStringFieldConverterTest {
     @Test
     void testConvertFieldTimestampYearOneIsProlepticGregorian() {
         final LocalDateTime yearOne = LocalDateTime.of(1, 1, 1, 12, 0, 0);
-        final Timestamp timestamp = Timestamp.from(yearOne.atZone(ZoneId.systemDefault()).toInstant());
+        final ZonedDateTime zonedYearOne = yearOne.atZone(ZoneId.systemDefault());
+        final Timestamp timestamp = Timestamp.from(zonedYearOne.toInstant());
         final String formatted = CONVERTER.convertField(timestamp, Optional.of(DEFAULT_PATTERN), FIELD_NAME);
         final String expected = DateTimeFormatter.ofPattern(DEFAULT_PATTERN, Locale.ROOT).format(yearOne);
+
         assertEquals(expected, formatted);
     }
 

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverterTest.java
@@ -162,13 +162,9 @@ class ObjectStringFieldConverterTest {
 
     @Test
     void testConvertFieldTimestampYearOneIsProlepticGregorian() {
-        // A Timestamp built from a proleptic-Gregorian year-1 Instant must format with year 1
-        // (not "0000-12-30" produced when Timestamp#toLocalDateTime applies Julian semantics).
         final LocalDateTime yearOne = LocalDateTime.of(1, 1, 1, 12, 0, 0);
         final Timestamp timestamp = Timestamp.from(yearOne.atZone(ZoneId.systemDefault()).toInstant());
-
         final String formatted = CONVERTER.convertField(timestamp, Optional.of(DEFAULT_PATTERN), FIELD_NAME);
-
         final String expected = DateTimeFormatter.ofPattern(DEFAULT_PATTERN, Locale.ROOT).format(yearOne);
         assertEquals(expected, formatted);
     }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverterTest.java
@@ -164,18 +164,22 @@ public class ObjectTimestampFieldConverterTest {
 
     @Test
     public void testConvertFieldStringYearOneIsProlepticGregorian() {
-        final String yearOne = "0001-01-01 12:00:00";
-        final Timestamp timestamp = CONVERTER.convertField(yearOne, DEFAULT_PATTERN, FIELD_NAME);
-        final Instant expected = LocalDateTime.of(1, 1, 1, 12, 0, 0).atZone(ZoneId.systemDefault()).toInstant();
-        assertEquals(expected, timestamp.toInstant());
+        final LocalDateTime yearOne = LocalDateTime.of(1, 1, 1, 12, 0, 0);
+        final ZonedDateTime zonedYearOne = yearOne.atZone(ZoneId.systemDefault());
+        final Timestamp timestamp = CONVERTER.convertField("0001-01-01 12:00:00", DEFAULT_PATTERN, FIELD_NAME);
+        final Timestamp expected = Timestamp.from(zonedYearOne.toInstant());
+
+        assertEquals(expected, timestamp);
     }
 
     @Test
     public void testConvertFieldLocalDateTimeYearOneIsProlepticGregorian() {
         final LocalDateTime yearOne = LocalDateTime.of(1, 1, 1, 12, 0, 0);
+        final ZonedDateTime zonedYearOne = yearOne.atZone(ZoneId.systemDefault());
         final Timestamp timestamp = CONVERTER.convertField(yearOne, DEFAULT_PATTERN, FIELD_NAME);
-        final Instant expected = yearOne.atZone(ZoneId.systemDefault()).toInstant();
-        assertEquals(expected, timestamp.toInstant());
+        final Timestamp expected = Timestamp.from(zonedYearOne.toInstant());
+        
+        assertEquals(expected, timestamp);
     }
 
     private Timestamp getDateTimeCoordinatedUniversalTime() {

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverterTest.java
@@ -178,7 +178,7 @@ public class ObjectTimestampFieldConverterTest {
         final ZonedDateTime zonedYearOne = yearOne.atZone(ZoneId.systemDefault());
         final Timestamp timestamp = CONVERTER.convertField(yearOne, DEFAULT_PATTERN, FIELD_NAME);
         final Timestamp expected = Timestamp.from(zonedYearOne.toInstant());
-        
+
         assertEquals(expected, timestamp);
     }
 

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverterTest.java
@@ -162,6 +162,26 @@ public class ObjectTimestampFieldConverterTest {
         assertEquals(expected, timestamp);
     }
 
+    @Test
+    public void testConvertFieldStringYearOneIsProlepticGregorian() {
+        // Verify that year 1 in the source string is interpreted via proleptic Gregorian
+        // (matching java.time semantics) rather than the Julian calendar that would route
+        // through the deprecated GregorianCalendar in Timestamp.valueOf and shift the value
+        // by approximately two days.
+        final String yearOne = "0001-01-01 12:00:00";
+        final Timestamp timestamp = CONVERTER.convertField(yearOne, DEFAULT_PATTERN, FIELD_NAME);
+        final Instant expected = LocalDateTime.of(1, 1, 1, 12, 0, 0).atZone(ZoneId.systemDefault()).toInstant();
+        assertEquals(expected, timestamp.toInstant());
+    }
+
+    @Test
+    public void testConvertFieldLocalDateTimeYearOneIsProlepticGregorian() {
+        final LocalDateTime yearOne = LocalDateTime.of(1, 1, 1, 12, 0, 0);
+        final Timestamp timestamp = CONVERTER.convertField(yearOne, DEFAULT_PATTERN, FIELD_NAME);
+        final Instant expected = yearOne.atZone(ZoneId.systemDefault()).toInstant();
+        assertEquals(expected, timestamp.toInstant());
+    }
+
     private Timestamp getDateTimeCoordinatedUniversalTime() {
         final Timestamp dateTime = Timestamp.valueOf(DATE_TIME_DEFAULT);
         final LocalDateTime localDateTime = dateTime.toLocalDateTime();

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverterTest.java
@@ -164,10 +164,6 @@ public class ObjectTimestampFieldConverterTest {
 
     @Test
     public void testConvertFieldStringYearOneIsProlepticGregorian() {
-        // Verify that year 1 in the source string is interpreted via proleptic Gregorian
-        // (matching java.time semantics) rather than the Julian calendar that would route
-        // through the deprecated GregorianCalendar in Timestamp.valueOf and shift the value
-        // by approximately two days.
         final String yearOne = "0001-01-01 12:00:00";
         final Timestamp timestamp = CONVERTER.convertField(yearOne, DEFAULT_PATTERN, FIELD_NAME);
         final Instant expected = LocalDateTime.of(1, 1, 1, 12, 0, 0).atZone(ZoneId.systemDefault()).toInstant();

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
@@ -23,6 +23,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
@@ -105,14 +106,17 @@ public class TestObjectLocalDateTimeFieldConverter {
     @Test
     public void testConvertTimestampYearOneIsProlepticGregorian() {
         final LocalDateTime yearOne = LocalDateTime.of(1, 1, 1, 12, 0, 0);
-        final Timestamp timestamp = Timestamp.from(yearOne.atZone(ZoneId.systemDefault()).toInstant());
+        final ZonedDateTime zonedYearOne = yearOne.atZone(ZoneId.systemDefault());
+        final Timestamp timestamp = Timestamp.from(zonedYearOne.toInstant());
         final LocalDateTime result = converter.convertField(timestamp, Optional.empty(), FIELD_NAME);
+
         assertEquals(yearOne, result);
     }
 
     @Test
     public void testConvertStringYearOneIsProlepticGregorian() {
         final LocalDateTime result = converter.convertField("0001-01-01 12:00:00", Optional.of("yyyy-MM-dd HH:mm:ss"), FIELD_NAME);
-        assertEquals(LocalDateTime.of(1, 1, 1, 12, 0, 0), result);
+        final LocalDateTime expected = LocalDateTime.of(1, 1, 1, 12, 0, 0);
+        assertEquals(expected, result);
     }
 }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
@@ -104,14 +104,9 @@ public class TestObjectLocalDateTimeFieldConverter {
 
     @Test
     public void testConvertTimestampYearOneIsProlepticGregorian() {
-        // A Timestamp constructed directly from a proleptic-Gregorian year-1 Instant must
-        // round-trip back to year 1, not be shifted to year 0 by Julian calendar semantics
-        // in Timestamp#toLocalDateTime.
         final LocalDateTime yearOne = LocalDateTime.of(1, 1, 1, 12, 0, 0);
         final Timestamp timestamp = Timestamp.from(yearOne.atZone(ZoneId.systemDefault()).toInstant());
-
         final LocalDateTime result = converter.convertField(timestamp, Optional.empty(), FIELD_NAME);
-
         assertEquals(yearOne, result);
     }
 

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
@@ -19,6 +19,7 @@ package org.apache.nifi.serialization.record.field;
 
 import org.junit.jupiter.api.Test;
 
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -99,5 +100,24 @@ public class TestObjectLocalDateTimeFieldConverter {
     public void testWithDateFormatMicrosecondPrecision() {
         final LocalDateTime result = converter.convertField(MICROS_TIMESTAMP_LONG, Optional.of("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"), FIELD_NAME);
         assertEquals(LOCAL_DATE_TIME_MICROS_PRECISION, result);
+    }
+
+    @Test
+    public void testConvertTimestampYearOneIsProlepticGregorian() {
+        // A Timestamp constructed directly from a proleptic-Gregorian year-1 Instant must
+        // round-trip back to year 1, not be shifted to year 0 by Julian calendar semantics
+        // in Timestamp#toLocalDateTime.
+        final LocalDateTime yearOne = LocalDateTime.of(1, 1, 1, 12, 0, 0);
+        final Timestamp timestamp = Timestamp.from(yearOne.atZone(ZoneId.systemDefault()).toInstant());
+
+        final LocalDateTime result = converter.convertField(timestamp, Optional.empty(), FIELD_NAME);
+
+        assertEquals(yearOne, result);
+    }
+
+    @Test
+    public void testConvertStringYearOneIsProlepticGregorian() {
+        final LocalDateTime result = converter.convertField("0001-01-01 12:00:00", Optional.of("yyyy-MM-dd HH:mm:ss"), FIELD_NAME);
+        assertEquals(LocalDateTime.of(1, 1, 1, 12, 0, 0), result);
     }
 }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
@@ -68,6 +68,7 @@ import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -1154,8 +1155,15 @@ public class AvroTypeUtil {
                 if (LOGICAL_TYPE_DATE.equals(logicalName)) {
                     // date logical name means that the value is number of days since Jan 1, 1970
                     // Handle both Integer (legacy) and LocalDate (newer Avro libraries).
-                    final LocalDate localDate = (value instanceof LocalDate ld) ? ld : LocalDate.ofEpochDay((int) value);
-                    return new java.sql.Date(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
+                    final LocalDate localDate;
+                    if (value instanceof LocalDate ld) {
+                        localDate = ld;
+                    } else {
+                        localDate = LocalDate.ofEpochDay((int) value);
+                    }
+
+                    final ZonedDateTime zonedDate = localDate.atStartOfDay(ZoneId.systemDefault());
+                    return new java.sql.Date(zonedDate.toInstant().toEpochMilli());
                 } else if (LOGICAL_TYPE_TIME_MILLIS.equals(logicalName)) {
                     // time-millis logical name means that the value is number of milliseconds since midnight.
                     // Handle both Integer (legacy) and LocalTime (newer Avro libraries)

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
@@ -63,12 +63,12 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
+import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -1163,7 +1163,7 @@ public class AvroTypeUtil {
                     }
 
                     final ZonedDateTime zonedDate = localDate.atStartOfDay(ZoneId.systemDefault());
-                    return new java.sql.Date(zonedDate.toInstant().toEpochMilli());
+                    return new Date(zonedDate.toInstant().toEpochMilli());
                 } else if (LOGICAL_TYPE_TIME_MILLIS.equals(logicalName)) {
                     // time-millis logical name means that the value is number of milliseconds since midnight.
                     // Handle both Integer (legacy) and LocalTime (newer Avro libraries)

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
@@ -1162,8 +1162,12 @@ public class AvroTypeUtil {
                         localDate = LocalDate.ofEpochDay((int) value);
                     }
 
+                    // Convert to ZonedDateTime using system default zone to allow for later conversion to Instant
                     final ZonedDateTime zonedDate = localDate.atStartOfDay(ZoneId.systemDefault());
-                    return new Date(zonedDate.toInstant().toEpochMilli());
+
+                    // Create Date from Instant epoch millis to preserve proleptic Gregorian calendar for pre-1582 dates
+                    final long epochMillis = zonedDate.toInstant().toEpochMilli();
+                    return new Date(epochMillis);
                 } else if (LOGICAL_TYPE_TIME_MILLIS.equals(logicalName)) {
                     // time-millis logical name means that the value is number of milliseconds since midnight.
                     // Handle both Integer (legacy) and LocalTime (newer Avro libraries)

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
@@ -1154,8 +1154,6 @@ public class AvroTypeUtil {
                 if (LOGICAL_TYPE_DATE.equals(logicalName)) {
                     // date logical name means that the value is number of days since Jan 1, 1970
                     // Handle both Integer (legacy) and LocalDate (newer Avro libraries).
-                    // Avoid Date.valueOf(LocalDate) which routes through deprecated GregorianCalendar
-                    // and applies Julian calendar semantics for years before 1582.
                     final LocalDate localDate = (value instanceof LocalDate ld) ? ld : LocalDate.ofEpochDay((int) value);
                     return new java.sql.Date(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
                 } else if (LOGICAL_TYPE_TIME_MILLIS.equals(logicalName)) {

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
@@ -1153,11 +1153,11 @@ public class AvroTypeUtil {
                 final String logicalName = logicalType.getName();
                 if (LOGICAL_TYPE_DATE.equals(logicalName)) {
                     // date logical name means that the value is number of days since Jan 1, 1970
-                    // Handle both Integer (legacy) and LocalDate (newer Avro libraries)
-                    if (value instanceof LocalDate localDate) {
-                        return java.sql.Date.valueOf(localDate);
-                    }
-                    return java.sql.Date.valueOf(LocalDate.ofEpochDay((int) value));
+                    // Handle both Integer (legacy) and LocalDate (newer Avro libraries).
+                    // Avoid Date.valueOf(LocalDate) which routes through deprecated GregorianCalendar
+                    // and applies Julian calendar semantics for years before 1582.
+                    final LocalDate localDate = (value instanceof LocalDate ld) ? ld : LocalDate.ofEpochDay((int) value);
+                    return new java.sql.Date(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
                 } else if (LOGICAL_TYPE_TIME_MILLIS.equals(logicalName)) {
                     // time-millis logical name means that the value is number of milliseconds since midnight.
                     // Handle both Integer (legacy) and LocalTime (newer Avro libraries)


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15973](https://issues.apache.org/jira/browse/NIFI-15973)
  
Avoid Julian-calendar shift when converting `java.sql.Date` / `java.sql.Timestamp` values to `java.time` types (and back) in NiFi's record framework.

`java.sql.Timestamp#toLocalDateTime`, `java.sql.Timestamp#valueOf(LocalDateTime)`, `java.sql.Date#toLocalDate`, and `java.sql.Date#valueOf(LocalDate)` all route through GregorianCalendar, which applies Julian-calendar semantics for years before 1582-10-15. As a result, a value whose epoch milliseconds represent year 0001 in the proleptic Gregorian calendar (the calendar `java.time`, Avro, BigQuery, or Snowflake all use) is rendered as year 0000 — about a 2-day backward shift. Downstream sinks that validate against an inclusive year-1-to-9999 range (e.g., the Snowflake Ingest SDK) then reject the row: `Timestamp out of representable inclusive range of years between 1 and 9999, ... value:0000-12-30T10:47Z`.

The fix replaces every Julian-aware bridge between `java.sql.*` and `java.time.*` with an Instant-based one, which preserves the proleptic-Gregorian instant the source actually carried.
  
**Tests:**

  - ObjectLocalDateFieldConverterTest (new): null input, LocalDate passthrough, java.sql.Date modern-year round-trip, and a year-0001 java.sql.Date regression test that asserts the result is year 0001 (not year 0000).
  - TestObjectLocalDateTimeFieldConverter: add testConvertTimestampYearOneIsProlepticGregorian (year-0001 Timestamp round-trip) and testConvertStringYearOneIsProlepticGregorian (year-0001 string parsed via formatter).
  - ObjectTimestampFieldConverterTest: add testConvertFieldStringYearOneIsProlepticGregorian and testConvertFieldLocalDateTimeYearOneIsProlepticGregorian to lock in the year-0001 result for both string and LocalDateTime inputs.
  - ObjectStringFieldConverterTest: add testConvertFieldTimestampYearOneIsProlepticGregorian covering the formatted-output path.
  - New regression tests fail on main and pass on this branch.
  
**Compatibility:**
  
Backwards compatible. Instant-based conversion and Julian-aware Timestamp / Date conversion agree for every date from 1582-10-15 onward, so all values produced after the Gregorian cutover (i.e., everything the vast majority of users have ever ingested) are unchanged. Pre-cutover values — including the 1582-10-05 → 1582-10-14 gap that Julian had but proleptic Gregorian does not — now match the proleptic-Gregorian instant the source actually carried, which is what `java.time`, Avro, and downstream sinks already assume.

No public API signatures change, the fix is purely internal to the existing converter implementations.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
