### PR TITLE
NIFI-16008 Check commit sha string in registerFlowSnapshot()

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
@@ -504,6 +504,11 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
                 .build();
 
         final String createContentCommitSha = repositoryClient.createContent(createContentRequest);
+        if (createContentCommitSha == null) {
+            throw new FlowRegistryException("Created Content Commit SHA is null");
+        } else if (createContentCommitSha.isEmpty() || createContentCommitSha.isBlank()) {
+            throw new FlowRegistryException("Created Content Commit SHA is empty");
+        }
 
         final VersionedFlowCoordinates versionedFlowCoordinates = new VersionedFlowCoordinates();
         versionedFlowCoordinates.setRegistryId(getIdentifier());


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16008](https://issues.apache.org/jira/browse/NIFI-16008)

In `registerFlowSnapshot()` of the `AbstractGitFlowRegistryClient` the check for the result of the `repositoryClient.createContent()` call is missing.

https://github.com/apache/nifi/blob/8c593dbfaf3eb8f4cac9a2ea0a625b5198e66622/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java#L506

While writing a custom git flow registry client for Cloudogu (which is using SCM-Manager) I ran into an issue while returning an empty string instead of the expected commit SHA hash.

The expected behaviour should be that an error will be thrown instead of using an empty version string for the `VersionedFlowCoordinates`.

https://github.com/apache/nifi/blob/8c593dbfaf3eb8f4cac9a2ea0a625b5198e66622/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java#L513

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
