### PR TITLE
NIFI-15976 Bump frontend dependencies via npm audit fix

### DIFF
--- a/nifi-frontend/src/main/frontend/package-lock.json
+++ b/nifi-frontend/src/main/frontend/package-lock.json
@@ -2960,47 +2960,10 @@
             "dev": true,
             "license": "(Apache-2.0 AND BSD-3-Clause)"
         },
-        "node_modules/@chevrotain/cst-dts-gen": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
-            "integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@chevrotain/gast": "11.1.2",
-                "@chevrotain/types": "11.1.2",
-                "lodash-es": "4.17.23"
-            }
-        },
-        "node_modules/@chevrotain/gast": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
-            "integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@chevrotain/types": "11.1.2",
-                "lodash-es": "4.17.23"
-            }
-        },
-        "node_modules/@chevrotain/regexp-to-ast": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
-            "integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
-            "license": "Apache-2.0",
-            "optional": true
-        },
         "node_modules/@chevrotain/types": {
             "version": "11.1.2",
             "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
             "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
-            "license": "Apache-2.0",
-            "optional": true
-        },
-        "node_modules/@chevrotain/utils": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
-            "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
             "license": "Apache-2.0",
             "optional": true
         },
@@ -3735,9 +3698,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5223,13 +5186,13 @@
             "license": "MIT"
         },
         "node_modules/@mermaid-js/parser": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.1.tgz",
-            "integrity": "sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+            "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "langium": "^4.0.0"
+                "@chevrotain/types": "~11.1.1"
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
@@ -5520,17 +5483,16 @@
             }
         },
         "node_modules/@module-federation/node": {
-            "version": "2.7.36",
-            "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.36.tgz",
-            "integrity": "sha512-RN2R7VRdZpxuFRPJHco5EONAKmAHg7k97cFKGyj6R00lKkMvfBG2jJo6CgXDDomRfZM6ijYFgq1GJwH8boHXSw==",
+            "version": "2.7.43",
+            "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.43.tgz",
+            "integrity": "sha512-oKoLm7dqb5EvkiNIfsEdLmmBX7XLWHtPSx3M9kEYuXAaNAppoRWC9WtgrrZYXWErB2BG9wxMlx/8Xq3awRUCdQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/enhanced": "2.2.2",
-                "@module-federation/runtime": "2.2.2",
-                "@module-federation/sdk": "2.2.2",
-                "btoa": "1.2.1",
-                "encoding": "^0.1.13",
+                "@module-federation/enhanced": "2.5.0",
+                "@module-federation/runtime": "2.5.0",
+                "@module-federation/sdk": "2.5.0",
+                "encoding": "0.1.13",
                 "node-fetch": "2.7.0",
                 "tapable": "2.3.0"
             },
@@ -5544,27 +5506,26 @@
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/bridge-react-webpack-plugin": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.2.2.tgz",
-            "integrity": "sha512-zA2BW8B5iY1Jdrdv8U+u2kpaR4sGyO4IxrqnDA0i+v1DJx8L4MAldNaDT7TuEuB23nnfu1Are/szc/73rRcTmw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.5.0.tgz",
+            "integrity": "sha512-Ux9XVW//K6K+KHKPdc0Jnc7RtTpZaEXgbVhp5yovtFkCJVt8hEClcTeuI18MvvLiV/q2hUpCU5Wsf9zNaIYStQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/sdk": "2.2.2",
+                "@module-federation/sdk": "2.5.0",
                 "@types/semver": "7.5.8",
                 "semver": "7.6.3"
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/cli": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.2.2.tgz",
-            "integrity": "sha512-UGSHE8LHYjbRf1oxghjpq8fYjCVXceU4PbmaLrtX9fPCeIgmwSrNxujvvRMV3KsAfr8F2v4RJMPZH/G3zvoJxw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.5.0.tgz",
+            "integrity": "sha512-+czXA6yoiiF9W6+YEOCpQE6zpGZpA89X0oCEz3EaWPTkL4chEbxurjpME8CMnJk9iuFxl167+cBQiQlVBiHGGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/dts-plugin": "2.2.2",
-                "@module-federation/sdk": "2.2.2",
-                "chalk": "3.0.0",
+                "@module-federation/dts-plugin": "2.5.0",
+                "@module-federation/sdk": "2.5.0",
                 "commander": "11.1.0",
                 "jiti": "2.4.2"
             },
