### PR TITLE
NIFI-15889 Cache Parameter Context name mapping to fix O(N_PG x N_PC^…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -1854,7 +1854,7 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                     }
 
                     parameterContext.setParameters(updatedParameters);
-                    parameterContext.setName(proposed.getName());
+                    contextManager.setParameterContextName(parameterContext.getIdentifier(), proposed.getName());
                     parameterContext.setDescription(proposed.getDescription());
                     parameterContext.setInheritedParameterContexts(inheritedContexts);
                     LOG.info("Successfully synchronized {} by updating it to match the proposed version", parameterContext);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContextManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContextManager.java
@@ -16,19 +16,20 @@
  */
 package org.apache.nifi.parameter;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class StandardParameterContextManager implements ParameterContextManager {
     private final Map<String, ParameterContext> parameterContexts = new HashMap<>();
+    private final Map<String, ParameterContext> nameIndex = new HashMap<>();
+    private volatile Map<String, ParameterContext> cachedNameMapping = Collections.emptyMap();
 
     @Override
-    public boolean hasParameterContext(final String id) {
+    public synchronized boolean hasParameterContext(final String id) {
         return parameterContexts.get(id) != null;
     }
 
@@ -41,25 +42,55 @@ public class StandardParameterContextManager implements ParameterContextManager 
     public synchronized void addParameterContext(final ParameterContext parameterContext) {
         Objects.requireNonNull(parameterContext);
 
-        if (parameterContexts.containsKey(parameterContext.getIdentifier())) {
-            if (!(parameterContexts.get(parameterContext.getIdentifier()) instanceof ReferenceOnlyParameterContext)) {
-                throw new IllegalStateException("Cannot add Parameter Context because another Parameter Context already exists with the same ID");
-            }
+        final ParameterContext existingById = parameterContexts.get(parameterContext.getIdentifier());
+        if (existingById != null && !(existingById instanceof ReferenceOnlyParameterContext)) {
+            throw new IllegalStateException("Cannot add Parameter Context because another Parameter Context already exists with the same ID");
         }
 
-        for (final ParameterContext context : parameterContexts.values()) {
-            if (context.getName().equals(parameterContext.getName())) {
-                throw new IllegalStateException("Cannot add Parameter Context because another Parameter Context already exists with the name '" + parameterContext + "'");
-            }
+        final ParameterContext existingByName = nameIndex.get(parameterContext.getName());
+        if (existingByName != null && existingByName != existingById) {
+            throw new IllegalStateException("Cannot add Parameter Context because another Parameter Context already exists with the name '" + parameterContext + "'");
+        }
+
+        if (existingById instanceof ReferenceOnlyParameterContext) {
+            nameIndex.remove(existingById.getName(), existingById);
         }
 
         parameterContexts.put(parameterContext.getIdentifier(), parameterContext);
+        nameIndex.put(parameterContext.getName(), parameterContext);
+        updateCachedNameMapping();
     }
 
     @Override
     public synchronized ParameterContext removeParameterContext(final String parameterContextId) {
         Objects.requireNonNull(parameterContextId);
-        return parameterContexts.remove(parameterContextId);
+        final ParameterContext removed = parameterContexts.remove(parameterContextId);
+        if (removed != null) {
+            nameIndex.remove(removed.getName(), removed);
+            updateCachedNameMapping();
+        }
+        return removed;
+    }
+
+    @Override
+    public synchronized void setParameterContextName(final String parameterContextId, final String name) {
+        Objects.requireNonNull(parameterContextId);
+        Objects.requireNonNull(name);
+
+        final ParameterContext parameterContext = parameterContexts.get(parameterContextId);
+        if (parameterContext == null) {
+            throw new IllegalStateException("Cannot rename Parameter Context because no Parameter Context exists with the specified ID");
+        }
+
+        final ParameterContext existingByName = nameIndex.get(name);
+        if (existingByName != null && existingByName != parameterContext) {
+            throw new IllegalStateException("Cannot rename Parameter Context because another Parameter Context already exists with the name '" + name + "'");
+        }
+
+        nameIndex.remove(parameterContext.getName(), parameterContext);
+        parameterContext.setName(name);
+        nameIndex.put(parameterContext.getName(), parameterContext);
+        updateCachedNameMapping();
     }
 
     @Override
@@ -69,6 +100,10 @@ public class StandardParameterContextManager implements ParameterContextManager 
 
     @Override
     public Map<String, ParameterContext> getParameterContextNameMapping() {
-        return parameterContexts.values().stream().collect(Collectors.toMap(ParameterContext::getName, Function.identity()));
+        return cachedNameMapping;
+    }
+
+    private void updateCachedNameMapping() {
+        cachedNameMapping = Collections.unmodifiableMap(new HashMap<>(nameIndex));
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/parameter/TestStandardParameterContextManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/parameter/TestStandardParameterContextManager.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.parameter;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestStandardParameterContextManager {
+
+    @Test
+    public void testNameMappingUpdatedOnAddRemoveAndRename() {
+        final StandardParameterContextManager manager = new StandardParameterContextManager();
+        final ParameterContext firstContext = createParameterContext("id-1", "Context 1");
+
+        manager.addParameterContext(firstContext);
+
+        final Map<String, ParameterContext> initialNameMapping = manager.getParameterContextNameMapping();
+        assertSame(firstContext, initialNameMapping.get("Context 1"));
+        assertThrows(UnsupportedOperationException.class, () -> initialNameMapping.put("Other", firstContext));
+        assertSame(initialNameMapping, manager.getParameterContextNameMapping());
+
+        manager.setParameterContextName("id-1", "Renamed");
+
+        final Map<String, ParameterContext> renamedMapping = manager.getParameterContextNameMapping();
+        assertFalse(renamedMapping.containsKey("Context 1"));
+        assertSame(firstContext, renamedMapping.get("Renamed"));
+
+        final ParameterContext secondContext = createParameterContext("id-2", "Context 2");
+        manager.addParameterContext(secondContext);
+        assertThrows(IllegalStateException.class, () -> manager.setParameterContextName("id-2", "Renamed"));
+
+        assertSame(firstContext, manager.removeParameterContext("id-1"));
+        final Map<String, ParameterContext> removedMapping = manager.getParameterContextNameMapping();
+        assertFalse(removedMapping.containsKey("Renamed"));
+        assertSame(secondContext, removedMapping.get("Context 2"));
+    }
+
+    @Test
+    public void testReferenceOnlyParameterContextReplacementRemovesPlaceholderName() {
+        final StandardParameterContextManager manager = new StandardParameterContextManager();
+        final ReferenceOnlyParameterContext referenceOnlyContext = new ReferenceOnlyParameterContext("id-1");
+
+        manager.addParameterContext(referenceOnlyContext);
+        final String placeholderName = referenceOnlyContext.getName();
+        assertSame(referenceOnlyContext, manager.getParameterContextNameMapping().get(placeholderName));
+
+        final ParameterContext realContext = createParameterContext("id-1", "Real Context");
+        manager.addParameterContext(realContext);
+
+        final Map<String, ParameterContext> nameMapping = manager.getParameterContextNameMapping();
+        assertFalse(nameMapping.containsKey(placeholderName));
+        assertSame(realContext, nameMapping.get("Real Context"));
+        assertSame(realContext, manager.getParameterContext("id-1"));
+
+        assertSame(realContext, manager.removeParameterContext("id-1"));
+        assertTrue(manager.getParameterContextNameMapping().isEmpty());
+    }
+
+    @Test
+    public void testDuplicateNameRejected() {
+        final StandardParameterContextManager manager = new StandardParameterContextManager();
+        manager.addParameterContext(createParameterContext("id-1", "Context"));
+
+        assertThrows(IllegalStateException.class, () -> manager.addParameterContext(createParameterContext("id-2", "Context")));
+    }
+
+    @Test
+    public void testDuplicateIdentifierRejected() {
+        final StandardParameterContextManager manager = new StandardParameterContextManager();
+        manager.addParameterContext(createParameterContext("id-1", "Context 1"));
+
+        assertThrows(IllegalStateException.class, () -> manager.addParameterContext(createParameterContext("id-1", "Context 2")));
+    }
+
+    private static ParameterContext createParameterContext(final String id, final String name) {
+        return new StandardParameterContext.Builder()
+                .id(id)
+                .name(name)
+                .parameterReferenceManager(ParameterReferenceManager.EMPTY)
+                .build();
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/parameter/ParameterContextManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/parameter/ParameterContextManager.java
@@ -25,6 +25,15 @@ public interface ParameterContextManager extends ParameterContextLookup {
 
     ParameterContext removeParameterContext(String parameterContextId);
 
+    default void setParameterContextName(final String parameterContextId, final String name) {
+        final ParameterContext parameterContext = getParameterContext(parameterContextId);
+        if (parameterContext == null) {
+            throw new IllegalStateException("Cannot rename Parameter Context because no Parameter Context exists with the specified ID");
+        }
+
+        parameterContext.setName(name);
+    }
+
     Set<ParameterContext> getParameterContexts();
 
     Map<String, ParameterContext> getParameterContextNameMapping();

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardParameterContextDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardParameterContextDAO.java
@@ -287,7 +287,7 @@ public class StandardParameterContextDAO implements ParameterContextDAO {
 
         if (parameterContextDto.getName() != null) {
             verifyNoNamingConflict(parameterContextDto.getName(), parameterContextDto.getId());
-            context.setName(parameterContextDto.getName());
+            flowManager.getParameterContextManager().setParameterContextName(parameterContextDto.getId(), parameterContextDto.getName());
         }
 
         if (parameterContextDto.getDescription() != null) {


### PR DESCRIPTION

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

`StandardParameterContextManager.getParameterContextNameMapping()` rebuilt the full name-to-context map on every call. During startup synchronization, this method is called repeatedly while processing versioned Process Groups, so rebuilding the map can become expensive for flows with large numbers of Parameter Contexts.
This change maintains the name mapping incrementally so reads return a cached unmodifiable map.


# Summary

[NIFI-15889](https://issues.apache.org/jira/browse/NIFI-15889)


## Changes
- Added an incremental `nameIndex` and cached unmodifiable name mapping in `StandardParameterContextManager`
- Added `setParameterContextName()` so renames update the cached mapping consistently
- Updated `StandardVersionedComponentSynchronizer` and `StandardParameterContextDAO` to rename Parameter Contexts through the manager
- Preserved compatibility with a default `ParameterContextManager.setParameterContextName()` implementation
- Covered `ReferenceOnlyParameterContext` replacement so placeholder names are removed from the index when replaced

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

## Local Validation
A temporary local JUnit timing harness was run on `main` and this branch with 5,000 Parameter Contexts and 5,000 repeated name lookups per sample.
- `main` median: about 600 ms
- `NIFI-15889` median: about 0.29 ms
These timings are local validation only, not JMH benchmark results. The primary improvement is avoiding repeated full-map rebuilds.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
