### PR TITLE
NIFI-15911 Add proxy support to StandardSnowflakeIngestManagerProviderService

### DIFF
--- a/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/main/java/org/apache/nifi/snowflake/service/SnowpipeIngestClient.java
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/main/java/org/apache/nifi/snowflake/service/SnowpipeIngestClient.java
@@ -24,7 +24,9 @@ import org.apache.nifi.processors.snowflake.snowpipe.InsertFiles;
 import org.apache.nifi.processors.snowflake.snowpipe.InsertReport;
 
 import java.io.IOException;
+import java.net.Authenticator;
 import java.net.HttpURLConnection;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -76,6 +78,25 @@ class SnowpipeIngestClient implements AutoCloseable {
             final String pipeName,
             final RSAKeyAuthorizationProvider authorizationProvider
     ) {
+        this(baseUri, pipeName, authorizationProvider, null, null);
+    }
+
+    /**
+     * Snowpipe Ingest Client with proxy support
+     *
+     * @param baseUri Base URI for the Snowpipe REST API
+     * @param pipeName Fully qualified pipe name
+     * @param authorizationProvider RSA Key Authorization Provider for JWT authentication
+     * @param proxySelector Optional proxy selector; {@code null} uses the system default
+     * @param proxyAuthenticator Optional authenticator for proxy credentials; {@code null} when not required
+     */
+    SnowpipeIngestClient(
+            final URI baseUri,
+            final String pipeName,
+            final RSAKeyAuthorizationProvider authorizationProvider,
+            final ProxySelector proxySelector,
+            final Authenticator proxyAuthenticator
+    ) {
         Objects.requireNonNull(baseUri, "Base URI required");
         Objects.requireNonNull(pipeName, "Pipe Name required");
         Objects.requireNonNull(authorizationProvider, "Authorization Provider required");
@@ -87,9 +108,16 @@ class SnowpipeIngestClient implements AutoCloseable {
         this.insertReportUri = baseUri.resolve(insertReportPath);
 
         this.authorizationProvider = authorizationProvider;
-        this.httpClient = HttpClient.newBuilder()
-                .connectTimeout(CONNECT_TIMEOUT)
-                .build();
+
+        final HttpClient.Builder builder = HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT);
+        if (proxySelector != null) {
+            builder.proxy(proxySelector);
+        }
+        if (proxyAuthenticator != null) {
+            builder.authenticator(proxyAuthenticator);
+        }
+        this.httpClient = builder.build();
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/main/java/org/apache/nifi/snowflake/service/StandardSnowflakeIngestManagerProviderService.java
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/main/java/org/apache/nifi/snowflake/service/StandardSnowflakeIngestManagerProviderService.java
@@ -22,6 +22,8 @@ import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnDisabled;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
@@ -32,14 +34,24 @@ import org.apache.nifi.processors.snowflake.SnowflakeIngestManagerProviderServic
 import org.apache.nifi.processors.snowflake.snowpipe.InsertFiles;
 import org.apache.nifi.processors.snowflake.snowpipe.InsertReport;
 import org.apache.nifi.processors.snowflake.util.SnowflakeProperties;
+import org.apache.nifi.proxy.ProxyConfiguration;
+import org.apache.nifi.proxy.ProxySpec;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.snowflake.service.util.AccountIdentifierFormat;
 import org.apache.nifi.snowflake.service.util.AccountIdentifierFormatParameters;
 import org.apache.nifi.snowflake.service.util.ConnectionUrlFormat;
 
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateCrtKey;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @Tags({"snowflake", "snowpipe", "database", "connection"})
@@ -124,6 +136,19 @@ public class StandardSnowflakeIngestManagerProviderService extends AbstractContr
             .required(true)
             .build();
 
+    // Only HTTP proxy type is supported. SOCKS is silently ignored by java.net.http.HttpClient.
+    // For authenticated proxies: the JDK disables Basic auth over CONNECT tunneling by default
+    // (jdk.http.auth.tunneling.disabledSchemes=Basic). To use proxy credentials with an HTTPS
+    // target like Snowflake, add -Djdk.http.auth.tunneling.disabledSchemes="" to bootstrap.conf.
+    static final PropertyDescriptor PROXY_CONFIGURATION = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxySpec.HTTP_AUTH))
+            .description("Specifies the Proxy Configuration Controller Service to proxy network requests."
+                    + " Only HTTP proxy type is supported."
+                    + " For authenticated proxy with HTTPS targets, the JDK disables Basic authentication"
+                    + " over CONNECT tunneling by default. To enable it, add"
+                    + " -Djdk.http.auth.tunneling.disabledSchemes=\"\" to bootstrap.conf.")
+            .build();
+
     static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ACCOUNT_IDENTIFIER_FORMAT,
             HOST_URL,
