### PR TITLE
NIFI-16068 Removed unnecessary calls to close() and flush() at the end of a try-with-resources block.

### DIFF
--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/FlowStatusReport.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/FlowStatusReport.java
@@ -170,7 +170,6 @@ public class FlowStatusReport implements java.io.Serializable {
             generator.writeObjectField("reportingTaskStatusList", reportingTaskStatusList);
             generator.writeObjectField("errorsGeneratingReport", errorsGeneratingReport);
             generator.writeEndObject();
-            generator.close();
         } catch (IOException e) {
             //this should not occur since we are using a StringWriter, however, in the event it does. Generate
             //the old style report

--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFilePackagerV1.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFilePackagerV1.java
@@ -49,7 +49,6 @@ public class FlowFilePackagerV1 implements FlowFilePackager {
             writeAttributesEntry(attributes, tout);
             writeContentEntry(tout, in, fileSize);
             tout.finish();
-            tout.flush();
         }
     }
 

--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFilePackagerV1.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFilePackagerV1.java
@@ -50,7 +50,6 @@ public class FlowFilePackagerV1 implements FlowFilePackager {
             writeContentEntry(tout, in, fileSize);
             tout.finish();
             tout.flush();
-            tout.close();
         }
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16068](https://issues.apache.org/jira/browse/NIFI-16068)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
