### PR TITLE
NIFI-15977 Configurable port in PutSmbFile

### DIFF
--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/PutSmbFile.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/PutSmbFile.java
@@ -97,6 +97,13 @@ public class PutSmbFile extends AbstractProcessor {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
+    public static final PropertyDescriptor PORT = new PropertyDescriptor.Builder()
+            .name("Port")
+            .description("The port to use for the SMB connection.")
+            .required(true)
+            .addValidator(StandardValidators.PORT_VALIDATOR)
+            .defaultValue("445")
+            .build();
     public static final PropertyDescriptor SHARE = new PropertyDescriptor.Builder()
             .name("Share")
             .description("The network share to which files should be written. This is the \"first folder\"" +
@@ -179,6 +186,7 @@ public class PutSmbFile extends AbstractProcessor {
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             HOSTNAME,
+            PORT,
             SHARE,
             DIRECTORY,
             DOMAIN,
@@ -297,6 +305,7 @@ public class PutSmbFile extends AbstractProcessor {
 
         final String hostname = flowFileFilter.getHostName();
         final String shareName = flowFileFilter.getShare();
+        final int port = context.getProperty(PORT).asInteger();
         final String domain = context.getProperty(DOMAIN).getValue();
         final String username = context.getProperty(USERNAME).getValue();
         String password = context.getProperty(PASSWORD).getValue();
@@ -311,7 +320,7 @@ public class PutSmbFile extends AbstractProcessor {
             ac = AuthenticationContext.anonymous();
         }
 
-        try (Connection connection = smbClient.connect(hostname);
+        try (Connection connection = smbClient.connect(hostname, port);
             Session smbSession = connection.authenticate(ac);
             DiskShare share = (DiskShare) smbSession.connectShare(shareName)) {
 

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/PutSmbFileTest.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/PutSmbFileTest.java
@@ -50,6 +50,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
@@ -96,7 +97,7 @@ public class PutSmbFileTest {
         serverList = mock(ServerList.class);
         baOutputStream = new ByteArrayOutputStream();
 
-        when(smbClient.connect(any(String.class))).thenReturn(connection);
+        when(smbClient.connect(any(String.class), anyInt())).thenReturn(connection);
         when(smbClient.getServerList()).thenReturn(serverList);
 
         when(connection.authenticate(any(AuthenticationContext.class))).thenReturn(session);
@@ -240,6 +241,23 @@ public class PutSmbFileTest {
 
         // 20 FlowFiles share the same hostname and share as the first processed FlowFile, but since the batch size is 10, 30 FlowFiles should remain in the queue
         assertEquals(30, testRunner.getQueueSize().getObjectCount());
+    }
+
+    @Test
+    public void testDefaultPortIsUsed() throws IOException {
+        testRunner.enqueue("data");
+        testRunner.run();
+
+        verify(smbClient).connect(HOSTNAME, 445);
+    }
+
+    @Test
+    public void testCustomPortIsUsed() throws IOException {
+        testRunner.setProperty(PutSmbFile.PORT, "4445");
+        testRunner.enqueue("data");
+        testRunner.run();
+
+        verify(smbClient).connect(HOSTNAME, 4445);
     }
 
     @Test
@@ -431,7 +449,7 @@ public class PutSmbFileTest {
     @Test
     public void testConnectionError() throws IOException {
         String emsg = "mock connection exception";
-        when(smbClient.connect(any(String.class))).thenThrow(new IOException(emsg));
+        when(smbClient.connect(any(String.class), anyInt())).thenThrow(new IOException(emsg));
 
         testRunner.enqueue("1");
         testRunner.enqueue("2");


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

NIFI-15977 Configurable port in PutSmbFile

This is likely a short term solution, long term would be to utilize `SmbClientProviderService`, but it is yet to be decided whether an in-place migration of `PutSmbFile` would make sense or would creating a new processor be better approach.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [x] JDK 25

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
