### PR TITLE
NIFI-16018: Handle port number in header validator

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
@@ -107,7 +107,7 @@ public class FrameworkServerConnectorFactory extends StandardServerConnectorFact
         // Add HostHeaderCustomizer to set Host Header for HTTP/2
         httpConfiguration.addCustomizer(new HostHeaderCustomizer());
 
-        final ProxyHeaderValidatorCustomizer proxyHeaderValidatorCustomizer = new ProxyHeaderValidatorCustomizer(validProxyHosts);
+        final ProxyHeaderValidatorCustomizer proxyHeaderValidatorCustomizer = new ProxyHeaderValidatorCustomizer(validProxyHosts, validPorts);
         httpConfiguration.addCustomizer(proxyHeaderValidatorCustomizer);
 
         final HostPortValidatorCustomizer hostPortValidatorCustomizer = new HostPortValidatorCustomizer(validPorts);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/ProxyHeaderValidatorCustomizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/ProxyHeaderValidatorCustomizer.java
@@ -31,12 +31,16 @@ import org.eclipse.jetty.server.Request;
 import java.security.cert.X509Certificate;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Jetty Request Customizer implementing validation for supported Proxy Request Headers
  */
 public class ProxyHeaderValidatorCustomizer implements HttpConfiguration.Customizer {
     private static final String MISDIRECTED_REQUEST_REASON = "Invalid Proxy Host Requested";
+    private static final String MISDIRECTED_REQUEST_REASON_INVALID_PORT = "Invalid Port Requested";
+
+    private static final Pattern HOST_PORT_SEPARATOR = Pattern.compile(":");
 
     private static final Set<String> SUPPORTED_PROXY_HOST_HEADERS = Set.of(
             ProxyHeader.PROXY_HOST.getHeader(),
@@ -44,9 +48,11 @@ public class ProxyHeaderValidatorCustomizer implements HttpConfiguration.Customi
     );
 
     private final Set<String> validProxyHosts;
+    private final Set<Integer> validPorts;
 
-    public ProxyHeaderValidatorCustomizer(final Set<String> validProxyHosts) {
+    public ProxyHeaderValidatorCustomizer(final Set<String> validProxyHosts, final Set<Integer> validPorts) {
         this.validProxyHosts = Objects.requireNonNull(validProxyHosts, "Valid Proxy Hosts required");
+        this.validPorts = Objects.requireNonNull(validPorts, "Valid Ports required");
     }
 
     /**
@@ -95,20 +101,45 @@ public class ProxyHeaderValidatorCustomizer implements HttpConfiguration.Customi
 
         final HttpFields requestHeaders = request.getHeaders();
         for (final String proxyHostHeader : SUPPORTED_PROXY_HOST_HEADERS) {
-            final String hostHeader = requestHeaders.get(proxyHostHeader);
+            String hostHeader = requestHeaders.get(proxyHostHeader);
             // Include empty and blank values for enforced validation of request headers
             if (hostHeader == null) {
                 continue;
             }
+
+            final String[] hostHeaderParts = HOST_PORT_SEPARATOR.split(hostHeader);
+            if (hostHeaderParts.length == 2) {
+                hostHeader = hostHeaderParts[0];
+            }
+
             // Allow proxy host header matching request host header based on TLS SNI and DNS SAN requirements
             if (requestHost.equals(hostHeader)) {
-                continue;
-            }
-            if (validProxyHosts.contains(hostHeader)) {
+                processProxyHostHeaderPortNumber(hostHeaderParts);
                 continue;
             }
 
-            throw new HttpException.RuntimeException(HttpStatus.MISDIRECTED_REQUEST_421, MISDIRECTED_REQUEST_REASON);
+            if (validProxyHosts.contains(hostHeader)) {
+                processProxyHostHeaderPortNumber(hostHeaderParts);
+                continue;
+            }
+
+        throw new HttpException.RuntimeException(HttpStatus.MISDIRECTED_REQUEST_421, MISDIRECTED_REQUEST_REASON);
+
+        }
+    }
+
+    private void processProxyHostHeaderPortNumber(String[] hostHeaderParts) {
+        if (hostHeaderParts.length == 2) {
+            try {
+                final int port = Integer.parseInt(hostHeaderParts[1]);
+                if (validPorts.contains(port)) {
+                    return;
+                } else {
+                    throw new HttpException.RuntimeException(HttpStatus.MISDIRECTED_REQUEST_421, MISDIRECTED_REQUEST_REASON_INVALID_PORT);
+                }
+            } catch (final NumberFormatException e) {
+                throw new HttpException.RuntimeException(HttpStatus.MISDIRECTED_REQUEST_421, MISDIRECTED_REQUEST_REASON_INVALID_PORT);
+            }
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.springframework.web.util.UriBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -86,6 +87,12 @@ class StandardServerProviderTest {
     private static final String PUBLIC_HOST = "nifi.apache.org";
 
     private static final String PUBLIC_STAGED_HOST = "nifi.staged.apache.org";
+
+    private static final String PUBLIC_STAGED_HOST_WITH_PORT = "nifi.staged.apache.org:8443";
+
+    private static final String PUBLIC_STAGED_HOST_WITH_INVALID_PORT = "nifi.staged.apache.org:8444";
+
+    private static final String PUBLIC_STAGED_HOST_WITH_A_PORT_WHICH_NOT_NUMBER = "nifi.staged.apache.org:aaa";
 
     private static final String PROXY_HOST_PROPERTY = "nifi.apache.org,nifi.staged.apache.org:8443";
 
@@ -350,6 +357,12 @@ class StandardServerProviderTest {
                 .header(ProxyHeader.FORWARDED_HOST.getHeader(), PUBLIC_STAGED_HOST)
                 .build();
         assertResponseStatusCode(httpClient, forwardedHostRequest, HttpStatus.MOVED_TEMPORARILY_302);
+
+        final HttpRequest forwardedHostRequestWithPort = HttpRequest.newBuilder(localhostUri)
+                .version(HttpClient.Version.HTTP_1_1)
+                .header(ProxyHeader.FORWARDED_HOST.getHeader(), PUBLIC_STAGED_HOST_WITH_PORT)
+                .build();
+        assertResponseStatusCode(httpClient, forwardedHostRequestWithPort, HttpStatus.MOVED_TEMPORARILY_302);
     }
 
     void assertBadRequestsCompleted(final HttpClient httpClient, final URI localhostUri) throws IOException, InterruptedException {
@@ -384,6 +397,24 @@ class StandardServerProviderTest {
                 .header(ProxyHeader.FORWARDED_HOST.getHeader(), PUBLIC_UNKNOWN_HOST)
                 .build();
         assertResponseStatusCode(httpClient, publicUnknownForwardedHostRequest, HttpStatus.MISDIRECTED_REQUEST_421);
+
+        final HttpRequest publicStagedHostWithInvalidPort = HttpRequest.newBuilder(localhostUri)
+                .version(HttpClient.Version.HTTP_1_1)
+                .header(ProxyHeader.FORWARDED_HOST.getHeader(), PUBLIC_STAGED_HOST_WITH_INVALID_PORT)
+                .build();
+        assertResponseStatusCode(httpClient, publicStagedHostWithInvalidPort, HttpStatus.MISDIRECTED_REQUEST_421);
+
+        final HttpRequest publicStagedHostWithAPortWhichNotNumber = HttpRequest.newBuilder(localhostUri)
+                .version(HttpClient.Version.HTTP_1_1)
+                .header(ProxyHeader.FORWARDED_HOST.getHeader(), PUBLIC_STAGED_HOST_WITH_A_PORT_WHICH_NOT_NUMBER)
+                .build();
+        assertResponseStatusCode(httpClient, publicStagedHostWithAPortWhichNotNumber, HttpStatus.MISDIRECTED_REQUEST_421);
+
+        final HttpRequest sameHostNameWithInvalidPort = HttpRequest.newBuilder(localhostUri)
+                .version(HttpClient.Version.HTTP_1_1)
+                .header(ProxyHeader.FORWARDED_HOST.getHeader(), localhostUri.getHost() + ":" + localhostUri.getPort())
+                .build();
+        assertResponseStatusCode(httpClient, sameHostNameWithInvalidPort, HttpStatus.MISDIRECTED_REQUEST_421);
     }
 
     void assertStandardResponseHeadersFound(final HttpResponse<Void> response) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16018](https://issues.apache.org/jira/browse/NIFI-16018)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-16018`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
