### PR TITLE
NIFI-15989: Improve purge threshold time formatting

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
@@ -336,19 +336,19 @@ public class FormatUtils {
         final List<String> parts = new ArrayList<>();
 
         if (days > 0) {
-            parts.add(days + (days == 1 ? " day" : " days"));
+            parts.add(days + "d");
         }
         if (hours > 0 || !parts.isEmpty()) {
-            parts.add(hours + (hours == 1 ? " hour" : " hours"));
+            parts.add(hours + "h");
         }
         if (minutes > 0 || !parts.isEmpty()) {
-            parts.add(minutes + (minutes == 1 ? " minute" : " minutes"));
+            parts.add(minutes + "m");
         }
         if (seconds > 0 || !parts.isEmpty()) {
-            parts.add(seconds + (seconds == 1 ? " second" : " seconds"));
+            parts.add(seconds + "s");
         }
         if (nanos > 0 || !parts.isEmpty()) {
-            parts.add(nanos + " ns");
+            parts.add(nanos + "ns");
         }
 
         return String.join(" ", parts);

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
@@ -20,6 +20,7 @@ import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.time.DurationFormat;
 
 import java.text.NumberFormat;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -28,8 +29,12 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
+import java.time.temporal.TemporalUnit;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -297,5 +302,45 @@ public class FormatUtils {
 
         final OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, zoneOffset);
         return offsetDateTime.toInstant();
+    }
+
+    public static String formatDurationToWords(long value, ChronoUnit unit) {
+        return formatDurationToWords(Duration.ZERO.plus(value, unit));
+    }
+
+    /**
+     * Format a Duration using words (days, hours, minutes, seconds, ns) where all lower units are
+     *   included once a non-zero unit is found. Unit plurality is preserved.
+     * Maximum resolution is in terms of days.
+     *
+     * @param source duration to convert to words
+     * @return String representation of the given duration
+     */
+    public static String formatDurationToWords(Duration source) {
+        long days = source.toDaysPart();
+        long hours = source.toHoursPart();
+        long minutes = source.toMinutesPart();
+        int seconds = source.toSecondsPart();
+        int nanos = source.toNanosPart();
+
+        List<String> parts = new ArrayList<>();
+
+        if (days > 0) {
+            parts.add(days + (days == 1 ? " day" : " days"));
+        }
+        if (hours > 0 || !parts.isEmpty()) {
+            parts.add(hours + (hours == 1 ? " hour" : " hours"));
+        }
+        if (minutes > 0 || !parts.isEmpty()) {
+            parts.add(minutes + (minutes == 1 ? " minute" : " minutes"));
+        }
+        if (seconds > 0 || !parts.isEmpty()) {
+            parts.add(seconds + (seconds == 1 ? " second" : " seconds"));
+        }
+        if(nanos > 0 || !parts.isEmpty()) {
+            parts.add(nanos + " ns");
+        }
+
+        return String.join(" ", parts);
     }
 }

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
@@ -32,7 +32,7 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
-import java.time.temporal.TemporalUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -304,7 +304,17 @@ public class FormatUtils {
         return offsetDateTime.toInstant();
     }
 