@@ -136,7 +161,8 @@ public class StandardSnowflakeIngestManagerProviderService extends AbstractContr
             PRIVATE_KEY_SERVICE,
             DATABASE,
             SCHEMA,
-            PIPE
+            PIPE,
+            PROXY_CONFIGURATION
     );
 
     private static final String HTTPS_URI_FORMAT = "https://%s";
@@ -146,6 +172,13 @@ public class StandardSnowflakeIngestManagerProviderService extends AbstractContr
     private static final char UNDERSCORE = '_';
 
     private static final char HYPHEN = '-';
+
+    @Override
+    protected Collection<ValidationResult> customValidate(final ValidationContext context) {
+        final List<ValidationResult> results = new ArrayList<>(super.customValidate(context));
+        ProxyConfiguration.validateProxySpec(context, results, ProxySpec.HTTP_AUTH);
+        return results;
+    }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -173,7 +206,11 @@ public class StandardSnowflakeIngestManagerProviderService extends AbstractContr
 
             final URI baseUri = URI.create(HTTPS_URI_FORMAT.formatted(hostNormalized));
             final RSAKeyAuthorizationProvider authorizationProvider = new RSAKeyAuthorizationProvider(account, user, rsaPrivateKey);
-            ingestClient = new SnowpipeIngestClient(baseUri, qualifiedPipeName, authorizationProvider);
+
+            final ProxyConfiguration proxyConfiguration = ProxyConfiguration.getConfiguration(context);
+            final ProxySelector proxySelector = buildProxySelector(proxyConfiguration);
+            final Authenticator proxyAuthenticator = buildProxyAuthenticator(proxyConfiguration);
+            ingestClient = new SnowpipeIngestClient(baseUri, qualifiedPipeName, authorizationProvider, proxySelector, proxyAuthenticator);
         } else {
             throw new InitializationException("RSA Private Key not provided");
         }
@@ -211,6 +248,37 @@ public class StandardSnowflakeIngestManagerProviderService extends AbstractContr
         config.renameProperty(SnowflakeProperties.OLD_ACCOUNT_NAME_PROPERTY_NAME, SnowflakeProperties.ACCOUNT_NAME.getName());
         config.renameProperty(SnowflakeProperties.OLD_DATABASE_PROPERTY_NAME, SnowflakeProperties.DATABASE.getName());
         config.renameProperty(SnowflakeProperties.OLD_SCHEMA_PROPERTY_NAME, SnowflakeProperties.SCHEMA.getName());
