### PR TITLE
NIFI-15971 Add Allow Missing Directory option to ListFile and GetFile

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFile.java
@@ -26,6 +26,8 @@ import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
@@ -52,6 +54,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -98,8 +101,18 @@ public class GetFile extends AbstractProcessor {
             .name("Input Directory")
             .description("The input directory from which to pull files")
             .required(true)
-            .addValidator(StandardValidators.createDirectoryExistsValidator(true, false))
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .build();
+    public static final PropertyDescriptor ALLOW_MISSING_DIRECTORY = new PropertyDescriptor.Builder()
+            .name("allow-missing-directory")
+            .displayName("Allow Missing Directory")
+            .description("When set to true, the processor will not fail validation if the Input Directory does not exist. " +
+                    "Instead, the processor will yield and log a warning when the directory is missing at runtime. " +
+                    "This is useful in environments such as MiNiFi where the directory may be created after the flow starts.")
+            .required(true)
+            .allowableValues("true", "false")
+            .defaultValue("false")
             .build();
     public static final PropertyDescriptor RECURSE = new PropertyDescriptor.Builder()
             .name("Recurse Subdirectories")
@@ -185,6 +198,7 @@ public class GetFile extends AbstractProcessor {
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DIRECTORY,
+            ALLOW_MISSING_DIRECTORY,
             FILE_FILTER,
             PATH_FILTER,
             BATCH_SIZE,
@@ -222,6 +236,35 @@ public class GetFile extends AbstractProcessor {
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return PROPERTY_DESCRIPTORS;
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(final ValidationContext context) {
+        final List<ValidationResult> results = new ArrayList<>(super.customValidate(context));
+
+        if (!context.getProperty(ALLOW_MISSING_DIRECTORY).asBoolean()) {
+            final String path = context.getProperty(DIRECTORY).evaluateAttributeExpressions().getValue();
+            if (path != null && !path.isBlank()) {
+                final File dir = new File(path);
+                if (!dir.exists()) {
+                    results.add(new ValidationResult.Builder()
+                            .subject(DIRECTORY.getDisplayName())
+                            .input(path)
+                            .valid(false)
+                            .explanation("Directory does not exist: " + path)
+                            .build());
+                } else if (!dir.isDirectory()) {
+                    results.add(new ValidationResult.Builder()
+                            .subject(DIRECTORY.getDisplayName())
+                            .input(path)
+                            .valid(false)
+                            .explanation("Path is not a directory: " + path)
+                            .build());
+                }
+            }
+        }
+
+        return results;
     }
 
     @Override
@@ -291,13 +334,13 @@ public class GetFile extends AbstractProcessor {
 
     private Set<File> performListing(final File directory, final FileFilter filter, final boolean recurseSubdirectories) {
         Path p = directory.toPath();
+        if (!directory.exists()) {
+            return new HashSet<>();
+        }
         if (!Files.isWritable(p) || !Files.isReadable(p)) {
             throw new IllegalStateException("Directory '" + directory + "' does not have sufficient permissions (i.e., not writable and readable)");
         }
         final Set<File> queue = new HashSet<>();
-        if (!directory.exists()) {
-            return queue;
-        }
 
         final File[] children = directory.listFiles();
         if (children == null) {
@@ -359,6 +402,16 @@ public class GetFile extends AbstractProcessor {
         final File directory = new File(context.getProperty(DIRECTORY).evaluateAttributeExpressions().getValue());
         final boolean keepingSourceFile = context.getProperty(KEEP_SOURCE_FILE).asBoolean();
         final ComponentLog logger = getLogger();
+
+        if (!directory.exists()) {
+            if (context.getProperty(ALLOW_MISSING_DIRECTORY).asBoolean()) {
+                logger.warn("Input Directory does not exist: {}; yielding", directory);
+                context.yield();
+                return;
+            }
+            throw new ProcessException("Input Directory does not exist: " + directory);
+        }
+
         final FileFilter fileFilter = createFileFilter(context, directory.toPath());
 
         if (fileQueue.size() < 100) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -32,6 +32,8 @@ import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyDescriptor.Builder;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
@@ -69,6 +71,8 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -140,8 +144,19 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
             .name("Input Directory")
             .description("The input directory from which files to pull files")
             .required(true)
-            .addValidator(StandardValidators.createDirectoryExistsValidator(true, false))
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ENVIRONMENT)
+            .build();
+
+    public static final PropertyDescriptor ALLOW_MISSING_DIRECTORY = new Builder()
+            .name("allow-missing-directory")
+            .displayName("Allow Missing Directory")
+            .description("When set to true, the processor will not fail validation if the Input Directory does not exist. " +
+                    "Instead, the processor will log a warning and return an empty listing when the directory is missing. " +
+                    "This is useful in environments such as MiNiFi where the directory may be created after the flow starts.")
+            .required(true)
+            .allowableValues("true", "false")
+            .defaultValue("false")
             .build();
 
     public static final PropertyDescriptor RECURSE = new Builder()
@@ -266,6 +281,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DIRECTORY,
+            ALLOW_MISSING_DIRECTORY,
             LISTING_STRATEGY,
             RECURSE,
             RECORD_WRITER,
@@ -324,6 +340,33 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return PROPERTY_DESCRIPTORS;
+    }
+
+    @Override
+    protected void customValidate(final ValidationContext context, final Collection<ValidationResult> results) {
+        super.customValidate(context, results);
+
+        if (!context.getProperty(ALLOW_MISSING_DIRECTORY).asBoolean()) {
+            final String path = context.getProperty(DIRECTORY).evaluateAttributeExpressions().getValue();
+            if (path != null && !path.isBlank()) {
+                final File dir = new File(path);
+                if (!dir.exists()) {
+                    results.add(new ValidationResult.Builder()
+                            .subject(DIRECTORY.getDisplayName())
+                            .input(path)
+                            .valid(false)
+                            .explanation("Directory does not exist: " + path)
+                            .build());
+                } else if (!dir.isDirectory()) {
+                    results.add(new ValidationResult.Builder()
+                            .subject(DIRECTORY.getDisplayName())
+                            .input(path)
+                            .valid(false)
+                            .explanation("Path is not a directory: " + path)
+                            .build());
+                }
+            }
+        }
     }
 
     @Override
@@ -524,6 +567,15 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
 
         final Path basePath = new File(evaluatedPath).toPath();
         final Boolean recurse = context.getProperty(RECURSE).asBoolean();
+
+        if (!basePath.toFile().exists()) {
+            if (context.getProperty(ALLOW_MISSING_DIRECTORY).asBoolean()) {
+                getLogger().warn("Input Directory does not exist: {}; returning empty listing", basePath);
+                return Collections.emptyList();
+            }
+            throw new IOException("Input Directory does not exist: " + basePath);
+        }
+
         final Map<Path, BasicFileAttributes> lastModifiedMap = new HashMap<>();
 
         final BiPredicate<Path, BasicFileAttributes> fileFilter;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetFile.java
@@ -64,6 +64,24 @@ public class TestGetFile {
         assertEquals(absTargetPathStr, absolutePath);
     }
 
+    @Test
+    public void testMissingDirectoryInvalidWhenAllowMissingFalse() {
+        final TestRunner runner = TestRunners.newTestRunner(new GetFile());
+        runner.setProperty(GetFile.DIRECTORY, "target/test/data/nonexistent-" + System.currentTimeMillis());
+        runner.setProperty(GetFile.ALLOW_MISSING_DIRECTORY, "false");
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void testMissingDirectoryValidWhenAllowMissingTrue() {
+        final TestRunner runner = TestRunners.newTestRunner(new GetFile());
+        runner.setProperty(GetFile.DIRECTORY, "target/test/data/nonexistent-" + System.currentTimeMillis());
+        runner.setProperty(GetFile.ALLOW_MISSING_DIRECTORY, "true");
+        runner.assertValid();
+        runner.run();
+        runner.assertAllFlowFilesTransferred(GetFile.REL_SUCCESS, 0);
+    }
+
     private void deleteDirectory(final File directory) {
         if (directory != null && directory.exists()) {
             for (final File file : directory.listFiles()) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListFile.java
@@ -893,6 +893,22 @@ public class TestListFile {
     }
 
     @Test
+    void testMissingDirectoryInvalidWhenAllowMissingFalse() {
+        runner.setProperty(ListFile.DIRECTORY, "target/test/data/nonexistent-" + System.currentTimeMillis());
+        runner.setProperty(ListFile.ALLOW_MISSING_DIRECTORY, "false");
+        runner.assertNotValid();
+    }
+
+    @Test
+    void testMissingDirectoryValidAndProducesEmptyListingWhenAllowMissingTrue() {
+        runner.setProperty(ListFile.DIRECTORY, "target/test/data/nonexistent-" + System.currentTimeMillis());
+        runner.setProperty(ListFile.ALLOW_MISSING_DIRECTORY, "true");
+        runner.assertValid();
+        runner.run();
+        runner.assertTransferCount(ListFile.REL_SUCCESS, 0);
+    }
+
+    @Test
     void testMigrateProperties() {
         final Map<String, String> expectedRenamed = Map.ofEntries(
                 Map.entry("track-performance", ListFile.TRACK_PERFORMANCE.getName()),


### PR DESCRIPTION
Add ALLOW_MISSING_DIRECTORY property (default false) to both ListFile and GetFile. When enabled, processors bypass directory existence validation at flow startup and handle a missing directory gracefully at runtime - logging a warning and yielding/returning an empty listing instead of failing.

This allows MiNiFi and NiFi flows to start successfully when the configured input directory does not yet exist, which is a common deployment scenario.

Changes:
- ListFile: replace createDirectoryExistsValidator with NON_BLANK_VALIDATOR, add customValidate() override using AbstractListProcessor extension point, return empty listing with warning when directory is missing at runtime
- GetFile: same validator change, add customValidate(), yield with warning when directory is missing at runtime, fix performListing() to check existence before checking permissions (avoids IllegalStateException on missing dir)
- Add tests for both valid/invalid configurations and runtime empty-listing behavior when ALLOW_MISSING_DIRECTORY is true

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15971](https://issues.apache.org/jira/browse/NIFI-15971)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
