### PR TITLE
NIFI-16040 - Correct branches paging in BitBucket registry client

### DIFF
--- a/nifi-extension-bundles/nifi-atlassian-bundle/nifi-atlassian-extensions/src/main/java/org/apache/nifi/atlassian/bitbucket/BitbucketRepositoryClient.java
+++ b/nifi-extension-bundles/nifi-atlassian-bundle/nifi-atlassian-extensions/src/main/java/org/apache/nifi/atlassian/bitbucket/BitbucketRepositoryClient.java
@@ -251,29 +251,19 @@ public class BitbucketRepositoryClient implements GitRepositoryClient {
 
     private Set<String> getBranchesCloud() throws FlowRegistryException {
         final URI uri = getRepositoryUriBuilder().addPathSegment("refs").addPathSegment("branches").build();
-        try (final HttpResponseEntity response = this.webClient.getWebClientService()
-                .get()
-                .uri(uri)
-                .header(AUTHORIZATION_HEADER, authToken.getAuthzHeaderValue())
-                .retrieve()) {
+        final String errorMessage = "Error while listing branches for repository [%s]".formatted(repoName);
+        final Iterator<JsonNode> branches = getPagedResponseValues(uri, errorMessage);
 
-            verifyStatusCode(response, "Error while listing branches for repository [%s]".formatted(repoName), HttpURLConnection.HTTP_OK);
-
-            final JsonNode jsonResponse = parseResponseBody(response, uri);
-            final JsonNode values = jsonResponse.get(FIELD_VALUES);
-            final Set<String> result = new HashSet<>();
-            if (values != null && values.isArray()) {
-                for (JsonNode branch : values) {
-                    final String branchName = branch.path(FIELD_NAME).asText(EMPTY_STRING);
-                    if (!branchName.isEmpty()) {
-                        result.add(branchName);
-                    }
-                }
+        final Set<String> result = new HashSet<>();
+        while (branches.hasNext()) {
+            final JsonNode branch = branches.next();
+            final String branchName = branch.path(FIELD_NAME).asText(EMPTY_STRING);
+            if (!branchName.isEmpty()) {
+                result.add(branchName);
             }
-            return result;
-        } catch (final IOException e) {
-            throw new FlowRegistryException("Failed closing Bitbucket branch listing response", e);
         }
+
+        return result;
     }
 
     private Set<String> getBranchesDataCenter() throws FlowRegistryException {

--- a/nifi-extension-bundles/nifi-atlassian-bundle/nifi-atlassian-extensions/src/test/java/org/apache/nifi/atlassian/bitbucket/BitbucketRepositoryClientTest.java
+++ b/nifi-extension-bundles/nifi-atlassian-bundle/nifi-atlassian-extensions/src/test/java/org/apache/nifi/atlassian/bitbucket/BitbucketRepositoryClientTest.java
@@ -42,6 +42,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -368,6 +369,23 @@ class BitbucketRepositoryClientTest {
         stubGetChain(branchListResponse());
         final BitbucketRepositoryClient client = buildCloudClient();
         assertThrows(IllegalArgumentException.class, () -> client.createBranch("feature", "  ", Optional.empty()));
+    }
+
+    @Test
+    void testGetBranchesCloudFollowsPagination() throws FlowRegistryException {
+        final String firstPage = "{\"values\":[{\"name\":\"main\"},{\"name\":\"develop\"}],"
+                + "\"next\":\"https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo/refs/branches?page=2\"}";
+        final String secondPage = "{\"values\":[{\"name\":\"feature-1\"},{\"name\":\"feature-2\"}]}";
+        stubGetChain(
+                branchListResponse(),
+                mockResponse(HttpURLConnection.HTTP_OK, firstPage),
+                mockResponse(HttpURLConnection.HTTP_OK, secondPage)
+        );
+
+        final BitbucketRepositoryClient client = buildCloudClient();
+        final Set<String> branches = client.getBranches();
+
+        assertEquals(Set.of("main", "develop", "feature-1", "feature-2"), branches);
     }
 
     private BitbucketRepositoryClient buildDataCenterClient() throws FlowRegistryException {


### PR DESCRIPTION
# Summary

NIFI-16040 - Correct branches paging in BitBucket registry client

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