+    }
+
+    private ProxySelector buildProxySelector(final ProxyConfiguration proxyConfiguration) {
+        final Proxy proxy = proxyConfiguration.createProxy();
+        return new ProxySelector() {
+            @Override
+            public List<Proxy> select(final URI uri) {
+                return List.of(proxy);
+            }
+
+            @Override
+            public void connectFailed(final URI uri, final SocketAddress sa, final IOException ioe) {
+            }
+        };
+    }
+
+    private Authenticator buildProxyAuthenticator(final ProxyConfiguration proxyConfiguration) {
+        if (!proxyConfiguration.hasCredential()) {
+            return null;
+        }
+        final String proxyUser = proxyConfiguration.getProxyUserName();
+        final String proxyPassword = proxyConfiguration.getProxyUserPassword();
+        return new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                if (getRequestorType() == RequestorType.PROXY) {
+                    return new PasswordAuthentication(proxyUser, proxyPassword.toCharArray());
+                }
+                return super.getPasswordAuthentication();
+            }
+        };
     }
 
     private AccountIdentifierFormatParameters getAccountIdentifierFormatParameters(ConfigurationContext context) {

--- a/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/test/java/org/apache/nifi/snowflake/service/SnowpipeIngestClientTest.java
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/test/java/org/apache/nifi/snowflake/service/SnowpipeIngestClientTest.java
@@ -31,7 +31,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -262,6 +267,49 @@ class SnowpipeIngestClientTest {
                 () -> client.getInsertReport()
         );
         assertTrue(exception.getMessage().contains(String.valueOf(HttpURLConnection.HTTP_INTERNAL_ERROR)));
+    }
+
+    @Test
+    void testInsertFilesViaProxy() throws InterruptedException, NoSuchAlgorithmException {
+        // MockWebServer acts as the HTTP proxy. The base URI points to a distinct fake host
+        // so that the request only reaches MockWebServer if the proxy selector is honoured.
+        // When Java's HttpClient routes a request through an HTTP proxy it sends the target
+        // in absolute form (e.g. "http://fake-snowflake.example.com/v1/..."), which lets us
+        // assert that the proxy path was actually exercised.
+        mockWebServer.enqueue(new MockResponse.Builder()
+                .code(HttpURLConnection.HTTP_OK)
+                .addHeader(CONTENT_TYPE_HEADER, APPLICATION_JSON)
+                .body(INSERT_FILES_SUCCESS_RESPONSE)
+                .build());
+
+        final InetSocketAddress proxyAddress = new InetSocketAddress(mockWebServer.getHostName(), mockWebServer.getPort());
+        final Proxy proxy = new Proxy(Proxy.Type.HTTP, proxyAddress);
+        final ProxySelector proxySelector = new ProxySelector() {
+            @Override
+            public List<Proxy> select(final URI uri) {
+                return List.of(proxy);
+            }
+
+            @Override
+            public void connectFailed(final URI uri, final SocketAddress sa, final IOException ioe) {
+            }
+        };
+
+        // Intentionally different from the proxy address to prove routing goes via the proxy
+        final URI targetBaseUri = URI.create("http://fake-snowflake.example.com");
+        final RSAPrivateCrtKey privateKey = generatePrivateKey();
+        final RSAKeyAuthorizationProvider authProvider = new RSAKeyAuthorizationProvider(ACCOUNT, USER, privateKey);
+
+        try (final SnowpipeIngestClient proxyClient = new SnowpipeIngestClient(targetBaseUri, PIPE_NAME, authProvider, proxySelector, null)) {
+            proxyClient.insertFiles(new InsertFiles(List.of(new InsertFile(STAGED_FILE_PATH))));
+        }
+
+        final RecordedRequest request = mockWebServer.takeRequest();
+        // Absolute-form target confirms the request was routed through the configured proxy
+        final String target = request.getTarget();
+        assertNotNull(target);
+        assertTrue(target.startsWith("http://fake-snowflake.example.com"), "Expected absolute-form proxy target but got: " + target);
+        assertNotNull(request.getHeaders().get(AUTHORIZATION_HEADER));
     }
 
     private static RSAPrivateCrtKey generatePrivateKey() throws NoSuchAlgorithmException {

--- a/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/test/java/org/apache/nifi/snowflake/service/TestStandardSnowflakeIngestManagerProviderService.java
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/test/java/org/apache/nifi/snowflake/service/TestStandardSnowflakeIngestManagerProviderService.java
@@ -137,6 +137,15 @@ public class TestStandardSnowflakeIngestManagerProviderService {
     }
 
     @Test
+    void testProxyConfigurationServicePropertyPresent() {
+        final StandardSnowflakeIngestManagerProviderService service = new StandardSnowflakeIngestManagerProviderService();
+        final boolean hasProxyProperty = service.getSupportedPropertyDescriptors()
+                .stream()
+                .anyMatch(pd -> pd.getName().equals(StandardSnowflakeIngestManagerProviderService.PROXY_CONFIGURATION.getName()));
+        assertTrue(hasProxyProperty, "Proxy Configuration Service property should be present");
+    }
+
+    @Test
     void testInsertFilesRequest() throws Exception {
         mockWebServer.enqueue(new MockResponse.Builder()
                 .code(HttpURLConnection.HTTP_OK)


### PR DESCRIPTION
NIFI-15911 Add proxy support to StandardSnowflakeIngestManagerProviderService

StandardSnowflakeIngestManagerProviderService uses SnowpipeIngestClient to send data to Snowflake via the Snowpipe REST API. Previously, the HTTP client had no proxy configuration, causing failures for NiFi deployments running behind a corporate or network proxy.

This change adds proxy support by wiring ProxyConfigurationService into the controller service.

Changes:
- Added PROXY_CONFIGURATION_SERVICE property to StandardSnowflakeIngestManagerProviderService
- Used a custom ProxySelector that correctly handles HTTP, SOCKS, and DIRECT proxy types
- Added scoped Authenticator for proxy username/password credentials
- Extended SnowpipeIngestClient with a constructor accepting ProxySelector and Authenticator

SnowpipeIngestClient

 - Added a constructor accepting ProxySelector and Authenticator, applied to the underlying HttpClient
 - Existing 3-arg constructor delegates to the new one with nulls (backward compatible)

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15911](https://issues.apache.org/jira/browse/NIFI-15911)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
