### PR TITLE
NIFI-15978: Rendering allowable value descriptions in the Connector w…

### DIFF
--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.spec.ts
@@ -44,9 +44,9 @@ function makeProp(overrides: Partial<ConnectorPropertyDescriptor> = {}): Connect
     };
 }
 
-function makeAllowable(value: string, displayName: string = value): AllowableValue {
+function makeAllowable(value: string, displayName: string = value, description?: string): AllowableValue {
     return {
-        allowableValue: { value, displayName },
+        allowableValue: { value, displayName, description },
         canRead: true
     };
 }
@@ -289,8 +289,24 @@ describe('ConnectorPropertyInput', () => {
             });
 
             expect(inputComponent.selectOptions).toEqual([
-                { value: 'v1', label: 'Value One' },
-                { value: 'v2', label: 'Value Two' }
+                { value: 'v1', label: 'Value One', description: undefined },
+                { value: 'v2', label: 'Value Two', description: undefined }
+            ]);
+        });
+
+        it('includes allowable value descriptions in select options when present', async () => {
+            const { inputComponent } = await setup({
+                property: makeProp({
+                    allowableValues: [
+                        makeAllowable('v1', 'Value One', 'First option description'),
+                        makeAllowable('v2', 'Value Two', 'Second option description')
+                    ]
+                })
+            });
+
+            expect(inputComponent.selectOptions).toEqual([
+                { value: 'v1', label: 'Value One', description: 'First option description' },
+                { value: 'v2', label: 'Value Two', description: 'Second option description' }
             ]);
         });
 
@@ -309,8 +325,27 @@ describe('ConnectorPropertyInput', () => {
             fixture.detectChanges();
 
             expect(inputComponent.selectOptions).toEqual([
-                { value: 'dyn-1', label: 'Dynamic 1' },
-                { value: 'dyn-2', label: 'Dynamic 2' }
+                { value: 'dyn-1', label: 'Dynamic 1', description: undefined },
+                { value: 'dyn-2', label: 'Dynamic 2', description: undefined }
+            ]);
+        });
+
+        it('includes descriptions from dynamic allowable values state', async () => {
+            const { inputComponent, host, fixture } = await setup({
+                property: makeProp({ allowableValuesFetchable: true })
+            });
+
+            host.dynamicAllowableValuesState.set({
+                loading: false,
+                error: null,
+                values: [makeAllowable('dyn-1', 'Dynamic 1', 'Fetched option description')]
+            });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(inputComponent.selectOptions).toEqual([
+                { value: 'dyn-1', label: 'Dynamic 1', description: 'Fetched option description' }
             ]);
         });
 

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.ts
@@ -538,7 +538,8 @@ export class ConnectorPropertyInput implements ControlValueAccessor, DoCheck, On
 
         const options: SearchableSelectOption<string>[] = allowableValues.map((av) => ({
             value: av.allowableValue.value,
-            label: av.allowableValue.displayName
+            label: av.allowableValue.displayName,
+            description: av.allowableValue.description
         }));
 
         // Surface saved values that are no longer in the loaded allowable list

--- a/nifi-frontend/src/main/frontend/libs/shared/src/types/index.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/types/index.ts
@@ -415,6 +415,7 @@ export interface AllowableValue {
     allowableValue: {
         displayName: string;
         value: string;
+        description?: string;
     };
     canRead: boolean;
 }


### PR DESCRIPTION
…izard.

### NIFI-15978 Rendering allowable value descriptions in the Connector wizard

## Summary

The Connector wizard's property dropdowns currently render only an allowable value's display name, even though the framework's `AllowableValueDTO` already serializes a `description` field (used elsewhere — e.g. processor property dialogs — to give users context about each option). This PR plumbs that description through to the wizard's `searchable-select` so users see the same secondary descriptive text per option that they see in the rest of the UI.

## Changes

- **`libs/shared/src/types/index.ts`** — Added the optional `description?: string` to the nested `AllowableValue.allowableValue` shape so it matches what the backend already returns from `AllowableValueDTO`.
- **`libs/shared/src/components/connector-property-input/connector-property-input.component.ts`** — In `computeSelectOptions`, propagate `av.allowableValue.description` onto the emitted `SearchableSelectOption`. The `searchable-select` component already renders an option's `description` as a secondary line (and already sizes virtual-scroll rows accordingly), so no template or styling changes are needed.
- **`libs/shared/src/components/connector-property-input/connector-property-input.component.spec.ts`** — Extended the `makeAllowable` helper to accept an optional description, adjusted existing assertions to expect `description: undefined` where appropriate, and added focused specs covering description propagation for both the static `property.allowableValues` path and the dynamic `PropertyAllowableValuesState` path.

## Backend alignment

No backend changes are required. Verified that:

- `AllowableValueDTO` already exposes `description` (`getDescription()` / `setDescription()`).
- `DtoFactory.createAllowableValueDto(...)` populates the description for statically declared allowable values.
- `StandardNiFiServiceFacade` populates the description for allowable values produced dynamically via a property's `AllowableValuesProvider`.

So any connector that declares descriptions on its `AllowableValue`s — static or dynamic — will surface them in the wizard with no further wiring.
