### PR TITLE
NIFI-16005 Adjust proxy header validation for requests forwarded to c…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ReplicationHeaderUtils.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ReplicationHeaderUtils.java
@@ -110,6 +110,19 @@ public final class ReplicationHeaderUtils {
     }
 
     /**
+     * Removes the trust-bearing {@link ReplicationHeader} marker headers from the map (case-insensitive) so that an
+     * inbound client request cannot spoof the markers that cause a receiving node to bypass proxy host validation. The
+     * caller is expected to set the appropriate marker explicitly after invoking this method. Other replication protocol
+     * headers, such as {@code replication-target-id}, are intentionally left intact because they are set by the framework
+     * and must transit to the receiving node.
+     */
+    public static void stripReplicationMarkerHeaders(final Map<String, String> headers) {
+        for (final ReplicationHeader rh : ReplicationHeader.values()) {
+            removeHeader(headers, rh.getHeader());
+        }
+    }
+
+    /**
      * Removes hop-by-hop / transport-framing headers that should not be forwarded in a
      * replicated request (case-insensitive).
      */

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ThreadPoolRequestReplicator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ThreadPoolRequestReplicator.java
@@ -256,6 +256,10 @@ public class ThreadPoolRequestReplicator implements RequestReplicator, Closeable
                                           final boolean indicateReplicated, final boolean performVerification) {
         final Map<String, String> updatedHeaders = new HashMap<>(headers);
 
+        // Strip any inbound replication marker headers so a client cannot spoof them; the framework sets the
+        // appropriate marker explicitly below
+        ReplicationHeaderUtils.stripReplicationMarkerHeaders(updatedHeaders);
+
         updatedHeaders.put(RequestReplicationHeader.CLUSTER_ID_GENERATION_SEED.getHeader(), ComponentIdGenerator.generateId().toString());
         if (indicateReplicated) {
             updatedHeaders.put(ReplicationHeader.REQUEST_REPLICATED.getHeader(), Boolean.TRUE.toString());
@@ -307,6 +311,10 @@ public class ThreadPoolRequestReplicator implements RequestReplicator, Closeable
     public AsyncClusterResponse forwardToCoordinator(final NodeIdentifier coordinatorNodeId, final NiFiUser user, final String method,
                 final URI uri, final Object entity, final Map<String, String> headers) {
         final Map<String, String> updatedHeaders = new HashMap<>(headers);
+
+        // Strip any inbound replication marker headers so a client cannot spoof them; the forwarded marker is set
+        // explicitly below
+        ReplicationHeaderUtils.stripReplicationMarkerHeaders(updatedHeaders);
 
         // Indicate to the Cluster Coordinator that this request was forwarded by a node over mutual TLS, so the
         // Coordinator can trust the proxy host headers without re-validating them against its own allowed proxy hosts

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ThreadPoolRequestReplicator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ThreadPoolRequestReplicator.java
@@ -308,6 +308,10 @@ public class ThreadPoolRequestReplicator implements RequestReplicator, Closeable
                 final URI uri, final Object entity, final Map<String, String> headers) {
         final Map<String, String> updatedHeaders = new HashMap<>(headers);
 
+        // Indicate to the Cluster Coordinator that this request was forwarded by a node over mutual TLS, so the
+        // Coordinator can trust the proxy host headers without re-validating them against its own allowed proxy hosts
+        updatedHeaders.put(ReplicationHeader.REQUEST_FORWARDED_TO_COORDINATOR.getHeader(), Boolean.TRUE.toString());
+
         // include the proxied entities header
         updateRequestHeaders(updatedHeaders, user);
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestReplicationHeaderUtils.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestReplicationHeaderUtils.java
@@ -18,6 +18,7 @@ package org.apache.nifi.cluster.coordination.http.replication;
 
 import org.apache.nifi.authorization.user.NiFiUser;
 import org.apache.nifi.authorization.user.StandardNiFiUser;
+import org.apache.nifi.cluster.coordination.http.ReplicationHeader;
 import org.apache.nifi.web.security.ProxiedEntitiesUtils;
 import org.junit.jupiter.api.Test;
 
@@ -88,11 +89,17 @@ class TestReplicationHeaderUtils {
         for (final RequestReplicationHeader rh : RequestReplicationHeader.values()) {
             headers.put(rh.getHeader(), SPOOFED_VALUE);
         }
+        for (final ReplicationHeader rh : ReplicationHeader.values()) {
+            headers.put(rh.getHeader(), SPOOFED_VALUE);
+        }
         headers.put(CUSTOM_HEADER, SHOULD_SURVIVE_VALUE);
 
         ReplicationHeaderUtils.stripRequestReplicationHeaders(headers);
 
         for (final RequestReplicationHeader rh : RequestReplicationHeader.values()) {
+            assertNull(headers.get(rh.getHeader()), "Replication header should have been stripped: " + rh.getHeader());
+        }
+        for (final ReplicationHeader rh : ReplicationHeader.values()) {
             assertNull(headers.get(rh.getHeader()), "Replication header should have been stripped: " + rh.getHeader());
         }
         assertEquals(SHOULD_SURVIVE_VALUE, headers.get(CUSTOM_HEADER));

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestReplicationHeaderUtils.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestReplicationHeaderUtils.java
@@ -106,6 +106,42 @@ class TestReplicationHeaderUtils {
     }
 
     @Test
+    void testStripReplicationMarkerHeadersRemovesOnlyMarkers() {
+        final Map<String, String> headers = new HashMap<>();
+        for (final ReplicationHeader rh : ReplicationHeader.values()) {
+            headers.put(rh.getHeader(), SPOOFED_VALUE);
+        }
+        for (final RequestReplicationHeader rh : RequestReplicationHeader.values()) {
+            headers.put(rh.getHeader(), SHOULD_SURVIVE_VALUE);
+        }
+        headers.put(CUSTOM_HEADER, SHOULD_SURVIVE_VALUE);
+
+        ReplicationHeaderUtils.stripReplicationMarkerHeaders(headers);
+
+        for (final ReplicationHeader rh : ReplicationHeader.values()) {
+            assertNull(headers.get(rh.getHeader()), "Replication marker header should have been stripped: " + rh.getHeader());
+        }
+        for (final RequestReplicationHeader rh : RequestReplicationHeader.values()) {
+            assertEquals(SHOULD_SURVIVE_VALUE, headers.get(rh.getHeader()), "Request replication header should have been preserved: " + rh.getHeader());
+        }
+        assertEquals(SHOULD_SURVIVE_VALUE, headers.get(CUSTOM_HEADER));
+    }
+
+    @Test
+    void testStripReplicationMarkerHeadersCaseInsensitive() {
+        final Map<String, String> headers = new HashMap<>();
+        headers.put("Request-Replicated", "true");
+        headers.put("Request-Forwarded-To-Coordinator", "true");
+        headers.put("Replication-Target-Id", SHOULD_SURVIVE_VALUE);
+
+        ReplicationHeaderUtils.stripReplicationMarkerHeaders(headers);
+
+        assertFalse(headers.containsKey("Request-Replicated"));
+        assertFalse(headers.containsKey("Request-Forwarded-To-Coordinator"));
+        assertEquals(SHOULD_SURVIVE_VALUE, headers.get("Replication-Target-Id"));
+    }
+
+    @Test
     void testStripRequestReplicationHeadersCaseInsensitive() {
         final Map<String, String> headers = new HashMap<>();
         headers.put("Request-Replicated", "true");

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestThreadPoolRequestReplicator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestThreadPoolRequestReplicator.java
@@ -26,6 +26,7 @@ import org.apache.nifi.authorization.user.NiFiUserUtils;
 import org.apache.nifi.authorization.user.StandardNiFiUser;
 import org.apache.nifi.authorization.user.StandardNiFiUser.Builder;
 import org.apache.nifi.cluster.coordination.ClusterCoordinator;
+import org.apache.nifi.cluster.coordination.http.ReplicationHeader;
 import org.apache.nifi.cluster.coordination.http.replication.util.MockReplicationClient;
 import org.apache.nifi.cluster.coordination.node.NodeConnectionState;
 import org.apache.nifi.cluster.coordination.node.NodeConnectionStatus;
@@ -56,6 +57,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -377,6 +379,46 @@ public class TestThreadPoolRequestReplicator {
                 new NodeConnectionStatus(invocation.getArgument(0), NodeConnectionState.CONNECTED));
 
         return coordinator;
+    }
+
+    @Test
+    @Timeout(value = 15)
+    public void testForwardToCoordinatorSetsForwardedHeader() throws Exception {
+        final NodeIdentifier coordinatorNodeId = new NodeIdentifier("1", "localhost", 8100, "localhost", 8101, "localhost", 8102, 8103, false);
+
+        final ClusterCoordinator coordinator = createClusterCoordinator();
+        final NiFiProperties props = NiFiProperties.createBasicNiFiProperties((String) null);
+        final MockReplicationClient client = new MockReplicationClient();
+        final RequestCompletionCallback callback = (uri, method, responses) -> { };
+
+        final Map<String, String> capturedHeaders = new ConcurrentHashMap<>();
+        final ThreadPoolRequestReplicator replicator = new ThreadPoolRequestReplicator(5, 100, client, coordinator, callback, EventReporter.NO_OP, props) {
+            @Override
+            protected NodeResponse replicateRequest(final PreparedRequest request, final NodeIdentifier nodeId, final URI uri, final String requestId,
+                    final StandardAsyncClusterResponse response) {
+                capturedHeaders.putAll(request.getHeaders());
+
+                final Response clientResponse = mock(Response.class);
+                when(clientResponse.getStatus()).thenReturn(Status.OK.getStatusCode());
+                return new NodeResponse(nodeId, request.getMethod(), uri, clientResponse, -1L, requestId);
+            }
+        };
+
+        try {
+            final Authentication authentication = new NiFiAuthenticationToken(new NiFiUserDetails(StandardNiFiUser.ANONYMOUS));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            final URI uri = new URI("http://localhost:8080/nifi-api/controller/registry-types");
+            final Entity entity = new ProcessorEntity();
+
+            final AsyncClusterResponse response = replicator.forwardToCoordinator(coordinatorNodeId, HttpMethod.GET, uri, entity, new HashMap<>());
+            response.awaitMergedResponse(3, TimeUnit.SECONDS);
+
+            assertEquals(Boolean.TRUE.toString(), capturedHeaders.get(ReplicationHeader.REQUEST_FORWARDED_TO_COORDINATOR.getHeader()));
+            assertNull(capturedHeaders.get(ReplicationHeader.REQUEST_REPLICATED.getHeader()));
+        } finally {
+            replicator.shutdown();
+        }
     }
 
     @Test

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestThreadPoolRequestReplicator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestThreadPoolRequestReplicator.java
@@ -381,18 +381,13 @@ public class TestThreadPoolRequestReplicator {
         return coordinator;
     }
 
-    @Test
-    @Timeout(value = 15)
-    public void testForwardToCoordinatorSetsForwardedHeader() throws Exception {
-        final NodeIdentifier coordinatorNodeId = new NodeIdentifier("1", "localhost", 8100, "localhost", 8101, "localhost", 8102, 8103, false);
-
+    private ThreadPoolRequestReplicator createHeaderCapturingReplicator(final Map<String, String> capturedHeaders) {
         final ClusterCoordinator coordinator = createClusterCoordinator();
         final NiFiProperties props = NiFiProperties.createBasicNiFiProperties((String) null);
         final MockReplicationClient client = new MockReplicationClient();
         final RequestCompletionCallback callback = (uri, method, responses) -> { };
 
-        final Map<String, String> capturedHeaders = new ConcurrentHashMap<>();
-        final ThreadPoolRequestReplicator replicator = new ThreadPoolRequestReplicator(5, 100, client, coordinator, callback, EventReporter.NO_OP, props) {
+        return new ThreadPoolRequestReplicator(5, 100, client, coordinator, callback, EventReporter.NO_OP, props) {
             @Override
             protected NodeResponse replicateRequest(final PreparedRequest request, final NodeIdentifier nodeId, final URI uri, final String requestId,
                     final StandardAsyncClusterResponse response) {
@@ -403,6 +398,15 @@ public class TestThreadPoolRequestReplicator {
                 return new NodeResponse(nodeId, request.getMethod(), uri, clientResponse, -1L, requestId);
             }
         };
+    }
+
+    @Test
+    @Timeout(value = 15)
+    public void testForwardToCoordinatorSetsForwardedHeader() throws Exception {
+        final NodeIdentifier coordinatorNodeId = new NodeIdentifier("1", "localhost", 8100, "localhost", 8101, "localhost", 8102, 8103, false);
+
+        final Map<String, String> capturedHeaders = new ConcurrentHashMap<>();
+        final ThreadPoolRequestReplicator replicator = createHeaderCapturingReplicator(capturedHeaders);
 
         try {
             final Authentication authentication = new NiFiAuthenticationToken(new NiFiUserDetails(StandardNiFiUser.ANONYMOUS));
@@ -416,6 +420,39 @@ public class TestThreadPoolRequestReplicator {
 
             assertEquals(Boolean.TRUE.toString(), capturedHeaders.get(ReplicationHeader.REQUEST_FORWARDED_TO_COORDINATOR.getHeader()));
             assertNull(capturedHeaders.get(ReplicationHeader.REQUEST_REPLICATED.getHeader()));
+        } finally {
+            replicator.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(value = 15)
+    public void testForwardToCoordinatorStripsSpoofedMarkersAndPreservesTargetId() throws Exception {
+        final NodeIdentifier coordinatorNodeId = new NodeIdentifier("1", "localhost", 8100, "localhost", 8101, "localhost", 8102, 8103, false);
+
+        final Map<String, String> capturedHeaders = new ConcurrentHashMap<>();
+        final ThreadPoolRequestReplicator replicator = createHeaderCapturingReplicator(capturedHeaders);
+
+        try {
+            final Authentication authentication = new NiFiAuthenticationToken(new NiFiUserDetails(StandardNiFiUser.ANONYMOUS));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            final URI uri = new URI("http://localhost:8080/nifi-api/controller/registry-types");
+            final Entity entity = new ProcessorEntity();
+
+            final Map<String, String> inboundHeaders = new HashMap<>();
+            inboundHeaders.put(ReplicationHeader.REQUEST_REPLICATED.getHeader(), "spoofed");
+            inboundHeaders.put(ReplicationHeader.REQUEST_FORWARDED_TO_COORDINATOR.getHeader(), "spoofed");
+            inboundHeaders.put(RequestReplicationHeader.REPLICATION_TARGET_ID.getHeader(), "node-uuid");
+
+            final AsyncClusterResponse response = replicator.forwardToCoordinator(coordinatorNodeId, HttpMethod.GET, uri, entity, inboundHeaders);
+            response.awaitMergedResponse(3, TimeUnit.SECONDS);
+
+            // The spoofed replicated marker is stripped, the forwarded marker is set by the framework, and the
+            // framework-supplied replication target id is preserved
+            assertNull(capturedHeaders.get(ReplicationHeader.REQUEST_REPLICATED.getHeader()));
+            assertEquals(Boolean.TRUE.toString(), capturedHeaders.get(ReplicationHeader.REQUEST_FORWARDED_TO_COORDINATOR.getHeader()));
+            assertEquals("node-uuid", capturedHeaders.get(RequestReplicationHeader.REPLICATION_TARGET_ID.getHeader()));
         } finally {
             replicator.shutdown();
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/cluster/coordination/http/ReplicationHeader.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/cluster/coordination/http/ReplicationHeader.java
@@ -21,7 +21,10 @@ package org.apache.nifi.cluster.coordination.http;
  */
 public enum ReplicationHeader {
     /** Boolean indicator that the Cluster Coordinator is initiating the replicated request to other nodes */
-    REQUEST_REPLICATED("request-replicated");
+    REQUEST_REPLICATED("request-replicated"),
+
+    /** Boolean indicator that a node is forwarding a request to the Cluster Coordinator for subsequent replication */
+    REQUEST_FORWARDED_TO_COORDINATOR("request-forwarded-to-coordinator");
 
     private final String header;
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/ProxyHeaderValidatorCustomizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/ProxyHeaderValidatorCustomizer.java
@@ -76,10 +76,12 @@ public class ProxyHeaderValidatorCustomizer implements HttpConfiguration.Customi
         if (peerCertificate == null) {
             processProxyHostHeaders(request);
         } else {
-            // Requests authenticated with Client Certificates but not indicated as replicated require header validation
+            // Requests authenticated with Client Certificates that are replicated to nodes or forwarded to the Cluster
+            // Coordinator originate from trusted nodes over mutual TLS, so their proxy host headers are not re-validated
             final HttpFields requestHeaders = request.getHeaders();
             final String requestReplicated = requestHeaders.get(ReplicationHeader.REQUEST_REPLICATED.getHeader());
-            if (requestReplicated == null) {
+            final String requestForwardedToCoordinator = requestHeaders.get(ReplicationHeader.REQUEST_FORWARDED_TO_COORDINATOR.getHeader());
+            if (requestReplicated == null && requestForwardedToCoordinator == null) {
                 processProxyHostHeaders(request);
             }
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
@@ -255,6 +255,7 @@ class StandardServerProviderTest {
             assertMisdirectedRequestsCompleted(httpClient, localhostUri);
 
             assertReplicatedRequestCompleted(httpClient, localhostUri, HttpStatus.MISDIRECTED_REQUEST_421);
+            assertForwardedToCoordinatorRequestCompleted(httpClient, localhostUri, HttpStatus.MISDIRECTED_REQUEST_421);
         }
     }
 
@@ -272,6 +273,7 @@ class StandardServerProviderTest {
             assertMisdirectedRequestsCompleted(httpClient, localhostUri);
 
             assertReplicatedRequestCompleted(httpClient, localhostUri, HttpStatus.MOVED_TEMPORARILY_302);
+            assertForwardedToCoordinatorRequestCompleted(httpClient, localhostUri, HttpStatus.MOVED_TEMPORARILY_302);
         }
     }
 
@@ -282,6 +284,15 @@ class StandardServerProviderTest {
                 .header(ReplicationHeader.REQUEST_REPLICATED.getHeader(), Boolean.TRUE.toString())
                 .build();
         assertResponseStatusCode(httpClient, proxyHostRequestReplicatedRequest, statusCodeExpected);
+    }
+
+    void assertForwardedToCoordinatorRequestCompleted(final HttpClient httpClient, final URI localhostUri, final int statusCodeExpected) throws IOException, InterruptedException {
+        final HttpRequest proxyHostForwardedToCoordinatorRequest = HttpRequest.newBuilder(localhostUri)
+                .version(HttpClient.Version.HTTP_1_1)
+                .header(ProxyHeader.PROXY_HOST.getHeader(), PUBLIC_UNKNOWN_HOST)
+                .header(ReplicationHeader.REQUEST_FORWARDED_TO_COORDINATOR.getHeader(), Boolean.TRUE.toString())
+                .build();
+        assertResponseStatusCode(httpClient, proxyHostForwardedToCoordinatorRequest, statusCodeExpected);
     }
 
     void assertFrontendRedirectRequestsCompleted(final HttpClient httpClient, final URI localhostUri) throws IOException, InterruptedException {


### PR DESCRIPTION
…luster coordinator

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16005](https://issues.apache.org/jira/browse/NIFI-16005)

Adds a new header `request-forwarded-to-coordinator` that is set when a node forwards a request to the cluster coordinator, similar to `request-replicated` which is set when the coordinator replicates requests to the other nodes. The `ProxyHeaderValidatorCustomizer` was then updated to skip validation when the request was forwarded to the coordinator, similar to how it skips when the coordinator replicated to other nodes.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
