### PR TITLE
NIFI-15943 Shorten logging messages in ParameterProviderSecretsManager

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/components/connector/secrets/ParameterProviderSecretsManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/components/connector/secrets/ParameterProviderSecretsManager.java
@@ -117,8 +117,7 @@ public class ParameterProviderSecretsManager implements SecretsManager {
             if (providerId != null) {
                 final ValidationStatus priorWarnedStatus = lastWarnedStatus.remove(providerId);
                 if (priorWarnedStatus != null) {
-                    logger.info("Parameter Provider [{}] (id={}) returned to VALID after being logged as {};"
-                                    + " SecretReferences backed by this provider will resolve again",
+                    logger.info("Parameter Provider [{}] (id={}) returned to VALID from {}; SecretReferences will resolve again",
                             parameterProviderNode.getName(), providerId, priorWarnedStatus);
                 }
             }
@@ -307,8 +306,7 @@ public class ParameterProviderSecretsManager implements SecretsManager {
             return;
         }
 
-        logger.warn("Skipping Parameter Provider [{}] (id={}) as a Secret Provider because its current validation status is {}; "
-                        + "SecretReferences backed by this provider will resolve to null until it returns to VALID",
+        logger.warn("Skipping Parameter Provider [{}] (id={}) with status {}; SecretReferences will resolve to null until VALID",
                 parameterProviderNode.getName(), providerId, effectiveStatus);
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

Shortened logging messages in ParameterProviderSecretsManager
Replaced string concatenation with parameterized logging

# Summary

[NIFI-15943](https://issues.apache.org/jira/browse/NIFI-15943)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
