### PR TITLE
NIFI-16066 Release lingering rename in ConsumeKinesis

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/main/java/org/apache/nifi/processors/aws/kinesis/LegacyCheckpointMigrator.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/main/java/org/apache/nifi/processors/aws/kinesis/LegacyCheckpointMigrator.java
@@ -85,9 +85,14 @@ final class LegacyCheckpointMigrator {
         logger.info("Checkpoint table [{}] is in place but migration table [{}] still exists from a prior rename; not all checkpoints may have been migrated, re-copying before deletion",
                 checkpointTableName, lingeringMigration);
         if (acquireRenameLock(lingeringMigration)) {
-            CheckpointTableUtils.waitForTableActive(dynamoDbClient, logger, lingeringMigration);
-            CheckpointTableUtils.copyCheckpointItems(dynamoDbClient, logger, lingeringMigration, checkpointTableName);
-            CheckpointTableUtils.deleteTable(dynamoDbClient, logger, lingeringMigration);
+            try {
+                CheckpointTableUtils.waitForTableActive(dynamoDbClient, logger, lingeringMigration);
+                CheckpointTableUtils.copyCheckpointItems(dynamoDbClient, logger, lingeringMigration, checkpointTableName);
+                CheckpointTableUtils.deleteTable(dynamoDbClient, logger, lingeringMigration);
+            } catch (final RuntimeException e) {
+                clearRenameLock(lingeringMigration);
+                throw e;
+            }
         } else {
             waitForTableRenamed(lingeringMigration);
         }
@@ -114,12 +119,17 @@ final class LegacyCheckpointMigrator {
 
     void renameMigrationTable(final String migrationTableName) {
         if (acquireRenameLock(migrationTableName)) {
-            CheckpointTableUtils.deleteTable(dynamoDbClient, logger, checkpointTableName);
-            CheckpointTableUtils.waitForTableDeleted(dynamoDbClient, logger, checkpointTableName);
-            CheckpointTableUtils.createNewSchemaTable(dynamoDbClient, logger, checkpointTableName);
-            CheckpointTableUtils.waitForTableActive(dynamoDbClient, logger, checkpointTableName);
-            CheckpointTableUtils.copyCheckpointItems(dynamoDbClient, logger, migrationTableName, checkpointTableName);
-            CheckpointTableUtils.deleteTable(dynamoDbClient, logger, migrationTableName);
+            try {
+                CheckpointTableUtils.deleteTable(dynamoDbClient, logger, checkpointTableName);
+                CheckpointTableUtils.waitForTableDeleted(dynamoDbClient, logger, checkpointTableName);
+                CheckpointTableUtils.createNewSchemaTable(dynamoDbClient, logger, checkpointTableName);
+                CheckpointTableUtils.waitForTableActive(dynamoDbClient, logger, checkpointTableName);
+                CheckpointTableUtils.copyCheckpointItems(dynamoDbClient, logger, migrationTableName, checkpointTableName);
+                CheckpointTableUtils.deleteTable(dynamoDbClient, logger, migrationTableName);
+            } catch (final RuntimeException e) {
+                clearRenameLock(migrationTableName);
+                throw e;
+            }
         } else {
             waitForTableRenamed(migrationTableName);
         }
@@ -181,11 +191,40 @@ final class LegacyCheckpointMigrator {
                 "shardId", AttributeValue.builder().s(CheckpointTableUtils.MIGRATION_MARKER_SHARD_ID).build());
     }
 
+    private void clearRenameLock(final String migrationTableName) {
+        try {
+            final UpdateItemRequest request = UpdateItemRequest.builder()
+                    .tableName(migrationTableName)
+                    .key(migrationMarkerKey())
+                    .updateExpression("REMOVE renameOwner, renameStartedAt")
+                    .conditionExpression("renameOwner = :owner")
+                    .expressionAttributeValues(Map.of(
+                            ":owner", AttributeValue.builder().s(nodeId).build()))
+                    .build();
+            dynamoDbClient.updateItem(request);
+            logger.info("Released rename lock on migration table [{}] after an error", migrationTableName);
+        } catch (final ConditionalCheckFailedException e) {
+            logger.debug("Rename lock on migration table [{}] is no longer held by this node; leaving it in place", migrationTableName);
+        } catch (final ResourceNotFoundException e) {
+            logger.debug("Migration table [{}] no longer exists; rename lock already released", migrationTableName);
+        } catch (final RuntimeException e) {
+            logger.warn("Failed to release rename lock on migration table [{}] after an error; it will expire via the stale-lock timeout",
+                    migrationTableName, e);
+        }
+    }
+
+    private boolean isRenameCompleted(final String migrationTableName) {
+        return CheckpointTableUtils.getTableSchema(dynamoDbClient, checkpointTableName)
+                    == CheckpointTableUtils.TableSchema.NEW
+                && CheckpointTableUtils.getTableSchema(dynamoDbClient, migrationTableName)
+                    == CheckpointTableUtils.TableSchema.NOT_FOUND;
+    }
+
     private void waitForTableRenamed(final String migrationTableName) {
         for (int i = 0; i < RENAME_POLL_MAX_ATTEMPTS; i++) {
-            if (CheckpointTableUtils.getTableSchema(dynamoDbClient, checkpointTableName)
-                    == CheckpointTableUtils.TableSchema.NEW) {
-                logger.info("Migration table rename complete; table [{}] is now available", checkpointTableName);
+            if (isRenameCompleted(migrationTableName)) {
+                logger.info("Migration table rename complete; table [{}] is now available and migration table [{}] has been dropped",
+                        checkpointTableName, migrationTableName);
                 return;
             }
 
@@ -199,14 +238,18 @@ final class LegacyCheckpointMigrator {
 
         logger.warn("Timed out waiting for migration table rename; attempting stale lock takeover");
         if (forceAcquireStaleRenameLock(migrationTableName)) {
-            CheckpointTableUtils.deleteTable(dynamoDbClient, logger, checkpointTableName);
-            CheckpointTableUtils.waitForTableDeleted(dynamoDbClient, logger, checkpointTableName);
-            CheckpointTableUtils.createNewSchemaTable(dynamoDbClient, logger, checkpointTableName);
-            CheckpointTableUtils.waitForTableActive(dynamoDbClient, logger, checkpointTableName);
-            CheckpointTableUtils.copyCheckpointItems(dynamoDbClient, logger, migrationTableName, checkpointTableName);
-            CheckpointTableUtils.deleteTable(dynamoDbClient, logger, migrationTableName);
-        } else if (CheckpointTableUtils.getTableSchema(dynamoDbClient, checkpointTableName)
-                == CheckpointTableUtils.TableSchema.NEW) {
+            try {
+                CheckpointTableUtils.deleteTable(dynamoDbClient, logger, checkpointTableName);
+                CheckpointTableUtils.waitForTableDeleted(dynamoDbClient, logger, checkpointTableName);
+                CheckpointTableUtils.createNewSchemaTable(dynamoDbClient, logger, checkpointTableName);
+                CheckpointTableUtils.waitForTableActive(dynamoDbClient, logger, checkpointTableName);
+                CheckpointTableUtils.copyCheckpointItems(dynamoDbClient, logger, migrationTableName, checkpointTableName);
+                CheckpointTableUtils.deleteTable(dynamoDbClient, logger, migrationTableName);
+            } catch (final RuntimeException e) {
+                clearRenameLock(migrationTableName);
+                throw e;
+            }
+        } else if (isRenameCompleted(migrationTableName)) {
             logger.info("Migration table rename completed during takeover attempt");
         } else {
             throw new ProcessException(

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/main/java/org/apache/nifi/processors/aws/kinesis/LegacyCheckpointMigrator.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/main/java/org/apache/nifi/processors/aws/kinesis/LegacyCheckpointMigrator.java
@@ -89,7 +89,7 @@ final class LegacyCheckpointMigrator {
                 CheckpointTableUtils.waitForTableActive(dynamoDbClient, logger, lingeringMigration);
                 CheckpointTableUtils.copyCheckpointItems(dynamoDbClient, logger, lingeringMigration, checkpointTableName);
                 CheckpointTableUtils.deleteTable(dynamoDbClient, logger, lingeringMigration);
-            } catch (final RuntimeException e) {
+            } catch (final Exception e) {
                 clearRenameLock(lingeringMigration);
                 throw e;
             }
@@ -126,7 +126,7 @@ final class LegacyCheckpointMigrator {
                 CheckpointTableUtils.waitForTableActive(dynamoDbClient, logger, checkpointTableName);
                 CheckpointTableUtils.copyCheckpointItems(dynamoDbClient, logger, migrationTableName, checkpointTableName);
                 CheckpointTableUtils.deleteTable(dynamoDbClient, logger, migrationTableName);
-            } catch (final RuntimeException e) {
+            } catch (final Exception e) {
                 clearRenameLock(migrationTableName);
                 throw e;
             }
@@ -207,17 +207,15 @@ final class LegacyCheckpointMigrator {
             logger.debug("Rename lock on migration table [{}] is no longer held by this node; leaving it in place", migrationTableName);
         } catch (final ResourceNotFoundException e) {
             logger.debug("Migration table [{}] no longer exists; rename lock already released", migrationTableName);
-        } catch (final RuntimeException e) {
+        } catch (final Exception e) {
             logger.warn("Failed to release rename lock on migration table [{}] after an error; it will expire via the stale-lock timeout",
                     migrationTableName, e);
         }
     }
 
     private boolean isRenameCompleted(final String migrationTableName) {
-        return CheckpointTableUtils.getTableSchema(dynamoDbClient, checkpointTableName)
-                    == CheckpointTableUtils.TableSchema.NEW
-                && CheckpointTableUtils.getTableSchema(dynamoDbClient, migrationTableName)
-                    == CheckpointTableUtils.TableSchema.NOT_FOUND;
+        return CheckpointTableUtils.getTableSchema(dynamoDbClient, checkpointTableName) == CheckpointTableUtils.TableSchema.NEW
+                && CheckpointTableUtils.getTableSchema(dynamoDbClient, migrationTableName) == CheckpointTableUtils.TableSchema.NOT_FOUND;
     }
 
     private void waitForTableRenamed(final String migrationTableName) {
@@ -245,7 +243,7 @@ final class LegacyCheckpointMigrator {
                 CheckpointTableUtils.waitForTableActive(dynamoDbClient, logger, checkpointTableName);
                 CheckpointTableUtils.copyCheckpointItems(dynamoDbClient, logger, migrationTableName, checkpointTableName);
                 CheckpointTableUtils.deleteTable(dynamoDbClient, logger, migrationTableName);
-            } catch (final RuntimeException e) {
+            } catch (final Exception e) {
                 clearRenameLock(migrationTableName);
                 throw e;
             }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/test/java/org/apache/nifi/processors/aws/kinesis/KinesisShardManagerTest.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/test/java/org/apache/nifi/processors/aws/kinesis/KinesisShardManagerTest.java
@@ -51,9 +51,12 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -360,6 +363,100 @@ class KinesisShardManagerTest {
         verify(dynamoDb).deleteTable(deleteCaptor.capture());
         assertEquals("test-table_migration", deleteCaptor.getValue().tableName(),
                 "Migration table must be deleted only after the recovery copy succeeds");
+    }
+
+    /**
+     * NIFI-16066: when an error occurs while a node holds the rename lock (for example the
+     * checkpoint copy fails after the new table has been recreated), the lock must be released
+     * so a subsequent attempt can re-acquire it and retry the rename. Previously the lingering
+     * renameOwner attribute on the migration table blocked all future rename attempts until the
+     * stale-lock timeout elapsed.
+     */
+    @Test
+    void testRenameMigrationTableReleasesRenameLockOnCopyError() {
+        final AtomicInteger mainTableDescribeCount = new AtomicInteger();
+        when(dynamoDb.describeTable(any(DescribeTableRequest.class))).thenAnswer(invocation -> {
+            final DescribeTableRequest req = invocation.getArgument(0);
+            if ("test-table".equals(req.tableName())) {
+                if (mainTableDescribeCount.incrementAndGet() <= 3) {
+                    throw ResourceNotFoundException.builder().build();
+                }
+                return newSchemaActiveResponse();
+            }
+            if ("test-table_migration".equals(req.tableName())) {
+                return newSchemaActiveResponse();
+            }
+            throw ResourceNotFoundException.builder().build();
+        });
+
+        when(dynamoDb.updateItem(any(UpdateItemRequest.class))).thenReturn(UpdateItemResponse.builder().build());
+        when(dynamoDb.createTable(any(CreateTableRequest.class))).thenReturn(CreateTableResponse.builder().build());
+        when(dynamoDb.deleteTable(any(DeleteTableRequest.class))).thenReturn(DeleteTableResponse.builder().build());
+
+        final Map<String, AttributeValue> checkpointItem = Map.of(
+                "streamName", AttributeValue.builder().s("test-stream").build(),
+                "shardId", AttributeValue.builder().s("shard-1").build(),
+                "sequenceNumber", AttributeValue.builder().s("12345").build());
+        when(dynamoDb.scan(any(ScanRequest.class))).thenReturn(ScanResponse.builder().items(checkpointItem).build());
+
+        final InternalServerErrorException copyFailure = InternalServerErrorException.builder()
+                .message("simulated transient DynamoDB failure during checkpoint copy")
+                .build();
+        when(dynamoDb.putItem(any(PutItemRequest.class))).thenThrow(copyFailure);
+
+        assertThrows(InternalServerErrorException.class, () -> manager.ensureCheckpointTableExists(),
+                "A failed checkpoint copy under the rename lock must propagate");
+
+        final ArgumentCaptor<UpdateItemRequest> updateCaptor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(dynamoDb, atLeastOnce()).updateItem(updateCaptor.capture());
+        final boolean lockReleased = updateCaptor.getAllValues().stream()
+                .anyMatch(req -> "test-table_migration".equals(req.tableName())
+                        && req.updateExpression() != null
+                        && req.updateExpression().startsWith("REMOVE renameOwner"));
+        assertTrue(lockReleased, "Rename lock (renameOwner) must be released on the migration table when the rename fails");
+
+        final ArgumentCaptor<DeleteTableRequest> deleteCaptor = ArgumentCaptor.forClass(DeleteTableRequest.class);
+        verify(dynamoDb, times(1)).deleteTable(deleteCaptor.capture());
+        final boolean migrationDeleted = deleteCaptor.getAllValues().stream()
+                .map(DeleteTableRequest::tableName)
+                .anyMatch("test-table_migration"::equals);
+        assertFalse(migrationDeleted, "Migration table must not be deleted when the rename copy fails");
+    }
+
+    /**
+     * NIFI-16066: a node that loses the race for the rename lock must wait for the migration
+     * table to be dropped (the real signal that the rename finished) rather than returning as
+     * soon as the checkpoint table simply has the new schema. The new checkpoint table is
+     * created empty before the checkpoint copy runs, so schema presence alone does not mean the
+     * migration completed.
+     */
+    @Test
+    void testWaitForTableRenamedRequiresMigrationTableDropped() {
+        final AtomicInteger migrationDescribeCount = new AtomicInteger();
+        when(dynamoDb.describeTable(any(DescribeTableRequest.class))).thenAnswer(invocation -> {
+            final DescribeTableRequest req = invocation.getArgument(0);
+            if ("test-table".equals(req.tableName())) {
+                return newSchemaActiveResponse();
+            }
+            if ("test-table_migration".equals(req.tableName())) {
+                // Count 1: findMigrationTable() in completeLingeringMigration; count 2+: waitForTableRenamed poll loop.
+                if (migrationDescribeCount.incrementAndGet() == 1) {
+                    return newSchemaActiveResponse();
+                }
+                throw ResourceNotFoundException.builder().build();
+            }
+            throw ResourceNotFoundException.builder().build();
+        });
+
+        // Losing the rename-lock race: acquireRenameLock's conditional update fails.
+        when(dynamoDb.updateItem(any(UpdateItemRequest.class)))
+                .thenThrow(ConditionalCheckFailedException.builder().build());
+
+        manager.ensureCheckpointTableExists();
+
+        assertTrue(migrationDescribeCount.get() >= 2,
+                "waitForTableRenamed must confirm the migration table was dropped, not just that the checkpoint table has the new schema");
+        verify(dynamoDb, never()).deleteTable(any(DeleteTableRequest.class));
     }
 
     private static DescribeTableResponse newSchemaActiveResponse() {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/test/java/org/apache/nifi/processors/aws/kinesis/KinesisShardManagerTest.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/test/java/org/apache/nifi/processors/aws/kinesis/KinesisShardManagerTest.java
@@ -366,11 +366,10 @@ class KinesisShardManagerTest {
     }
 
     /**
-     * NIFI-16066: when an error occurs while a node holds the rename lock (for example the
-     * checkpoint copy fails after the new table has been recreated), the lock must be released
-     * so a subsequent attempt can re-acquire it and retry the rename. Previously the lingering
-     * renameOwner attribute on the migration table blocked all future rename attempts until the
-     * stale-lock timeout elapsed.
+     * When an error occurs while a node holds the rename lock (for example the checkpoint copy
+     * fails after the new checkpoint table has been recreated), the rename lock on the migration
+     * table is released so a later attempt can re-acquire it and retry, and the migration table
+     * is left in place so no checkpoints are lost.
      */
     @Test
     void testRenameMigrationTableReleasesRenameLockOnCopyError() {
@@ -424,11 +423,10 @@ class KinesisShardManagerTest {
     }
 
     /**
-     * NIFI-16066: a node that loses the race for the rename lock must wait for the migration
-     * table to be dropped (the real signal that the rename finished) rather than returning as
-     * soon as the checkpoint table simply has the new schema. The new checkpoint table is
-     * created empty before the checkpoint copy runs, so schema presence alone does not mean the
-     * migration completed.
+     * A node that does not hold the rename lock treats the rename as complete only once the
+     * migration table has been dropped. Because the new checkpoint table is created empty before
+     * the checkpoint copy runs, the presence of the new schema on the checkpoint table alone is
+     * not sufficient to conclude the migration finished.
      */
     @Test
     void testWaitForTableRenamedRequiresMigrationTableDropped() {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16066](https://issues.apache.org/jira/browse/NIFI-16066)

1. Releasing rename lock if an exception is thrown during table reaming.
2. In addition to the checkpoint table schema it's essential to ensure the migration table is dropped.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
