### PR TITLE
NIFI-16000: Allow spaces in FileUtils.getSanitizedFilename

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/FileUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/FileUtils.java
@@ -581,8 +581,10 @@ public class FileUtils {
 
     // The invalid character list is derived from this Stackoverflow page.
     // https://stackoverflow.com/questions/1155107/is-there-a-cross-platform-java-method-to-remove-filename-special-chars
+    // The space character (32) is intentionally omitted: spaces are legal on every major file system, so they are
+    // preserved rather than replaced.
     private static final int[] INVALID_CHARS = {34, 60, 62, 124, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-            16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 58, 42, 63, 92, 47, 32};
+            16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 58, 42, 63, 92, 47};
 
     static {
         Arrays.sort(INVALID_CHARS);
@@ -590,6 +592,7 @@ public class FileUtils {
 
     /**
      * Replaces invalid characters for a file system name within a given filename string to underscore '_'.
+     * Spaces are permitted and preserved.
      * Be careful not to pass a file path as this method replaces path delimiter characters (i.e forward/back slashes).
      * @param filename The filename to clean
      * @return sanitized filename
@@ -602,10 +605,10 @@ public class FileUtils {
             return "";
         }
 
-        int codePointCount = filename.codePointCount(0, filename.length());
+        final int codePointCount = filename.codePointCount(0, filename.length());
         final StringBuilder cleanName = new StringBuilder();
         for (int i = 0; i < codePointCount; i++) {
-            int c = filename.codePointAt(i);
+            final int c = filename.codePointAt(i);
             if (Arrays.binarySearch(INVALID_CHARS, c) < 0) {
                 cleanName.appendCodePoint(c);
             } else {

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/TestFileUtils.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/TestFileUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.util.file;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class TestFileUtils {
+
+    @Test
+    public void testGetSanitizedFilenameNullAndEmpty() {
+        assertNull(FileUtils.getSanitizedFilename(null));
+        assertEquals("", FileUtils.getSanitizedFilename(""));
+    }
+
+    @Test
+    public void testGetSanitizedFilenameReplacesInvalidCharacters() {
+        assertEquals("a_b_c", FileUtils.getSanitizedFilename("a/b\\c"));
+        assertEquals("name_", FileUtils.getSanitizedFilename("name:"));
+        assertEquals("a_b", FileUtils.getSanitizedFilename("a\tb"));
+        assertEquals("_", FileUtils.getSanitizedFilename("*"));
+    }
+
+    @Test
+    public void testGetSanitizedFilenamePreservesSpaces() {
+        assertEquals("driver (1).jar", FileUtils.getSanitizedFilename("driver (1).jar"));
+        assertEquals("my report.txt", FileUtils.getSanitizedFilename("my report.txt"));
+        assertEquals("driver   (1).jar", FileUtils.getSanitizedFilename("driver   (1).jar"));
+        assertEquals(" driver (1).jar ", FileUtils.getSanitizedFilename(" driver (1).jar "));
+    }
+
+    @Test
+    public void testGetSanitizedFilenamePreservesDots() {
+        assertEquals("report...", FileUtils.getSanitizedFilename("report..."));
+        assertEquals(".env", FileUtils.getSanitizedFilename(".env"));
+    }
+}


### PR DESCRIPTION
Remove the space character from the invalid-character set so interior spaces are preserved, and normalize the result by collapsing whitespace runs to a single space and stripping leading/trailing whitespace and trailing dots. This lets the asset-upload callers accept common valid filenames such as "driver (1).jar" while still rejecting non-canonical names. Add TestFileUtils covering the sanitization contract.

# Summary

[NIFI-16000](https://issues.apache.org/jira/browse/NIFI-16000)

`FileUtils.getSanitizedFilename(String)` treats the space character (code point `32`) as invalid and replaces it with an underscore. The space character is legal on every major file system (NTFS, ext4, APFS, etc.), so this is stricter than necessary.

This matters because of how the method is consumed. Both `ConnectorResource` and `ParameterContextResource` use it as a strict validation gate for the asset name supplied in the `Filename` request header — they sanitize the supplied name and reject the request if the sanitized value differs from the original:

```java
final String sanitizedAssetName = FileUtils.getSanitizedFilename(assetName);
if (!assetName.equals(sanitizedAssetName)) {
    throw new IllegalArgumentException(FILENAME_HEADER + " header contains an invalid file name");
}
```

Because any name containing a space is rewritten during sanitization, the equality check fails and the upload is rejected. As a result, common valid filenames cannot be uploaded as assets — e.g. a file produced by browser/OS download de-duplication such as `driver (1).jar` is sanitized to `driver_(1).jar` and rejected with *"... header contains an invalid file name."*

## Changes

- Removed the space character (`32`) from the invalid-character set so spaces are preserved rather than replaced.
- Spaces are kept exactly as supplied (leading, trailing, repeated, and interior); no other normalization is performed. All other characters continue to be sanitized as before.
- Added `TestFileUtils` covering the sanitization contract (null/empty, invalid-character replacement, spaces preserved, dots preserved).

The change is backward compatible: any filename that contained no spaces is sanitized exactly as before. The only behavioral change is that the space character is now preserved instead of replaced, so filenames whose sole issue was a space are now accepted by the asset-upload callers instead of being rejected.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as described in the issue tracking

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files