### PR TITLE
NIFI-16080 Switch to JDBC Enquote Identifier in UpdateDatabaseTable

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UpdateDatabaseTable.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UpdateDatabaseTable.java
@@ -588,16 +588,17 @@ public class UpdateDatabaseTable extends AbstractProcessor {
                 }
 
                 if (!columnsToAdd.isEmpty()) {
-                    final List<ColumnDefinition> columnDefinitions = columnsToAdd.stream().map(columnDescription ->
-                            new StandardColumnDefinition(
-                                    enquoteIdentifier(s, columnDescription.getColumnName(), quoteColumnNames),
-                                    columnDescription.getDataType(),
-                                    columnDescription.isNullable() ? ColumnDefinition.Nullable.YES : ColumnDefinition.Nullable.UNKNOWN,
-                                    columnDescription.isRequired()
-                            )
-                            )
-                            .map(ColumnDefinition.class::cast)
-                            .toList();
+                    final List<ColumnDefinition> columnDefinitions = new ArrayList<>(columnsToAdd.size());
+                    for (final ColumnDescription columnDescription : columnsToAdd) {
+                        final ColumnDefinition columnDefinition = new StandardColumnDefinition(
+                                enquoteIdentifier(s, columnDescription.getColumnName(), quoteColumnNames),
+                                columnDescription.getDataType(),
+                                columnDescription.isNullable() ? ColumnDefinition.Nullable.YES : ColumnDefinition.Nullable.UNKNOWN,
+                                columnDescription.isRequired()
+                        );
+                        columnDefinitions.add(columnDefinition);
+                    }
+
                     final String qualifiedTableName = enquoteIdentifier(s, tableName, quoteTableName);
                     final TableDefinition tableDefinition = new TableDefinition(Optional.empty(), Optional.empty(), qualifiedTableName, columnDefinitions);
                     final StatementRequest statementRequest = new StandardStatementRequest(StatementType.ALTER, tableDefinition);
@@ -708,17 +709,13 @@ public class UpdateDatabaseTable extends AbstractProcessor {
         );
     }
 