@@ -5575,51 +5536,22 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@module-federation/node/node_modules/@module-federation/data-prefetch": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-2.2.2.tgz",
-            "integrity": "sha512-SFyf6zCOSx2g/ztT+Z9LVMZZZ5MbIwoLVpFdpumidlrr0ce6tgkRICo21X4b6i8d+Sb6kPgH0CpeiGsjBh8EBw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@module-federation/runtime": "2.2.2",
-                "@module-federation/sdk": "2.2.2",
-                "fs-extra": "9.1.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.9.0",
-                "react-dom": ">=16.9.0"
-            },
-            "peerDependenciesMeta": {
-                "react": {
-                    "optional": true
-                },
-                "react-dom": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@module-federation/node/node_modules/@module-federation/dts-plugin": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.2.2.tgz",
-            "integrity": "sha512-o9zIGAQAELgVHmhJfGU28lqxYe9ccUL6x72vMC/fDC2WXv9O+ASt0jBDaXktGitR5hJRStdQMU+BQN27DIFSDg==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.5.0.tgz",
+            "integrity": "sha512-q7KDhJ5tn2HrUV7uMuh/L3TaaztUosE+4LAb90sxx0pPPqWRwlpBpxu1REubv5BWXmU1K/Ozn14u6jRbjLVaGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/error-codes": "2.2.2",
-                "@module-federation/managers": "2.2.2",
-                "@module-federation/sdk": "2.2.2",
-                "@module-federation/third-party-dts-extractor": "2.2.2",
-                "adm-zip": "^0.5.10",
-                "ansi-colors": "^4.1.3",
-                "axios": "^1.13.5",
-                "chalk": "3.0.0",
-                "fs-extra": "9.1.0",
+                "@module-federation/error-codes": "2.5.0",
+                "@module-federation/managers": "2.5.0",
+                "@module-federation/sdk": "2.5.0",
+                "@module-federation/third-party-dts-extractor": "2.5.0",
+                "adm-zip": "0.5.10",
+                "ansi-colors": "4.1.3",
                 "isomorphic-ws": "5.0.0",
-                "lodash.clonedeepwith": "4.5.0",
-                "log4js": "6.9.1",
                 "node-schedule": "2.1.1",
-                "rambda": "^9.1.0",
+                "undici": "7.24.7",
                 "ws": "8.18.0"
             },
             "peerDependencies": {
@@ -5633,26 +5565,24 @@
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/enhanced": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.2.2.tgz",
-            "integrity": "sha512-J15hPFvXs8VoJXCXTq5ocgvy9hBqxX8G6KKg5iogpmY3wT9mSTf4klbpaaZSXwbVURdnjaUK06aKN9i6tJY31Q==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.5.0.tgz",
+            "integrity": "sha512-P91tzwyKSCQ6AwirqvAvTqWqmTY79ndpH0uenejFw+bbLpWrjuY0q+iZUXCV/7CSNmqwH2bkA/ssuyZljmcMVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/bridge-react-webpack-plugin": "2.2.2",
-                "@module-federation/cli": "2.2.2",
-                "@module-federation/data-prefetch": "2.2.2",
-                "@module-federation/dts-plugin": "2.2.2",
-                "@module-federation/error-codes": "2.2.2",
-                "@module-federation/inject-external-runtime-core-plugin": "2.2.2",
-                "@module-federation/managers": "2.2.2",
-                "@module-federation/manifest": "2.2.2",
-                "@module-federation/rspack": "2.2.2",
-                "@module-federation/runtime-tools": "2.2.2",
-                "@module-federation/sdk": "2.2.2",
-                "@module-federation/webpack-bundler-runtime": "2.2.2",
-                "btoa": "^1.2.1",
-                "schema-utils": "^4.3.0",
+                "@module-federation/bridge-react-webpack-plugin": "2.5.0",
+                "@module-federation/cli": "2.5.0",
+                "@module-federation/dts-plugin": "2.5.0",
+                "@module-federation/error-codes": "2.5.0",
+                "@module-federation/inject-external-runtime-core-plugin": "2.5.0",
+                "@module-federation/managers": "2.5.0",
+                "@module-federation/manifest": "2.5.0",
+                "@module-federation/rspack": "2.5.0",
+                "@module-federation/runtime-tools": "2.5.0",
+                "@module-federation/sdk": "2.5.0",
+                "@module-federation/webpack-bundler-runtime": "2.5.0",
+                "schema-utils": "4.3.0",
                 "tapable": "2.3.0",
                 "upath": "2.0.1"
             },
