### PR TITLE
NIFI-16062 - Bump FastCSV to 4.3.1, HTTPClient5 to 5.6.2, and others

### DIFF
--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
@@ -20,7 +20,7 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <amqp-client.version>5.32.0</amqp-client.version>
+        <amqp-client.version>5.33.0</amqp-client.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
-                <version>5.6.1</version>
+                <version>5.6.2</version>
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>

--- a/nifi-extension-bundles/nifi-dropbox-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-dropbox-bundle/pom.xml
@@ -27,7 +27,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <dropbox.client.version>8.0.0</dropbox.client.version>
+        <dropbox.client.version>8.0.1</dropbox.client.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -24,7 +24,7 @@ language governing permissions and limitations under the License. -->
 
     <modules>
         <module>nifi-elasticsearch-test-utils</module>
-	    <module>nifi-elasticsearch-client-service-api</module>
+        <module>nifi-elasticsearch-client-service-api</module>
         <module>nifi-elasticsearch-client-service-api-nar</module>
         <module>nifi-elasticsearch-client-service</module>
         <module>nifi-elasticsearch-client-service-nar</module>
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>9.4.2</elasticsearch.client.version>
+        <elasticsearch.client.version>9.4.3</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <janusgraph.version>1.2.0-20260627-173607.cb8644d</janusgraph.version>
         <guava.version>33.6.0-jre</guava.version>
-        <amqp-client.version>5.32.0</amqp-client.version>
+        <amqp-client.version>5.33.0</amqp-client.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
@@ -73,7 +73,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
-                <version>5.6.1</version>
+                <version>5.6.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <protobuf.version>4.35.1</protobuf.version>
-        <wire.version>6.4.1</wire.version>
+        <wire.version>6.4.5</wire.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <spring.data.redis.version>4.1.0</spring.data.redis.version>
-        <jedis.version>7.5.2</jedis.version>
+        <jedis.version>7.5.3</jedis.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -565,7 +565,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.11</version>
+            <version>42.7.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>de.siegmar</groupId>
             <artifactId>fastcsv</artifactId>
-            <version>4.3.0</version>
+            <version>4.3.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.palindromicity</groupId>

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.11</version>
+            <version>42.7.12</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>4.1.0</spring.boot.version>
-        <flyway.version>12.9.0</flyway.version>
+        <flyway.version>12.10.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.7.0.202606012155-r</jgit.version>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <jline.version>4.2.1</jline.version>
+        <jline.version>4.3.1</jline.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.46.17</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.46.19</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.7</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 


### PR DESCRIPTION
# Summary

NIFI-16062 - Bump FastCSV to 4.3.1, HTTPClient5 to 5.6.2, and others

- AMQP Client from 5.32.0 to 5.33.0 - https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.33.0
- HTTPClient5 from 5.6.1 to 5.6.2 - https://downloads.apache.org/httpcomponents/httpclient/RELEASE_NOTES-5.6.x.txt
- Dropbox SDK from 8.0.0 to 8.0.1 - https://github.com/dropbox/dropbox-sdk-java/releases/tag/v8.0.1
- Elasticsearch client from 9.4.2 to 9.4.3 - https://github.com/elastic/elasticsearch/releases/tag/v9.4.3
- Wire from 6.4.1 to 6.4.5 - https://github.com/square/wire/releases/tag/6.4.5
- Jedis from 7.5.2 to 7.5.3 - https://github.com/redis/jedis/releases/tag/v7.5.3
- PostgreSQL from 42.7.11 to 42.7.12 - https://github.com/pgjdbc/pgjdbc/releases/tag/REL42.7.12
- FastCSV from 4.3.0 to 4.3.1 - https://github.com/osiegmar/FastCSV/releases/tag/v4.3.1
- FlywayDB from 12.9.0 to 12.10.0 - https://github.com/flyway/flyway/releases/tag/flyway-12.10.0
- JLine from 4.2.1 to 4.3.1 - https://github.com/jline/jline3/releases/tag/4.3.1
- AWS SDK BOM from 2.46.17 to 2.46.19 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.46.19Fa

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