-    public static String formatDurationToWords(long value, ChronoUnit unit) {
+    /**
+     * Format a value of ChronoUnit into a word representation.
+     * Does not handle estimated ChronoUnit values.
+     * For anything greater than {@link ChronoUnit#DAYS}, use {@link #formatDurationToWords(Duration)}.
+     *
+     * @param value the number of the given {@link ChronoUnit} to measure
+     * @param unit {@link ChronoUnit} that the value represents
+     * @return String representation of the given value and unit
+     * @throws UnsupportedTemporalTypeException if the unit is not supported ({@link ChronoUnit#isDurationEstimated()} == true)
+     */
+    public static String formatDurationToWords(long value, ChronoUnit unit) throws UnsupportedTemporalTypeException {
         return formatDurationToWords(Duration.ZERO.plus(value, unit));
     }
 
@@ -337,7 +347,7 @@ public class FormatUtils {
         if (seconds > 0 || !parts.isEmpty()) {
             parts.add(seconds + (seconds == 1 ? " second" : " seconds"));
         }
-        if(nanos > 0 || !parts.isEmpty()) {
+        if (nanos > 0 || !parts.isEmpty()) {
             parts.add(nanos + " ns");
         }
 

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
@@ -314,7 +314,7 @@ public class FormatUtils {
      * @return String representation of the given value and unit
      * @throws UnsupportedTemporalTypeException if the unit is not supported ({@link ChronoUnit#isDurationEstimated()} == true)
      */
-    public static String formatDurationToWords(long value, ChronoUnit unit) throws UnsupportedTemporalTypeException {
+    public static String formatDurationToWords(final long value, final ChronoUnit unit) throws UnsupportedTemporalTypeException {
         return formatDurationToWords(Duration.ZERO.plus(value, unit));
     }
 
@@ -326,14 +326,14 @@ public class FormatUtils {
      * @param source duration to convert to words
      * @return String representation of the given duration
      */
-    public static String formatDurationToWords(Duration source) {
-        long days = source.toDaysPart();
-        long hours = source.toHoursPart();
-        long minutes = source.toMinutesPart();
-        int seconds = source.toSecondsPart();
-        int nanos = source.toNanosPart();
+    public static String formatDurationToWords(final Duration source) {
+        final long days = source.toDaysPart();
+        final long hours = source.toHoursPart();
+        final long minutes = source.toMinutesPart();
+        final int seconds = source.toSecondsPart();
+        final int nanos = source.toNanosPart();
 
-        List<String> parts = new ArrayList<>();
+        final List<String> parts = new ArrayList<>();
 
         if (days > 0) {
             parts.add(days + (days == 1 ? " day" : " days"));

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/TestFormatUtils.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/TestFormatUtils.java
@@ -16,16 +16,19 @@
  */
 package org.apache.nifi.util;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.DecimalFormatSymbols;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -193,5 +196,27 @@ public class TestFormatUtils {
                          + TimeUnit.MILLISECONDS.convert(60, TimeUnit.MINUTES)
                          + TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS)
                          + TimeUnit.MILLISECONDS.convert(1001, TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS, "1000:01:01.001"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getDurationValues")
+    public void testFormatDurationToWords(Duration duration, String expected) {
+        assertEquals(expected, FormatUtils.formatDurationToWords(duration));
+    }
+
+    private static Stream<Arguments> getDurationValues() {
+        return Stream.of(
+                Arguments.of(Duration.parse("PT0.000000001S"), "1 ns"),
+                Arguments.of(Duration.parse("PT0.000000002S"), "2 ns"),
+                Arguments.of(Duration.parse("PT1S"), "1 second 0 ns"),
+                Arguments.of(Duration.parse("PT2S"), "2 seconds 0 ns"),
+                Arguments.of(Duration.parse("PT1M"), "1 minute 0 seconds 0 ns"),
+                Arguments.of(Duration.parse("PT2M"), "2 minutes 0 seconds 0 ns"),
+                Arguments.of(Duration.parse("PT1H"), "1 hour 0 minutes 0 seconds 0 ns"),
+                Arguments.of(Duration.parse("PT2H"), "2 hours 0 minutes 0 seconds 0 ns"),
+                Arguments.of(Duration.parse("P1D"), "1 day 0 hours 0 minutes 0 seconds 0 ns"),
+                Arguments.of(Duration.parse("P35D"), "35 days 0 hours 0 minutes 0 seconds 0 ns"),
+                Arguments.of(Duration.parse("P366D"), "366 days 0 hours 0 minutes 0 seconds 0 ns")
+        );
     }
 }

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/TestFormatUtils.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/TestFormatUtils.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.util;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,7 +27,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/TestFormatUtils.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/TestFormatUtils.java
@@ -204,17 +204,17 @@ public class TestFormatUtils {
 
     private static Stream<Arguments> getDurationValues() {
         return Stream.of(
-                Arguments.of(Duration.parse("PT0.000000001S"), "1 ns"),
-                Arguments.of(Duration.parse("PT0.000000002S"), "2 ns"),
-                Arguments.of(Duration.parse("PT1S"), "1 second 0 ns"),
-                Arguments.of(Duration.parse("PT2S"), "2 seconds 0 ns"),
-                Arguments.of(Duration.parse("PT1M"), "1 minute 0 seconds 0 ns"),
-                Arguments.of(Duration.parse("PT2M"), "2 minutes 0 seconds 0 ns"),
-                Arguments.of(Duration.parse("PT1H"), "1 hour 0 minutes 0 seconds 0 ns"),
-                Arguments.of(Duration.parse("PT2H"), "2 hours 0 minutes 0 seconds 0 ns"),
-                Arguments.of(Duration.parse("P1D"), "1 day 0 hours 0 minutes 0 seconds 0 ns"),
-                Arguments.of(Duration.parse("P35D"), "35 days 0 hours 0 minutes 0 seconds 0 ns"),
-                Arguments.of(Duration.parse("P366D"), "366 days 0 hours 0 minutes 0 seconds 0 ns")
+                Arguments.of(Duration.parse("PT0.000000001S"), "1ns"),
+                Arguments.of(Duration.parse("PT0.000000002S"), "2ns"),
+                Arguments.of(Duration.parse("PT1S"), "1s 0ns"),
+                Arguments.of(Duration.parse("PT2S"), "2s 0ns"),
+                Arguments.of(Duration.parse("PT1M"), "1m 0s 0ns"),
+                Arguments.of(Duration.parse("PT2M"), "2m 0s 0ns"),
+                Arguments.of(Duration.parse("PT1H"), "1h 0m 0s 0ns"),
+                Arguments.of(Duration.parse("PT2H"), "2h 0m 0s 0ns"),
+                Arguments.of(Duration.parse("P1D"), "1d 0h 0m 0s 0ns"),
+                Arguments.of(Duration.parse("P35D"), "35d 0h 0m 0s 0ns"),
+                Arguments.of(Duration.parse("P366D"), "366d 0h 0m 0s 0ns")
         );
     }
 }

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/pom.xml
@@ -51,5 +51,9 @@
             <artifactId>lucene-backward-codecs</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/pom.xml
@@ -51,9 +51,5 @@
             <artifactId>lucene-backward-codecs</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/EventStorePartition.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/EventStorePartition.java
@@ -23,9 +23,9 @@ import org.apache.nifi.provenance.store.iterator.EventIterator;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 public interface EventStorePartition extends Closeable {
     /**
@@ -102,7 +102,7 @@ public interface EventStorePartition extends Closeable {
      * @param olderThan the amount of time for which any event older than this should be removed
      * @param timeUnit the unit of time that applies to the first argument
      */
-    void purgeOldEvents(long olderThan, TimeUnit timeUnit);
+    void purgeOldEvents(long olderThan, ChronoUnit timeUnit);
 
     /**
      * Purges some number of events from the partition. The oldest events will be purged.

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/PartitionedEventStore.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/PartitionedEventStore.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -243,7 +244,7 @@ public abstract class PartitionedEventStore implements EventStore {
             final long maxFileLife = repoConfig.getMaxRecordLife(TimeUnit.MILLISECONDS);
             for (final EventStorePartition partition : getPartitions()) {
                 try {
-                    partition.purgeOldEvents(maxFileLife, TimeUnit.MILLISECONDS);
+                    partition.purgeOldEvents(maxFileLife, ChronoUnit.MILLIS);
                 } catch (final Exception e) {
                     logger.error("Failed to purge expired events from {}", partition, e);
                     eventReporter.reportEvent(Severity.WARNING, EVENT_CATEGORY,

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/WriteAheadStorePartition.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/WriteAheadStorePartition.java
@@ -17,6 +17,7 @@
 
 package org.apache.nifi.provenance.store;
 
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.nifi.events.EventReporter;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.RepositoryConfiguration;
@@ -498,10 +499,12 @@ public class WriteAheadStorePartition implements EventStorePartition {
             .filter(this::delete)
             .collect(Collectors.toList());
 
+        String thresholdWords = DurationFormatUtils.formatDurationWords(olderThan, true, true);
+
         if (removed.isEmpty()) {
-            logger.debug("No Provenance Event files that exceed time-based threshold of {} {}", olderThan, unit);
+            logger.debug("No Provenance Event files that exceed time-based threshold of {}", thresholdWords);
         } else {
-            logger.info("Purged {} Provenance Event files from Provenance Repository because the events were older than {} {}: {}", removed.size(), olderThan, unit, removed);
+            logger.info("Purged {} Provenance Event files from Provenance Repository because the events were older than {} : {}", removed.size(), thresholdWords, removed);
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/WriteAheadStorePartition.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/WriteAheadStorePartition.java
@@ -41,8 +41,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.time.Duration;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/WriteAheadStorePartition.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/WriteAheadStorePartition.java
@@ -17,7 +17,6 @@
 
 package org.apache.nifi.provenance.store;
 
-import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.nifi.events.EventReporter;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.RepositoryConfiguration;
@@ -42,6 +41,10 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -491,15 +494,17 @@ public class WriteAheadStorePartition implements EventStorePartition {
     }
 
     @Override
-    public void purgeOldEvents(final long olderThan, final TimeUnit unit) {
-        final long timeCutoff = System.currentTimeMillis() - unit.toMillis(olderThan);
-
+    public void purgeOldEvents(final long olderThan, final ChronoUnit timeUnit) {
+        // Use ZDT to allow the system to handle a ChronoUnit that is otherwise "estimated"
+        final long timeCutoff = ZonedDateTime.now()
+                .minus(olderThan, timeUnit)
+                .toInstant().toEpochMilli();
         final List<File> removed = getEventFilesFromDisk().filter(file -> file.lastModified() < timeCutoff)
             .sorted(DirectoryUtils.SMALLEST_ID_FIRST)
             .filter(this::delete)
             .collect(Collectors.toList());
 
-        String thresholdWords = DurationFormatUtils.formatDurationWords(olderThan, true, true);
+        String thresholdWords = FormatUtils.formatDurationToWords(olderThan, timeUnit);
 
         if (removed.isEmpty()) {
             logger.debug("No Provenance Event files that exceed time-based threshold of {}", thresholdWords);


### PR DESCRIPTION
Update the purge threshold output to be more human readable.

Existing output will show the value in milliseconds which can be
  difficult to read quickly. Convert milliseconds to a `Duration` to get the
  threshold in a format like "30 days", "7 days 4 hours", etc.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary
[NIFI-15989](https://issues.apache.org/jira/browse/NIFI-15989)

Specifically in WriteAheadStorePartition, the maintenance task outputs the threshold as a measure of milliseconds which can be difficult to parse quickly.

Pass the value of the field `olderThan` that's passed to `purgeOldEvents` through a new formatting function in `nifi-utils` to convert it into a words representation. e.g.:

* 2592000000 -> "30 days 0 hours 0 minutes 0 seconds 0 ns"
* 2592010000 -> "30 days 0 hours 0 minutes 10 seconds 0 ns"
* 3600000 -> "1 hour 0 minutes 0 seconds 0 ns"

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