@@ -5677,63 +5607,60 @@
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/error-codes": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.2.2.tgz",
-            "integrity": "sha512-e+dxUrqrdRbhfvg8TyG0UQBQAjYZ8pI2b3HWfESLXqWi3xCiivZSnqsPN+zychrQ1hDZAdCheZ9zT91zhMrkxw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.5.0.tgz",
+            "integrity": "sha512-sq05/8Gp3csy1nr2/f76K3vLy0/xRqVtP71ibGy8BiLg7h1UxWN7G4EwAKSrPZ4FnsERGeFlIszg5Z+MqlwhFg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/inject-external-runtime-core-plugin": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.2.2.tgz",
-            "integrity": "sha512-wGN6nsjJVhM6T2PBx4FVfbfkXCBwewNmZJ81Rc23/9nzX9GXtKAe4YHojnzcxLRrnQnhdzd/8W2OTUKEsqCLgg==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.5.0.tgz",
+            "integrity": "sha512-e2KyTHpesBrPXGHMh4d4+s2xBiNoxbiFJkPRYHMCl81a/Gu+byrMkriZcV4VM/TFvBIlrgOJisVc1nnBI5UDRQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
-                "@module-federation/runtime-tools": "2.2.2"
+                "@module-federation/runtime-tools": "2.5.0"
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/managers": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.2.2.tgz",
-            "integrity": "sha512-YuUCUdjwXGsFEWC6YwNjX+XC8V4i47549ljXarHBhCVIYIluigivpG5ZDq/kyoZQoeR9UnUwzMiKzt79y0f7Dg==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.5.0.tgz",
+            "integrity": "sha512-9b5mU/7OYbKrYUJmhZ1kkfeJCZqR7qX6/FWp+oOfZMzUynN7Rb41dwoUs3TdnOKzbZ3CCwtZ2WsR4pF9ZNvuJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/sdk": "2.2.2",
-                "find-pkg": "2.0.0",
-                "fs-extra": "9.1.0"
+                "@module-federation/sdk": "2.5.0",
+                "find-pkg": "2.0.0"
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/manifest": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.2.2.tgz",
-            "integrity": "sha512-6oiyzCIdmqTuDF8FZEKbV7raFUtkPLhMfsjiSXQWzmeKrSTNtPYQ0qGqhTG5Qsc3p6DF16JqhoKu3LOvaV47cA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.5.0.tgz",
+            "integrity": "sha512-pmwQCGWjM2oKY7CkR7nEDOfMK0bNFJUifuDxuOB5iOWhU+Rp92UyyBI9IbJAtiISTSFGtuKRy40peJGvQq2VcQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/dts-plugin": "2.2.2",
-                "@module-federation/managers": "2.2.2",
-                "@module-federation/sdk": "2.2.2",
-                "chalk": "3.0.0",
+                "@module-federation/dts-plugin": "2.5.0",
+                "@module-federation/managers": "2.5.0",
+                "@module-federation/sdk": "2.5.0",
                 "find-pkg": "2.0.0"
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/rspack": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.2.2.tgz",
-            "integrity": "sha512-0ZZGt7+3636OX2NUoGaykdRdtGw0B24NSGnOs839T80Z1eShRErrtDCjo1FLLZ/DkShNkOuJ0ntxVeDWB78Sdg==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.5.0.tgz",
+            "integrity": "sha512-OAFMpMXuLEQFmWBuC1I7LNDQ8N3CDANXe0YGPWkIPNxKq5Tj/KNfDidmutoYgvXlZKOM4yKBKBsL6Xt/UvtOIw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/bridge-react-webpack-plugin": "2.2.2",
-                "@module-federation/dts-plugin": "2.2.2",
-                "@module-federation/inject-external-runtime-core-plugin": "2.2.2",
-                "@module-federation/managers": "2.2.2",
-                "@module-federation/manifest": "2.2.2",
-                "@module-federation/runtime-tools": "2.2.2",
-                "@module-federation/sdk": "2.2.2",
-                "btoa": "1.2.1"
+                "@module-federation/bridge-react-webpack-plugin": "2.5.0",
+                "@module-federation/dts-plugin": "2.5.0",
+                "@module-federation/inject-external-runtime-core-plugin": "2.5.0",
+                "@module-federation/managers": "2.5.0",
+                "@module-federation/manifest": "2.5.0",
+                "@module-federation/runtime-tools": "2.5.0",
+                "@module-federation/sdk": "2.5.0"
             },
             "peerDependencies": {
                 "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
@@ -5750,47 +5677,47 @@
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/runtime": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.2.2.tgz",
-            "integrity": "sha512-zV6kbAUU1tQZr4KrZXQhzQP3WTb7oMRlIFw4UBhbh2JhAKGYS5CNc/n7+RV+mDxIs//qVmVzdSpJtTOMBLeFCw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.5.0.tgz",
+            "integrity": "sha512-dOc7pFEf8aruHBk5hoJLnvwkCa5ELT78q3o9dqcdaa/TT74X5z0FT0BsaGaRBPcse/iP6czK3fWd7RLv5ZKP5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/error-codes": "2.2.2",
-                "@module-federation/runtime-core": "2.2.2",
-                "@module-federation/sdk": "2.2.2"
+                "@module-federation/error-codes": "2.5.0",
+                "@module-federation/runtime-core": "2.5.0",
+                "@module-federation/sdk": "2.5.0"
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/runtime-core": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.2.2.tgz",
-            "integrity": "sha512-JL+W6Yol1+CPJ662H1SEQLwxfBU2kCKhUcYrMr/X6j0qFWB8x5PBSpQbwAIcJiKfflHgBaJZypmCKmq8qRv3Aw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.5.0.tgz",
+            "integrity": "sha512-STmhQ3c6/hunba2FMP6GrHazXU/8GuN7Gk4dOkWNRpnqYIoD8Wx4MNl76j3HdCzBESC7uSMXTniksVaM1+xxyA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/error-codes": "2.2.2",
-                "@module-federation/sdk": "2.2.2"
+                "@module-federation/error-codes": "2.5.0",
+                "@module-federation/sdk": "2.5.0"
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/runtime-tools": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.2.2.tgz",
-            "integrity": "sha512-UnlKvy/zrbLTLItrI1tORiS6wdp5pYOCrR2LtDEbjJ2r+avzANSf2vJ7lAIT4SX5Pi9WwY5RhE4Y/BOwhAj4DA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.5.0.tgz",
+            "integrity": "sha512-fR3Na6V78ov3/O17Mev+1vydfmqlYWP4ZNxD/bBkmqKhCO7jMdthNTT02yDljlCyhYl6+X90UJlFhwFle6rIsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/runtime": "2.2.2",
-                "@module-federation/webpack-bundler-runtime": "2.2.2"
+                "@module-federation/runtime": "2.5.0",
+                "@module-federation/webpack-bundler-runtime": "2.5.0"
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/sdk": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.2.2.tgz",
-            "integrity": "sha512-BgbiLXl0sZ04IE6G2C1iZRLOaawfZqeJi9XjrQyoh3nJOHHL39rDhJ6xFCB5ayAjjoPqwB4Rc6xPpFXbO5PssQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.0.tgz",
+            "integrity": "sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
-                "node-fetch": "^3.3.2"
+                "node-fetch": "^2.7.0 || ^3.3.2"
             },
             "peerDependenciesMeta": {
                 "node-fetch": {
@@ -5799,41 +5726,79 @@
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/third-party-dts-extractor": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.2.2.tgz",
-            "integrity": "sha512-BWKLXQ2Me+zw6y2yhk8/URuVcyYFP1aJZlTqb7KpYeSJEp2z5jk8sZX2R42GraAGAwSe9IwcW6Y4Za/eoxt/tA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.5.0.tgz",
+            "integrity": "sha512-5di43LGk2ies86Cj8QyzYr540Ijc+nyPqYziyFotL6Pparnu+uf3b3ERfEyQfBmEcyGk1MpitQIO2J3bd9BcNw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "find-pkg": "2.0.0",
-                "fs-extra": "9.1.0",
                 "resolve": "1.22.8"
             }
         },
         "node_modules/@module-federation/node/node_modules/@module-federation/webpack-bundler-runtime": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.2.2.tgz",
