### PR TITLE
NIFI-16020 Consume request body before two-phase cluster replication responses to prevent HTTP/2 stream resets

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -247,7 +247,6 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String CLUSTER_NODE_ADDRESS = "nifi.cluster.node.address";
     public static final String CLUSTER_NODE_PROTOCOL_PORT = "nifi.cluster.node.protocol.port";
     public static final String CLUSTER_NODE_PROTOCOL_MAX_THREADS = "nifi.cluster.node.protocol.max.threads";
-    public static final String CLUSTER_NODE_PROTOCOL_HTTP_VERSION = "nifi.cluster.node.protocol.http.version";
     public static final String CLUSTER_NODE_CONNECTION_TIMEOUT = "nifi.cluster.node.connection.timeout";
     public static final String CLUSTER_NODE_READ_TIMEOUT = "nifi.cluster.node.read.timeout";
     public static final String CLUSTER_NODE_MAX_CONCURRENT_REQUESTS = "nifi.cluster.node.max.concurrent.requests";
@@ -420,7 +419,6 @@ public class NiFiProperties extends ApplicationProperties {
     // cluster node defaults
     public static final int DEFAULT_CLUSTER_NODE_PROTOCOL_THREADS = 10;
     public static final int DEFAULT_CLUSTER_NODE_PROTOCOL_MAX_THREADS = 50;
-    public static final String DEFAULT_CLUSTER_NODE_PROTOCOL_HTTP_VERSION = "HTTP_2";
     public static final String DEFAULT_FLOW_ELECTION_MAX_WAIT_TIME = "5 mins";
 
     // cluster load balance defaults
@@ -924,21 +922,6 @@ public class NiFiProperties extends ApplicationProperties {
         } catch (NumberFormatException nfe) {
             return DEFAULT_CLUSTER_NODE_PROTOCOL_MAX_THREADS;
         }
-    }
-
-    /**
-     * Returns the configured HTTP protocol version that the cluster node web client should prefer when communicating with other nodes.
-     * Returned as a raw String matching one of the values of {@code java.net.http.HttpClient.Version} (i.e. {@code HTTP_1_1} or {@code HTTP_2}).
-     * Defaults to {@link #DEFAULT_CLUSTER_NODE_PROTOCOL_HTTP_VERSION} when the property is missing or blank.
-     *
-     * @return the configured cluster node protocol HTTP version, or {@link #DEFAULT_CLUSTER_NODE_PROTOCOL_HTTP_VERSION} when the property is missing or blank
-     */
-    public String getClusterNodeProtocolHttpVersion() {
-        final String configured = getProperty(CLUSTER_NODE_PROTOCOL_HTTP_VERSION);
-        if (configured == null || configured.isBlank()) {
-            return DEFAULT_CLUSTER_NODE_PROTOCOL_HTTP_VERSION;
-        }
-        return configured.trim();
     }
 
     public boolean isClustered() {

--- a/nifi-commons/nifi-properties/src/test/java/org/apache/nifi/util/NiFiPropertiesTest.java
+++ b/nifi-commons/nifi-properties/src/test/java/org/apache/nifi/util/NiFiPropertiesTest.java
@@ -241,26 +241,6 @@ public class NiFiPropertiesTest {
     }
 
     @Test
-    public void testGetClusterNodeProtocolHttpVersionDefault() {
-        final NiFiProperties properties = NiFiProperties.createBasicNiFiProperties(null, new HashMap<>());
-        assertEquals(NiFiProperties.DEFAULT_CLUSTER_NODE_PROTOCOL_HTTP_VERSION, properties.getClusterNodeProtocolHttpVersion());
-    }
-
-    @Test
-    public void testGetClusterNodeProtocolHttpVersionOverride() {
-        final NiFiProperties properties = NiFiProperties.createBasicNiFiProperties(null,
-                Map.of(NiFiProperties.CLUSTER_NODE_PROTOCOL_HTTP_VERSION, "HTTP_1_1"));
-        assertEquals("HTTP_1_1", properties.getClusterNodeProtocolHttpVersion());
-    }
-
-    @Test
-    public void testGetClusterNodeProtocolHttpVersionBlankFallsBackToDefault() {
-        final NiFiProperties properties = NiFiProperties.createBasicNiFiProperties(null,
-                Map.of(NiFiProperties.CLUSTER_NODE_PROTOCOL_HTTP_VERSION, "   "));
-        assertEquals(NiFiProperties.DEFAULT_CLUSTER_NODE_PROTOCOL_HTTP_VERSION, properties.getClusterNodeProtocolHttpVersion());
-    }
-
-    @Test
     public void testShouldHaveReasonableMaxContentLengthValues() {
         // Arrange with default values:
         NiFiProperties properties = NiFiProperties.createBasicNiFiProperties(null, new HashMap<>());

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/framework/configuration/FlowControllerConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/framework/configuration/FlowControllerConfiguration.java
@@ -74,14 +74,11 @@ import org.apache.nifi.web.client.api.WebClientService;
 import org.apache.nifi.web.client.redirect.RedirectHandling;
 import org.apache.nifi.web.client.ssl.TlsContext;
 import org.apache.nifi.web.revision.RevisionManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -94,8 +91,6 @@ import javax.net.ssl.X509TrustManager;
  */
 @Configuration
 public class FlowControllerConfiguration {
-
-    private static final Logger logger = LoggerFactory.getLogger(FlowControllerConfiguration.class);
 
     private static final String FLOW_ACTION_REPORTER_IMPLEMENTATION = "nifi.flow.action.reporter.implementation";
 
@@ -391,7 +386,6 @@ public class FlowControllerConfiguration {
         webClientService.setConnectTimeout(timeout);
         webClientService.setReadTimeout(timeout);
         webClientService.setRedirectHandling(RedirectHandling.FOLLOWED);
-        webClientService.setHttpVersion(resolveClusterNodeProtocolHttpVersion());
 
         if (sslContext != null) {
             webClientService.setTlsContext(new TlsContext() {
@@ -413,17 +407,6 @@ public class FlowControllerConfiguration {
         }
 
         return webClientService;
-    }
-
-    private HttpClient.Version resolveClusterNodeProtocolHttpVersion() {
-        final String configured = properties.getClusterNodeProtocolHttpVersion();
-        try {
-            return HttpClient.Version.valueOf(configured);
-        } catch (final IllegalArgumentException e) {
-            logger.warn("Property {} value [{}] is not a valid HttpClient.Version; falling back to {}",
-                    NiFiProperties.CLUSTER_NODE_PROTOCOL_HTTP_VERSION, configured, NiFiProperties.DEFAULT_CLUSTER_NODE_PROTOCOL_HTTP_VERSION);
-            return HttpClient.Version.valueOf(NiFiProperties.DEFAULT_CLUSTER_NODE_PROTOCOL_HTTP_VERSION);
-        }
     }
 
     @Bean

--- a/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -204,7 +204,6 @@
         <nifi.cluster.node.address />
         <nifi.cluster.node.protocol.port />
         <nifi.cluster.node.protocol.max.threads>50</nifi.cluster.node.protocol.max.threads>
-        <nifi.cluster.node.protocol.http.version>HTTP_2</nifi.cluster.node.protocol.http.version>
         <nifi.cluster.node.event.history.size>25</nifi.cluster.node.event.history.size>
         <nifi.cluster.node.connection.timeout>5 sec</nifi.cluster.node.connection.timeout>
         <nifi.cluster.node.read.timeout>5 sec</nifi.cluster.node.read.timeout>

--- a/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -268,7 +268,6 @@ nifi.cluster.leader.election.implementation=${nifi.cluster.leader.election.imple
 nifi.cluster.node.address=${nifi.cluster.node.address}
 nifi.cluster.node.protocol.port=${nifi.cluster.node.protocol.port}
 nifi.cluster.node.protocol.max.threads=${nifi.cluster.node.protocol.max.threads}
-nifi.cluster.node.protocol.http.version=${nifi.cluster.node.protocol.http.version}
 nifi.cluster.node.event.history.size=${nifi.cluster.node.event.history.size}
 nifi.cluster.node.connection.timeout=${nifi.cluster.node.connection.timeout}
 nifi.cluster.node.read.timeout=${nifi.cluster.node.read.timeout}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
@@ -86,6 +86,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -551,6 +554,8 @@ public abstract class ApplicationResource {
         final NiFiUser user = NiFiUserUtils.getNiFiUser();
 
         if (isTwoPhaseRequest(httpServletRequest)) {
+            drainRequestBody();
+
             if (isValidationPhase(httpServletRequest)) {
                 // authorize access
                 serviceFacade.authorizeAccess(authorizer);
@@ -605,6 +610,8 @@ public abstract class ApplicationResource {
         final NiFiUser user = NiFiUserUtils.getNiFiUser();
 
         if (isTwoPhaseRequest(httpServletRequest)) {
+            drainRequestBody();
+
             if (isValidationPhase(httpServletRequest)) {
                 // authorize access
                 serviceFacade.authorizeAccess(authorizer);
@@ -656,6 +663,8 @@ public abstract class ApplicationResource {
                                                         final Runnable verifier, final Function<T, Response> action) {
 
         if (isTwoPhaseRequest(httpServletRequest)) {
+            drainRequestBody();
+
             if (isValidationPhase(httpServletRequest)) {
                 // authorize access
                 serviceFacade.authorizeAccess(authorizer);
@@ -690,6 +699,25 @@ public abstract class ApplicationResource {
 
             // run the action
             return action.apply(entity);
+        }
+    }
+
+    /**
+     * Fully consumes the request body for a request received as part of a two-phase commit replication.
+     *
+     * Several resource methods do not declare a request entity parameter, so the JAX-RS layer never reads the
+     * request body even though the replicating node always sends one. When a node returns the validation,
+     * execution, or cancellation response without first consuming that body, an HTTP/2 server resets the stream
+     * with CANCEL, which surfaces on the replicating node as an "RST_STREAM received Stream cancelled" failure.
+     * Reading the body to end-of-stream before responding allows the replicating node to complete its upload
+     * cleanly. When the body has already been consumed (for example by entity deserialization) this is a no-op.
+     */
+    private void drainRequestBody() {
+        try {
+            final InputStream requestInputStream = httpServletRequest.getInputStream();
+            requestInputStream.transferTo(OutputStream.nullOutputStream());
+        } catch (final IOException e) {
+            logger.debug("Failed to drain request body before returning early cluster replication response", e);
         }
     }
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/nifi.properties
@@ -200,11 +200,6 @@ nifi.cluster.node.address=
 nifi.cluster.node.protocol.port=48101
 nifi.cluster.node.protocol.threads=10
 nifi.cluster.node.protocol.max.threads=50
-# Short-term workaround: force HTTP/1.1 for cluster node-to-node traffic in system tests to avoid the
-# intermittent "RST_STREAM received Stream cancelled" failures caused by Jetty 12.1.10's HTTP/2 stream
-# reset rewrite (https://github.com/jetty/jetty.project/pull/15087). Remove this override once the
-# upstream Jetty regression is resolved.
-nifi.cluster.node.protocol.http.version=HTTP_1_1
 nifi.cluster.node.event.history.size=25
 nifi.cluster.node.connection.timeout=5 sec
 nifi.cluster.node.read.timeout=30 sec

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/nifi.properties
@@ -200,11 +200,6 @@ nifi.cluster.node.address=
 nifi.cluster.node.protocol.port=48102
 nifi.cluster.node.protocol.threads=10
 nifi.cluster.node.protocol.max.threads=50
-# Short-term workaround: force HTTP/1.1 for cluster node-to-node traffic in system tests to avoid the
-# intermittent "RST_STREAM received Stream cancelled" failures caused by Jetty 12.1.10's HTTP/2 stream
-# reset rewrite (https://github.com/jetty/jetty.project/pull/15087). Remove this override once the
-# upstream Jetty regression is resolved.
-nifi.cluster.node.protocol.http.version=HTTP_1_1
 nifi.cluster.node.event.history.size=25
 nifi.cluster.node.connection.timeout=5 sec
 nifi.cluster.node.read.timeout=30 sec

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/nifi.properties
@@ -201,11 +201,6 @@ nifi.cluster.node.address=
 nifi.cluster.node.protocol.port=
 nifi.cluster.node.protocol.threads=10
 nifi.cluster.node.protocol.max.threads=50
-# Short-term workaround: force HTTP/1.1 for cluster node-to-node traffic in system tests to avoid the
-# intermittent "RST_STREAM received Stream cancelled" failures caused by Jetty 12.1.10's HTTP/2 stream
-# reset rewrite (https://github.com/jetty/jetty.project/pull/15087). Remove this override once the
-# upstream Jetty regression is resolved.
-nifi.cluster.node.protocol.http.version=HTTP_1_1
 nifi.cluster.node.event.history.size=25
 nifi.cluster.node.connection.timeout=5 sec
 nifi.cluster.node.read.timeout=5 sec

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/nifi.properties
@@ -205,11 +205,6 @@ nifi.cluster.node.address=
 nifi.cluster.node.protocol.port=
 nifi.cluster.node.protocol.threads=10
 nifi.cluster.node.protocol.max.threads=50
-# Short-term workaround: force HTTP/1.1 for cluster node-to-node traffic in system tests to avoid the
-# intermittent "RST_STREAM received Stream cancelled" failures caused by Jetty 12.1.10's HTTP/2 stream
-# reset rewrite (https://github.com/jetty/jetty.project/pull/15087). Remove this override once the
-# upstream Jetty regression is resolved.
-nifi.cluster.node.protocol.http.version=HTTP_1_1
 nifi.cluster.node.event.history.size=25
 nifi.cluster.node.connection.timeout=5 sec
 nifi.cluster.node.read.timeout=5 sec


### PR DESCRIPTION
# Summary

NIFI-16020 Consume request body before two-phase cluster replication responses to prevent HTTP/2 stream resets

Several REST resource methods do not declare a request entity parameter (for example `POST /flowfile-queues/{id}/drop-requests`), so the JAX-RS layer never reads the request body even though the replicating node always sends one. When a node returns the two-phase commit validation, execution, or cancellation response without consuming that body, Jetty 12.1.10 resets the HTTP/2 stream with `CANCEL`, which surfaces on the replicating node as "RST_STREAM received Stream cancelled" and fails the replicated request (which cannot be retried).

`ApplicationResource.withWriteLock` now fully consumes the request input stream for two-phase requests before any early response is returned, allowing the replicating node to complete its upload cleanly. When the body has already been consumed (for example via entity deserialization) the drain is a no-op.

This server-side fix replaces the temporary HTTP/1.1 cluster workaround added in NIFI-16011, so the configurable `nifi.cluster.node.protocol.http.version` property introduced there and the HTTP_1_1 overrides in the system-test configurations are reverted.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
