### PR TITLE
NIFI-16077 Change default Security Protocol for Kafka components from PLAINTEXT to SSL

### DIFF
--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/AbstractKafkaBaseIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/AbstractKafkaBaseIT.java
@@ -23,6 +23,7 @@ import org.apache.nifi.json.JsonRecordSetWriter;
 import org.apache.nifi.json.JsonTreeReader;
 import org.apache.nifi.kafka.service.Kafka3ConnectionService;
 import org.apache.nifi.kafka.service.api.KafkaConnectionService;
+import org.apache.nifi.kafka.shared.property.SecurityProtocol;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.serialization.RecordReaderFactory;
 import org.apache.nifi.serialization.RecordSetWriterFactory;
@@ -78,6 +79,7 @@ public abstract class AbstractKafkaBaseIT {
         final KafkaConnectionService connectionService = new Kafka3ConnectionService();
         runner.addControllerService(CONNECTION_SERVICE_ID, connectionService);
         runner.setProperty(connectionService, Kafka3ConnectionService.BOOTSTRAP_SERVERS, kafkaContainer.getBootstrapServers());
+        runner.setProperty(connectionService, Kafka3ConnectionService.SECURITY_PROTOCOL, SecurityProtocol.PLAINTEXT.name());
         runner.setProperty(connectionService, Kafka3ConnectionService.MAX_POLL_RECORDS, "1000");
         runner.setProperty(connectionService, DYNAMIC_PROPERTY_KEY_PUBLISH, DYNAMIC_PROPERTY_VALUE_PUBLISH);
         runner.setProperty(connectionService, DYNAMIC_PROPERTY_KEY_CONSUME, DYNAMIC_PROPERTY_VALUE_CONSUME);

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/test/java/org/apache/nifi/kafka/service/Kafka3ConnectionServiceBaseIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/test/java/org/apache/nifi/kafka/service/Kafka3ConnectionServiceBaseIT.java
@@ -35,6 +35,7 @@ import org.apache.nifi.kafka.service.api.producer.PublishContext;
 import org.apache.nifi.kafka.service.api.producer.RecordSummary;
 import org.apache.nifi.kafka.service.api.record.ByteRecord;
 import org.apache.nifi.kafka.service.api.record.KafkaRecord;
+import org.apache.nifi.kafka.shared.property.SecurityProtocol;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.security.cert.builder.StandardCertificateBuilder;
 import org.apache.nifi.security.ssl.EphemeralKeyStoreBuilder;
@@ -210,6 +211,7 @@ public class Kafka3ConnectionServiceBaseIT {
     protected Map<String, String> getKafkaServiceConfigProperties() throws InitializationException {
         final Map<String, String> properties = new LinkedHashMap<>();
         properties.put(Kafka3ConnectionService.BOOTSTRAP_SERVERS.getName(), kafkaContainer.getBootstrapServers());
+        properties.put(Kafka3ConnectionService.SECURITY_PROTOCOL.getName(), SecurityProtocol.PLAINTEXT.name());
         properties.put(Kafka3ConnectionService.CLIENT_TIMEOUT.getName(), CLIENT_TIMEOUT);
         properties.put(DELIVERY_TIMEOUT_MS_KEY, DELIVERY_TIMEOUT_MS_VALUE);
         properties.put(FETCH_MAX_WAIT_MS_KEY, FETCH_MAX_WAIT_MS_VALUE);
@@ -324,6 +326,7 @@ public class Kafka3ConnectionServiceBaseIT {
         final String bootstrapServers = kafkaContainer.getBootstrapServers();
         final Map<PropertyDescriptor, String> properties = Map.of(
                 Kafka3ConnectionService.BOOTSTRAP_SERVERS, bootstrapServers,
+                Kafka3ConnectionService.SECURITY_PROTOCOL, SecurityProtocol.PLAINTEXT.name(),
                 Kafka3ConnectionService.CLIENT_TIMEOUT, CLIENT_TIMEOUT
         );
         final MockConfigurationContext configurationContext = new MockConfigurationContext(properties, null, null);
@@ -342,6 +345,7 @@ public class Kafka3ConnectionServiceBaseIT {
         final String bootstrapServers = "127.0.0.1:707070";
         final Map<PropertyDescriptor, String> properties = Map.of(
                 Kafka3ConnectionService.BOOTSTRAP_SERVERS, bootstrapServers,
+                Kafka3ConnectionService.SECURITY_PROTOCOL, SecurityProtocol.PLAINTEXT.name(),
                 Kafka3ConnectionService.CLIENT_TIMEOUT, CLIENT_TIMEOUT
         );
         final MockConfigurationContext configurationContext = new MockConfigurationContext(properties, null, null);
@@ -357,6 +361,7 @@ public class Kafka3ConnectionServiceBaseIT {
     void testVerifyConnectionFailed() {
         final Map<PropertyDescriptor, String> properties = Map.of(
                 Kafka3ConnectionService.BOOTSTRAP_SERVERS, UNREACHABLE_BOOTSTRAP_SERVERS,
+                Kafka3ConnectionService.SECURITY_PROTOCOL, SecurityProtocol.PLAINTEXT.name(),
                 Kafka3ConnectionService.CLIENT_TIMEOUT, CLIENT_TIMEOUT
         );
         final MockConfigurationContext configurationContext = new MockConfigurationContext(properties, null, null);

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
@@ -47,7 +47,7 @@ public interface KafkaClientComponent {
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .allowableValues(SecurityProtocol.values())
-            .defaultValue(SecurityProtocol.PLAINTEXT.name())
+            .defaultValue(SecurityProtocol.SSL.name())
             .build();
 
     PropertyDescriptor SASL_MECHANISM = new PropertyDescriptor.Builder()


### PR DESCRIPTION
# Summary

[NIFI-16077](https://issues.apache.org/jira/browse/NIFI-16077)

Changes the default value of the shared **Security Protocol** property (`KafkaClientComponent.SECURITY_PROTOCOL`) from `PLAINTEXT` to `SSL`. The descriptor is defined once in the shared `KafkaClientComponent` interface and reused by `ConsumeKafka`, `PublishKafka` and the Kafka connection service, so a single change applies the new default uniformly.

## Motivation

When `security.protocol` is set to a plaintext variant (e.g. `SASL_PLAINTEXT`) while the broker actually requires TLS, the Kafka client reads the returned TLS alert record as a message length (`0x15030300`, ~336 MB) and attempts to allocate that amount per broker connection, exhausting the heap and causing an OOM crash-loop within ~30-60s. The root cause lives in the Kafka client (KAFKA-4090, open since 2016 and unresolved), so NiFi cannot prevent it directly — but a TLS-based default meaningfully reduces the chance of falling into this trap.

`SSL` is used as the default rather than `SASL_SSL` so that transport security is enabled without also mandating SASL authentication. The property is `required`, so existing flows already persist an explicit value and are unaffected. The new default primarily impacts newly added components on the canvas.

## Verification

Built `nifi-kafka-shared` and related modules and ran the unit tests for `nifi-kafka-shared`, `nifi-kafka-service-shared`, `nifi-kafka-3-service`, `nifi-kafka-service-aws` and `nifi-kafka-processors` — all pass. Tests that exercise the protocol set it explicitly, so none depend on the previous default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
