### PR TITLE
NIFI-16033 Add AGENTS.md and SECURITY.md for security-model discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Agent Guide for Apache NiFi
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` and the
+threat model it links before reporting issues.
+
+The project security model is published at https://nifi.apache.org/documentation/security/#security-model linked in SECURITY.md.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,3 +50,9 @@ Apache NiFi follows the [ASF Project Security For Committers](https://www.apache
 * The [Apache NiFi Security Page](https://nifi.apache.org/security.html)
 
 Thank you for helping keep Apache NiFi and our users safe!
+
+## Threat Model
+
+What the project treats as in scope and out of scope, the security
+properties it provides and disclaims, the adversary model, and how
+findings are triaged are documented in the project [Security Model](https://nifi.apache.org/documentation/security/#security-model).


### PR DESCRIPTION
**This is a proposal for the NiFi PMC to review — please correct, reject, or discuss as needed.**

This wires the conventional `AGENTS.md -> SECURITY.md -> security model` discoverability chain so an automated security-scan agent can mechanically locate NiFi's existing published security model (https://nifi.apache.org/documentation/security/#security-model).

- Adds `AGENTS.md` with a Security section pointing at `SECURITY.md`.
- Adds a "Threat Model" pointer in `SECURITY.md` linking the published security-model page.

No security-model *content* is added or changed — this is purely the discoverability pointer to the model NiFi already maintains. Context: the ASF Security team is preparing the project for an automated agentic security scan we're piloting; such scans refuse to run unless the model is reachable via this chain. Wording/placement tweaks welcome.

Generated-by: Claude Opus 4.8 (1M context)