-            "integrity": "sha512-g5UEn5APnNYvajwWQ0oc3Um+HO1z/jBcBkLSKAoSOCI6XxQk5eAV1PNDuDehAgJEtJw5yFD25kZPW3X7m39y7g==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.5.0.tgz",
+            "integrity": "sha512-UxVad+tNZYkBnZzqJQsZa0pB5gO5cJoCjMumOo3bhzXBJVqHsFupfeHa8Nk7WrRVbJE6zRT9ZHK0s0NDWBMyJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/runtime": "2.2.2",
-                "@module-federation/sdk": "2.2.2"
+                "@module-federation/error-codes": "2.5.0",
+                "@module-federation/runtime": "2.5.0",
+                "@module-federation/sdk": "2.5.0"
             }
         },
-        "node_modules/@module-federation/node/node_modules/chalk": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+        "node_modules/@module-federation/node/node_modules/adm-zip": {
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+            "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0"
+            }
+        },
+        "node_modules/@module-federation/node/node_modules/ajv": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
             },
-            "engines": {
-                "node": ">=8"
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
+        },
+        "node_modules/@module-federation/node/node_modules/ajv-formats": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@module-federation/node/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@module-federation/node/node_modules/resolve": {
             "version": "1.22.8",
@@ -5851,6 +5816,26 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/@module-federation/node/node_modules/schema-utils": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+            "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/@module-federation/node/node_modules/semver": {
@@ -6693,9 +6678,9 @@
             }
         },
         "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7084,9 +7069,9 @@
             }
         },
         "node_modules/@nx/module-federation/node_modules/body-parser": {
-            "version": "1.20.4",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-            "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+            "version": "1.20.5",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7098,7 +7083,7 @@
                 "http-errors": "~2.0.1",
                 "iconv-lite": "~0.4.24",
                 "on-finished": "~2.4.1",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "raw-body": "~2.5.3",
                 "type-is": "~1.6.18",
                 "unpipe": "~1.0.0"
@@ -7146,15 +7131,15 @@
             "license": "MIT"
         },
         "node_modules/@nx/module-federation/node_modules/express": {
-            "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-            "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+            "version": "4.22.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
+                "body-parser": "~1.20.5",
                 "content-disposition": "~0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "~0.7.1",
@@ -7173,7 +7158,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "~0.19.0",
@@ -7293,22 +7278,6 @@
             "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@nx/module-federation/node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/@nx/module-federation/node_modules/raw-body": {
             "version": "2.5.3",
@@ -7580,9 +7549,9 @@
             }
         },
         "node_modules/@nx/rspack/node_modules/body-parser": {
-            "version": "1.20.4",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-            "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+            "version": "1.20.5",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7594,7 +7563,7 @@
                 "http-errors": "~2.0.1",
                 "iconv-lite": "~0.4.24",
                 "on-finished": "~2.4.1",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "raw-body": "~2.5.3",
                 "type-is": "~1.6.18",
                 "unpipe": "~1.0.0"
@@ -7678,15 +7647,15 @@
             "license": "MIT"
         },
         "node_modules/@nx/rspack/node_modules/express": {
-            "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-            "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+            "version": "4.22.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
+                "body-parser": "~1.20.5",
                 "content-disposition": "~0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "~0.7.1",
@@ -7705,7 +7674,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "~0.19.0",
@@ -7865,22 +7834,6 @@
             "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@nx/rspack/node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/@nx/rspack/node_modules/raw-body": {
             "version": "2.5.3",
@@ -9487,9 +9440,9 @@
             }
         },
         "node_modules/@rspack/dev-server/node_modules/body-parser": {
-            "version": "1.20.4",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-            "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+            "version": "1.20.5",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9501,7 +9454,7 @@
                 "http-errors": "~2.0.1",
                 "iconv-lite": "~0.4.24",
                 "on-finished": "~2.4.1",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "raw-body": "~2.5.3",
                 "type-is": "~1.6.18",
                 "unpipe": "~1.0.0"
@@ -9574,15 +9527,15 @@
             "license": "MIT"
         },
         "node_modules/@rspack/dev-server/node_modules/express": {
-            "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-            "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+            "version": "4.22.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
+                "body-parser": "~1.20.5",
                 "content-disposition": "~0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "~0.7.1",
@@ -9601,7 +9554,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "~0.19.0",
@@ -9778,22 +9731,6 @@
             "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@rspack/dev-server/node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/@rspack/dev-server/node_modules/raw-body": {
             "version": "2.5.3",
@@ -10401,9 +10338,9 @@
             }
         },
         "node_modules/@tufjs/models/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11289,9 +11226,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12670,9 +12607,9 @@
             }
         },
         "node_modules/cacache/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12851,34 +12788,6 @@
             "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/chevrotain": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
