### PR TITLE
NIFI-15981 - Fix NPE in ResultSetRecordSet for ARRAY columns when no reader schema is provided

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -285,15 +285,17 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
 
     private DataType getArrayDataType(final ResultSet rs, final RecordSchema readerSchema, final int columnIndex, final boolean useLogicalTypes) throws SQLException {
         // We first want to check if the Reader Schema can tell us what the type of the array is.
-        final String columnName = rs.getMetaData().getColumnName(columnIndex);
-        final Optional<RecordField> optionalRecordField = readerSchema.getField(columnName);
-        if (optionalRecordField.isPresent()) {
-            final RecordField recordField = optionalRecordField.get();
-            final DataType dataType = recordField.getDataType();
-            if (dataType.getFieldType() == RecordFieldType.ARRAY) {
-                final ArrayDataType arrayDataType = (ArrayDataType) dataType;
-                if (arrayDataType.getElementType() != null) {
-                    return dataType;
+        if (readerSchema != null) {
+            final String columnName = rs.getMetaData().getColumnName(columnIndex);
+            final Optional<RecordField> optionalRecordField = readerSchema.getField(columnName);
+            if (optionalRecordField.isPresent()) {
+                final RecordField recordField = optionalRecordField.get();
+                final DataType dataType = recordField.getDataType();
+                if (dataType.getFieldType() == RecordFieldType.ARRAY) {
+                    final ArrayDataType arrayDataType = (ArrayDataType) dataType;
+                    if (arrayDataType.getElementType() != null) {
+                        return dataType;
+                    }
                 }
             }
         }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/ResultSetRecordSetTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/ResultSetRecordSetTest.java
@@ -386,6 +386,25 @@ public class ResultSetRecordSetTest {
     }
 
     @Test
+    public void testCreateSchemaArrayWithNullReaderSchema() throws SQLException {
+        final ResultSet resultSet = Mockito.mock(ResultSet.class);
+        final ResultSetMetaData resultSetMetaData = Mockito.mock(ResultSetMetaData.class);
+        when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+        when(resultSetMetaData.getColumnCount()).thenReturn(1);
+        when(resultSetMetaData.getColumnLabel(1)).thenReturn("enabled_products");
+        when(resultSetMetaData.getColumnType(1)).thenReturn(Types.ARRAY);
+
+        final ResultSqlArray array = Mockito.mock(ResultSqlArray.class);
+        when(array.getArray()).thenReturn(new String[]{"Test"});
+        when(resultSet.getArray(1)).thenReturn(array);
+
+        final ResultSetRecordSet testSubject = new ResultSetRecordSet(resultSet, null);
+        final RecordSchema resultSchema = testSubject.getSchema();
+
+        assertEquals(RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.STRING.getDataType()), resultSchema.getField(0).getDataType());
+    }
+
+    @Test
     public void testArrayTypeWithLogicalTypes() throws SQLException {
         testArrayType(true);
     }


### PR DESCRIPTION
# Summary

NIFI-15981 - Fix NPE in ResultSetRecordSet for ARRAY columns when no reader schema is provided

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
