### PR TITLE
NIFI-16044 - Bump Kafka to 4.3.1, Logback to 1.5.35, and others

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
-            <version>3.4.3</version>
+            <version>3.5.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <protobuf.version>4.35.1</protobuf.version>
-        <wire.version>6.4.0</wire.version>
+        <wire.version>6.4.1</wire.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
@@ -20,8 +20,8 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <snmp4j.version>3.11.0</snmp4j.version>
-        <snmp4j-agent.version>3.8.3</snmp4j-agent.version>
+        <snmp4j.version>3.12.1</snmp4j.version>
+        <snmp4j-agent.version>3.9.0</snmp4j-agent.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <guava.version>33.6.0-jre</guava.version>
         <protobuf.version>4.35.1</protobuf.version>
-        <grpc.version>1.82.0</grpc.version>
+        <grpc.version>1.82.1</grpc.version>
         <snowflake-jdbc-thin.version>4.3.1</snowflake-jdbc-thin.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.46.15</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.46.17</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.7</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -150,7 +150,7 @@
         <hsqldb.version>2.7.4</hsqldb.version>
 
         <!-- Data formats and serialization -->
-        <kafka-clients.version>4.3.0</kafka-clients.version>
+        <kafka-clients.version>4.3.1</kafka-clients.version>
         <avro.version>1.12.1</avro.version>
         <calcite.version>1.42.0</calcite.version>
         <com.github.luben.zstd-jni.version>1.5.7-11</com.github.luben.zstd-jni.version>
@@ -169,7 +169,7 @@
 
         <!-- Logging and observability -->
         <log4j2.version>2.26.0</log4j2.version>
-        <logback.version>1.5.34</logback.version>
+        <logback.version>1.5.35</logback.version>
         <org.slf4j.version>2.0.18</org.slf4j.version>
         <prometheus.version>0.16.0</prometheus.version>
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
@@ -203,7 +203,7 @@
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.security.version>7.1.0</spring.security.version>
         <spring.version>7.0.8</spring.version>
-        <swagger.annotations.version>2.2.51</swagger.annotations.version>
+        <swagger.annotations.version>2.2.52</swagger.annotations.version>
 
         <!-- Testing and quality -->
         <junit.version>6.1.0</junit.version>
@@ -839,7 +839,7 @@
                 <plugin>
                     <groupId>io.swagger.core.v3</groupId>
                     <artifactId>swagger-maven-plugin-jakarta</artifactId>
-                    <version>2.2.51</version>
+                    <version>2.2.52</version>
                 </plugin>
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>


### PR DESCRIPTION
# Summary

NIFI-16044 - Bump Kafka to 4.3.1, Logback to 1.5.35, and others

- AWS Kinesis Client from 3.4.3 to 3.5.0 - https://github.com/awslabs/amazon-kinesis-client/releases/tag/v3.5.0
- AWS SDK BOM from 2.46.15 to 2.46.17 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.46.17
- Wire from 6.4.0 to 6.4.1 - https://github.com/square/wire/releases/tag/6.4.1
- SNMP4J from 3.11.0 to 3.12.1 - https://www.snmp4j.org/CHANGES.txt
- SNMP4J Agent from 3.8.3 to 3.9.0 - https://snmp4j.org/agent/CHANGES.txt
- gRPC from 1.82.0 to 1.82.1 - https://github.com/grpc/grpc/releases/tag/v1.81.1
- Kafka from 4.3.0 to 4.3.1 - https://github.com/apache/kafka/releases/tag/4.3.1
- Logback from 1.5.34 to 1.5.35 - https://github.com/qos-ch/logback/releases/tag/v_1.5.35
- Swagger from 2.2.51 to 2.2.52 - https://github.com/swagger-api/swagger-core/releases/tag/v2.2.52

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
