### PR TITLE
NIFI-16049 Corrected if else logic in FlowFileUnpackagerV1

### DIFF
--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV1.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV1.java
@@ -82,13 +82,13 @@ public class FlowFileUnpackagerV1 implements FlowFileUnpackager {
                 throw new IOException("Flow file attributes object contains key of type "
                         + keyObject.getClass().getCanonicalName()
                         + " but expected java.lang.String");
-            } else if (!(keyObject instanceof String)) {
+            }
+            if (!(valueObject instanceof final String value)) {
                 throw new IOException("Flow file attributes object contains value of type "
                         + keyObject.getClass().getCanonicalName()
                         + " but expected java.lang.String");
             }
 
-            final String value = (String) valueObject;
             result.put(key, value);
         }
 

--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV1.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV1.java
@@ -85,7 +85,7 @@ public class FlowFileUnpackagerV1 implements FlowFileUnpackager {
             }
             if (!(valueObject instanceof final String value)) {
                 throw new IOException("Flow file attributes object contains value of type "
-                        + keyObject.getClass().getCanonicalName()
+                        + valueObject.getClass().getCanonicalName()
                         + " but expected java.lang.String");
             }
 

--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV1.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV1.java
@@ -22,10 +22,9 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 public class FlowFileUnpackagerV1 implements FlowFileUnpackager {
 
@@ -70,29 +69,12 @@ public class FlowFileUnpackagerV1 implements FlowFileUnpackager {
     }
 
     protected Map<String, String> getAttributes(final TarArchiveInputStream stream) throws IOException {
-
         final Properties props = new Properties();
         props.loadFromXML(new NonCloseableInputStream(stream));
+        final Map<String, String> attributes = props.stringPropertyNames().stream()
+                .collect(Collectors.toMap(key -> key, props::getProperty));
 
-        final Map<String, String> result = new HashMap<>();
-        for (final Entry<Object, Object> entry : props.entrySet()) {
-            final Object keyObject = entry.getKey();
-            final Object valueObject = entry.getValue();
-            if (!(keyObject instanceof final String key)) {
-                throw new IOException("Flow file attributes object contains key of type "
-                        + keyObject.getClass().getCanonicalName()
-                        + " but expected java.lang.String");
-            }
-            if (!(valueObject instanceof final String value)) {
-                throw new IOException("Flow file attributes object contains value of type "
-                        + valueObject.getClass().getCanonicalName()
-                        + " but expected java.lang.String");
-            }
-
-            result.put(key, value);
-        }
-
-        return result;
+        return attributes;
     }
 
     @Override

--- a/nifi-commons/nifi-flowfile-packager/src/test/java/org/apache/nifi/util/TestPackageUnpackageV1.java
+++ b/nifi-commons/nifi-flowfile-packager/src/test/java/org/apache/nifi/util/TestPackageUnpackageV1.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestPackageUnpackageV1 {
+    @Test
+    @SuppressWarnings("unchecked")
+    void testPackageWithNonStringAttributes() {
+        final FlowFilePackager packager = new FlowFilePackagerV1();
+        final byte[] data = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+        final Map<Object, Object> map = new HashMap<>();
+        map.put(12, 34);
+        map.put(56, 78);
+        map.put(9, 10);
+
+        final Map<String, String> cast = (Map) map;
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ByteArrayInputStream in = new ByteArrayInputStream(data);
+
+        assertThrows(ClassCastException.class, () -> packager.packageFlowFile(in, baos, cast, data.length));
+    }
+
+    @Test
+    void testPackageAndUnpackage() throws Exception {
+        final FlowFilePackager packager = new FlowFilePackagerV1();
+        final FlowFileUnpackager unpackager = new FlowFileUnpackagerV1();
+
+        final byte[] data = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+        final Map<String, String> map = new HashMap<>();
+        map.put("abc", "cba");
+        map.put("123", null);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ByteArrayInputStream in = new ByteArrayInputStream(data);
+        packager.packageFlowFile(in, baos, map, data.length);
+
+        final byte[] encoded = baos.toByteArray();
+        final ByteArrayInputStream encodedIn = new ByteArrayInputStream(encoded);
+        final ByteArrayOutputStream decodedOut = new ByteArrayOutputStream();
+        final Map<String, String> unpackagedAttributes = unpackager.unpackageFlowFile(encodedIn, decodedOut);
+        final byte[] decoded = decodedOut.toByteArray();
+
+        /*Since the properties serialized as XML has the value null specified between the entry tags,
+          when loaded into a java.util.Properties it is read as string whose value is "null" hence for
+          verification must change to the expected value.*/
+        map.put("123", "null");
+        assertEquals(map, unpackagedAttributes);
+        assertArrayEquals(data, decoded);
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16049](https://issues.apache.org/jira/browse/NIFI-16049)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
