### PR TITLE
NIFI-15991 - Flaky test TestFileSystemRepository.testClaimsArchivedWhenMarkedDestructable

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestFileSystemRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestFileSystemRepository.java
@@ -68,6 +68,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestFileSystemRepository {
 
@@ -154,28 +155,58 @@ public class TestFileSystemRepository {
     @Test
     @Timeout(30)
     public void testClaimsArchivedWhenMarkedDestructable() throws IOException, InterruptedException {
-        final ContentClaim contentClaim = repository.create(false);
-        final Map<String, Path> containerPaths = nifiProperties.getContentRepositoryPaths();
-        assertEquals(1, containerPaths.size());
-        final String containerName = containerPaths.keySet().iterator().next();
+        // Release the repository created during setup and use one that reports no disk pressure. Otherwise, on a
+        // host whose content repository partition is nearly full, the background archive cleanup task can reclaim
+        // the freshly archived claim before this test observes it, leaving the archive count oscillating at 0.
+        shutdown();
 
-        try (final OutputStream out = repository.write(contentClaim)) {
-            long bytesWritten = 0L;
-            final byte[] bytes = "Hello World".getBytes(StandardCharsets.UTF_8);
-
-            while (bytesWritten <= maxClaimLength) {
-                out.write(bytes);
-                bytesWritten += bytes.length;
+        final FileSystemRepository localRepository = new FileSystemRepository(nifiProperties) {
+            @Override
+            public long getContainerUsableSpace(final String containerName) {
+                return Long.MAX_VALUE;
             }
-        }
+        };
 
-        assertEquals(0, repository.getArchiveCount(containerName));
-        assertEquals(0, claimManager.decrementClaimantCount(contentClaim.getResourceClaim()));
-        claimManager.markDestructable(contentClaim.getResourceClaim());
+        try {
+            final StandardResourceClaimManager localClaimManager = new StandardResourceClaimManager();
+            localRepository.initialize(new StandardContentRepositoryContext(localClaimManager, EventReporter.NO_OP));
+            localRepository.purge();
 
-        // The claim should become archived but it may take a few seconds, as it's handled by background threads
-        while (repository.getArchiveCount(containerName) != 1) {
-            Thread.sleep(50L);
+            final ContentClaim contentClaim = localRepository.create(false);
+            final Map<String, Path> containerPaths = nifiProperties.getContentRepositoryPaths();
+            assertEquals(1, containerPaths.size());
+            final String containerName = containerPaths.keySet().iterator().next();
+
+            try (final OutputStream out = localRepository.write(contentClaim)) {
+                long bytesWritten = 0L;
+                final byte[] bytes = "Hello World".getBytes(StandardCharsets.UTF_8);
+
+                while (bytesWritten <= maxClaimLength) {
+                    out.write(bytes);
+                    bytesWritten += bytes.length;
+                }
+            }
+
+            assertEquals(0, localRepository.getArchiveCount(containerName));
+            assertEquals(0, localClaimManager.decrementClaimantCount(contentClaim.getResourceClaim()));
+            localClaimManager.markDestructable(contentClaim.getResourceClaim());
+
+            // The claim is archived by background threads, so poll until the archive count reflects it. With disk
+            // pressure disabled the count remains at 1 once archived, so this terminates reliably within a few seconds.
+            final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (localRepository.getArchiveCount(containerName) != 1) {
+                if (System.nanoTime() > deadline) {
+                    final Path livePath = getPath(localRepository, contentClaim);
+                    final Path archivePath = livePath == null ? null : FileSystemRepository.getArchivePath(livePath);
+                    fail("Claim was not archived for container %s; archive count is %d. Live path %s exists=%s, archive path %s exists=%s".formatted(
+                        containerName, localRepository.getArchiveCount(containerName),
+                        livePath, livePath != null && Files.exists(livePath),
+                        archivePath, archivePath != null && Files.exists(archivePath)));
+                }
+                Thread.sleep(50L);
+            }
+        } finally {
+            localRepository.shutdown();
         }
     }
 


### PR DESCRIPTION
# Summary

NIFI-15991 - Flaky test TestFileSystemRepository.testClaimsArchivedWhenMarkedDestructable

```
Error:  Tests run: 38, Failures: 0, Errors: 1, Skipped: 1, Time elapsed: 72.03 s <<< FAILURE! -- in org.apache.nifi.controller.repository.TestFileSystemRepository
Error:  org.apache.nifi.controller.repository.TestFileSystemRepository.testClaimsArchivedWhenMarkedDestructable -- Time elapsed: 30.45 s <<< ERROR!
java.util.concurrent.TimeoutException: testClaimsArchivedWhenMarkedDestructable() timed out after 30 seconds
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	Suppressed: java.lang.InterruptedException: sleep interrupted
		at java.base/java.lang.Thread.sleep0(Native Method)
		at java.base/java.lang.Thread.sleep(Thread.java:509)
		at org.apache.nifi.controller.repository.TestFileSystemRepository.testClaimsArchivedWhenMarkedDestructable(TestFileSystemRepository.java:178)
```

Stabilizes the intermittently failing TestFileSystemRepository.testClaimsArchivedWhenMarkedDestructable by running it against a local FileSystemRepository that reports unlimited usable space, so the background archive-cleanup task can no longer reclaim the freshly archived claim and drive the archive count back to 0 on disk-constrained CI hosts. Also replaces the unbounded while (count != 1) busy-wait with a bounded 10s poll that fails with diagnostic context (archive count, live vs. archive path existence) instead of an opaque TimeoutException.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
