### PR TITLE
NIFI-15943 Streamline log messages in ParameterProviderSecretsManager

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/components/connector/secrets/ParameterProviderSecretsManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/components/connector/secrets/ParameterProviderSecretsManager.java
@@ -22,6 +22,7 @@ import org.apache.nifi.components.connector.SecretReference;
 import org.apache.nifi.components.validation.ValidationStatus;
 import org.apache.nifi.controller.ParameterProviderNode;
 import org.apache.nifi.controller.flow.FlowManager;
+import org.apache.nifi.parameter.ParameterProvider;
 import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.util.NiFiProperties;
 import org.slf4j.Logger;
@@ -117,9 +118,8 @@ public class ParameterProviderSecretsManager implements SecretsManager {
             if (providerId != null) {
                 final ValidationStatus priorWarnedStatus = lastWarnedStatus.remove(providerId);
                 if (priorWarnedStatus != null) {
-                    logger.info("Parameter Provider [{}] (id={}) returned to VALID after being logged as {};"
-                                    + " SecretReferences backed by this provider will resolve again",
-                            parameterProviderNode.getName(), providerId, priorWarnedStatus);
+                    final ParameterProvider parameterProvider = parameterProviderNode.getParameterProvider();
+                    logger.info("{} returned to VALID after being logged as [{}] now resolving Secret References", parameterProvider, priorWarnedStatus);
                 }
             }
             providers.add(new ParameterProviderSecretProvider(parameterProviderNode));
@@ -144,7 +144,7 @@ public class ParameterProviderSecretsManager implements SecretsManager {
         if (!cacheDuration.isZero()) {
             final CachedSecret cached = secretCache.get(fqn);
             if (cached != null && !isExpired(cached)) {
-                logger.debug("Cache hit for secret [{}]", fqn);
+                logger.debug("Cached Secret found [{}]", fqn);
                 return Optional.ofNullable(cached.secret());
             }
         }
@@ -228,7 +228,7 @@ public class ParameterProviderSecretsManager implements SecretsManager {
             if (fqn != null) {
                 final CachedSecret cached = secretCache.get(fqn);
                 if (cached != null && !isExpired(cached)) {
-                    logger.debug("Cache hit for secret [{}]", fqn);
+                    logger.debug("Cached Secret found [{}]", fqn);
                     results.put(secretReference, cached.secret());
                     continue;
                 }
@@ -307,9 +307,8 @@ public class ParameterProviderSecretsManager implements SecretsManager {
             return;
         }
 
-        logger.warn("Skipping Parameter Provider [{}] (id={}) as a Secret Provider because its current validation status is {}; "
-                        + "SecretReferences backed by this provider will resolve to null until it returns to VALID",
-                parameterProviderNode.getName(), providerId, effectiveStatus);
+        final ParameterProvider parameterProvider = parameterProviderNode.getParameterProvider();
+        logger.warn("{} skipped as a Secret Provider with validation status [{}] resolving Secret References as null until VALID", parameterProvider, effectiveStatus);
     }
 
     private SecretProvider findProvider(final SecretReference secretReference, final Set<SecretProvider> providers) {


### PR DESCRIPTION
# Summary

[NIFI-15943](https://issues.apache.org/jira/browse/NIFI-15943) Streamlines log messages in `ParameterProviderSecretsManager` using the `toString()` representation of the wrapped `ParameterProvider` where applicable and making the log message more concise.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
