### PR TITLE
NIFI-16007 - Bump Spring to 7.0.8, OkHTTP to 5.4.0, Jackson to 2.22.0, and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -72,7 +72,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.3.5</version>
+                <version>1.3.6</version>
                 <exclusions>
                     <!--
                         Reactor Netty 1.3 includes HTTP/3 support requiring native QUIC libraries.

--- a/nifi-extension-bom/pom.xml
+++ b/nifi-extension-bom/pom.xml
@@ -248,7 +248,7 @@
             <dependency>
                 <groupId>org.eclipse.jdt</groupId>
                 <artifactId>ecj</artifactId>
-                <version>3.45.0</version>
+                <version>3.46.0</version>
                 <scope>provided</scope>
             </dependency>
             <!-- Jetty EE11 Glassfish JSTL and deps -->

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
-            <version>2.7.2</version>
+            <version>2.7.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.8.5</version>
+            <version>3.8.6</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.8.5</version>
+            <version>3.8.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -78,7 +78,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.3.5</version>
+                <version>1.3.6</version>
                 <exclusions>
                     <!--
                         Reactor Netty 1.3 includes HTTP/3 support requiring native QUIC libraries.

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/pom.xml
@@ -36,7 +36,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>mysql-binlog-connector-java</artifactId>
-            <version>0.40.7</version>
+            <version>0.41.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-parquet-writer/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-parquet-writer/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
-            <version>7.2.0</version>
+            <version>7.2.1</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
@@ -20,7 +20,7 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <snmp4j.version>3.10.0</snmp4j.version>
+        <snmp4j.version>3.11.0</snmp4j.version>
         <snmp4j-agent.version>3.8.3</snmp4j-agent.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -24,7 +24,7 @@
         <guava.version>33.6.0-jre</guava.version>
         <protobuf.version>4.35.0</protobuf.version>
         <grpc.version>1.81.0</grpc.version>
-        <snowflake-jdbc-thin.version>4.2.0</snowflake-jdbc-thin.version>
+        <snowflake-jdbc-thin.version>4.3.0</snowflake-jdbc-thin.version>
     </properties>
 
     <modules>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.springframework.retry</groupId>
             <artifactId>spring-retry</artifactId>
-            <version>2.0.12</version>
+            <version>2.0.13</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
@@ -244,7 +244,7 @@
         <dependency>
             <groupId>org.springframework.ldap</groupId>
             <artifactId>spring-ldap-core</artifactId>
-            <version>4.0.3</version>
+            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>4.0.6</spring.boot.version>
-        <flyway.version>12.7.0</flyway.version>
+        <flyway.version>12.8.1</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.6.0.202603022253-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.46.1</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.46.6</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.7</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -157,15 +157,15 @@
         <com.jayway.jsonpath.version>3.0.0</com.jayway.jsonpath.version>
         <gson.version>2.14.0</gson.version>
         <jackson.annotations.version>2.22</jackson.annotations.version>
-        <jackson.bom.version>2.21.4</jackson.bom.version>
-        <jackson3.bom.version>3.1.4</jackson3.bom.version>
+        <jackson.bom.version>2.22.0</jackson.bom.version>
+        <jackson3.bom.version>3.2.0</jackson3.bom.version>
         <json.smart.version>2.6.0</json.smart.version>
         <snakeyaml.version>2.6</snakeyaml.version>
 
         <!-- JVM languages and bytecode -->
         <aspectj.version>1.9.25.1</aspectj.version>
         <groovy.version>5.0.6</groovy.version>
-        <kotlin.version>2.3.21</kotlin.version>
+        <kotlin.version>2.4.0</kotlin.version>
 
         <!-- Logging and observability -->
         <log4j2.version>2.26.0</log4j2.version>
@@ -176,7 +176,7 @@
 
         <!-- Networking and transport -->
         <netty.4.version>4.2.15.Final</netty.4.version>
-        <okhttp.version>5.3.2</okhttp.version>
+        <okhttp.version>5.4.0</okhttp.version>
         <okio.version>3.17.0</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
@@ -202,7 +202,7 @@
         <jetty.version>12.1.10</jetty.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.security.version>7.0.5</spring.security.version>
-        <spring.version>7.0.7</spring.version>
+        <spring.version>7.0.8</spring.version>
         <swagger.annotations.version>2.2.50</swagger.annotations.version>
 
         <!-- Testing and quality -->
@@ -211,7 +211,7 @@
         <pmd.version>7.25.0</pmd.version>
         <checkstyle.version>13.5.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
-        <jacoco.version>0.8.14</jacoco.version>
+        <jacoco.version>0.8.15</jacoco.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
# Summary

NIFI-16007 - Bump Spring to 7.0.8, OkHTTP to 5.4.0, Jackson to 2.22.0, and others

- Amazon Kinesis Client from 2.7.2 to 2.7.3 - https://github.com/awslabs/amazon-kinesis-client/releases/tag/v2.7.3
- MySQL Binlog Connector from 0.40.7 to 0.41.0 - https://github.com/debezium/mysql-binlog-connector-java/tags
- SNMP4J from 3.10.0 to 3.11.0 - https://snmp4j.org/CHANGES.txt
- FlywayDB from 12.7.0 to 12.8.1 - https://github.com/flyway/flyway/releases/tag/flyway-12.8.1
- AWS SDK BOM from 2.46.1 to 2.46.6 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Jackson 2.x from 2.21.4 to 2.22.0 - https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.22
- Jackson 3.x from 3.1.4 to 3.2.0 - https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.2
- Kotlin from 2.3.21 to 2.4.0 - https://github.com/JetBrains/kotlin/releases/tag/v2.4.0
- JaCoCo from 0.8.14 to 0.8.15 - https://github.com/jacoco/jacoco/releases/tag/v0.8.15
- OkHTTP from 5.3.2 to 5.4.0 - https://square.github.io/okhttp/changelogs/changelog/#version-540
- Snowflake JDBC from 4.2.0 to 4.3.0 - https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc-2026#version-430-jun-09-2026
- Reactor Netty HTTP from 1.3.5 to 1.3.6 - https://github.com/reactor/reactor-netty/releases/tag/v1.3.6
- Eclipse ECJ from 3.45.0 to 3.46.0 - https://github.com/eclipse-jdt/eclipse.jdt.core
- Spring Framework from 7.0.7 to 7.0.8 - https://github.com/spring-projects/spring-framework/releases/tag/v7.0.8
- Spring LDAP from 4.0.3 to 4.1.0 - https://github.com/spring-projects/spring-ldap/releases/tag/4.1.0
- Spring Retry from 2.0.12 to 2.0.13 - https://github.com/spring-projects/spring-retry/releases/tag/v2.0.13
- Reactor from 3.8.5 to 3.8.6 - https://github.com/reactor/reactor-core/releases/tag/v3.8.6
- Woodstox from 7.2.0 to 7.2.1 - https://github.com/FasterXML/woodstox/releases/tag/woodstox-core-7.2.1

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