-            "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@chevrotain/cst-dts-gen": "11.1.2",
-                "@chevrotain/gast": "11.1.2",
-                "@chevrotain/regexp-to-ast": "11.1.2",
-                "@chevrotain/types": "11.1.2",
-                "@chevrotain/utils": "11.1.2",
-                "lodash-es": "4.17.23"
-            }
-        },
-        "node_modules/chevrotain-allstar": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-            "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "lodash-es": "^4.17.21"
-            },
-            "peerDependencies": {
-                "chevrotain": "^11.0.0"
-            }
         },
         "node_modules/chokidar": {
             "version": "5.0.0",
@@ -15125,6 +15034,17 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-toolkit": {
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+            "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+            "license": "MIT",
+            "optional": true,
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
+        },
         "node_modules/esbuild": {
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
@@ -15356,9 +15276,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16760,9 +16680,9 @@
             }
         },
         "node_modules/happy-dom/node_modules/ws": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17291,9 +17211,9 @@
             }
         },
         "node_modules/ignore-walk/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17858,12 +17778,12 @@
             }
         },
         "node_modules/js-cookie": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+            "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
             "license": "MIT",
             "engines": {
-                "node": ">=14"
+                "node": ">=20"
             }
         },
         "node_modules/js-tokens": {
@@ -18206,24 +18126,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/langium": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
-            "integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "chevrotain": "~11.1.1",
-                "chevrotain-allstar": "~0.3.1",
-                "vscode-languageserver": "~9.0.1",
-                "vscode-languageserver-textdocument": "~1.0.11",
-                "vscode-uri": "~3.1.0"
-            },
-            "engines": {
-                "node": ">=20.10.0",
-                "npm": ">=10.2.3"
             }
         },
         "node_modules/launch-editor": {
@@ -19248,15 +19150,15 @@
             }
         },
         "node_modules/mermaid": {
-            "version": "11.13.0",
-            "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.13.0.tgz",
-            "integrity": "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==",
+            "version": "11.15.0",
+            "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+            "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
                 "@braintree/sanitize-url": "^7.1.1",
                 "@iconify/utils": "^3.0.2",
-                "@mermaid-js/parser": "^1.0.1",
+                "@mermaid-js/parser": "^1.1.1",
                 "@types/d3": "^7.4.3",
                 "@upsetjs/venn.js": "^2.0.0",
                 "cytoscape": "^3.33.1",
@@ -19267,14 +19169,14 @@
                 "dagre-d3-es": "7.0.14",
                 "dayjs": "^1.11.19",
                 "dompurify": "^3.3.1",
+                "es-toolkit": "^1.45.1",
                 "katex": "^0.16.25",
                 "khroma": "^2.1.0",
-                "lodash-es": "^4.17.23",
                 "marked": "^16.3.0",
                 "roughjs": "^4.6.6",
                 "stylis": "^4.3.6",
                 "ts-dedent": "^2.2.0",
-                "uuid": "^11.1.0"
+                "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
             }
         },
         "node_modules/mermaid/node_modules/marked": {
@@ -19288,20 +19190,6 @@
             },
             "engines": {
                 "node": ">= 20"
-            }
-        },
-        "node_modules/mermaid/node_modules/uuid": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/methods": {
@@ -19681,9 +19569,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "dev": true,
             "funding": [
                 {
@@ -21211,9 +21099,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "dev": true,
             "funding": [
                 {
@@ -21231,7 +21119,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -22081,9 +21969,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-            "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -25431,61 +25319,6 @@
                 }
             }
         },
-        "node_modules/vscode-jsonrpc": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/vscode-languageserver": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-            "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "vscode-languageserver-protocol": "3.17.5"
-            },
-            "bin": {
-                "installServerIntoExtension": "bin/installServerIntoExtension"
-            }
-        },
-        "node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "vscode-jsonrpc": "8.2.0",
-                "vscode-languageserver-types": "3.17.5"
-            }
-        },
-        "node_modules/vscode-languageserver-textdocument": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/vscode-languageserver-types": {
-            "version": "3.17.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/vscode-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-            "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/w3c-keyname": {
             "version": "2.2.8",
             "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -25723,9 +25556,9 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/body-parser": {
-            "version": "1.20.4",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-            "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+            "version": "1.20.5",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -25737,7 +25570,7 @@
                 "http-errors": "~2.0.1",
                 "iconv-lite": "~0.4.24",
                 "on-finished": "~2.4.1",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "raw-body": "~2.5.3",
                 "type-is": "~1.6.18",
                 "unpipe": "~1.0.0"
@@ -25810,15 +25643,15 @@
             "license": "MIT"
         },
         "node_modules/webpack-dev-server/node_modules/express": {
-            "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-            "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+            "version": "4.22.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
+                "body-parser": "~1.20.5",
                 "content-disposition": "~0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "~0.7.1",
@@ -25837,7 +25670,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "~0.19.0",
@@ -26014,22 +25847,6 @@
             "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/webpack-dev-server/node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/webpack-dev-server/node_modules/raw-body": {
             "version": "2.5.3",


### PR DESCRIPTION
Run npm audit fix on nifi-frontend to address advisories in qs and express. Upgrades qs 6.15.0 -> 6.15.2 and express 4.22.1 -> 4.22.2 (across nested webpack-dev-server / @nx / @rspack copies). Resolver also picks up in-range updates for js-cookie 3.0.5 -> 3.0.7, brace-expansion 5.0.5 -> 5.0.6, @mermaid-js/parser 1.0.1 -> 1.1.1, and @module-federation/* 2.7.36/2.2.2 -> 2.7.43/2.5.0, and dedupes nested qs/uuid/chalk copies. No package.json changes.