### PR TITLE
NIFI-16078 - Fix StandardHashiCorpVaultClientService for non-token authentication

### DIFF
--- a/nifi-commons/nifi-hashicorp-vault/src/main/java/org/apache/nifi/vault/hashicorp/StandardHashiCorpVaultCommunicationService.java
+++ b/nifi-commons/nifi-hashicorp-vault/src/main/java/org/apache/nifi/vault/hashicorp/StandardHashiCorpVaultCommunicationService.java
@@ -107,6 +107,8 @@ public class StandardHashiCorpVaultCommunicationService implements HashiCorpVaul
         final VaultEndpoint vaultEndpoint = vaultConfiguration.vaultEndpoint();
         final RestTemplate restTemplate = VaultClients.createRestTemplate(vaultEndpoint, clientHttpRequestFactory);
 
+        vaultConfiguration.setClientHttpRequestFactory(clientHttpRequestFactory);
+
         final VaultClient.Builder vaultClientBuilder = VaultClient.builder(restTemplate).endpoint(vaultEndpoint);
         final String namespace = vaultConfiguration.getNamespace();
         if (namespace != null && !namespace.isEmpty()) {

--- a/nifi-commons/nifi-hashicorp-vault/src/main/java/org/apache/nifi/vault/hashicorp/config/HashiCorpVaultConfiguration.java
+++ b/nifi-commons/nifi-hashicorp-vault/src/main/java/org/apache/nifi/vault/hashicorp/config/HashiCorpVaultConfiguration.java
@@ -23,6 +23,9 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.support.ResourcePropertySource;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.vault.client.RestTemplateFactory;
+import org.springframework.vault.config.AbstractVaultConfiguration;
 import org.springframework.vault.config.EnvironmentVaultConfiguration;
 import org.springframework.vault.core.VaultKeyValueOperationsSupport.KeyValueBackend;
 import org.springframework.vault.support.ClientOptions;
@@ -65,9 +68,14 @@ public class HashiCorpVaultConfiguration extends EnvironmentVaultConfiguration {
 
     private static final String HTTPS = "https";
 
+    private static final String CLIENT_HTTP_REQUEST_FACTORY_WRAPPER_BEAN = "clientHttpRequestFactoryWrapper";
+
     private final SslConfiguration sslConfiguration;
     private final ClientOptions clientOptions;
     private final KeyValueBackend keyValueBackend;
+    private final HashiCorpVaultApplicationContext applicationContext;
+
+    private AbstractVaultConfiguration.ClientFactoryWrapper clientFactoryWrapper;
 
     /**
      * Creates a HashiCorpVaultConfiguration from property sources, in increasing precedence.
@@ -118,7 +126,8 @@ public class HashiCorpVaultConfiguration extends EnvironmentVaultConfiguration {
         }
         this.keyValueBackend = keyValueBackend;
 
-        this.setApplicationContext(new HashiCorpVaultApplicationContext(env));
+        this.applicationContext = new HashiCorpVaultApplicationContext(env);
+        this.setApplicationContext(applicationContext);
 
         sslConfiguration = env.getProperty(VaultConfigurationKey.URI.key).contains(HTTPS)
                 ? super.sslConfiguration() : SslConfiguration.unconfigured();
@@ -128,6 +137,23 @@ public class HashiCorpVaultConfiguration extends EnvironmentVaultConfiguration {
 
     public KeyValueBackend getKeyValueBackend() {
         return keyValueBackend;
+    }
+
+    /**
+     * Registers the given request factory as the {@code clientHttpRequestFactoryWrapper} bean and uses it
+     * to build the {@link RestTemplateFactory}. Spring Vault authentication methods other than token
+     * authentication build their own Vault client from these, so this must be called before
+     * {@link #clientAuthentication()} to supply NiFi's configured request factory.
+     * @param clientHttpRequestFactory The request factory used for Vault communication
+     */
+    public void setClientHttpRequestFactory(final ClientHttpRequestFactory clientHttpRequestFactory) {
+        this.clientFactoryWrapper = new AbstractVaultConfiguration.ClientFactoryWrapper(clientHttpRequestFactory);
+        applicationContext.getBeanFactory().registerSingleton(CLIENT_HTTP_REQUEST_FACTORY_WRAPPER_BEAN, clientFactoryWrapper);
+    }
+
+    @Override
+    protected RestTemplateFactory getRestTemplateFactory() {
+        return clientFactoryWrapper == null ? super.getRestTemplateFactory() : restTemplateFactory(clientFactoryWrapper);
     }
 
     /**

--- a/nifi-commons/nifi-hashicorp-vault/src/test/java/org/apache/nifi/vault/hashicorp/TestHashiCorpVaultConfiguration.java
+++ b/nifi-commons/nifi-hashicorp-vault/src/test/java/org/apache/nifi/vault/hashicorp/TestHashiCorpVaultConfiguration.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.vault.authentication.ClientAuthentication;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.core.VaultKeyValueOperationsSupport;
@@ -146,6 +147,60 @@ public class TestHashiCorpVaultConfiguration {
     @Test
     public void testBasicProperties() {
         this.runTest("http");
+    }
+
+    @Test
+    public void testKubernetesClientAuthentication() throws IOException {
+        File k8sAuthProps = null;
+        Path tokenFile = null;
+        try {
+            tokenFile = Files.createTempFile("vault-k8s-token", ".jwt");
+            Files.writeString(tokenFile, "test-jwt-token");
+
+            final Map<String, String> props = new HashMap<>();
+            props.put(VAULT_AUTHENTICATION, "KUBERNETES");
+            props.put("vault.kubernetes.role", "test-role");
+            props.put("vault.kubernetes.service-account-token-file", tokenFile.toFile().getAbsolutePath());
+            k8sAuthProps = writeVaultAuthProperties(props);
+            propertiesBuilder.setAuthPropertiesFilename(k8sAuthProps.getAbsolutePath());
+
+            config = new HashiCorpVaultConfiguration(
+                    createIsolatedEnvironment(), new HashiCorpVaultPropertySource(propertiesBuilder.build()));
+            config.setClientHttpRequestFactory(new SimpleClientHttpRequestFactory());
+
+            final ClientAuthentication clientAuthentication = config.clientAuthentication();
+            assertNotNull(clientAuthentication);
+        } finally {
+            if (k8sAuthProps != null) {
+                Files.deleteIfExists(k8sAuthProps.toPath());
+            }
+            if (tokenFile != null) {
+                Files.deleteIfExists(tokenFile);
+            }
+        }
+    }
+
+    @Test
+    public void testAwsEc2ClientAuthentication() throws IOException {
+        File awsAuthProps = null;
+        try {
+            final Map<String, String> props = new HashMap<>();
+            props.put(VAULT_AUTHENTICATION, "AWS_EC2");
+            props.put("vault.aws-ec2.role", "test-role");
+            awsAuthProps = writeVaultAuthProperties(props);
+            propertiesBuilder.setAuthPropertiesFilename(awsAuthProps.getAbsolutePath());
+
+            config = new HashiCorpVaultConfiguration(
+                    createIsolatedEnvironment(), new HashiCorpVaultPropertySource(propertiesBuilder.build()));
+            config.setClientHttpRequestFactory(new SimpleClientHttpRequestFactory());
+
+            final ClientAuthentication clientAuthentication = config.clientAuthentication();
+            assertNotNull(clientAuthentication);
+        } finally {
+            if (awsAuthProps != null) {
+                Files.deleteIfExists(awsAuthProps.toPath());
+            }
+        }
     }
 
     @Test

--- a/nifi-commons/nifi-hashicorp-vault/src/test/java/org/apache/nifi/vault/hashicorp/TestHashiCorpVaultConfiguration.java
+++ b/nifi-commons/nifi-hashicorp-vault/src/test/java/org/apache/nifi/vault/hashicorp/TestHashiCorpVaultConfiguration.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -150,57 +151,41 @@ public class TestHashiCorpVaultConfiguration {
     }
 
     @Test
-    public void testKubernetesClientAuthentication() throws IOException {
-        File k8sAuthProps = null;
-        Path tokenFile = null;
-        try {
-            tokenFile = Files.createTempFile("vault-k8s-token", ".jwt");
-            Files.writeString(tokenFile, "test-jwt-token");
+    public void testKubernetesClientAuthentication(@TempDir Path tempDir) throws IOException {
+        final Path tokenFile = Files.createTempFile(tempDir, "vault-k8s-token", ".jwt");
+        Files.writeString(tokenFile, "test-jwt-token");
 
-            final Map<String, String> props = new HashMap<>();
-            props.put(VAULT_AUTHENTICATION, "KUBERNETES");
-            props.put("vault.kubernetes.role", "test-role");
-            props.put("vault.kubernetes.service-account-token-file", tokenFile.toFile().getAbsolutePath());
-            k8sAuthProps = writeVaultAuthProperties(props);
-            propertiesBuilder.setAuthPropertiesFilename(k8sAuthProps.getAbsolutePath());
+        final Map<String, String> props = new HashMap<>();
+        props.put(VAULT_AUTHENTICATION, "KUBERNETES");
+        props.put("vault.kubernetes.role", "test-role");
+        props.put("vault.kubernetes.service-account-token-file", tokenFile.toFile().getAbsolutePath());
+        final File k8sAuthProps = Files.createTempFile(tempDir, "vault-", ".properties").toFile();
+        writeProperties(props, k8sAuthProps);
+        propertiesBuilder.setAuthPropertiesFilename(k8sAuthProps.getAbsolutePath());
 
-            config = new HashiCorpVaultConfiguration(
-                    createIsolatedEnvironment(), new HashiCorpVaultPropertySource(propertiesBuilder.build()));
-            config.setClientHttpRequestFactory(new SimpleClientHttpRequestFactory());
+        config = new HashiCorpVaultConfiguration(
+                createIsolatedEnvironment(), new HashiCorpVaultPropertySource(propertiesBuilder.build()));
+        config.setClientHttpRequestFactory(new SimpleClientHttpRequestFactory());
 
-            final ClientAuthentication clientAuthentication = config.clientAuthentication();
-            assertNotNull(clientAuthentication);
-        } finally {
-            if (k8sAuthProps != null) {
-                Files.deleteIfExists(k8sAuthProps.toPath());
-            }
-            if (tokenFile != null) {
-                Files.deleteIfExists(tokenFile);
-            }
-        }
+        final ClientAuthentication clientAuthentication = config.clientAuthentication();
+        assertNotNull(clientAuthentication);
     }
 
     @Test
-    public void testAwsEc2ClientAuthentication() throws IOException {
-        File awsAuthProps = null;
-        try {
-            final Map<String, String> props = new HashMap<>();
-            props.put(VAULT_AUTHENTICATION, "AWS_EC2");
-            props.put("vault.aws-ec2.role", "test-role");
-            awsAuthProps = writeVaultAuthProperties(props);
-            propertiesBuilder.setAuthPropertiesFilename(awsAuthProps.getAbsolutePath());
+    public void testAwsEc2ClientAuthentication(@TempDir Path tempDir) throws IOException {
+        final Map<String, String> props = new HashMap<>();
+        props.put(VAULT_AUTHENTICATION, "AWS_EC2");
+        props.put("vault.aws-ec2.role", "test-role");
+        final File awsAuthProps = Files.createTempFile(tempDir, "vault-", ".properties").toFile();
+        writeProperties(props, awsAuthProps);
+        propertiesBuilder.setAuthPropertiesFilename(awsAuthProps.getAbsolutePath());
 
-            config = new HashiCorpVaultConfiguration(
-                    createIsolatedEnvironment(), new HashiCorpVaultPropertySource(propertiesBuilder.build()));
-            config.setClientHttpRequestFactory(new SimpleClientHttpRequestFactory());
+        config = new HashiCorpVaultConfiguration(
+                createIsolatedEnvironment(), new HashiCorpVaultPropertySource(propertiesBuilder.build()));
+        config.setClientHttpRequestFactory(new SimpleClientHttpRequestFactory());
 
-            final ClientAuthentication clientAuthentication = config.clientAuthentication();
-            assertNotNull(clientAuthentication);
-        } finally {
-            if (awsAuthProps != null) {
-                Files.deleteIfExists(awsAuthProps.toPath());
-            }
-        }
+        final ClientAuthentication clientAuthentication = config.clientAuthentication();
+        assertNotNull(clientAuthentication);
     }
 
     @Test


### PR DESCRIPTION
# Summary

NIFI-16078 - Fix StandardHashiCorpVaultClientService for non-token authentication

In NiFi 2.10.0, `spring-vault-core` was upgraded 4.0.1 → 4.1.0. Non-token auth methods now build their client via `AbstractVaultConfiguration.vaultClient()`, which looks up a `clientHttpRequestFactoryWrapper` bean; AWS EC2 / Azure MSI also go through `restClient()` → `getRestTemplateFactory()`. Alsok, NiFi's `getRestTemplateFactory()` override was removed.

NiFi configures `HashiCorpVaultConfiguration` programmatically with an empty `StaticApplicationContext`, so these bean lookups fail. Token authentication is unaffected (it needs no Vault client).

With this change, `HashiCorpVaultConfiguration.setClientHttpRequestFactory(...)` registers the request factory as the `clientHttpRequestFactoryWrapper` bean. We also restore the `getRestTemplateFactory()` override built from that same factory. And `StandardHashiCorpVaultCommunicationService` passes its configured (SSL Context Service–aware) factory before `clientAuthentication()`, so the auth client uses the same TLS material.

Added new unit tests cover Kubernetes and AWS EC2 authentication; both reproduce the reported failure without the fix.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
