### PR TITLE
NIFI-15975 Fixed single line comment bug, multiple let statements bug and improved the invalid read JSLT transform message.

### DIFF
--- a/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/main/java/org/apache/nifi/processors/jslt/JSLTTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/main/java/org/apache/nifi/processors/jslt/JSLTTransformJSON.java
@@ -272,8 +272,7 @@ public class JSLTTransformJSON extends AbstractProcessor {
             getJstlExpression(transform, null);
             builder.valid(true);
         } catch (final RuntimeException e) {
-            final String explanation = String.format("%s not valid: %s", property.getDisplayName(), e.getMessage());
-            builder.valid(false).explanation(explanation);
+            builder.valid(false).explanation(e.getMessage());
         }
         return builder.build();
     }
@@ -430,9 +429,9 @@ public class JSLTTransformJSON extends AbstractProcessor {
             return propertyValue.getValue();
         }
         try (final BufferedReader reader = new BufferedReader(new InputStreamReader(resourceReference.read()))) {
-            return reader.lines().collect(Collectors.joining());
+            return reader.lines().collect(Collectors.joining(System.lineSeparator()));
         } catch (final IOException e) {
-            throw new UncheckedIOException("Read JSLT Transform failed", e);
+            throw new UncheckedIOException(String.format("Read JSLT Transform failed, reason: %s", e.getMessage()), e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
@@ -23,9 +23,11 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentest4j.AssertionFailedError;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -40,13 +42,20 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import static org.apache.nifi.processors.jslt.JSLTTransformJSON.TransformationStrategy.ENTIRE_FLOWFILE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestJSLTTransformJSON {
 
-    private TestRunner runner = TestRunners.newTestRunner(new JSLTTransformJSON());
     private static final Path RESOURCE_DIR = Paths.get("src/test/resources");
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @TempDir
+    private static Path tempDir;
+
+    private TestRunner runner = TestRunners.newTestRunner(new JSLTTransformJSON());
 
     @BeforeEach
     public void setup() {
@@ -72,6 +81,88 @@ public class TestJSLTTransformJSON {
         final String invalidTransform = "invalid";
         runner.setProperty(JSLTTransformJSON.JSLT_TRANSFORM, invalidTransform);
         runner.assertNotValid();
+    }
+
+    @Test
+    public void testMultipleLetStatementsOnDifferentLinesDoNotCollide() {
+        final String transformWithMultilines = """
+                let id = .value.id
+                let client_name = replace(.value.client_name, "-[^-]+$", ""){
+                "id": $id,
+                "name": $client_name
+                }
+                """;
+
+        runner.setProperty(JSLTTransformJSON.JSLT_TRANSFORM, transformWithMultilines);
+        runner.setProperty(JSLTTransformJSON.TRANSFORMATION_STRATEGY, ENTIRE_FLOWFILE.getValue());
+        final String json = """
+                {
+                    "value" : {
+                        "id" : "jdoe",
+                        "client_name": "John"
+                    }
+                }
+                """;
+        runner.enqueue(json);
+
+        assertDoesNotThrow(() -> runner.run());
+        runner.assertTransferCount(JSLTTransformJSON.REL_SUCCESS, 1);
+    }
+
+    @Test
+    public void testImprovedInvalidTransformReadMessage() {
+        final Path nonExistentTransformFile = tempDir.resolve("transform.json");
+        runner.setProperty(JSLTTransformJSON.JSLT_TRANSFORM, nonExistentTransformFile.toString());
+        runner.setProperty(JSLTTransformJSON.TRANSFORMATION_STRATEGY, ENTIRE_FLOWFILE.getValue());
+
+        final String json = """
+                {
+                    "userId" : "jdoe",
+                    "firstName": "John"
+                }
+                """;
+        runner.enqueue(json);
+
+        AssertionFailedError assertionFailedError = assertThrows(AssertionFailedError.class, () -> runner.run());
+        assertTrue(assertionFailedError.getMessage().contains("No such file or directory"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("singleLineCommentArgs")
+    public void testJSLTTransformWithSingleLineComment(String transform) {
+        runner.setProperty(JSLTTransformJSON.JSLT_TRANSFORM, transform);
+        runner.setProperty(JSLTTransformJSON.TRANSFORMATION_STRATEGY, ENTIRE_FLOWFILE.getValue());
+
+        final String json = """
+                {
+                    "userId" : "jdoe",
+                    "firstName": "John"
+                }
+                """;
+        runner.enqueue(json);
+
+        // TODO Uncomment after NIFI-15982 is accepted and merged and NIFI uses the next version of nifi-api
+        //  since with that fix then even the text case should pass.
+        assertDoesNotThrow(() -> runner.run());
+        runner.assertTransferCount(JSLTTransformJSON.REL_SUCCESS, 1);
+    }
+
+    private static Stream<Arguments> singleLineCommentArgs() throws IOException {
+        final String transformWithSingleLineComment = """
+                // This is a single line comment in JSLT
+                {
+                "id": .userId,
+                "name": .firstName
+                }
+                """;
+
+        final Path transformFile = tempDir.resolve("transformWithComment.json");
+        Files.writeString(transformFile, transformWithSingleLineComment);
+
+        return Stream.of(
+                Arguments.argumentSet("File", transformFile.toString()),
+                Arguments.argumentSet("Text", transformWithSingleLineComment)
+        );
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
@@ -123,8 +123,7 @@ public class TestJSLTTransformJSON {
                 """;
         runner.enqueue(json);
 
-        AssertionFailedError assertionFailedError = assertThrows(AssertionFailedError.class, () -> runner.run());
-        assertTrue(assertionFailedError.getMessage().contains("No such file or directory"));
+        assertThrows(AssertionFailedError.class, () -> runner.run());
     }
 
     @ParameterizedTest

--- a/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
@@ -54,7 +54,7 @@ public class TestJSLTTransformJSON {
     @TempDir
     private static Path tempDir;
 
-    private TestRunner runner = TestRunners.newTestRunner(new JSLTTransformJSON());
+    private TestRunner runner;
 
     @BeforeEach
     public void setup() {

--- a/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
@@ -45,7 +45,6 @@ import static org.apache.nifi.processors.jslt.JSLTTransformJSON.TransformationSt
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestJSLTTransformJSON {
 

--- a/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
@@ -42,9 +42,9 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import static org.apache.nifi.processors.jslt.JSLTTransformJSON.TransformationStrategy.ENTIRE_FLOWFILE;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestJSLTTransformJSON {
 
@@ -104,7 +104,7 @@ public class TestJSLTTransformJSON {
                 """;
         runner.enqueue(json);
 
-        assertDoesNotThrow(() -> runner.run());
+        runner.run();
         runner.assertTransferCount(JSLTTransformJSON.REL_SUCCESS, 1);
     }
 
@@ -122,7 +122,8 @@ public class TestJSLTTransformJSON {
                 """;
         runner.enqueue(json);
 
-        assertThrows(AssertionFailedError.class, () -> runner.run());
+        final AssertionFailedError assertionFailedError = assertThrows(AssertionFailedError.class, () -> runner.run());
+        assertTrue(assertionFailedError.getMessage().contains("'JSLT Transformation' is invalid because Read JSLT Transform failed, reason:"));
     }
 
     @ParameterizedTest
@@ -139,9 +140,7 @@ public class TestJSLTTransformJSON {
                 """;
         runner.enqueue(json);
 
-        // TODO Uncomment after NIFI-15982 is accepted and merged and NIFI uses the next version of nifi-api
-        //  since with that fix then even the text case should pass.
-        assertDoesNotThrow(() -> runner.run());
+        runner.run();
         runner.assertTransferCount(JSLTTransformJSON.REL_SUCCESS, 1);
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15975](https://issues.apache.org/jira/browse/NIFI-15975)
This PR along with the fix in the `nifi-api` for [NIFI-15982](https://issues.apache.org/jira/browse/NIFI-15982) solve three issues that were reported in NIFI-15975.
The first two issues had to do with when single line Java comments are used in the JSLT transform. Before the fix for NIFI-15982, the framework mistook the leading forward slash of the Java comment as a file path. The second issue was the code in the `JSLTTransformJSON` actually did not report the true reason why it failed which was the JSLT transform was not a valid file path. The fix for NIFI-15982 took care of NIFI mistakenly thinking the single line Java comment is a file and the fix in this PR ensures the real reason for failure is displayed.
The final issue reported what was the inability to place two `let` statements on separate lines without placing an additional space between them. That was due to the JSLT transform being read with the new lines being stripped out. The fix for this was to reintroduce the new lines when reconstituting the JSLT transform after it is read from the given source.

As an aside, the fix for NIFI-15982 also fixed `JoltTransformJSON` and  `ValidateJson`, as the Jolt spec and schema source could be text and single Java comments are allowed.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
