### PR TITLE
NIFI-15980 - Bump Logback to 1.5.33, Tika to 3.3.1, SSHd to 2.18.0, and others

### DIFF
--- a/nifi-commons/nifi-metrics/pom.xml
+++ b/nifi-commons/nifi-metrics/pom.xml
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jvm</artifactId>
-            <version>4.2.38</version>
+            <version>4.2.39</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>4.2.38</version>
+            <version>4.2.39</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
-            <version>1.1.7</version>
+            <version>1.1.9</version>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>

--- a/nifi-extension-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.box</groupId>
                 <artifactId>box-java-sdk</artifactId>
-                <version>5.11.0</version>
+                <version>5.12.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-reporting-utils/pom.xml
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-reporting-utils/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
-            <version>1.1.7</version>
+            <version>1.1.9</version>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tika.version>3.3.0</tika.version>
+        <tika.version>3.3.1</tika.version>
     </properties>
     <dependencies>
         <dependency>

--- a/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
@@ -34,6 +34,6 @@
     </modules>
 
     <properties>
-        <mongo.driver.version>5.7.0</mongo.driver.version>
+        <mongo.driver.version>5.7.1</mongo.driver.version>
     </properties>
 </project>

--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/pom.xml
+++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
-            <version>1.1.7</version>
+            <version>1.1.9</version>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -34,7 +34,7 @@
         <module>nifi-standard-content-viewer-nar</module>
     </modules>
     <properties>
-        <tika.version>3.3.0</tika.version>
+        <tika.version>3.3.1</tika.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.44.12</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.44.14</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.7</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -131,7 +131,7 @@
         <org.apache.commons.codec.version>1.22.0</org.apache.commons.codec.version>
         <org.apache.commons.collections4.version>4.5.0</org.apache.commons.collections4.version>
         <org.apache.commons.compress.version>1.28.0</org.apache.commons.compress.version>
-        <org.apache.commons.configuration.version>2.15.0</org.apache.commons.configuration.version>
+        <org.apache.commons.configuration.version>2.15.1</org.apache.commons.configuration.version>
         <org.apache.commons.csv.version>1.14.1</org.apache.commons.csv.version>
         <org.apache.commons.io.version>2.22.0</org.apache.commons.io.version>
         <org.apache.commons.lang3.version>3.20.0</org.apache.commons.lang3.version>
@@ -168,7 +168,7 @@
 
         <!-- Logging and observability -->
         <log4j2.version>2.26.0</log4j2.version>
-        <logback.version>1.5.32</logback.version>
+        <logback.version>1.5.33</logback.version>
         <org.slf4j.version>2.0.18</org.slf4j.version>
         <prometheus.version>0.16.0</prometheus.version>
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
@@ -179,7 +179,7 @@
         <okio.version>3.17.0</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
-        <org.apache.sshd.version>2.17.1</org.apache.sshd.version>
+        <org.apache.sshd.version>2.18.0</org.apache.sshd.version>
 
         <!-- Security -->
         <nimbus-jose-jwt.version>10.9</nimbus-jose-jwt.version>
@@ -196,7 +196,7 @@
         <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
         <jakarta.xml.bind-api.version>4.0.5</jakarta.xml.bind-api.version>
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
-        <jaxb.runtime.version>4.0.8</jaxb.runtime.version>
+        <jaxb.runtime.version>4.0.9</jaxb.runtime.version>
         <jersey.bom.version>4.0.2</jersey.bom.version>
         <jetty.version>12.1.9</jetty.version>
         <servlet-api.version>6.1.0</servlet-api.version>


### PR DESCRIPTION
# Summary

NIFI-15980 - Bump Logback to 1.5.33, Tika to 3.3.1, SSHd to 2.18.0, and others

- DropWizard Metrics from 4.2.38 to 4.2.39 - https://github.com/dropwizard/metrics/releases/tag/v4.2.39
- Eclipse Parsson from 1.1.7 to 1.1.9 - https://github.com/eclipse-ee4j/parsson/releases/tag/1.1.9
- Box SDK from 5.11.0 to 5.12.0 - https://github.com/box/box-java-sdk/releases/tag/v5.12.0
- Apache Tika from 3.3.0 to 3.3.1 - https://dist.apache.org/repos/dist/release/tika/3.3.1/CHANGES-3.3.1.txt
- Apache SSHD from 2.17.1 to 2.18.0 - https://github.com/apache/mina-sshd/releases/tag/sshd-2.18.0
- Apache Commons Configuration from 2.15.0 to 2.15.1 - https://commons.apache.org/proper/commons-configuration/changes.html#a2.15.1
- MongoDB Driver from 5.7.0 to 5.7.1 - https://github.com/mongodb/mongo-java-driver/releases/tag/r5.7.1
- AWS SDK BOM from 2.44.12 to 2.44.14 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Logback from 1.5.32 to 1.5.33 - https://github.com/qos-ch/logback/releases/tag/v_1.5.33
- JAXB from 4.0.8 to 4.0.9 - https://github.com/eclipse-ee4j/jaxb-ri/releases/tag/4.0.9-RI

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
