### PR TITLE
NIFI-16054 - Bump Apache Lucene to 10.5.0, Logback to 1.5.37, and others

### DIFF
--- a/nifi-extension-bundles/nifi-dropbox-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-dropbox-bundle/pom.xml
@@ -27,7 +27,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <dropbox.client.version>7.0.0</dropbox.client.version>
+        <dropbox.client.version>8.0.0</dropbox.client.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20260428-2.0.0</version>
+            <version>v3-rev20260624-2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.tdunning</groupId>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>nifi-graph-test-clients</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <janusgraph.version>1.2.0-20260518-231441.3ed2758</janusgraph.version>
+        <janusgraph.version>1.2.0-20260627-173607.cb8644d</janusgraph.version>
         <guava.version>33.6.0-jre</guava.version>
         <amqp-client.version>5.32.0</amqp-client.version>
     </properties>

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <activemq.version>6.2.6</activemq.version>
+        <activemq.version>6.2.7</activemq.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
@@ -56,7 +56,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/test/java/org/apache/nifi/schemaregistry/services/TestStandardJsonSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/test/java/org/apache/nifi/schemaregistry/services/TestStandardJsonSchemaRegistry.java
@@ -116,7 +116,7 @@ class TestStandardJsonSchemaRegistry {
     private static Stream<Arguments> dynamicProperties() {
         return Stream.of(
                 Arguments.of(SUPPORTED_DYNAMIC_PROPERTY_DESCRIPTOR, "{}", 0, "empty object schema"),
-                Arguments.of(SUPPORTED_DYNAMIC_PROPERTY_DESCRIPTOR, "[]", 0, "empty array schema"),
+                Arguments.of(SUPPORTED_DYNAMIC_PROPERTY_DESCRIPTOR, "[]", 1, "array is not a valid schema"),
                 Arguments.of(SUPPORTED_DYNAMIC_PROPERTY_DESCRIPTOR, "not a schema", 1, "non whitespace")
         );
     }

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
@@ -20,8 +20,8 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <snmp4j.version>3.12.1</snmp4j.version>
-        <snmp4j-agent.version>3.9.0</snmp4j-agent.version>
+        <snmp4j.version>3.12.2</snmp4j.version>
+        <snmp4j-agent.version>3.9.1</snmp4j-agent.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -407,7 +407,7 @@
         <dependency>
             <groupId>net.datafaker</groupId>
             <artifactId>datafaker</artifactId>
-            <version>2.6.0</version>
+            <version>2.7.0</version>
             <exclusions>
                 <!-- Exclude snakeyaml with android qualifier -->
                 <exclusion>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -214,7 +214,7 @@
             <dependency>
                 <groupId>com.networknt</groupId>
                 <artifactId>json-schema-validator</artifactId>
-                <version>2.0.1</version>
+                <version>2.0.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/pom.xml
@@ -27,7 +27,7 @@
         <module>nifi-provenance-repository-nar</module>
     </modules>
     <properties>
-        <lucene.version>10.4.0</lucene.version>
+        <lucene.version>10.5.0</lucene.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
 
         <!-- Logging and observability -->
         <log4j2.version>2.26.0</log4j2.version>
-        <logback.version>1.5.35</logback.version>
+        <logback.version>1.5.37</logback.version>
         <org.slf4j.version>2.0.18</org.slf4j.version>
         <prometheus.version>0.16.0</prometheus.version>
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <ozone.version>1.4.1</ozone.version>
 
         <!-- Kubernetes -->
-        <io.fabric8.kubernetes.client.version>7.7.0</io.fabric8.kubernetes.client.version>
+        <io.fabric8.kubernetes.client.version>7.8.0</io.fabric8.kubernetes.client.version>
 
         <!-- Data access -->
         <commons.dbcp2.version>2.14.0</commons.dbcp2.version>
@@ -206,10 +206,10 @@
         <swagger.annotations.version>2.2.52</swagger.annotations.version>
 
         <!-- Testing and quality -->
-        <junit.version>6.1.0</junit.version>
+        <junit.version>6.1.1</junit.version>
         <mockito.version>5.23.0</mockito.version>
         <pmd.version>7.25.0</pmd.version>
-        <checkstyle.version>13.6.0</checkstyle.version>
+        <checkstyle.version>13.7.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
     </properties>


### PR DESCRIPTION
# Summary

NIFI-16054 - Bump Apache Lucene to 10.5.0, Logback to 1.5.37, and others

- JSON Schema Validator from 2.0.1 to 2.0.3 - https://github.com/networknt/json-schema-validator/releases/tag/2.0.3
- SNMP4J from 3.12.1 to 3.12.2 - https://www.snmp4j.org/CHANGES.txt
- SNMP4J Agent from 3.9.0 to 3.9.1 - https://snmp4j.org/agent/CHANGES.txt
- Data Faker from 2.6.0 to 2.7.0 - https://github.com/datafaker-net/datafaker/releases/tag/2.7.0
- Apache Lucene from 10.4.0 to 10.5.0 - https://github.com/apache/lucene/releases/tag/releases%2Flucene%2F10.5.0
- Logback from 1.5.35 to 1.5.37 - https://github.com/qos-ch/logback/releases/tag/v_1.5.37
- Google Drive API from v3-rev20260428-2.0.0 to v3-rev20260624-2.0.0 - https://github.com/googleapis/google-api-java-client-services/blob/main/clients/google-api-services-drive/v3/README.md
- Dropbox Java SDK from 7.0.0 to 8.0.0 - https://github.com/dropbox/dropbox-sdk-java/releases/tag/v8.0.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
