### PR TITLE
NIFI-15888 Add size limit to Standard Content Viewer

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/controller/StandardContentViewerController.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/controller/StandardContentViewerController.java
@@ -28,6 +28,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.io.DatumReader;
 import org.apache.nifi.authorization.AccessDeniedException;
+import org.apache.nifi.stream.io.LimitingInputStream;
 import org.apache.nifi.web.ContentAccess;
 import org.apache.nifi.web.ContentRequestContext;
 import org.apache.nifi.web.DownloadableContent;
@@ -45,6 +46,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
@@ -52,17 +57,24 @@ public class StandardContentViewerController extends HttpServlet {
 
     static final String CONTENT_ACCESS_ATTRIBUTE = "nifi-content-access";
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final int CONTENT_LENGTH_LIMIT = 10_485_760;
+
+    private static final Map<String, ContentType> CONTENT_TYPES = Arrays.stream(ContentType.values())
+            .collect(
+                    Collectors.toMap(ContentType::name, Function.identity())
+            );
+
     private static final Logger logger = LoggerFactory.getLogger(StandardContentViewerController.class);
 
     @Override
     public void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
         final ContentRequestContext requestContext = new HttpServletContentRequestContext(request);
 
-        // get the content
         final ServletContext servletContext = request.getServletContext();
         final ContentAccess contentAccess = (ContentAccess) servletContext.getAttribute(CONTENT_ACCESS_ATTRIBUTE);
 
-        // get the content
         final DownloadableContent downloadableContent;
         try {
             downloadableContent = contentAccess.getContent(requestContext);
@@ -80,38 +92,47 @@ public class StandardContentViewerController extends HttpServlet {
             return;
         }
 
-        response.setStatus(HttpServletResponse.SC_OK);
-
+        final LimitingInputStream contentStream = getContentStream(downloadableContent);
         final boolean formatted = Boolean.parseBoolean(request.getParameter("formatted"));
-        if (!formatted) {
-            final InputStream contentStream = downloadableContent.getContent();
+        if (formatted) {
+            final ContentType formattedContentType = getFormattedContentType(request, downloadableContent.getType());
+            if (formattedContentType == null) {
+                response.sendError(HttpURLConnection.HTTP_NOT_ACCEPTABLE, "Unknown Content Type");
+            } else {
+                final String dataUri = requestContext.getDataUri();
+                writeContentFormatted(dataUri, formattedContentType, contentStream, response);
+                response.setStatus(HttpServletResponse.SC_OK);
+            }
+        } else {
             contentStream.transferTo(response.getOutputStream());
-            return;
+            if (contentStream.hasReachedLimit()) {
+                response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
+            } else {
+                response.setStatus(HttpServletResponse.SC_OK);
+            }
         }
+    }
 
-        // allow the user to drive the data type but fall back to the content type if necessary
-        String displayName = request.getParameter("mimeTypeDisplayName");
-        if (displayName == null) {
-            final String contentType = downloadableContent.getType();
-            displayName = getDisplayName(contentType);
-        }
+    protected LimitingInputStream getContentStream(final DownloadableContent downloadableContent) {
+        final InputStream contentStream = downloadableContent.getContent();
+        return new LimitingInputStream(contentStream, CONTENT_LENGTH_LIMIT);
+    }
 
-        if (displayName == null) {
-            response.sendError(HttpURLConnection.HTTP_BAD_REQUEST, "Unknown content type");
-            return;
-        }
-
+    private void writeContentFormatted(
+            final String dataUri,
+            final ContentType contentType,
+            final LimitingInputStream contentStream,
+            final HttpServletResponse response
+    ) throws IOException {
         try {
-            switch (displayName) {
-                case "json": {
-                    // format json
-                    final ObjectMapper mapper = new ObjectMapper();
-                    final Object objectJson = mapper.readValue(downloadableContent.getContent(), Object.class);
-                    mapper.writerWithDefaultPrettyPrinter().writeValue(response.getOutputStream(), objectJson);
+            switch (contentType) {
+                case JSON: {
+                    final Object objectJson = OBJECT_MAPPER.readValue(contentStream, Object.class);
+                    OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValue(response.getOutputStream(), objectJson);
                     break;
                 }
-                case "xml": {
-                    final StreamSource source = new StreamSource(downloadableContent.getContent());
+                case XML: {
+                    final StreamSource source = new StreamSource(contentStream);
                     try (OutputStream outputStream = new FormattingOutputStream(response.getOutputStream())) {
                         final StreamResult result = new StreamResult(outputStream);
                         final StandardTransformProvider transformProvider = new StandardTransformProvider();
@@ -121,7 +142,7 @@ public class StandardContentViewerController extends HttpServlet {
                     }
                     break;
                 }
-                case "avro": {
+                case AVRO: {
                     final StringBuilder sb = new StringBuilder();
                     sb.append("[");
                     // Use Avro conversions to display logical type values in human readable way.
@@ -135,16 +156,12 @@ public class StandardContentViewerController extends HttpServlet {
                     genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
                     genericData.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
                     final DatumReader<GenericData.Record> datumReader = new GenericDatumReader<>(null, null, genericData);
-                    try (final DataFileStream<GenericData.Record> dataFileReader = new DataFileStream<>(downloadableContent.getContent(), datumReader)) {
+                    try (final DataFileStream<GenericData.Record> dataFileReader = new DataFileStream<>(contentStream, datumReader)) {
                         while (dataFileReader.hasNext()) {
                             final GenericData.Record record = dataFileReader.next();
                             final String formattedRecord = genericData.toString(record);
                             sb.append(formattedRecord);
                             sb.append(",");
-                            // Do not format more than 10 MB of content.
-                            if (sb.length() > 1024 * 1024 * 2) {
-                                break;
-                            }
                         }
                     }
 
@@ -154,16 +171,14 @@ public class StandardContentViewerController extends HttpServlet {
                     sb.append("]");
                     final String json = sb.toString();
 
-                    final ObjectMapper mapper = new ObjectMapper();
-                    final Object objectJson = mapper.readValue(json, Object.class);
-
-                    mapper.writerWithDefaultPrettyPrinter().writeValue(response.getOutputStream(), objectJson);
+                    final Object objectJson = OBJECT_MAPPER.readValue(json, Object.class);
+                    OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValue(response.getOutputStream(), objectJson);
                     break;
                 }
-                case "yaml": {
+                case YAML: {
                     Yaml yaml = new Yaml();
                     // Parse the YAML file
-                    final Object yamlObject = yaml.load(downloadableContent.getContent());
+                    final Object yamlObject = yaml.load(contentStream);
                     DumperOptions options = new DumperOptions();
                     options.setIndent(2);
                     options.setPrettyFlow(true);
@@ -174,33 +189,64 @@ public class StandardContentViewerController extends HttpServlet {
                     output.dump(yamlObject, response.getWriter());
                     break;
                 }
-                case "csv":
-                case "text": {
-                    final InputStream contentStream = downloadableContent.getContent();
+                case CSV:
+                case TEXT: {
                     contentStream.transferTo(response.getOutputStream());
                     break;
                 }
                 default: {
-                    response.sendError(HttpURLConnection.HTTP_BAD_REQUEST, "Unsupported content type: " + displayName);
+                    response.sendError(HttpURLConnection.HTTP_NOT_ACCEPTABLE, "Unsupported Content Type: %s".formatted(contentType));
                 }
             }
         } catch (final Throwable t) {
-            logger.warn("Unable to format FlowFile content", t);
-            response.sendError(HttpURLConnection.HTTP_INTERNAL_ERROR, "Unable to format FlowFile content");
+            final String message;
+
+            if (contentStream.hasReachedLimit()) {
+                message = "FlowFile Content-Length exceeds maximum allowed";
+                logger.warn("Requested FlowFile [{}] Content-Length exceeds maximum allowed [{} bytes]", dataUri, CONTENT_LENGTH_LIMIT, t);
+            } else {
+                message = "FlowFile formatting failed";
+                logger.warn("Requested FlowFile [{}] formatting failed for Content Type [{}]", dataUri, contentType, t);
+            }
+
+            response.sendError(HttpURLConnection.HTTP_INTERNAL_ERROR, message);
         }
     }
 
-    private String getDisplayName(final String contentType) {
+    private ContentType getFormattedContentType(final HttpServletRequest request, final String downloadableContentType) {
+        final ContentType formattedContentType;
+
+        final String mimeTypeDisplayName = request.getParameter("mimeTypeDisplayName");
+        if (mimeTypeDisplayName == null) {
+            formattedContentType = getFormattedContentType(downloadableContentType);
+        } else {
+            final String upperCasedContentType = mimeTypeDisplayName.toUpperCase();
+            formattedContentType = CONTENT_TYPES.get(upperCasedContentType);
+        }
+
+        return formattedContentType;
+    }
+
+    private ContentType getFormattedContentType(final String contentType) {
         return switch (contentType) {
-            case "application/json" -> "json";
-            case "application/xml", "text/xml" -> "xml";
-            case "application/avro-binary", "avro/binary", "application/avro+binary" -> "avro";
+            case "application/json" -> ContentType.JSON;
+            case "application/xml", "text/xml" -> ContentType.XML;
+            case "application/avro-binary", "avro/binary", "application/avro+binary" -> ContentType.AVRO;
             case "text/x-yaml", "text/yaml", "text/yml", "application/x-yaml", "application/x-yml", "application/yaml",
-                 "application/yml" -> "yaml";
-            case "text/plain" -> "text";
-            case "text/csv" -> "csv";
+                 "application/yml" -> ContentType.YAML;
+            case "text/plain" -> ContentType.TEXT;
+            case "text/csv" -> ContentType.CSV;
             case null, default -> null;
         };
+    }
+
+    private enum ContentType {
+        AVRO,
+        CSV,
+        JSON,
+        TEXT,
+        XML,
+        YAML
     }
 
     private static class FormattingOutputStream extends FilterOutputStream {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/controller/StandardContentViewerController.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/main/java/org/apache/nifi/web/controller/StandardContentViewerController.java
@@ -92,7 +92,12 @@ public class StandardContentViewerController extends HttpServlet {
             return;
         }
 
+        // Set Response Status before committing based on formatted or unformatted stream handling
+        final int responseStatus = getResponseStatus(downloadableContent);
+        response.setStatus(responseStatus);
+
         final LimitingInputStream contentStream = getContentStream(downloadableContent);
+
         final boolean formatted = Boolean.parseBoolean(request.getParameter("formatted"));
         if (formatted) {
             final ContentType formattedContentType = getFormattedContentType(request, downloadableContent.getType());
@@ -100,28 +105,37 @@ public class StandardContentViewerController extends HttpServlet {
                 response.sendError(HttpURLConnection.HTTP_NOT_ACCEPTABLE, "Unknown Content Type");
             } else {
                 final String dataUri = requestContext.getDataUri();
-                writeContentFormatted(dataUri, formattedContentType, contentStream, response);
-                response.setStatus(HttpServletResponse.SC_OK);
+                final long contentLength = downloadableContent.getContentLength();
+                writeContentFormatted(dataUri, formattedContentType, contentStream, contentLength, response);
             }
         } else {
             contentStream.transferTo(response.getOutputStream());
-            if (contentStream.hasReachedLimit()) {
-                response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
-            } else {
-                response.setStatus(HttpServletResponse.SC_OK);
-            }
         }
     }
 
-    protected LimitingInputStream getContentStream(final DownloadableContent downloadableContent) {
+    private LimitingInputStream getContentStream(final DownloadableContent downloadableContent) {
         final InputStream contentStream = downloadableContent.getContent();
         return new LimitingInputStream(contentStream, CONTENT_LENGTH_LIMIT);
+    }
+
+    private int getResponseStatus(final DownloadableContent downloadableContent) {
+        final int responseStatus;
+
+        final long contentLength = downloadableContent.getContentLength();
+        if (contentLength > CONTENT_LENGTH_LIMIT) {
+            responseStatus = HttpURLConnection.HTTP_PARTIAL;
+        } else {
+            responseStatus = HttpURLConnection.HTTP_OK;
+        }
+
+        return responseStatus;
     }
 
     private void writeContentFormatted(
             final String dataUri,
             final ContentType contentType,
             final LimitingInputStream contentStream,
+            final long contentLength,
             final HttpServletResponse response
     ) throws IOException {
         try {
@@ -201,7 +215,7 @@ public class StandardContentViewerController extends HttpServlet {
         } catch (final Throwable t) {
             final String message;
 
-            if (contentStream.hasReachedLimit()) {
+            if (contentLength > CONTENT_LENGTH_LIMIT) {
                 message = "FlowFile Content-Length exceeds maximum allowed";
                 logger.warn("Requested FlowFile [{}] Content-Length exceeds maximum allowed [{} bytes]", dataUri, CONTENT_LENGTH_LIMIT, t);
             } else {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/test/java/org/apache/nifi/web/controller/StandardContentViewerControllerTest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/test/java/org/apache/nifi/web/controller/StandardContentViewerControllerTest.java
@@ -21,7 +21,6 @@ import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.nifi.stream.io.LimitingInputStream;
 import org.apache.nifi.web.ContentAccess;
 import org.apache.nifi.web.DownloadableContent;
 import org.junit.jupiter.api.Test;
@@ -56,7 +55,7 @@ class StandardContentViewerControllerTest {
     private static final String MIME_TYPE_DISPLAY_NAME = "mimeTypeDisplayName";
     private static final String XML_DISPLAY_NAME = "xml";
 
-    private static final int MOCK_CONTENT_LENGTH_LIMIT = 10;
+    private static final int CONTENT_LENGTH_LIMIT_EXCEEDED = 10_485_761;
     private static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
     private static final String FILENAME = "FlowFile";
     private static final String TEXT_XML = "text/xml";
@@ -83,7 +82,7 @@ class StandardContentViewerControllerTest {
     @Test
     void testDoGetFormattedContentTypeNotSupported() throws IOException {
         final InputStream contentStream = new ByteArrayInputStream(XML_DOCUMENT.getBytes(StandardCharsets.UTF_8));
-        final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, APPLICATION_OCTET_STREAM, contentStream);
+        final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, APPLICATION_OCTET_STREAM, contentStream, XML_DOCUMENT.length());
         setDownloadableContent(downloadableContent);
         when(request.getParameter(eq(FORMATTED_PARAMETER))).thenReturn(Boolean.TRUE.toString());
         when(request.getParameter(eq(CLIENT_ID_PARAMETER))).thenReturn(UUID.randomUUID().toString());
@@ -96,14 +95,13 @@ class StandardContentViewerControllerTest {
     @Test
     void testDoGetNotFormattedPartialContent() throws IOException {
         final InputStream contentStream = new ByteArrayInputStream(XML_DOCUMENT.getBytes(StandardCharsets.UTF_8));
-        final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, APPLICATION_OCTET_STREAM, contentStream);
+        final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, APPLICATION_OCTET_STREAM, contentStream, CONTENT_LENGTH_LIMIT_EXCEEDED);
         setDownloadableContent(downloadableContent);
 
         final MockServletOutputStream mockServletOutputStream = new MockServletOutputStream();
         when(response.getOutputStream()).thenReturn(mockServletOutputStream);
 
-        final LimitedStandardContentViewerController limitedController = new LimitedStandardContentViewerController();
-        limitedController.doGet(request, response);
+        controller.doGet(request, response);
 
         verify(response).setStatus(eq(HttpServletResponse.SC_PARTIAL_CONTENT));
     }
@@ -111,7 +109,7 @@ class StandardContentViewerControllerTest {
     @Test
     void testDoGetNotFormatted() throws IOException {
         final InputStream contentStream = new ByteArrayInputStream(XML_DOCUMENT.getBytes(StandardCharsets.UTF_8));
-        final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, TEXT_XML, contentStream);
+        final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, TEXT_XML, contentStream, XML_DOCUMENT.length());
         setDownloadableContent(downloadableContent);
 
         final MockServletOutputStream mockServletOutputStream = new MockServletOutputStream();
@@ -164,14 +162,19 @@ class StandardContentViewerControllerTest {
     }
 
     @Test
-    void testDoGetFormattedXmlLimited() throws IOException {
-        setDownloadableContentXml(XML_DOCUMENT);
+    void testDoGetFormattedLimited() throws IOException {
+        final byte[] contentLimitExceededByteArray = new byte[CONTENT_LENGTH_LIMIT_EXCEEDED];
+        final InputStream contentStream = new ByteArrayInputStream(contentLimitExceededByteArray);
+        final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, TEXT_XML, contentStream, CONTENT_LENGTH_LIMIT_EXCEEDED);
+        setDownloadableContent(downloadableContent);
+
+        when(request.getParameter(eq(FORMATTED_PARAMETER))).thenReturn(Boolean.TRUE.toString());
+        when(request.getParameter(eq(CLIENT_ID_PARAMETER))).thenReturn(UUID.randomUUID().toString());
 
         final MockServletOutputStream mockServletOutputStream = new MockServletOutputStream();
         when(response.getOutputStream()).thenReturn(mockServletOutputStream);
 
-        final LimitedStandardContentViewerController limitedController = new LimitedStandardContentViewerController();
-        limitedController.doGet(request, response);
+        controller.doGet(request, response);
 
         verify(response).sendError(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR), errorMessageCaptor.capture());
         final String errorMessage = errorMessageCaptor.getValue();
@@ -180,7 +183,7 @@ class StandardContentViewerControllerTest {
 
     private void setDownloadableContentXml(final String contentXml) {
         final InputStream contentStream = new ByteArrayInputStream(contentXml.getBytes(StandardCharsets.UTF_8));
-        final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, TEXT_XML, contentStream);
+        final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, TEXT_XML, contentStream, XML_DOCUMENT.length());
         setDownloadableContent(downloadableContent);
 
         when(request.getParameter(eq(FORMATTED_PARAMETER))).thenReturn(Boolean.TRUE.toString());
@@ -193,14 +196,6 @@ class StandardContentViewerControllerTest {
         when(servletContext.getAttribute(eq(StandardContentViewerController.CONTENT_ACCESS_ATTRIBUTE))).thenReturn(contentAccess);
         when(request.getParameter(eq(REF_PARAMETER))).thenReturn(REF_URL);
         when(contentAccess.getContent(any())).thenReturn(downloadableContent);
-    }
-
-    private static class LimitedStandardContentViewerController extends StandardContentViewerController {
-        @Override
-        protected LimitingInputStream getContentStream(final DownloadableContent downloadableContent) {
-            final InputStream inputStream = downloadableContent.getContent();
-            return new LimitingInputStream(inputStream, MOCK_CONTENT_LENGTH_LIMIT);
-        }
     }
 
     private static class MockServletOutputStream extends ServletOutputStream {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/test/java/org/apache/nifi/web/controller/StandardContentViewerControllerTest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-content-viewer/src/test/java/org/apache/nifi/web/controller/StandardContentViewerControllerTest.java
@@ -21,10 +21,13 @@ import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.nifi.stream.io.LimitingInputStream;
 import org.apache.nifi.web.ContentAccess;
 import org.apache.nifi.web.DownloadableContent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -36,8 +39,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,6 +56,8 @@ class StandardContentViewerControllerTest {
     private static final String MIME_TYPE_DISPLAY_NAME = "mimeTypeDisplayName";
     private static final String XML_DISPLAY_NAME = "xml";
 
+    private static final int MOCK_CONTENT_LENGTH_LIMIT = 10;
+    private static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
     private static final String FILENAME = "FlowFile";
     private static final String TEXT_XML = "text/xml";
     private static final String XML_DOCUMENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><document><element/></document>";
@@ -67,7 +75,38 @@ class StandardContentViewerControllerTest {
     @Mock
     private ContentAccess contentAccess;
 
+    @Captor
+    private ArgumentCaptor<String> errorMessageCaptor;
+
     private final StandardContentViewerController controller = new StandardContentViewerController();
+
+    @Test
+    void testDoGetFormattedContentTypeNotSupported() throws IOException {
+        final InputStream contentStream = new ByteArrayInputStream(XML_DOCUMENT.getBytes(StandardCharsets.UTF_8));
+        final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, APPLICATION_OCTET_STREAM, contentStream);
+        setDownloadableContent(downloadableContent);
+        when(request.getParameter(eq(FORMATTED_PARAMETER))).thenReturn(Boolean.TRUE.toString());
+        when(request.getParameter(eq(CLIENT_ID_PARAMETER))).thenReturn(UUID.randomUUID().toString());
+
+        controller.doGet(request, response);
+
+        verify(response).sendError(eq(HttpServletResponse.SC_NOT_ACCEPTABLE), anyString());
+    }
+
+    @Test
+    void testDoGetNotFormattedPartialContent() throws IOException {
+        final InputStream contentStream = new ByteArrayInputStream(XML_DOCUMENT.getBytes(StandardCharsets.UTF_8));
+        final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, APPLICATION_OCTET_STREAM, contentStream);
+        setDownloadableContent(downloadableContent);
+
+        final MockServletOutputStream mockServletOutputStream = new MockServletOutputStream();
+        when(response.getOutputStream()).thenReturn(mockServletOutputStream);
+
+        final LimitedStandardContentViewerController limitedController = new LimitedStandardContentViewerController();
+        limitedController.doGet(request, response);
+
+        verify(response).setStatus(eq(HttpServletResponse.SC_PARTIAL_CONTENT));
+    }
 
     @Test
     void testDoGetNotFormatted() throws IOException {
@@ -110,6 +149,35 @@ class StandardContentViewerControllerTest {
         assertEquals(XML_DOCUMENT_FORMATTED, outputString);
     }
 
+    @Test
+    void testDoGetFormattedXmlMalformed() throws IOException {
+        setDownloadableContentXml(FILENAME);
+
+        final MockServletOutputStream mockServletOutputStream = new MockServletOutputStream();
+        when(response.getOutputStream()).thenReturn(mockServletOutputStream);
+
+        controller.doGet(request, response);
+
+        verify(response).sendError(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR), errorMessageCaptor.capture());
+        final String errorMessage = errorMessageCaptor.getValue();
+        assertTrue(errorMessage.contains("formatting"));
+    }
+
+    @Test
+    void testDoGetFormattedXmlLimited() throws IOException {
+        setDownloadableContentXml(XML_DOCUMENT);
+
+        final MockServletOutputStream mockServletOutputStream = new MockServletOutputStream();
+        when(response.getOutputStream()).thenReturn(mockServletOutputStream);
+
+        final LimitedStandardContentViewerController limitedController = new LimitedStandardContentViewerController();
+        limitedController.doGet(request, response);
+
+        verify(response).sendError(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR), errorMessageCaptor.capture());
+        final String errorMessage = errorMessageCaptor.getValue();
+        assertTrue(errorMessage.contains("Content-Length"));
+    }
+
     private void setDownloadableContentXml(final String contentXml) {
         final InputStream contentStream = new ByteArrayInputStream(contentXml.getBytes(StandardCharsets.UTF_8));
         final DownloadableContent downloadableContent = new DownloadableContent(FILENAME, TEXT_XML, contentStream);
@@ -125,6 +193,14 @@ class StandardContentViewerControllerTest {
         when(servletContext.getAttribute(eq(StandardContentViewerController.CONTENT_ACCESS_ATTRIBUTE))).thenReturn(contentAccess);
         when(request.getParameter(eq(REF_PARAMETER))).thenReturn(REF_URL);
         when(contentAccess.getContent(any())).thenReturn(downloadableContent);
+    }
+
+    private static class LimitedStandardContentViewerController extends StandardContentViewerController {
+        @Override
+        protected LimitingInputStream getContentStream(final DownloadableContent downloadableContent) {
+            final InputStream inputStream = downloadableContent.getContent();
+            return new LimitingInputStream(inputStream, MOCK_CONTENT_LENGTH_LIMIT);
+        }
     }
 
     private static class MockServletOutputStream extends ServletOutputStream {

--- a/nifi-framework-api/src/main/java/org/apache/nifi/web/DownloadableContent.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/web/DownloadableContent.java
@@ -26,11 +26,18 @@ public final class DownloadableContent {
     private final String filename;
     private final String type;
     private final InputStream content;
+    private final long contentLength;
 
-    public DownloadableContent(String filename, String type, InputStream content) {
+    public DownloadableContent(
+            final String filename,
+            final String type,
+            final InputStream content,
+            final long contentLength
+    ) {
         this.filename = filename;
         this.type = type;
         this.content = content;
+        this.contentLength = contentLength;
     }
 
     /**
@@ -58,5 +65,14 @@ public final class DownloadableContent {
      */
     public InputStream getContent() {
         return content;
+    }
+
+    /**
+     * Get length in bytes of the content stream
+     *
+     * @return Length in bytes of the content stream
+     */
+    public long getContentLength() {
+        return contentLength;
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiContentAccess.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiContentAccess.java
@@ -123,8 +123,10 @@ public class StandardNiFiContentAccess implements ContentAccess {
             // get the content type
             final String contentType = getHeader(responseHeaders, "content-type");
 
+            final int contentLength = clientResponse.getLength();
+
             // create the downloadable content
-            return new DownloadableContent(filename, contentType, nodeResponse.getInputStream());
+            return new DownloadableContent(filename, contentType, nodeResponse.getInputStream(), contentLength);
         } else {
             // example URIs:
             // http://localhost:8080/nifi-api/provenance/events/{id}/content/{input|output}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerFacade.java
@@ -1508,7 +1508,8 @@ public class ControllerFacade implements Authorizable {
 
             // get the content
             final InputStream content = flowController.getContent(event, contentDirection, user.getIdentity(), uri);
-            return new DownloadableContent(filename, type, content);
+            final long contentLength = event.getFileSize();
+            return new DownloadableContent(filename, type, content, contentLength);
         } catch (final ContentNotFoundException cnfe) {
             throw new ResourceNotFoundException("Unable to find the specified content.");
         } catch (final IOException ioe) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardConnectionDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardConnectionDAO.java
@@ -703,7 +703,9 @@ public class StandardConnectionDAO extends ComponentDAO implements ConnectionDAO
 
             // get the content
             final InputStream content = flowController.getContent(flowFile, user.getIdentity(), requestUri);
-            return new DownloadableContent(filename, type, content);
+            final long contentLength = flowFile.getSize();
+
+            return new DownloadableContent(filename, type, content, contentLength);
         } catch (final ContentNotFoundException cnfe) {
             throw new ResourceNotFoundException("Unable to find the specified content.");
         } catch (final IOException ioe) {


### PR DESCRIPTION
# Summary

[NIFI-15888](https://issues.apache.org/jira/browse/NIFI-15888) Adds an internal size limit of 10 MB to the Standard Content Viewer, avoiding attempts to load, format, and render large FlowFiles.

The internal limit of 10 MB aligns with a previous comment on Apache Avro formatting, which actually limited to the output size to 2 MB.

The implementation uses the `LimitingInputStream` to avoid reading more than 10 MB from the referenced FlowFile. The limit applies to both formatted and unformatted responses. Unformatted responses with content exceeding the limit return an `HTTP 206` status indicating Partial Content returned. Formatted may throw an exception when the limit does not align with expected structural boundaries. In this case, the server returns an HTTP 500 with message indicating length exceeds maximum. As a best effort viewer, returning an error avoids both server and client memory consumption concerns. The hexadecimal viewer continues to provide a general way to view initial bytes.

Additional unit tests exercise length limiting behavior with formatted and unformatted responses.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [X] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
