### PR TITLE
NIFI-16031 Replaced org.springframework.data.redis.connection.RedisStringCommands deprecated set method with suggested set method

### DIFF
--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/service/SimpleRedisDistributedMapCacheClientService.java
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/service/SimpleRedisDistributedMapCacheClientService.java
@@ -31,7 +31,7 @@ import org.apache.nifi.redis.RedisConnectionPool;
 import org.apache.nifi.redis.util.RedisAction;
 import org.apache.nifi.util.Tuple;
 import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.RedisStringCommands;
+import org.springframework.data.redis.connection.SetCondition;
 import org.springframework.data.redis.core.types.Expiration;
 
 import java.io.ByteArrayOutputStream;
@@ -120,16 +120,15 @@ public class SimpleRedisDistributedMapCacheClientService extends AbstractControl
 
                 // if the results list was empty, then the transaction failed (i.e. key was modified after we started watching), so keep looping to retry
                 // if the results list was null, then the transaction failed
-                // if the results list has results, then the transaction succeeded and it should have the result of the setNX operation
+                // if the results list has results, then the transaction succeeded, and it should have the result of the setNX operation
                 if (results != null && !results.isEmpty()) {
-                    final Object firstResult = results.get(0);
-                    if (firstResult instanceof Boolean) {
-                        final Boolean absent = (Boolean) firstResult;
+                    final Object firstResult = results.getFirst();
+                    if (firstResult instanceof Boolean absent) {
                         return absent ? null : valueDeserializer.deserialize(existingValue);
                     } else {
                         // this shouldn't really happen, but just in case there is a non-boolean result then bounce out of the loop
                         throw new IOException("Unexpected result from Redis transaction: Expected Boolean result, but got "
-                                + firstResult.getClass().getName() + " with value " + firstResult.toString());
+                                + firstResult.getClass().getName() + " with value " + firstResult);
                     }
                 }
             } while (isEnabled());
@@ -150,7 +149,7 @@ public class SimpleRedisDistributedMapCacheClientService extends AbstractControl
     public <K, V> void put(final K key, final V value, final Serializer<K> keySerializer, final Serializer<V> valueSerializer) throws IOException {
         withConnection(redisConnection -> {
             final Tuple<byte[], byte[]> kv = serialize(key, value, keySerializer, valueSerializer);
-            redisConnection.stringCommands().set(kv.getKey(), kv.getValue(), Expiration.seconds(ttl), RedisStringCommands.SetOption.upsert());
+            redisConnection.stringCommands().set(kv.getKey(), kv.getValue(), SetCondition.upsert(), Expiration.seconds(ttl));
             return null;
         });
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16031](https://issues.apache.org/jira/browse/NIFI-16031)
In addition to replacing the deprecated method, other small Intellij refactoring suggestions were done.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
