### PR TITLE
NIFI-15984 Use HOSTNAME_PORT_VALIDATOR for Token Request Endpoint in AwsRdsIamDatabasePasswordProvider

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/rds/AwsRdsIamDatabasePasswordProvider.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/rds/AwsRdsIamDatabasePasswordProvider.java
@@ -67,7 +67,7 @@ public class AwsRdsIamDatabasePasswordProvider extends AbstractControllerService
             .name("Token Request Endpoint")
             .description("Token Request Endpoint in hostname:port format used for IAM token signing, overriding the hostname and port from the JDBC URL.")
             .required(false)
-            .addValidator(StandardValidators.HOSTNAME_PORT_LIST_VALIDATOR)
+            .addValidator(StandardValidators.HOSTNAME_PORT_VALIDATOR)
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

depends on https://github.com/apache/nifi-api/pull/91

# Summary

[NIFI-15984](https://issues.apache.org/jira/browse/NIFI-15984)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [x] JDK 25

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