-    private String enquoteIdentifier(final Statement statement, final String identifier, final boolean quoteIdentifier) {
+    private String enquoteIdentifier(final Statement statement, final String identifier, final boolean quoteIdentifier) throws SQLException {
         final String enquoted;
 
         if (identifier == null) {
             enquoted = identifier;
         } else if (quoteIdentifier) {
-            try {
-                enquoted = statement.enquoteIdentifier(identifier, quoteIdentifier);
-            } catch (final SQLException e) {
-                throw new IllegalArgumentException("Enquote Identifier [%s] failed".formatted(identifier), e);
-            }
+            enquoted = statement.enquoteIdentifier(identifier, quoteIdentifier);
         } else {
             enquoted = identifier;
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UpdateDatabaseTable.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UpdateDatabaseTable.java
@@ -537,14 +537,14 @@ public class UpdateDatabaseTable extends AbstractProcessor {
                         }
 
                         final int dataType = DataTypeUtils.getSQLTypeValue(recordField.getDataType());
-                        final String quotedColumnName = enquoteIdentifier(columnName, quoteString, quoteColumnNames);
+                        final String quotedColumnName = enquoteIdentifier(s, columnName, quoteColumnNames);
                         columns.add(new ColumnDescription(quotedColumnName, dataType, required, null, recordField.isNullable()));
                         getLogger().debug("Adding column {} to table {}", columnName, tableName);
                     }
 
-                    final String quotedCatalogName = enquoteIdentifier(catalogName, quoteString, quoteTableName);
-                    final String quotedSchemaName = enquoteIdentifier(schemaName, quoteString, quoteTableName);
-                    final String quotedTableName = enquoteIdentifier(tableName, quoteString, quoteTableName);
+                    final String quotedCatalogName = enquoteIdentifier(s, catalogName, quoteTableName);
+                    final String quotedSchemaName = enquoteIdentifier(s, schemaName, quoteTableName);
+                    final String quotedTableName = enquoteIdentifier(s, tableName, quoteTableName);
                     tableSchema = new TableSchema(quotedCatalogName, quotedSchemaName, quotedTableName, columns, translateFieldNames, normalizer, primaryKeyColumnNames, quoteString);
 
                     final TableDefinition tableDefinition = getTableDefinition(tableSchema);
@@ -590,7 +590,7 @@ public class UpdateDatabaseTable extends AbstractProcessor {
                 if (!columnsToAdd.isEmpty()) {
                     final List<ColumnDefinition> columnDefinitions = columnsToAdd.stream().map(columnDescription ->
                             new StandardColumnDefinition(
-                                    enquoteIdentifier(columnDescription.getColumnName(), quoteString, quoteColumnNames),
+                                    enquoteIdentifier(s, columnDescription.getColumnName(), quoteColumnNames),
                                     columnDescription.getDataType(),
                                     columnDescription.isNullable() ? ColumnDefinition.Nullable.YES : ColumnDefinition.Nullable.UNKNOWN,
                                     columnDescription.isRequired()
@@ -598,7 +598,7 @@ public class UpdateDatabaseTable extends AbstractProcessor {
                             )
                             .map(ColumnDefinition.class::cast)
                             .toList();
-                    final String qualifiedTableName = enquoteIdentifier(tableName, quoteString, quoteTableName);
+                    final String qualifiedTableName = enquoteIdentifier(s, tableName, quoteTableName);
                     final TableDefinition tableDefinition = new TableDefinition(Optional.empty(), Optional.empty(), qualifiedTableName, columnDefinitions);
                     final StatementRequest statementRequest = new StandardStatementRequest(StatementType.ALTER, tableDefinition);
                     final StatementResponse statementResponse = databaseDialectService.getStatement(statementRequest);
@@ -708,11 +708,22 @@ public class UpdateDatabaseTable extends AbstractProcessor {
         );
     }
 
-    private String enquoteIdentifier(final String identifier, final String quotedIdentifierString, final boolean quoteIdentifier) {
-        if (identifier != null && quoteIdentifier) {
-            return quotedIdentifierString + identifier + quotedIdentifierString;
+    private String enquoteIdentifier(final Statement statement, final String identifier, final boolean quoteIdentifier) {
+        final String enquoted;
+
+        if (identifier == null) {
+            enquoted = identifier;
+        } else if (quoteIdentifier) {
+            try {
+                enquoted = statement.enquoteIdentifier(identifier, quoteIdentifier);
+            } catch (final SQLException e) {
+                throw new IllegalArgumentException("Enquote Identifier [%s] failed".formatted(identifier), e);
+            }
+        } else {
+            enquoted = identifier;
         }
-        return identifier;
+
+        return enquoted;
     }
 
     private static class OutputMetadataHolder {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUpdateDatabaseTable.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUpdateDatabaseTable.java
@@ -90,7 +90,7 @@ class TestUpdateDatabaseTable extends AbstractDatabaseConnectionServiceTest {
         readerFactory.addSchemaField(new RecordField("id", RecordFieldType.INT.getDataType(), false));
         readerFactory.addSchemaField(new RecordField("fractional", RecordFieldType.DOUBLE.getDataType(), true));
         readerFactory.addSchemaField(new RecordField("code", RecordFieldType.INT.getDataType(), 0, true));
-        readerFactory.addSchemaField(new RecordField("newField", RecordFieldType.DOUBLE.getDataType(), false));
+        readerFactory.addSchemaField(new RecordField("spaced Field", RecordFieldType.DOUBLE.getDataType(), false));
         readerFactory.addRecord(1, 1.2345, 10);
 
         runner.addControllerService("mock-reader-factory", readerFactory);
@@ -120,7 +120,7 @@ class TestUpdateDatabaseTable extends AbstractDatabaseConnectionServiceTest {
             assertColumnEquals(rs, "id", 1, "INTEGER");
             assertColumnEquals(rs, "fractional", 2, "DOUBLE PRECISION");
             assertColumnEquals(rs, "code", 3, "INTEGER");
-            assertColumnEquals(rs, "newField", 4, "DOUBLE PRECISION");
+            assertColumnEquals(rs, "spaced Field", 4, "DOUBLE PRECISION");
             assertFalse(rs.next());
         }
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUpdateDatabaseTable.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUpdateDatabaseTable.java
@@ -84,6 +84,32 @@ class TestUpdateDatabaseTable extends AbstractDatabaseConnectionServiceTest {
     }
 
     @Test
+    void testCreateTableIdentifierLengthExceeded() throws InitializationException {
+        final MockRecordParser recordReader = new MockRecordParser();
+        final String recordReaderId = MockRecordParser.class.getSimpleName();
+
+        // Column Name longer than 128 produces SQLException in default implementation of Statement.enquoteIdentifier()
+        final String columnName = "A".repeat(129);
+
+        recordReader.addSchemaField(new RecordField(columnName, RecordFieldType.INT.getDataType(), false));
+        recordReader.addRecord(1);
+
+        runner.addControllerService(recordReaderId, recordReader);
+        runner.enableControllerService(recordReader);
+
+        runner.setProperty(UpdateDatabaseTable.RECORD_READER, recordReaderId);
+        runner.setProperty(UpdateDatabaseTable.TABLE_NAME, "NEW_TABLE");
+        runner.setProperty(UpdateDatabaseTable.CREATE_TABLE, UpdateDatabaseTable.CREATE_IF_NOT_EXISTS);
+        runner.setProperty(UpdateDatabaseTable.QUOTE_COLUMN_IDENTIFIERS, Boolean.TRUE.toString());
+        runner.setProperty(UpdateDatabaseTable.DB_TYPE, TEST_DB_TYPE);
+
+        runner.enqueue(new byte[0]);
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(UpdateDatabaseTable.REL_FAILURE);
+    }
+
+    @Test
     public void testCreateTable() throws Exception {
         MockRecordParser readerFactory = new MockRecordParser();
 


### PR DESCRIPTION
# Summary

[NIFI-16080](https://issues.apache.org/jira/browse/NIFI-16080) Adjusts the implementation of database identifier quoting in the `UpdateDatabaseTable` Processor to use the JDBC `Statement.enquoteIdentifier()` method instead of the string concatenation method. Existing tests exercise the quoting behavior and confirm expected results. The adjusted approach maintains the configurable property on the Processor to enable or disable identifier quoting as needed.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
