### PR TITLE
NIFI-16060 Tolerate connector configuration load failures on read

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorRepository.java
@@ -552,7 +552,7 @@ public class StandardConnectorRepository implements ConnectorRepository {
         try {
             syncFromProvider(connector);
         } catch (final ConnectorConfigurationProviderException e) {
-            logger.warn("Failed to load configuration from provider for connector [{}] during a read operation; "
+            logger.error("Failed to load configuration from provider for connector [{}] during a read operation; "
                     + "returning the connector with its existing configuration so it remains readable and deletable",
                     connector.getIdentifier(), e);
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorRepository.java
@@ -540,20 +540,21 @@ public class StandardConnectorRepository implements ConnectorRepository {
 
     /**
      * Sync a connector from the provider for a read operation, tolerating a configuration-load failure.
-     * A corrupt or otherwise unreadable stored configuration must not make a connector unreadable (and
-     * therefore undeletable): on failure the connector is marked invalid so the failure is visible to
-     * clients, and the in-memory node is returned without updating its working configuration. Write paths
-     * ({@code addConnector}, {@code applyUpdate}) call {@link #syncFromProvider(ConnectorNode)} directly
-     * and continue to propagate the exception so they do not proceed on a bad configuration.
+     * A configuration that cannot be loaded or parsed (e.g. a transient provider error, or a corrupt
+     * stored configuration left by a failed commit) must not make a connector unreadable — and therefore
+     * undeletable. On failure we log and return the in-memory node without updating its working
+     * configuration; the connector's own state is left untouched, so a subsequent successful read recovers
+     * normally. Write paths ({@code addConnector}, {@code applyUpdate}) call
+     * {@link #syncFromProvider(ConnectorNode)} directly and continue to propagate the exception so they do
+     * not proceed on a configuration that could not be loaded.
      */
     private void syncFromProviderForRead(final ConnectorNode connector) {
         try {
             syncFromProvider(connector);
         } catch (final ConnectorConfigurationProviderException e) {
             logger.warn("Failed to load configuration from provider for connector [{}] during a read operation; "
-                    + "returning the connector marked invalid so it remains readable and deletable",
+                    + "returning the connector with its existing configuration so it remains readable and deletable",
                     connector.getIdentifier(), e);
-            connector.markInvalid("Configuration Load Failed", e.getMessage());
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorRepository.java
@@ -521,7 +521,7 @@ public class StandardConnectorRepository implements ConnectorRepository {
         Objects.requireNonNull(syncMode, "syncMode is required");
         final ConnectorNode connector = connectors.get(identifier);
         if (connector != null && syncMode == ConnectorSyncMode.SYNC_WITH_PROVIDER) {
-            syncFromProvider(connector);
+            syncFromProviderForRead(connector);
         }
         return connector;
     }
@@ -532,10 +532,29 @@ public class StandardConnectorRepository implements ConnectorRepository {
         final List<ConnectorNode> connectorList = List.copyOf(connectors.values());
         if (syncMode == ConnectorSyncMode.SYNC_WITH_PROVIDER) {
             for (final ConnectorNode connector : connectorList) {
-                syncFromProvider(connector);
+                syncFromProviderForRead(connector);
             }
         }
         return connectorList;
+    }
+
+    /**
+     * Sync a connector from the provider for a read operation, tolerating a configuration-load failure.
+     * A corrupt or otherwise unreadable stored configuration must not make a connector unreadable (and
+     * therefore undeletable): on failure the connector is marked invalid so the failure is visible to
+     * clients, and the in-memory node is returned without updating its working configuration. Write paths
+     * ({@code addConnector}, {@code applyUpdate}) call {@link #syncFromProvider(ConnectorNode)} directly
+     * and continue to propagate the exception so they do not proceed on a bad configuration.
+     */
+    private void syncFromProviderForRead(final ConnectorNode connector) {
+        try {
+            syncFromProvider(connector);
+        } catch (final ConnectorConfigurationProviderException e) {
+            logger.warn("Failed to load configuration from provider for connector [{}] during a read operation; "
+                    + "returning the connector marked invalid so it remains readable and deletable",
+                    connector.getIdentifier(), e);
+            connector.markInvalid("Configuration Load Failed", e.getMessage());
+        }
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorRepository.java
@@ -274,7 +274,7 @@ public class TestStandardConnectorRepository {
     }
 
     @Test
-    public void testGetConnectorWithProviderThrowsException() {
+    public void testGetConnectorToleratesProviderExceptionAndMarksInvalid() {
         final ConnectorConfigurationProvider provider = mock(ConnectorConfigurationProvider.class);
         final StandardConnectorRepository repository = createRepositoryWithProvider(provider);
 
@@ -283,8 +283,46 @@ public class TestStandardConnectorRepository {
 
         when(provider.load("connector-1")).thenThrow(new ConnectorConfigurationProviderException("Provider failure"));
 
-        assertThrows(ConnectorConfigurationProviderException.class, () -> repository.getConnector("connector-1", ConnectorSyncMode.SYNC_WITH_PROVIDER));
+        // A configuration-load failure on a read must not propagate: the connector must remain readable
+        // (and therefore deletable). It is returned marked invalid so the failure is visible to clients.
+        final ConnectorNode result = repository.getConnector("connector-1", ConnectorSyncMode.SYNC_WITH_PROVIDER);
+
+        assertNotNull(result);
+        assertEquals(connector, result);
+        verify(connector).markInvalid(eq("Configuration Load Failed"), anyString());
         verify(connector, never()).setName(anyString());
+    }
+
+    @Test
+    public void testGetConnectorsToleratesProviderExceptionAndMarksInvalid() {
+        final ConnectorConfigurationProvider provider = mock(ConnectorConfigurationProvider.class);
+        final StandardConnectorRepository repository = createRepositoryWithProvider(provider);
+
+        final ConnectorNode connector = createSimpleConnectorNode("connector-1", "Original Name");
+        repository.addConnector(connector);
+
+        when(provider.load("connector-1")).thenThrow(new ConnectorConfigurationProviderException("Provider failure"));
+
+        final List<ConnectorNode> results = repository.getConnectors(ConnectorSyncMode.SYNC_WITH_PROVIDER);
+
+        assertEquals(1, results.size());
+        assertTrue(results.contains(connector));
+        verify(connector).markInvalid(eq("Configuration Load Failed"), anyString());
+        verify(connector, never()).setName(anyString());
+    }
+
+    @Test
+    public void testAddConnectorPropagatesProviderException() {
+        final ConnectorConfigurationProvider provider = mock(ConnectorConfigurationProvider.class);
+        final StandardConnectorRepository repository = createRepositoryWithProvider(provider);
+
+        final ConnectorNode connector = createSimpleConnectorNode("connector-1", "Original Name");
+        when(provider.load("connector-1")).thenThrow(new ConnectorConfigurationProviderException("Provider failure"));
+
+        // Write paths must remain strict: a configuration-load failure during create must propagate so that
+        // create/apply-config does not silently proceed on a bad configuration (only reads are made tolerant).
+        assertThrows(ConnectorConfigurationProviderException.class, () -> repository.addConnector(connector));
+        verify(connector, never()).markInvalid(anyString(), anyString());
     }
 
     @Test

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorRepository.java
@@ -274,7 +274,7 @@ public class TestStandardConnectorRepository {
     }
 
     @Test
-    public void testGetConnectorToleratesProviderExceptionAndMarksInvalid() {
+    public void testGetConnectorToleratesProviderException() {
         final ConnectorConfigurationProvider provider = mock(ConnectorConfigurationProvider.class);
         final StandardConnectorRepository repository = createRepositoryWithProvider(provider);
 
@@ -284,17 +284,19 @@ public class TestStandardConnectorRepository {
         when(provider.load("connector-1")).thenThrow(new ConnectorConfigurationProviderException("Provider failure"));
 
         // A configuration-load failure on a read must not propagate: the connector must remain readable
-        // (and therefore deletable). It is returned marked invalid so the failure is visible to clients.
+        // (and therefore deletable). The node is returned with its existing state untouched -- in particular
+        // it is NOT marked invalid, so a transient failure does not leave a healthy connector permanently
+        // invalid (markInvalid is not cleared by a subsequent successful read).
         final ConnectorNode result = repository.getConnector("connector-1", ConnectorSyncMode.SYNC_WITH_PROVIDER);
 
         assertNotNull(result);
         assertEquals(connector, result);
-        verify(connector).markInvalid(eq("Configuration Load Failed"), anyString());
+        verify(connector, never()).markInvalid(anyString(), anyString());
         verify(connector, never()).setName(anyString());
     }
 
     @Test
-    public void testGetConnectorsToleratesProviderExceptionAndMarksInvalid() {
+    public void testGetConnectorsToleratesProviderException() {
         final ConnectorConfigurationProvider provider = mock(ConnectorConfigurationProvider.class);
         final StandardConnectorRepository repository = createRepositoryWithProvider(provider);
 
@@ -307,7 +309,7 @@ public class TestStandardConnectorRepository {
 
         assertEquals(1, results.size());
         assertTrue(results.contains(connector));
-        verify(connector).markInvalid(eq("Configuration Load Failed"), anyString());
+        verify(connector, never()).markInvalid(anyString(), anyString());
         verify(connector, never()).setName(anyString());
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16060](https://issues.apache.org/jira/browse/NIFI-16060)

When a connector's stored configuration cannot be loaded or parsed (e.g. a corrupt config left behind by a failed commit), the ConnectorConfigurationProvider throws ConnectorConfigurationProviderException. On the SYNC_WITH_PROVIDER read path this exception previously propagated uncaught and surfaced as an HTTP 500 from the connector REST endpoints. Because the delete flow reads the connector (for its revision, and to snapshot it before deletion), a corrupt connector became impossible to read or delete.

Make the two read retrieval methods (getConnector and getConnectors with SYNC_WITH_PROVIDER) tolerate a configuration-load failure: log a warning, mark the connector invalid so the failure remains visible to clients via the DTO's validation status, and return the in-memory node instead of propagating. The connector therefore stays readable and deletable.

Write paths (addConnector, applyUpdate) call syncFromProvider directly and continue to propagate the exception, so create/apply-config still fail on a bad configuration rather than proceeding silently.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
