### PR TITLE
NIFI-16081: Implement Migrate Connector Properties API

### DIFF
--- a/nifi-connector-mock-bundle/nifi-connector-mock/src/main/java/org/apache/nifi/mock/connector/migration/MockConnectorPropertyConfiguration.java
+++ b/nifi-connector-mock-bundle/nifi-connector-mock/src/main/java/org/apache/nifi/mock/connector/migration/MockConnectorPropertyConfiguration.java
@@ -1,0 +1,497 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.mock.connector.migration;
+
+import org.apache.nifi.components.connector.ConnectorValueReference;
+import org.apache.nifi.components.connector.StepConfiguration;
+import org.apache.nifi.components.connector.StringLiteralValue;
+import org.apache.nifi.migration.ConnectorPropertyConfiguration;
+import org.apache.nifi.migration.ConnectorStepPropertyConfiguration;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Test-only {@link ConnectorPropertyConfiguration} implementation for exercising a Connector's
+ * {@link org.apache.nifi.components.connector.Connector#migrateProperties(ConnectorPropertyConfiguration) migrateProperties}
+ * method in unit tests. Tracks per-step property renames, removals, and additions, plus step-level renames,
+ * removals, and additions. Callers can drive the mock with either a plain string-literal shorthand map or a
+ * fully typed {@link ConnectorValueReference} map and then inspect the outcome via
+ * {@link #toMigrationResult()}, {@link #getStepNames()}, and {@link #forStep(String)}.
+ */
+public class MockConnectorPropertyConfiguration implements ConnectorPropertyConfiguration {
+
+    private final Map<String, StepConfiguration> stepProperties = new HashMap<>();
+    private final Set<String> initialStepNames;
+
+    private final Map<String, StepPropertyRenames> propertiesRenamed = new HashMap<>();
+    private final Map<String, Set<String>> propertiesRemoved = new HashMap<>();
+    private final Map<String, Set<String>> propertiesUpdated = new HashMap<>();
+
+    private final Map<String, String> renamedSteps = new HashMap<>();
+    private final Set<String> removedSteps = new HashSet<>();
+    private final Set<String> addedSteps = new HashSet<>();
+
+    private MockConnectorPropertyConfiguration(final Map<String, StepConfiguration> initialProperties) {
+        if (initialProperties != null) {
+            for (final Map.Entry<String, StepConfiguration> entry : initialProperties.entrySet()) {
+                final Map<String, ConnectorValueReference> copy = new HashMap<>();
+                final StepConfiguration stepConfig = entry.getValue();
+                if (stepConfig != null && stepConfig.getPropertyValues() != null) {
+                    copy.putAll(stepConfig.getPropertyValues());
+                }
+                stepProperties.put(entry.getKey(), new StepConfiguration(copy));
+            }
+        }
+        this.initialStepNames = Collections.unmodifiableSet(new HashSet<>(stepProperties.keySet()));
+    }
+
+    /**
+     * Creates a {@link MockConnectorPropertyConfiguration} pre-populated with typed {@link ConnectorValueReference}
+     * values for each step.
+     *
+     * @param initialProperties per-step {@link StepConfiguration} snapshots of {@link ConnectorValueReference} values
+     * @return a new configuration
+     */
+    public static MockConnectorPropertyConfiguration fromValueReferences(final Map<String, StepConfiguration> initialProperties) {
+        return new MockConnectorPropertyConfiguration(initialProperties);
+    }
+
+    /**
+     * Creates a {@link MockConnectorPropertyConfiguration} pre-populated with plain string-literal values for each
+     * step. Each supplied string is wrapped in a {@link StringLiteralValue}.
+     *
+     * @param initialProperties per-step {@link StepLiteralProperties} of raw string values
+     * @return a new configuration
+     */
+    public static MockConnectorPropertyConfiguration fromStringLiterals(final Map<String, StepLiteralProperties> initialProperties) {
+        final Map<String, StepConfiguration> converted = new HashMap<>();
+        if (initialProperties != null) {
+            for (final Map.Entry<String, StepLiteralProperties> entry : initialProperties.entrySet()) {
+                final Map<String, ConnectorValueReference> stepMap = new HashMap<>();
+                final StepLiteralProperties stepLiterals = entry.getValue();
+                if (stepLiterals != null) {
+                    for (final String propertyName : stepLiterals.getPropertyNames()) {
+                        stepMap.put(propertyName, new StringLiteralValue(stepLiterals.getValue(propertyName)));
+                    }
+                }
+                converted.put(entry.getKey(), new StepConfiguration(stepMap));
+            }
+        }
+        return new MockConnectorPropertyConfiguration(converted);
+    }
+
+    @Override
+    public Set<String> getStepNames() {
+        return Collections.unmodifiableSet(stepProperties.keySet());
+    }
+
+    @Override
+    public boolean hasStep(final String stepName) {
+        return stepProperties.containsKey(stepName);
+    }
+
+    @Override
+    public boolean renameStep(final String oldStepName, final String newStepName) {
+        if (!stepProperties.containsKey(oldStepName)) {
+            return false;
+        }
+        if (Objects.equals(oldStepName, newStepName)) {
+            return false;
+        }
+        if (stepProperties.containsKey(newStepName)) {
+            throw new IllegalStateException("Cannot rename step [" + oldStepName + "] to [" + newStepName
+                + "] because a step with the new name already exists");
+        }
+
+        final StepConfiguration existing = stepProperties.remove(oldStepName);
+        stepProperties.put(newStepName, existing);
+        renamedSteps.put(oldStepName, newStepName);
+
+        final StepPropertyRenames renames = propertiesRenamed.remove(oldStepName);
+        if (renames != null) {
+            propertiesRenamed.put(newStepName, renames);
+        }
+        final Set<String> removed = propertiesRemoved.remove(oldStepName);
+        if (removed != null) {
+            propertiesRemoved.put(newStepName, removed);
+        }
+        final Set<String> updated = propertiesUpdated.remove(oldStepName);
+        if (updated != null) {
+            propertiesUpdated.put(newStepName, updated);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean removeStep(final String stepName) {
+        if (!stepProperties.containsKey(stepName)) {
+            return false;
+        }
+        stepProperties.remove(stepName);
+        removedSteps.add(stepName);
+        propertiesRenamed.remove(stepName);
+        propertiesRemoved.remove(stepName);
+        propertiesUpdated.remove(stepName);
+        return true;
+    }
+
+    @Override
+    public ConnectorStepPropertyConfiguration forStep(final String stepName) {
+        return new MockStepPropertyConfiguration(stepName);
+    }
+
+    /**
+     * @return a summary of every mutation observed during migration, suitable for assertions
+     */
+    public MigrationResult toMigrationResult() {
+        return new MigrationResult(
+            Collections.unmodifiableMap(new HashMap<>(renamedSteps)),
+            Collections.unmodifiableSet(new HashSet<>(removedSteps)),
+            Collections.unmodifiableSet(new HashSet<>(addedSteps)),
+            deepCopy(propertiesRenamed),
+            deepCopySets(propertiesRemoved),
+            deepCopySets(propertiesUpdated)
+        );
+    }
+
+    private static Map<String, StepPropertyRenames> deepCopy(final Map<String, StepPropertyRenames> source) {
+        final Map<String, StepPropertyRenames> copy = new HashMap<>();
+        for (final Map.Entry<String, StepPropertyRenames> entry : source.entrySet()) {
+            final StepPropertyRenames snapshot = new StepPropertyRenames();
+            for (final String oldName : entry.getValue().getOldNames()) {
+                snapshot.add(oldName, entry.getValue().getNewName(oldName));
+            }
+            copy.put(entry.getKey(), snapshot);
+        }
+        return Collections.unmodifiableMap(copy);
+    }
+
+    private static Map<String, Set<String>> deepCopySets(final Map<String, Set<String>> source) {
+        final Map<String, Set<String>> copy = new HashMap<>();
+        for (final Map.Entry<String, Set<String>> entry : source.entrySet()) {
+            copy.put(entry.getKey(), Collections.unmodifiableSet(new HashSet<>(entry.getValue())));
+        }
+        return Collections.unmodifiableMap(copy);
+    }
+
+    private Map<String, ConnectorValueReference> getOrCreateStepMap(final String stepName) {
+        return stepProperties.computeIfAbsent(stepName, key -> {
+            if (!initialStepNames.contains(key)) {
+                addedSteps.add(key);
+            }
+            return new StepConfiguration(new HashMap<>());
+        }).getPropertyValues();
+    }
+
+    private Map<String, ConnectorValueReference> getStepMap(final String stepName) {
+        final StepConfiguration stepConfig = stepProperties.get(stepName);
+        return stepConfig == null ? null : stepConfig.getPropertyValues();
+    }
+
+    private void trackRenamed(final String stepName, final String oldName, final String newName) {
+        propertiesRenamed.computeIfAbsent(stepName, key -> new StepPropertyRenames()).add(oldName, newName);
+    }
+
+    private void trackRemoved(final String stepName, final String propertyName) {
+        propertiesRemoved.computeIfAbsent(stepName, key -> new HashSet<>()).add(propertyName);
+    }
+
+    private void trackUpdated(final String stepName, final String propertyName) {
+        propertiesUpdated.computeIfAbsent(stepName, key -> new HashSet<>()).add(propertyName);
+    }
+
+    /**
+     * A summary of every step and property mutation observed during a call to
+     * {@link org.apache.nifi.components.connector.Connector#migrateProperties(ConnectorPropertyConfiguration)}.
+     *
+     * @param renamedSteps       old step name to new step name for every renamed step
+     * @param removedSteps       step names removed during migration
+     * @param addedSteps         step names introduced during migration
+     * @param propertiesRenamed  per-step {@link StepPropertyRenames} of old property name to new property name
+     * @param propertiesRemoved  per-step set of property names removed
+     * @param propertiesUpdated  per-step set of property names added or overwritten (including via setValueReference)
+     */
+    public record MigrationResult(
+        Map<String, String> renamedSteps,
+        Set<String> removedSteps,
+        Set<String> addedSteps,
+        Map<String, StepPropertyRenames> propertiesRenamed,
+        Map<String, Set<String>> propertiesRemoved,
+        Map<String, Set<String>> propertiesUpdated
+    ) {
+    }
+
+    /**
+     * Per-step property renames observed during migration. Callers accumulate rename pairs via
+     * {@link #add(String, String)} and read the outcome via {@link #getNewName(String)} and
+     * {@link #getOldNames()}. Instances compare equal when they contain the same set of rename pairs, so
+     * a builder-style expected value can be compared against the mock's recorded value with
+     * {@code assertEquals}.
+     */
+    public static final class StepPropertyRenames {
+
+        private final Map<String, String> renames = new HashMap<>();
+
+        /**
+         * Records a rename of {@code oldName} to {@code newName}.
+         *
+         * @return this instance for chaining
+         */
+        public StepPropertyRenames add(final String oldName, final String newName) {
+            renames.put(oldName, newName);
+            return this;
+        }
+
+        /**
+         * @return the new name recorded for {@code oldName}, or {@code null} if no rename was recorded
+         */
+        public String getNewName(final String oldName) {
+            return renames.get(oldName);
+        }
+
+        /**
+         * @return an unmodifiable view of the old property names that have been renamed
+         */
+        public Set<String> getOldNames() {
+            return Collections.unmodifiableSet(renames.keySet());
+        }
+
+        public boolean isEmpty() {
+            return renames.isEmpty();
+        }
+
+        public int size() {
+            return renames.size();
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof final StepPropertyRenames that)) {
+                return false;
+            }
+            return renames.equals(that.renames);
+        }
+
+        @Override
+        public int hashCode() {
+            return renames.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "StepPropertyRenames" + renames;
+        }
+    }
+
+    /**
+     * Per-step literal-only property values, used to seed a {@link MockConnectorPropertyConfiguration} through
+     * {@link #fromStringLiterals(Map)}. Callers accumulate name/value pairs via {@link #add(String, String)}
+     * and read them back via {@link #getValue(String)} and {@link #getPropertyNames()}.
+     */
+    public static final class StepLiteralProperties {
+
+        private final Map<String, String> properties = new HashMap<>();
+
+        /**
+         * Records the literal {@code value} for the property named {@code propertyName}.
+         *
+         * @return this instance for chaining
+         */
+        public StepLiteralProperties add(final String propertyName, final String value) {
+            properties.put(propertyName, value);
+            return this;
+        }
+
+        /**
+         * @return the literal value recorded for {@code propertyName}, or {@code null} if none was recorded
+         */
+        public String getValue(final String propertyName) {
+            return properties.get(propertyName);
+        }
+
+        /**
+         * @return an unmodifiable view of the property names that have been recorded
+         */
+        public Set<String> getPropertyNames() {
+            return Collections.unmodifiableSet(properties.keySet());
+        }
+
+        public boolean isEmpty() {
+            return properties.isEmpty();
+        }
+
+        public int size() {
+            return properties.size();
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof final StepLiteralProperties that)) {
+                return false;
+            }
+            return properties.equals(that.properties);
+        }
+
+        @Override
+        public int hashCode() {
+            return properties.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "StepLiteralProperties" + properties;
+        }
+    }
+
+    private final class MockStepPropertyConfiguration implements ConnectorStepPropertyConfiguration {
+        private final String stepName;
+
+        private MockStepPropertyConfiguration(final String stepName) {
+            this.stepName = stepName;
+        }
+
+        @Override
+        public String getStepName() {
+            return stepName;
+        }
+
+        @Override
+        public boolean renameProperty(final String propertyName, final String newName) {
+            final Map<String, ConnectorValueReference> properties = getStepMap(stepName);
+            if (properties == null || !properties.containsKey(propertyName)) {
+                return false;
+            }
+            if (Objects.equals(propertyName, newName)) {
+                return false;
+            }
+            final ConnectorValueReference existing = properties.remove(propertyName);
+            properties.put(newName, existing);
+            trackRenamed(stepName, propertyName, newName);
+            return true;
+        }
+
+        @Override
+        public boolean removeProperty(final String propertyName) {
+            final Map<String, ConnectorValueReference> properties = getStepMap(stepName);
+            if (properties == null || !properties.containsKey(propertyName)) {
+                return false;
+            }
+            properties.remove(propertyName);
+            trackRemoved(stepName, propertyName);
+            return true;
+        }
+
+        @Override
+        public boolean hasProperty(final String propertyName) {
+            final Map<String, ConnectorValueReference> properties = getStepMap(stepName);
+            return properties != null && properties.containsKey(propertyName);
+        }
+
+        @Override
+        public boolean isPropertySet(final String propertyName) {
+            final Map<String, ConnectorValueReference> properties = getStepMap(stepName);
+            if (properties == null) {
+                return false;
+            }
+            final ConnectorValueReference reference = properties.get(propertyName);
+            if (reference == null) {
+                return false;
+            }
+            if (reference instanceof StringLiteralValue literal) {
+                return literal.getValue() != null;
+            }
+            return true;
+        }
+
+        @Override
+        public void setProperty(final String propertyName, final String propertyValue) {
+            setValueReference(propertyName, new StringLiteralValue(propertyValue));
+        }
+
+        @Override
+        public void setValueReference(final String propertyName, final ConnectorValueReference valueReference) {
+            if (valueReference == null) {
+                removeProperty(propertyName);
+                return;
+            }
+            final ConnectorValueReference previous = getOrCreateStepMap(stepName).put(propertyName, valueReference);
+            if (Objects.equals(previous, valueReference)) {
+                return;
+            }
+            trackUpdated(stepName, propertyName);
+        }
+
+        @Override
+        public Optional<String> getPropertyValue(final String propertyName) {
+            final Map<String, ConnectorValueReference> properties = getStepMap(stepName);
+            if (properties == null) {
+                return Optional.empty();
+            }
+            final ConnectorValueReference reference = properties.get(propertyName);
+            if (reference instanceof StringLiteralValue literal) {
+                return Optional.ofNullable(literal.getValue());
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<ConnectorValueReference> getValueReference(final String propertyName) {
+            final Map<String, ConnectorValueReference> properties = getStepMap(stepName);
+            if (properties == null) {
+                return Optional.empty();
+            }
+            return Optional.ofNullable(properties.get(propertyName));
+        }
+
+        @Override
+        public Map<String, String> getProperties() {
+            final Map<String, ConnectorValueReference> properties = getStepMap(stepName);
+            if (properties == null || properties.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            final Map<String, String> literals = new HashMap<>();
+            for (final Map.Entry<String, ConnectorValueReference> entry : properties.entrySet()) {
+                if (entry.getValue() instanceof StringLiteralValue literal) {
+                    literals.put(entry.getKey(), literal.getValue());
+                }
+            }
+            return Collections.unmodifiableMap(literals);
+        }
+
+        @Override
+        public Map<String, ConnectorValueReference> getValueReferences() {
+            final Map<String, ConnectorValueReference> properties = getStepMap(stepName);
+            if (properties == null) {
+                return Collections.emptyMap();
+            }
+            return Collections.unmodifiableMap(new HashMap<>(properties));
+        }
+    }
+}

--- a/nifi-connector-mock-bundle/nifi-connector-mock/src/test/java/org/apache/nifi/mock/connector/migration/TestMockConnectorPropertyConfiguration.java
+++ b/nifi-connector-mock-bundle/nifi-connector-mock/src/test/java/org/apache/nifi/mock/connector/migration/TestMockConnectorPropertyConfiguration.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.mock.connector.migration;
+
+import org.apache.nifi.components.connector.ConnectorValueReference;
+import org.apache.nifi.components.connector.SecretReference;
+import org.apache.nifi.components.connector.StepConfiguration;
+import org.apache.nifi.components.connector.StringLiteralValue;
+import org.apache.nifi.migration.ConnectorStepPropertyConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestMockConnectorPropertyConfiguration {
+
+    private static final String STEP_ONE = "Step One";
+    private static final String STEP_TWO = "Step Two";
+
+    private static MockConnectorPropertyConfiguration newConfig() {
+        final Map<String, ConnectorValueReference> stepOne = new HashMap<>();
+        stepOne.put("literal", new StringLiteralValue("value"));
+        stepOne.put("secret", new SecretReference("provider-id", "Provider", "top-secret", "provider:top-secret"));
+
+        final Map<String, ConnectorValueReference> stepTwo = new HashMap<>();
+        stepTwo.put("other", new StringLiteralValue("value-two"));
+
+        final Map<String, StepConfiguration> initial = new HashMap<>();
+        initial.put(STEP_ONE, new StepConfiguration(stepOne));
+        initial.put(STEP_TWO, new StepConfiguration(stepTwo));
+
+        return MockConnectorPropertyConfiguration.fromValueReferences(initial);
+    }
+
+    @Test
+    public void testFromStringLiteralsWrapsInStringLiteralValue() {
+        final Map<String, MockConnectorPropertyConfiguration.StepLiteralProperties> initial =
+            Map.of(STEP_ONE, new MockConnectorPropertyConfiguration.StepLiteralProperties().add("greeting", "Hi"));
+
+        final MockConnectorPropertyConfiguration config = MockConnectorPropertyConfiguration.fromStringLiterals(initial);
+
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        assertTrue(stepOne.hasProperty("greeting"));
+        assertInstanceOf(StringLiteralValue.class, stepOne.getValueReference("greeting").orElseThrow());
+        assertEquals("Hi", stepOne.getPropertyValue("greeting").orElseThrow());
+    }
+
+    @Test
+    public void testRenamePropertyRecordsOnlyWhenMutated() {
+        final MockConnectorPropertyConfiguration config = newConfig();
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+
+        assertFalse(stepOne.renameProperty("missing", "renamed"), "Rename of missing property should return false");
+        assertFalse(stepOne.renameProperty("literal", "literal"), "Same-name rename should return false");
+
+        MockConnectorPropertyConfiguration.MigrationResult afterNoops = config.toMigrationResult();
+        assertTrue(afterNoops.propertiesRenamed().isEmpty(),
+                "No-op renames should not be recorded in propertiesRenamed()");
+
+        assertTrue(stepOne.renameProperty("literal", "renamed"), "Real rename should return true");
+
+        MockConnectorPropertyConfiguration.MigrationResult afterRealRename = config.toMigrationResult();
+        assertEquals(new MockConnectorPropertyConfiguration.StepPropertyRenames().add("literal", "renamed"),
+                afterRealRename.propertiesRenamed().get(STEP_ONE));
+    }
+
+    @Test
+    public void testRemovePropertyRecordsOnlyWhenMutated() {
+        final MockConnectorPropertyConfiguration config = newConfig();
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+
+        assertFalse(stepOne.removeProperty("missing"), "Remove of missing property should return false");
+
+        MockConnectorPropertyConfiguration.MigrationResult afterNoop = config.toMigrationResult();
+        assertTrue(afterNoop.propertiesRemoved().isEmpty(),
+                "No-op removes should not be recorded in propertiesRemoved()");
+
+        assertTrue(stepOne.removeProperty("literal"), "Real remove should return true");
+
+        MockConnectorPropertyConfiguration.MigrationResult afterRealRemove = config.toMigrationResult();
+        assertEquals(Set.of("literal"), afterRealRemove.propertiesRemoved().get(STEP_ONE));
+    }
+
+    @Test
+    public void testSetValueReferenceRecordsOnlyWhenValueChanges() {
+        final MockConnectorPropertyConfiguration config = newConfig();
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+
+        stepOne.setValueReference("literal", new StringLiteralValue("value"));
+
+        MockConnectorPropertyConfiguration.MigrationResult afterSameValue = config.toMigrationResult();
+        assertFalse(afterSameValue.propertiesUpdated().getOrDefault(STEP_ONE, Set.of()).contains("literal"),
+                "Same-value set should not be recorded in propertiesUpdated()");
+
+        stepOne.setValueReference("literal", new StringLiteralValue("different"));
+
+        MockConnectorPropertyConfiguration.MigrationResult afterChange = config.toMigrationResult();
+        assertEquals(Set.of("literal"), afterChange.propertiesUpdated().get(STEP_ONE));
+    }
+
+    @Test
+    public void testGetOrCreateStepMapAddsToAddedSteps() {
+        final MockConnectorPropertyConfiguration config = newConfig();
+
+        config.forStep(STEP_ONE).setProperty("literal", "value-updated");
+        assertFalse(config.toMigrationResult().addedSteps().contains(STEP_ONE),
+                "Writing to an initial step should not add it to addedSteps()");
+
+        config.forStep("Fresh Step").setProperty("prop", "value");
+        assertTrue(config.toMigrationResult().addedSteps().contains("Fresh Step"),
+                "Writing to a previously unknown step should add it to addedSteps()");
+    }
+
+    @Test
+    public void testRenameStepCarriesTrackingMaps() {
+        final MockConnectorPropertyConfiguration config = newConfig();
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+
+        stepOne.renameProperty("literal", "renamed-literal");
+        stepOne.removeProperty("secret");
+        stepOne.setProperty("added", "value");
+
+        assertTrue(config.renameStep(STEP_ONE, "Renamed Step"));
+
+        MockConnectorPropertyConfiguration.MigrationResult result = config.toMigrationResult();
+        assertEquals(new MockConnectorPropertyConfiguration.StepPropertyRenames().add("literal", "renamed-literal"),
+                result.propertiesRenamed().get("Renamed Step"),
+                "Renamed properties should follow the renamed step");
+        assertEquals(Set.of("secret"), result.propertiesRemoved().get("Renamed Step"),
+                "Removed properties should follow the renamed step");
+        assertEquals(Set.of("added"), result.propertiesUpdated().get("Renamed Step"),
+                "Updated properties should follow the renamed step");
+        assertFalse(result.propertiesRenamed().containsKey(STEP_ONE),
+                "Old step key should not remain in propertiesRenamed() after rename");
+        assertEquals(Map.of(STEP_ONE, "Renamed Step"), result.renamedSteps());
+    }
+
+    @Test
+    public void testRemoveStepClearsPerStepTracking() {
+        final MockConnectorPropertyConfiguration config = newConfig();
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+
+        stepOne.renameProperty("literal", "renamed-literal");
+        stepOne.removeProperty("secret");
+        stepOne.setProperty("added", "value");
+
+        assertTrue(config.removeStep(STEP_ONE));
+
+        MockConnectorPropertyConfiguration.MigrationResult result = config.toMigrationResult();
+        assertEquals(Set.of(STEP_ONE), result.removedSteps());
+        assertFalse(result.propertiesRenamed().containsKey(STEP_ONE),
+                "propertiesRenamed() should not contain a removed step");
+        assertFalse(result.propertiesRemoved().containsKey(STEP_ONE),
+                "propertiesRemoved() should not contain a removed step");
+        assertFalse(result.propertiesUpdated().containsKey(STEP_ONE),
+                "propertiesUpdated() should not contain a removed step");
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/migration/StandardConnectorPropertyConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/migration/StandardConnectorPropertyConfiguration.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.migration;
+
+import org.apache.nifi.components.connector.ConnectorValueReference;
+import org.apache.nifi.components.connector.StepConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Framework implementation of {@link ConnectorPropertyConfiguration}. Holds the per-step property map for a single
+ * {@link org.apache.nifi.components.connector.Connector Connector} configuration snapshot (active or working) and
+ * tracks whether any modification has been made so callers can conditionally persist the migrated state.
+ *
+ * <p>
+ *     Instances are not thread-safe; a Connector's {@code migrateProperties} invocation is expected to be
+ *     single-threaded.
+ * </p>
+ */
+public class StandardConnectorPropertyConfiguration implements ConnectorPropertyConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(StandardConnectorPropertyConfiguration.class);
+
+    private final Map<String, StepConfiguration> stepProperties;
+    private final Set<String> modifiedStepNames = new HashSet<>();
+    private final String componentDescription;
+    private boolean modified = false;
+
+    public StandardConnectorPropertyConfiguration(final Map<String, StepConfiguration> initialProperties, final String componentDescription) {
+        this.componentDescription = componentDescription;
+        // Preserve step insertion order because downstream framework code iterates the migrated step map to fire
+        // per-step configuration callbacks; property order within a step is not observed and uses HashMap.
+        this.stepProperties = new LinkedHashMap<>();
+        if (initialProperties != null) {
+            for (final Map.Entry<String, StepConfiguration> entry : initialProperties.entrySet()) {
+                final Map<String, ConnectorValueReference> copy = new HashMap<>();
+                final StepConfiguration stepConfig = entry.getValue();
+                if (stepConfig != null && stepConfig.getPropertyValues() != null) {
+                    copy.putAll(stepConfig.getPropertyValues());
+                }
+                stepProperties.put(entry.getKey(), new StepConfiguration(copy));
+            }
+        }
+    }
+
+    @Override
+    public Set<String> getStepNames() {
+        return Collections.unmodifiableSet(stepProperties.keySet());
+    }
+
+    @Override
+    public boolean hasStep(final String stepName) {
+        return stepProperties.containsKey(stepName);
+    }
+
+    @Override
+    public boolean renameStep(final String oldStepName, final String newStepName) {
+        if (!stepProperties.containsKey(oldStepName)) {
+            logger.debug("Will not rename step [{}] for [{}] because the step is not known", oldStepName, componentDescription);
+            return false;
+        }
+        if (Objects.equals(oldStepName, newStepName)) {
+            logger.debug("Will not rename step [{}] for [{}] because the new name matches the current name", oldStepName, componentDescription);
+            return false;
+        }
+        if (stepProperties.containsKey(newStepName)) {
+            throw new IllegalStateException("Cannot rename configuration step [" + oldStepName + "] to [" + newStepName
+                + "] for [" + componentDescription + "] because a step with the new name already exists");
+        }
+
+        final StepConfiguration existing = stepProperties.remove(oldStepName);
+        stepProperties.put(newStepName, existing);
+        markModified(oldStepName);
+        markModified(newStepName);
+        logger.info("Renamed configuration step [{}] to [{}] for [{}]", oldStepName, newStepName, componentDescription);
+        return true;
+    }
+
+    @Override
+    public boolean removeStep(final String stepName) {
+        if (!stepProperties.containsKey(stepName)) {
+            logger.debug("Will not remove step [{}] for [{}] because the step is not known", stepName, componentDescription);
+            return false;
+        }
+
+        stepProperties.remove(stepName);
+        markModified(stepName);
+        logger.info("Removed configuration step [{}] for [{}]", stepName, componentDescription);
+        return true;
+    }
+
+    @Override
+    public ConnectorStepPropertyConfiguration forStep(final String stepName) {
+        return new StandardConnectorStepPropertyConfiguration(stepName, this, componentDescription);
+    }
+
+    /**
+     * @return <code>true</code> if any step or property modification has been made through this configuration
+     */
+    public boolean isModified() {
+        return modified;
+    }
+
+    /**
+     * @return the names of steps that were mutated by this configuration (including steps that were removed)
+     */
+    public Set<String> getModifiedStepNames() {
+        return Collections.unmodifiableSet(modifiedStepNames);
+    }
+
+    /**
+     * @return the authoritative post-migration per-step configuration for this snapshot, keyed by step name
+     */
+    public Map<String, StepConfiguration> getMutatedProperties() {
+        final Map<String, StepConfiguration> snapshot = new LinkedHashMap<>();
+        for (final Map.Entry<String, StepConfiguration> entry : stepProperties.entrySet()) {
+            snapshot.put(entry.getKey(), new StepConfiguration(new HashMap<>(entry.getValue().getPropertyValues())));
+        }
+        return snapshot;
+    }
+
+    /**
+     * Returns the mutable per-step property map for the given step, or <code>null</code> if the step is not currently
+     * registered. Used by {@link StandardConnectorStepPropertyConfiguration} for read-only lookups.
+     */
+    Map<String, ConnectorValueReference> getStepMap(final String stepName) {
+        final StepConfiguration stepConfig = stepProperties.get(stepName);
+        return stepConfig == null ? null : stepConfig.getPropertyValues();
+    }
+
+    /**
+     * Returns the mutable per-step property map for the given step, allocating and registering a new empty map when
+     * the step is not currently registered. Used by {@link StandardConnectorStepPropertyConfiguration} for the first
+     * write into a lazily created step.
+     */
+    Map<String, ConnectorValueReference> getOrCreateStepMap(final String stepName) {
+        return stepProperties.computeIfAbsent(stepName, key -> {
+            logger.info("Registered new configuration step [{}] for [{}]", stepName, componentDescription);
+            return new StepConfiguration(new HashMap<>());
+        }).getPropertyValues();
+    }
+
+    /**
+     * Flags the configuration and the given step as modified. Invoked by
+     * {@link StandardConnectorStepPropertyConfiguration} on every mutating operation and by the top-level step
+     * operations on this class.
+     */
+    void markModified(final String stepName) {
+        modified = true;
+        modifiedStepNames.add(stepName);
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/migration/StandardConnectorStepPropertyConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/migration/StandardConnectorStepPropertyConfiguration.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.migration;
+
+import org.apache.nifi.components.connector.ConnectorValueReference;
+import org.apache.nifi.components.connector.StringLiteralValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Framework implementation of {@link ConnectorStepPropertyConfiguration}. Instances are created and managed by
+ * {@link StandardConnectorPropertyConfiguration}; they mutate the parent's per-step map on write and lazily register
+ * a new step in the parent's step map the first time a property is written into it.
+ */
+public class StandardConnectorStepPropertyConfiguration implements ConnectorStepPropertyConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(StandardConnectorStepPropertyConfiguration.class);
+
+    private final String stepName;
+    private final StandardConnectorPropertyConfiguration parent;
+    private final String componentDescription;
+
+    StandardConnectorStepPropertyConfiguration(final String stepName, final StandardConnectorPropertyConfiguration parent, final String componentDescription) {
+        this.stepName = stepName;
+        this.parent = parent;
+        this.componentDescription = componentDescription;
+    }
+
+    @Override
+    public String getStepName() {
+        return stepName;
+    }
+
+    @Override
+    public boolean renameProperty(final String propertyName, final String newName) {
+        final Map<String, ConnectorValueReference> properties = parent.getStepMap(stepName);
+        if (properties == null || !properties.containsKey(propertyName)) {
+            logger.debug("Will not rename property [{}] in step [{}] for [{}] because the property is not known", propertyName, stepName, componentDescription);
+            return false;
+        }
+
+        if (Objects.equals(propertyName, newName)) {
+            logger.debug("Will not rename property [{}] in step [{}] for [{}] because the new name matches the current name", propertyName, stepName, componentDescription);
+            return false;
+        }
+
+        final ConnectorValueReference existing = properties.remove(propertyName);
+        properties.put(newName, existing);
+        parent.markModified(stepName);
+        logger.info("Renamed property [{}] to [{}] in step [{}] for [{}]", propertyName, newName, stepName, componentDescription);
+        return true;
+    }
+
+    @Override
+    public boolean removeProperty(final String propertyName) {
+        final Map<String, ConnectorValueReference> properties = parent.getStepMap(stepName);
+        if (properties == null || !properties.containsKey(propertyName)) {
+            logger.debug("Will not remove property [{}] from step [{}] for [{}] because the property is not known", propertyName, stepName, componentDescription);
+            return false;
+        }
+
+        properties.remove(propertyName);
+        parent.markModified(stepName);
+        logger.info("Removed property [{}] from step [{}] for [{}]", propertyName, stepName, componentDescription);
+        return true;
+    }
+
+    @Override
+    public boolean hasProperty(final String propertyName) {
+        final Map<String, ConnectorValueReference> properties = parent.getStepMap(stepName);
+        return properties != null && properties.containsKey(propertyName);
+    }
+
+    @Override
+    public boolean isPropertySet(final String propertyName) {
+        final Map<String, ConnectorValueReference> properties = parent.getStepMap(stepName);
+        if (properties == null) {
+            return false;
+        }
+        final ConnectorValueReference reference = properties.get(propertyName);
+        if (reference == null) {
+            return false;
+        }
+        if (reference instanceof StringLiteralValue literal) {
+            return literal.getValue() != null;
+        }
+        return true;
+    }
+
+    @Override
+    public void setProperty(final String propertyName, final String propertyValue) {
+        setValueReference(propertyName, new StringLiteralValue(propertyValue));
+    }
+
+    @Override
+    public void setValueReference(final String propertyName, final ConnectorValueReference valueReference) {
+        if (valueReference == null) {
+            removeProperty(propertyName);
+            return;
+        }
+
+        final Map<String, ConnectorValueReference> properties = parent.getOrCreateStepMap(stepName);
+        final ConnectorValueReference previous = properties.put(propertyName, valueReference);
+        if (Objects.equals(previous, valueReference)) {
+            logger.debug("Will not update property [{}] in step [{}] for [{}] because the proposed value matches the current value", propertyName, stepName, componentDescription);
+            return;
+        }
+
+        parent.markModified(stepName);
+        if (previous == null) {
+            logger.info("Updated property [{}] in step [{}] for [{}], which was previously unset", propertyName, stepName, componentDescription);
+        } else {
+            logger.info("Updated property [{}] in step [{}] for [{}], overwriting previous value", propertyName, stepName, componentDescription);
+        }
+    }
+
+    @Override
+    public Optional<String> getPropertyValue(final String propertyName) {
+        final Map<String, ConnectorValueReference> properties = parent.getStepMap(stepName);
+        if (properties == null) {
+            return Optional.empty();
+        }
+        final ConnectorValueReference reference = properties.get(propertyName);
+        if (reference instanceof StringLiteralValue literal) {
+            return Optional.ofNullable(literal.getValue());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ConnectorValueReference> getValueReference(final String propertyName) {
+        final Map<String, ConnectorValueReference> properties = parent.getStepMap(stepName);
+        if (properties == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(properties.get(propertyName));
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        final Map<String, ConnectorValueReference> properties = parent.getStepMap(stepName);
+        if (properties == null || properties.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        final Map<String, String> literals = new HashMap<>();
+        for (final Map.Entry<String, ConnectorValueReference> entry : properties.entrySet()) {
+            if (entry.getValue() instanceof StringLiteralValue literal) {
+                literals.put(entry.getKey(), literal.getValue());
+            }
+        }
+        return Collections.unmodifiableMap(literals);
+    }
+
+    @Override
+    public Map<String, ConnectorValueReference> getValueReferences() {
+        final Map<String, ConnectorValueReference> properties = parent.getStepMap(stepName);
+        if (properties == null) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(properties);
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/migration/TestConnectorMigrateProperties.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/migration/TestConnectorMigrateProperties.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.migration;
+
+import org.apache.nifi.components.ConfigVerificationResult;
+import org.apache.nifi.components.connector.AbstractConnector;
+import org.apache.nifi.components.connector.ConfigurationStep;
+import org.apache.nifi.components.connector.ConnectorValueReference;
+import org.apache.nifi.components.connector.FlowUpdateException;
+import org.apache.nifi.components.connector.SecretReference;
+import org.apache.nifi.components.connector.StepConfiguration;
+import org.apache.nifi.components.connector.StringLiteralValue;
+import org.apache.nifi.components.connector.components.FlowContext;
+import org.apache.nifi.flow.VersionedExternalFlow;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises {@link org.apache.nifi.components.connector.Connector#migrateProperties(ConnectorPropertyConfiguration)}
+ * from real {@link AbstractConnector} subclasses. Each scenario is expressed as a tiny standalone connector whose only
+ * behaviour is a single {@code migrateProperties} override, driven against a live
+ * {@link StandardConnectorPropertyConfiguration}, so the tests double as canonical usage examples for connector
+ * authors.
+ */
+public class TestConnectorMigrateProperties {
+
+    private static final String STEP_A = "Step A";
+    private static final String LEGACY_STEP = "Legacy Step";
+    private static final String OBSOLETE_STEP = "Obsolete Step";
+    private static final String COMPONENT_DESCRIPTION = "Test Connector";
+
+    @Test
+    public void testAddProperty() {
+        final Map<String, StepConfiguration> initial = new HashMap<>();
+        final Map<String, ConnectorValueReference> stepMap = new HashMap<>();
+        stepMap.put("existing", new StringLiteralValue("keep"));
+        initial.put(STEP_A, new StepConfiguration(stepMap));
+
+        final StandardConnectorPropertyConfiguration config = new StandardConnectorPropertyConfiguration(initial, COMPONENT_DESCRIPTION);
+        new AddPropertyConnector().migrateProperties(config);
+
+        assertTrue(config.isModified());
+        final Map<String, ConnectorValueReference> migrated = config.forStep(STEP_A).getValueReferences();
+        assertTrue(migrated.containsKey("added"));
+        assertInstanceOf(StringLiteralValue.class, migrated.get("added"));
+        assertEquals("value", ((StringLiteralValue) migrated.get("added")).getValue());
+        assertTrue(migrated.containsKey("existing"));
+    }
+
+    @Test
+    public void testRemoveProperty() {
+        final Map<String, StepConfiguration> initial = new HashMap<>();
+        final Map<String, ConnectorValueReference> stepMap = new HashMap<>();
+        stepMap.put("legacy", new StringLiteralValue("unused"));
+        stepMap.put("keep", new StringLiteralValue("kept"));
+        initial.put(STEP_A, new StepConfiguration(stepMap));
+
+        final StandardConnectorPropertyConfiguration config = new StandardConnectorPropertyConfiguration(initial, COMPONENT_DESCRIPTION);
+        new RemovePropertyConnector().migrateProperties(config);
+
+        assertTrue(config.isModified());
+        assertFalse(config.forStep(STEP_A).hasProperty("legacy"));
+        assertTrue(config.forStep(STEP_A).hasProperty("keep"));
+    }
+
+    @Test
+    public void testRenamePropertyPreservesStringLiteral() {
+        final Map<String, StepConfiguration> initial = new HashMap<>();
+        final Map<String, ConnectorValueReference> stepMap = new HashMap<>();
+        stepMap.put("old", new StringLiteralValue("value"));
+        initial.put(STEP_A, new StepConfiguration(stepMap));
+
+        final StandardConnectorPropertyConfiguration config = new StandardConnectorPropertyConfiguration(initial, COMPONENT_DESCRIPTION);
+        new RenamePropertyStringConnector().migrateProperties(config);
+
+        assertTrue(config.isModified());
+        final Map<String, ConnectorValueReference> migrated = config.forStep(STEP_A).getValueReferences();
+        assertFalse(migrated.containsKey("old"));
+        assertInstanceOf(StringLiteralValue.class, migrated.get("new"));
+        assertEquals("value", ((StringLiteralValue) migrated.get("new")).getValue());
+    }
+
+    @Test
+    public void testRenamePropertyPreservesSecretReference() {
+        final SecretReference secret = new SecretReference("vault", "Vault", "credentials/path", "vault:credentials/path");
+        final Map<String, StepConfiguration> initial = new HashMap<>();
+        final Map<String, ConnectorValueReference> stepMap = new HashMap<>();
+        stepMap.put("old-secret", secret);
+        initial.put(STEP_A, new StepConfiguration(stepMap));
+
+        final StandardConnectorPropertyConfiguration config = new StandardConnectorPropertyConfiguration(initial, COMPONENT_DESCRIPTION);
+        new RenamePropertySecretConnector().migrateProperties(config);
+
+        assertTrue(config.isModified());
+        final ConnectorValueReference migrated = config.forStep(STEP_A).getValueReference("credentials").orElseThrow();
+        assertInstanceOf(SecretReference.class, migrated);
+        assertSame(secret, migrated);
+    }
+
+    @Test
+    public void testRenameStepCarriesAllPropertiesIntact() {
+        final SecretReference secret = new SecretReference("vault", "Vault", "credentials/path", "vault:credentials/path");
+        final Map<String, ConnectorValueReference> legacyProperties = new HashMap<>();
+        legacyProperties.put("string-prop", new StringLiteralValue("string-value"));
+        legacyProperties.put("secret-prop", secret);
+
+        final Map<String, StepConfiguration> initial = new HashMap<>();
+        initial.put(LEGACY_STEP, new StepConfiguration(legacyProperties));
+
+        final StandardConnectorPropertyConfiguration config = new StandardConnectorPropertyConfiguration(initial, COMPONENT_DESCRIPTION);
+        new RenameStepConnector().migrateProperties(config);
+
+        assertTrue(config.isModified());
+        assertFalse(config.hasStep(LEGACY_STEP));
+        assertTrue(config.hasStep(STEP_A));
+        final Map<String, ConnectorValueReference> migrated = config.forStep(STEP_A).getValueReferences();
+        assertEquals(legacyProperties, migrated);
+        assertSame(secret, migrated.get("secret-prop"));
+    }
+
+    @Test
+    public void testRemoveStepDropsAllProperties() {
+        final Map<String, StepConfiguration> initial = new HashMap<>();
+        final Map<String, ConnectorValueReference> obsolete = new HashMap<>();
+        obsolete.put("prop", new StringLiteralValue("value"));
+        initial.put(OBSOLETE_STEP, new StepConfiguration(obsolete));
+        final Map<String, ConnectorValueReference> survivor = new HashMap<>();
+        survivor.put("keep", new StringLiteralValue("kept"));
+        initial.put(STEP_A, new StepConfiguration(survivor));
+
+        final StandardConnectorPropertyConfiguration config = new StandardConnectorPropertyConfiguration(initial, COMPONENT_DESCRIPTION);
+        new RemoveStepConnector().migrateProperties(config);
+
+        assertTrue(config.isModified());
+        assertFalse(config.hasStep(OBSOLETE_STEP));
+        assertEquals(Set.of(STEP_A), config.getStepNames());
+    }
+
+    @Test
+    public void testCompositeMigrationAcrossAllScenarios() {
+        final SecretReference secret = new SecretReference("vault", "Vault", "credentials/path", "vault:credentials/path");
+        final Map<String, ConnectorValueReference> legacyProperties = new HashMap<>();
+        legacyProperties.put("old", new StringLiteralValue("string-value"));
+        legacyProperties.put("old-secret", secret);
+        legacyProperties.put("obsolete", new StringLiteralValue("drop-me"));
+
+        final Map<String, ConnectorValueReference> obsoleteStep = new HashMap<>();
+        obsoleteStep.put("prop", new StringLiteralValue("gone"));
+
+        final Map<String, StepConfiguration> initial = new HashMap<>();
+        initial.put(LEGACY_STEP, new StepConfiguration(legacyProperties));
+        initial.put(OBSOLETE_STEP, new StepConfiguration(obsoleteStep));
+
+        final StandardConnectorPropertyConfiguration config = new StandardConnectorPropertyConfiguration(initial, COMPONENT_DESCRIPTION);
+        new FullHistoryConnector().migrateProperties(config);
+
+        assertTrue(config.isModified());
+        assertFalse(config.hasStep(LEGACY_STEP));
+        assertFalse(config.hasStep(OBSOLETE_STEP));
+        assertEquals(Set.of(STEP_A), config.getStepNames());
+
+        final Map<String, ConnectorValueReference> migrated = config.forStep(STEP_A).getValueReferences();
+        assertEquals(Set.of("new", "credentials", "added"), migrated.keySet());
+        assertInstanceOf(StringLiteralValue.class, migrated.get("new"));
+        assertEquals("string-value", ((StringLiteralValue) migrated.get("new")).getValue());
+        assertSame(secret, migrated.get("credentials"));
+        assertInstanceOf(StringLiteralValue.class, migrated.get("added"));
+        assertEquals("value", ((StringLiteralValue) migrated.get("added")).getValue());
+    }
+
+    /**
+     * Base connector for migration scenarios. Provides no-op implementations of every abstract member of
+     * {@link org.apache.nifi.components.connector.Connector} and {@link AbstractConnector} other than
+     * {@code migrateProperties}, so scenario subclasses only need to express the migration itself.
+     */
+    private abstract static class MigrationScenarioConnector extends AbstractConnector {
+        @Override
+        public VersionedExternalFlow getInitialFlow() {
+            return null;
+        }
+
+        @Override
+        public VersionedExternalFlow getActiveFlow(final FlowContext activeFlowContext) {
+            return null;
+        }
+
+        @Override
+        public List<ConfigurationStep> getConfigurationSteps() {
+            return List.of();
+        }
+
+        @Override
+        public List<ConfigVerificationResult> verifyConfigurationStep(final String stepName, final Map<String, String> propertyValueOverrides, final FlowContext flowContext) {
+            return List.of();
+        }
+
+        @Override
+        public void applyUpdate(final FlowContext workingFlowContext, final FlowContext activeFlowContext) throws FlowUpdateException {
+        }
+
+        @Override
+        protected void onStepConfigured(final String stepName, final FlowContext workingContext) throws FlowUpdateException {
+        }
+    }
+
+    private static final class AddPropertyConnector extends MigrationScenarioConnector {
+        @Override
+        public void migrateProperties(final ConnectorPropertyConfiguration config) {
+            config.forStep(STEP_A).setProperty("added", "value");
+        }
+    }
+
+    private static final class RemovePropertyConnector extends MigrationScenarioConnector {
+        @Override
+        public void migrateProperties(final ConnectorPropertyConfiguration config) {
+            config.forStep(STEP_A).removeProperty("legacy");
+        }
+    }
+
+    private static final class RenamePropertyStringConnector extends MigrationScenarioConnector {
+        @Override
+        public void migrateProperties(final ConnectorPropertyConfiguration config) {
+            config.forStep(STEP_A).renameProperty("old", "new");
+        }
+    }
+
+    private static final class RenamePropertySecretConnector extends MigrationScenarioConnector {
+        @Override
+        public void migrateProperties(final ConnectorPropertyConfiguration config) {
+            config.forStep(STEP_A).renameProperty("old-secret", "credentials");
+        }
+    }
+
+    private static final class RenameStepConnector extends MigrationScenarioConnector {
+        @Override
+        public void migrateProperties(final ConnectorPropertyConfiguration config) {
+            config.renameStep(LEGACY_STEP, STEP_A);
+        }
+    }
+
+    private static final class RemoveStepConnector extends MigrationScenarioConnector {
+        @Override
+        public void migrateProperties(final ConnectorPropertyConfiguration config) {
+            config.removeStep(OBSOLETE_STEP);
+        }
+    }
+
+    private static final class FullHistoryConnector extends MigrationScenarioConnector {
+        @Override
+        public void migrateProperties(final ConnectorPropertyConfiguration config) {
+            config.renameStep(LEGACY_STEP, STEP_A);
+            final ConnectorStepPropertyConfiguration stepA = config.forStep(STEP_A);
+            stepA.renameProperty("old", "new");
+            stepA.renameProperty("old-secret", "credentials");
+            stepA.removeProperty("obsolete");
+            stepA.setProperty("added", "value");
+            config.removeStep(OBSOLETE_STEP);
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/migration/TestStandardConnectorPropertyConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/migration/TestStandardConnectorPropertyConfiguration.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.migration;
+
+import org.apache.nifi.components.connector.AssetReference;
+import org.apache.nifi.components.connector.ConnectorValueReference;
+import org.apache.nifi.components.connector.SecretReference;
+import org.apache.nifi.components.connector.StepConfiguration;
+import org.apache.nifi.components.connector.StringLiteralValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestStandardConnectorPropertyConfiguration {
+
+    private static final String STEP_ONE = "Step One";
+    private static final String STEP_TWO = "Step Two";
+
+    private StandardConnectorPropertyConfiguration config;
+
+    @BeforeEach
+    public void setup() {
+        final Map<String, StepConfiguration> initial = new HashMap<>();
+        final Map<String, ConnectorValueReference> stepOne = new HashMap<>();
+        stepOne.put("literal", new StringLiteralValue("value"));
+        stepOne.put("secret", new SecretReference("provider-id", "Provider", "top-secret", "provider:top-secret"));
+        stepOne.put("null-literal", StringLiteralValue.EMPTY);
+        initial.put(STEP_ONE, new StepConfiguration(stepOne));
+
+        final Map<String, ConnectorValueReference> stepTwo = new HashMap<>();
+        stepTwo.put("asset", new AssetReference(Set.of("asset-id-1")));
+        initial.put(STEP_TWO, new StepConfiguration(stepTwo));
+
+        config = new StandardConnectorPropertyConfiguration(initial, "Test Connector");
+    }
+
+    @Test
+    public void testInitialState() {
+        assertFalse(config.isModified());
+        assertEquals(Set.of(STEP_ONE, STEP_TWO), config.getStepNames());
+        assertTrue(config.hasStep(STEP_ONE));
+        assertFalse(config.hasStep("Missing Step"));
+        assertTrue(config.getModifiedStepNames().isEmpty());
+    }
+
+    @Test
+    public void testForStepReadOnlyLookups() {
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        assertEquals(STEP_ONE, stepOne.getStepName());
+        assertTrue(stepOne.hasProperty("literal"));
+        assertTrue(stepOne.isPropertySet("literal"));
+        assertTrue(stepOne.hasProperty("null-literal"));
+        assertFalse(stepOne.isPropertySet("null-literal"));
+        assertEquals(Optional.of("value"), stepOne.getPropertyValue("literal"));
+        assertEquals(Optional.empty(), stepOne.getPropertyValue("null-literal"));
+        assertEquals(Optional.empty(), stepOne.getPropertyValue("secret"));
+        assertInstanceOf(SecretReference.class, stepOne.getValueReference("secret").orElseThrow());
+
+        final Map<String, String> literalProperties = stepOne.getProperties();
+        assertEquals(2, literalProperties.size());
+        assertEquals("value", literalProperties.get("literal"));
+        assertTrue(literalProperties.containsKey("null-literal"));
+        assertNull(literalProperties.get("null-literal"));
+        assertEquals(3, stepOne.getValueReferences().size());
+    }
+
+    @Test
+    public void testAddProperty() {
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        stepOne.setProperty("added", "value");
+
+        assertTrue(config.isModified());
+        assertEquals(Set.of(STEP_ONE), config.getModifiedStepNames());
+        assertTrue(stepOne.hasProperty("added"));
+        assertEquals(Optional.of("value"), stepOne.getPropertyValue("added"));
+    }
+
+    @Test
+    public void testAddPropertyToNewStepLazyRegisters() {
+        assertFalse(config.hasStep("New Step"));
+        final ConnectorStepPropertyConfiguration newStep = config.forStep("New Step");
+
+        assertFalse(config.hasStep("New Step"));
+        assertFalse(config.isModified());
+
+        newStep.setProperty("prop", "value");
+
+        assertTrue(config.hasStep("New Step"));
+        assertTrue(config.isModified());
+        assertEquals(Optional.of("value"), config.forStep("New Step").getPropertyValue("prop"));
+    }
+
+    @Test
+    public void testForStepWithoutWriteDoesNotRegister() {
+        config.forStep("Unseen");
+        assertFalse(config.hasStep("Unseen"));
+        assertFalse(config.isModified());
+    }
+
+    @Test
+    public void testRemoveProperty() {
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        assertFalse(stepOne.removeProperty("missing"));
+        assertFalse(config.isModified());
+
+        assertTrue(stepOne.removeProperty("literal"));
+        assertTrue(config.isModified());
+        assertFalse(stepOne.hasProperty("literal"));
+    }
+
+    @Test
+    public void testRenamePropertyPreservesStringLiteral() {
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        assertTrue(stepOne.renameProperty("literal", "renamed"));
+
+        assertTrue(config.isModified());
+        assertFalse(stepOne.hasProperty("literal"));
+        assertEquals(Optional.of("value"), stepOne.getPropertyValue("renamed"));
+        assertInstanceOf(StringLiteralValue.class, stepOne.getValueReference("renamed").orElseThrow());
+    }
+
+    @Test
+    public void testRenamePropertyPreservesSecretReference() {
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        final ConnectorValueReference originalSecret = stepOne.getValueReference("secret").orElseThrow();
+
+        assertTrue(stepOne.renameProperty("secret", "renamed-secret"));
+
+        final ConnectorValueReference renamedSecret = stepOne.getValueReference("renamed-secret").orElseThrow();
+        assertInstanceOf(SecretReference.class, renamedSecret);
+        assertSame(originalSecret, renamedSecret);
+    }
+
+    @Test
+    public void testRenamePropertyPreservesAssetReference() {
+        final ConnectorStepPropertyConfiguration stepTwo = config.forStep(STEP_TWO);
+        final ConnectorValueReference originalAsset = stepTwo.getValueReference("asset").orElseThrow();
+
+        assertTrue(stepTwo.renameProperty("asset", "renamed-asset"));
+
+        final ConnectorValueReference renamedAsset = stepTwo.getValueReference("renamed-asset").orElseThrow();
+        assertInstanceOf(AssetReference.class, renamedAsset);
+        assertSame(originalAsset, renamedAsset);
+    }
+
+    @Test
+    public void testRenamePropertyToSameNameIsNoOp() {
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        assertFalse(stepOne.renameProperty("literal", "literal"));
+        assertFalse(config.isModified());
+    }
+
+    @Test
+    public void testRenameUnknownPropertyReturnsFalse() {
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        assertFalse(stepOne.renameProperty("missing", "renamed"));
+        assertFalse(config.isModified());
+    }
+
+    @Test
+    public void testSetValueReferenceForEachType() {
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        final SecretReference newSecret = new SecretReference("p", "P", "sec", "P:sec");
+        stepOne.setValueReference("added-secret", newSecret);
+        assertSame(newSecret, stepOne.getValueReference("added-secret").orElseThrow());
+
+        final AssetReference newAsset = new AssetReference(Set.of("id-2"));
+        stepOne.setValueReference("added-asset", newAsset);
+        assertSame(newAsset, stepOne.getValueReference("added-asset").orElseThrow());
+
+        final StringLiteralValue newLiteral = new StringLiteralValue("literal-value");
+        stepOne.setValueReference("added-literal", newLiteral);
+        assertEquals(Optional.of("literal-value"), stepOne.getPropertyValue("added-literal"));
+    }
+
+    @Test
+    public void testSetValueReferenceNullRemovesProperty() {
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        stepOne.setValueReference("literal", null);
+        assertFalse(stepOne.hasProperty("literal"));
+        assertTrue(config.isModified());
+    }
+
+    @Test
+    public void testRenameStepMovesAllProperties() {
+        final Map<String, ConnectorValueReference> originalSnapshot = new HashMap<>(config.forStep(STEP_ONE).getValueReferences());
+
+        assertTrue(config.renameStep(STEP_ONE, "Renamed"));
+
+        assertTrue(config.isModified());
+        assertFalse(config.hasStep(STEP_ONE));
+        assertTrue(config.hasStep("Renamed"));
+        final ConnectorStepPropertyConfiguration renamed = config.forStep("Renamed");
+        assertEquals(originalSnapshot, renamed.getValueReferences());
+        for (final Map.Entry<String, ConnectorValueReference> entry : originalSnapshot.entrySet()) {
+            assertSame(entry.getValue(), renamed.getValueReference(entry.getKey()).orElse(null));
+        }
+    }
+
+    @Test
+    public void testRenameStepToSameNameIsNoOp() {
+        assertFalse(config.renameStep(STEP_ONE, STEP_ONE));
+        assertFalse(config.isModified());
+    }
+
+    @Test
+    public void testRenameStepToExistingNameThrows() {
+        assertThrows(IllegalStateException.class, () -> config.renameStep(STEP_ONE, STEP_TWO));
+    }
+
+    @Test
+    public void testRenameUnknownStepReturnsFalse() {
+        assertFalse(config.renameStep("Missing", "Whatever"));
+        assertFalse(config.isModified());
+    }
+
+    @Test
+    public void testRemoveStep() {
+        assertFalse(config.removeStep("Missing"));
+        assertFalse(config.isModified());
+
+        assertTrue(config.removeStep(STEP_ONE));
+        assertTrue(config.isModified());
+        assertFalse(config.hasStep(STEP_ONE));
+        assertFalse(config.getStepNames().contains(STEP_ONE));
+    }
+
+    @Test
+    public void testGetPropertiesFiltersNonLiteralAndPreservesNulls() {
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        final Map<String, String> literals = stepOne.getProperties();
+        assertEquals(2, literals.size());
+        assertEquals("value", literals.get("literal"));
+        assertTrue(literals.containsKey("null-literal"));
+        assertNull(literals.get("null-literal"));
+        assertFalse(literals.containsKey("secret"));
+    }
+
+    @Test
+    public void testGetMutatedPropertiesReflectsFinalState() {
+        final ConnectorStepPropertyConfiguration stepOne = config.forStep(STEP_ONE);
+        stepOne.renameProperty("literal", "renamed");
+        stepOne.removeProperty("secret");
+        stepOne.setProperty("added", "new-value");
+        config.removeStep(STEP_TWO);
+        config.forStep("Fresh Step").setProperty("prop", "value");
+
+        final Map<String, StepConfiguration> mutated = config.getMutatedProperties();
+        assertEquals(Set.of(STEP_ONE, "Fresh Step"), mutated.keySet());
+
+        final Map<String, ConnectorValueReference> stepOneMap = mutated.get(STEP_ONE).getPropertyValues();
+        assertTrue(stepOneMap.containsKey("renamed"));
+        assertFalse(stepOneMap.containsKey("literal"));
+        assertFalse(stepOneMap.containsKey("secret"));
+        assertTrue(stepOneMap.containsKey("added"));
+        assertTrue(stepOneMap.containsKey("null-literal"));
+
+        assertEquals(1, mutated.get("Fresh Step").getPropertyValues().size());
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorNode.java
@@ -60,6 +60,7 @@ import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.groups.RemoteProcessGroup;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.logging.GroupedComponent;
+import org.apache.nifi.migration.StandardConnectorPropertyConfiguration;
 import org.apache.nifi.nar.ExtensionManager;
 import org.apache.nifi.nar.NarCloseable;
 import org.apache.nifi.util.StringUtils;
@@ -76,6 +77,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -378,41 +380,68 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
                 final Bundle flowContextBundle) throws FlowUpdateException {
 
         logger.debug("Inheriting configuration for {}", this);
-        final MutableConnectorConfigurationContext configurationContext = createConfigurationContext(activeConfig);
-        final FrameworkFlowContext inheritContext = flowContextFactory.createWorkingFlowContext(identifier,
-            connectorDetails.getComponentLog(), configurationContext, flowContextBundle);
 
-        // Apply the update for the active config
+        // Give the Connector a chance to evolve its persisted property/step names before we build the runtime
+        // configuration contexts. Active and working configs are migrated independently because they can diverge.
+        final Map<String, StepConfiguration> migratedActiveProperties = migrateProperties(activeConfig);
+        final Map<String, StepConfiguration> migratedWorkingProperties = migrateProperties(workingConfig);
+
+        final MutableConnectorConfigurationContext activeSeedContext = createConfigurationContext(migratedActiveProperties);
+        final FrameworkFlowContext inheritContext = flowContextFactory.createWorkingFlowContext(identifier, connectorDetails.getComponentLog(), activeSeedContext, flowContextBundle);
+
+        // Apply the active configuration. This restores activeFlowContext to migratedActiveProperties and internally
+        // rebuilds workingFlowContext aliased to activeFlowContext's configuration; we discard that alias below and
+        // construct an independent working context so active and working do not share configuration state when the
+        // two lists actually diverge.
         applyUpdate(inheritContext);
 
-        // Configure the working config but do not apply
-        for (final VersionedConfigurationStep step : workingConfig) {
-            final StepConfiguration stepConfig = createStepConfiguration(step);
-            setConfiguration(step.getName(), stepConfig, true);
+        // Tear down the working context that applyUpdate created aliased to active, and rebuild it around an
+        // independent configuration seeded from migratedWorkingProperties. Then fire onConfigurationStepConfigured
+        // for every step so renamed steps trigger the flow-builder callback under their new name and any
+        // value-derived flow state (resolved asset paths, secret values, etc.) is populated against the fresh
+        // working context.
+        destroyWorkingContext();
+        final MutableConnectorConfigurationContext workingConfigContext = createConfigurationContext(migratedWorkingProperties);
+        workingFlowContext = flowContextFactory.createWorkingFlowContext(identifier, connectorDetails.getComponentLog(), workingConfigContext, flowContextBundle);
+        getComponentLog().info("Working Flow Context has been rebuilt with independent configuration");
+        for (final String stepName : migratedWorkingProperties.keySet()) {
+            notifyStepConfigured(stepName);
         }
 
         logger.debug("Successfully inherited configuration for {}", this);
     }
 
-    private StepConfiguration createStepConfiguration(final VersionedConfigurationStep step) {
+    private Map<String, StepConfiguration> migrateProperties(final List<VersionedConfigurationStep> flowConfiguration) {
+        // Preserve persisted step order so the notifyStepConfigured loop in inheritConfiguration fires in a
+        // deterministic order matching the flow definition.
+        final Map<String, StepConfiguration> initial = new LinkedHashMap<>();
+        for (final VersionedConfigurationStep versionedConfigStep : flowConfiguration) {
+            initial.put(versionedConfigStep.getName(), new StepConfiguration(toValueReferenceMap(versionedConfigStep)));
+        }
+
+        final StandardConnectorPropertyConfiguration propertyConfiguration = new StandardConnectorPropertyConfiguration(initial, this.toString());
+        try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(extensionManager, getConnector().getClass(), getIdentifier())) {
+            getConnector().migrateProperties(propertyConfiguration);
+        }
+        return propertyConfiguration.getMutatedProperties();
+    }
+
+    private Map<String, ConnectorValueReference> toValueReferenceMap(final VersionedConfigurationStep step) {
         final Map<String, ConnectorValueReference> convertedProperties = new HashMap<>();
         if (step.getProperties() != null) {
             for (final Map.Entry<String, VersionedConnectorValueReference> entry : step.getProperties().entrySet()) {
-                final ConnectorValueReference valueReference = createValueReference(entry.getValue());
-                convertedProperties.put(entry.getKey(), valueReference);
+                convertedProperties.put(entry.getKey(), createValueReference(entry.getValue()));
             }
         }
-
-        return new StepConfiguration(convertedProperties);
+        return convertedProperties;
     }
 
-    private MutableConnectorConfigurationContext createConfigurationContext(final List<VersionedConfigurationStep> flowConfiguration) {
+    private MutableConnectorConfigurationContext createConfigurationContext(final Map<String, StepConfiguration> migratedConfiguration) {
         final StandardConnectorConfigurationContext configurationContext = new StandardConnectorConfigurationContext(
             initializationContext.getAssetManager(), initializationContext.getSecretsManager());
 
-        for (final VersionedConfigurationStep versionedConfigStep : flowConfiguration) {
-            final StepConfiguration stepConfig = createStepConfiguration(versionedConfigStep);
-            configurationContext.setProperties(versionedConfigStep.getName(), stepConfig);
+        for (final Map.Entry<String, StepConfiguration> entry : migratedConfiguration.entrySet()) {
+            configurationContext.setProperties(entry.getKey(), entry.getValue());
         }
 
         return configurationContext;
@@ -1153,10 +1182,10 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
      */
     @Override
     public boolean isModified() {
-        final Map<String, Map<String, String>> defaultValuesByStep = buildDefaultValuesByStep();
+        final Map<String, ConfigurationStep> stepsByName = indexConfigurationSteps();
 
-        if (configurationDiffersFromDefaults(activeFlowContext, defaultValuesByStep)
-            || configurationDiffersFromDefaults(workingFlowContext, defaultValuesByStep)) {
+        if (configurationDiffersFromDefaults(activeFlowContext, stepsByName)
+            || configurationDiffersFromDefaults(workingFlowContext, stepsByName)) {
             return true;
         }
 
@@ -1164,29 +1193,41 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
     }
 
     /**
-     * Builds a mapping of configuration step name to the declared default value of each property within that step, as
-     * defined by the Connector's {@link ConfigurationStep configuration steps}. A property with no default is
-     * represented by a {@code null} value so that an unset (or explicitly null) configured value compares equal to it.
+     * Indexes the Connector's declared {@link ConfigurationStep configuration steps} by name so that per-property
+     * default values can be resolved without pre-flattening every descriptor into an intermediate map.
      */
-    private Map<String, Map<String, String>> buildDefaultValuesByStep() {
-        final Map<String, Map<String, String>> defaultValuesByStep = new HashMap<>();
+    private Map<String, ConfigurationStep> indexConfigurationSteps() {
+        final Map<String, ConfigurationStep> stepsByName = new HashMap<>();
 
         final List<ConfigurationStep> configurationSteps = getConfigurationSteps();
         if (configurationSteps == null) {
-            return defaultValuesByStep;
+            return stepsByName;
         }
 
         for (final ConfigurationStep configurationStep : configurationSteps) {
-            final Map<String, String> propertyDefaults = new HashMap<>();
-            for (final ConnectorPropertyGroup propertyGroup : configurationStep.getPropertyGroups()) {
-                for (final ConnectorPropertyDescriptor descriptor : propertyGroup.getProperties()) {
-                    propertyDefaults.put(descriptor.getName(), descriptor.getDefaultValue());
-                }
-            }
-            defaultValuesByStep.put(configurationStep.getName(), propertyDefaults);
+            stepsByName.put(configurationStep.getName(), configurationStep);
         }
 
-        return defaultValuesByStep;
+        return stepsByName;
+    }
+
+    /**
+     * Returns the declared default value of the named property within the given configuration step, or {@code null}
+     * when the step is {@code null} or the property is not declared. A {@code null} return value matches an unset (or
+     * explicitly {@code null}) configured value under {@link Objects#equals(Object, Object)}.
+     */
+    private String defaultFor(final ConfigurationStep configurationStep, final String propertyName) {
+        if (configurationStep == null) {
+            return null;
+        }
+        for (final ConnectorPropertyGroup propertyGroup : configurationStep.getPropertyGroups()) {
+            for (final ConnectorPropertyDescriptor descriptor : propertyGroup.getProperties()) {
+                if (Objects.equals(descriptor.getName(), propertyName)) {
+                    return descriptor.getDefaultValue();
+                }
+            }
+        }
+        return null;
     }
 
     /**
@@ -1196,7 +1237,7 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
      * represent a default). A structurally-empty Secret or Asset reference is a placeholder for an unset property and is
      * not treated as a modification.
      */
-    private boolean configurationDiffersFromDefaults(final FrameworkFlowContext flowContext, final Map<String, Map<String, String>> defaultValuesByStep) {
+    private boolean configurationDiffersFromDefaults(final FrameworkFlowContext flowContext, final Map<String, ConfigurationStep> stepsByName) {
         if (flowContext == null) {
             return false;
         }
@@ -1208,7 +1249,7 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
 
         final ConnectorConfiguration configuration = configurationContext.toConnectorConfiguration();
         for (final NamedStepConfiguration namedStepConfiguration : configuration.getNamedStepConfigurations()) {
-            final Map<String, String> propertyDefaults = defaultValuesByStep.getOrDefault(namedStepConfiguration.stepName(), Map.of());
+            final ConfigurationStep configurationStep = stepsByName.get(namedStepConfiguration.stepName());
 
             for (final Map.Entry<String, ConnectorValueReference> propertyEntry : namedStepConfiguration.configuration().getPropertyValues().entrySet()) {
                 final String propertyName = propertyEntry.getKey();
@@ -1218,7 +1259,7 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
                 }
 
                 if (valueReference instanceof final StringLiteralValue stringLiteralValue) {
-                    if (!Objects.equals(stringLiteralValue.getValue(), propertyDefaults.get(propertyName))) {
+                    if (!Objects.equals(stringLiteralValue.getValue(), defaultFor(configurationStep, propertyName))) {
                         logger.debug("{} differs from its initial flow because property [{}] of configuration step [{}] is not set to its default value",
                             this, propertyName, namedStepConfiguration.stepName());
                         return true;

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorRepository.java
@@ -37,6 +37,7 @@ import org.apache.nifi.flow.VersionedExternalFlow;
 import org.apache.nifi.flow.VersionedProcessGroup;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.migration.ConnectorPropertyConfiguration;
 import org.apache.nifi.nar.ExtensionManager;
 import org.apache.nifi.util.MockComponentLog;
 import org.junit.jupiter.api.Test;
@@ -2171,6 +2172,188 @@ public class TestStandardConnectorRepository {
 
         public void reset() {
             onStepConfiguredCalls.clear();
+        }
+    }
+
+    @Test
+    public void testInheritConfigurationMigratesActiveAndWorkingIndependently() throws FlowUpdateException {
+        final MigratingConnector connector = new MigratingConnector();
+        connector.setMigration(config -> config.forStep("step1").renameProperty("legacy", "renamed"));
+        final StandardConnectorNode node = createRealConnectorNode("connector-1", connector);
+
+        final Bundle bundle = new Bundle();
+        bundle.setGroup("org.apache.nifi");
+        bundle.setArtifact("test-bundle");
+        bundle.setVersion("1.0.0");
+
+        final VersionedConfigurationStep activeStep = createVersionedStep("step1",
+                Map.of("legacy", createStringLiteralRef("active-value")));
+        final VersionedConfigurationStep workingStep = createVersionedStep("step1",
+                Map.of("legacy", createStringLiteralRef("working-value")));
+
+        node.transitionStateForUpdating();
+        node.prepareForUpdate();
+        node.inheritConfiguration(List.of(activeStep), List.of(workingStep), bundle);
+
+        assertNotSame(node.getActiveFlowContext().getConfigurationContext(),
+                node.getWorkingFlowContext().getConfigurationContext());
+        assertEquals("active-value",
+                node.getActiveFlowContext().getConfigurationContext().getProperty("step1", "renamed").getValue());
+        assertEquals("working-value",
+                node.getWorkingFlowContext().getConfigurationContext().getProperty("step1", "renamed").getValue());
+        assertFalse(node.getActiveFlowContext().getConfigurationContext().getPropertyNames("step1").contains("legacy"));
+        assertFalse(node.getWorkingFlowContext().getConfigurationContext().getPropertyNames("step1").contains("legacy"));
+    }
+
+    @Test
+    public void testInheritConfigurationInvokesMigratePropertiesWithEmptyStepLists() throws FlowUpdateException {
+        final MigratingConnector connector = new MigratingConnector();
+        connector.setMigration(config -> config.forStep("added-by-migration").setProperty("prop", "value"));
+        final StandardConnectorNode node = createRealConnectorNode("connector-1", connector);
+
+        final Bundle bundle = new Bundle();
+        bundle.setGroup("org.apache.nifi");
+        bundle.setArtifact("test-bundle");
+        bundle.setVersion("1.0.0");
+
+        node.transitionStateForUpdating();
+        node.prepareForUpdate();
+        node.inheritConfiguration(List.of(), List.of(), bundle);
+
+        assertNotSame(node.getActiveFlowContext().getConfigurationContext(),
+                node.getWorkingFlowContext().getConfigurationContext());
+        assertEquals("value",
+                node.getActiveFlowContext().getConfigurationContext().getProperty("added-by-migration", "prop").getValue());
+        assertEquals("value",
+                node.getWorkingFlowContext().getConfigurationContext().getProperty("added-by-migration", "prop").getValue());
+    }
+
+    @Test
+    public void testMigratePropertiesRenamePropertyPropagatesToLiveConfiguration() throws FlowUpdateException {
+        final MigratingConnector connector = new MigratingConnector();
+        connector.setMigration(config -> config.forStep("step1").renameProperty("legacy", "renamed"));
+        final StandardConnectorNode node = createRealConnectorNode("connector-1", connector);
+
+        final Bundle bundle = new Bundle();
+        bundle.setGroup("org.apache.nifi");
+        bundle.setArtifact("test-bundle");
+        bundle.setVersion("1.0.0");
+
+        final VersionedConfigurationStep step = createVersionedStep("step1", Map.of("legacy", createStringLiteralRef("kept-value")));
+        node.transitionStateForUpdating();
+        node.prepareForUpdate();
+        node.inheritConfiguration(List.of(step), List.of(step), bundle);
+
+        final Set<String> workingPropertyNames = node.getWorkingFlowContext().getConfigurationContext().getPropertyNames("step1");
+        assertTrue(workingPropertyNames.contains("renamed"));
+        assertFalse(workingPropertyNames.contains("legacy"));
+        assertEquals("kept-value", node.getWorkingFlowContext().getConfigurationContext().getProperty("step1", "renamed").getValue());
+
+        final Set<String> activePropertyNames = node.getActiveFlowContext().getConfigurationContext().getPropertyNames("step1");
+        assertTrue(activePropertyNames.contains("renamed"));
+        assertFalse(activePropertyNames.contains("legacy"));
+    }
+
+    @Test
+    public void testMigratePropertiesRemovePropertyPropagatesToLiveConfiguration() throws FlowUpdateException {
+        final MigratingConnector connector = new MigratingConnector();
+        connector.setMigration(config -> config.forStep("step1").removeProperty("obsolete"));
+        final StandardConnectorNode node = createRealConnectorNode("connector-1", connector);
+
+        final Bundle bundle = new Bundle();
+        bundle.setGroup("org.apache.nifi");
+        bundle.setArtifact("test-bundle");
+        bundle.setVersion("1.0.0");
+
+        final VersionedConfigurationStep step = createVersionedStep("step1",
+                Map.of("obsolete", createStringLiteralRef("gone"), "kept", createStringLiteralRef("value")));
+        node.transitionStateForUpdating();
+        node.prepareForUpdate();
+        node.inheritConfiguration(List.of(step), List.of(step), bundle);
+
+        final Set<String> propertyNames = node.getWorkingFlowContext().getConfigurationContext().getPropertyNames("step1");
+        assertFalse(propertyNames.contains("obsolete"));
+        assertTrue(propertyNames.contains("kept"));
+    }
+
+    @Test
+    public void testMigratePropertiesAddPropertyPropagatesToLiveConfiguration() throws FlowUpdateException {
+        final MigratingConnector connector = new MigratingConnector();
+        connector.setMigration(config -> config.forStep("step1").setProperty("added", "new-value"));
+        final StandardConnectorNode node = createRealConnectorNode("connector-1", connector);
+
+        final Bundle bundle = new Bundle();
+        bundle.setGroup("org.apache.nifi");
+        bundle.setArtifact("test-bundle");
+        bundle.setVersion("1.0.0");
+
+        final VersionedConfigurationStep step = createVersionedStep("step1", Map.of("original", createStringLiteralRef("v")));
+        node.transitionStateForUpdating();
+        node.prepareForUpdate();
+        node.inheritConfiguration(List.of(step), List.of(step), bundle);
+
+        final Set<String> propertyNames = node.getWorkingFlowContext().getConfigurationContext().getPropertyNames("step1");
+        assertTrue(propertyNames.contains("added"));
+        assertEquals("new-value", node.getWorkingFlowContext().getConfigurationContext().getProperty("step1", "added").getValue());
+    }
+
+    @Test
+    public void testMigratePropertiesRenameStepPreservesAllPropertiesAndFiresCallback() throws FlowUpdateException {
+        final MigratingConnector connector = new MigratingConnector();
+        connector.setMigration(config -> config.renameStep("old-step", "new-step"));
+        final StandardConnectorNode node = createRealConnectorNode("connector-1", connector);
+
+        final Bundle bundle = new Bundle();
+        bundle.setGroup("org.apache.nifi");
+        bundle.setArtifact("test-bundle");
+        bundle.setVersion("1.0.0");
+
+        final VersionedConfigurationStep step = createVersionedStep("old-step",
+                Map.of("a", createStringLiteralRef("A"), "b", createStringLiteralRef("B")));
+        node.transitionStateForUpdating();
+        node.prepareForUpdate();
+        node.inheritConfiguration(List.of(step), List.of(step), bundle);
+
+        assertTrue(node.getWorkingFlowContext().getConfigurationContext().getPropertyNames("old-step").isEmpty());
+        final Set<String> newStepProperties = node.getWorkingFlowContext().getConfigurationContext().getPropertyNames("new-step");
+        assertEquals(Set.of("a", "b"), newStepProperties);
+        assertEquals("A", node.getWorkingFlowContext().getConfigurationContext().getProperty("new-step", "a").getValue());
+        assertEquals("B", node.getWorkingFlowContext().getConfigurationContext().getProperty("new-step", "b").getValue());
+
+        assertTrue(connector.wasOnStepConfiguredCalled("new-step"));
+    }
+
+    @Test
+    public void testMigratePropertiesRemoveStepDropsAllProperties() throws FlowUpdateException {
+        final MigratingConnector connector = new MigratingConnector();
+        connector.setMigration(config -> config.removeStep("obsolete-step"));
+        final StandardConnectorNode node = createRealConnectorNode("connector-1", connector);
+
+        final Bundle bundle = new Bundle();
+        bundle.setGroup("org.apache.nifi");
+        bundle.setArtifact("test-bundle");
+        bundle.setVersion("1.0.0");
+
+        final VersionedConfigurationStep obsolete = createVersionedStep("obsolete-step", Map.of("a", createStringLiteralRef("A")));
+        final VersionedConfigurationStep survivor = createVersionedStep("survivor", Map.of("b", createStringLiteralRef("B")));
+        node.transitionStateForUpdating();
+        node.prepareForUpdate();
+        node.inheritConfiguration(List.of(obsolete, survivor), List.of(obsolete, survivor), bundle);
+
+        assertTrue(node.getWorkingFlowContext().getConfigurationContext().getPropertyNames("obsolete-step").isEmpty());
+        assertEquals(Set.of("b"), node.getWorkingFlowContext().getConfigurationContext().getPropertyNames("survivor"));
+    }
+
+    private static class MigratingConnector extends TrackingConnector {
+        private java.util.function.Consumer<ConnectorPropertyConfiguration> migration = config -> { };
+
+        public void setMigration(final java.util.function.Consumer<ConnectorPropertyConfiguration> migration) {
+            this.migration = migration;
+        }
+
+        @Override
+        public void migrateProperties(final ConnectorPropertyConfiguration config) {
+            migration.accept(config);
         }
     }
 }

--- a/nifi-system-tests/nifi-alternate-config-extensions-bundle/nifi-alternate-config-extensions/src/main/java/org/apache/nifi/connectors/tests/system/MigratePropertiesConnector.java
+++ b/nifi-system-tests/nifi-alternate-config-extensions-bundle/nifi-alternate-config-extensions/src/main/java/org/apache/nifi/connectors/tests/system/MigratePropertiesConnector.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.connectors.tests.system;
+
+import org.apache.nifi.components.ConfigVerificationResult;
+import org.apache.nifi.components.ConfigVerificationResult.Outcome;
+import org.apache.nifi.components.connector.AbstractConnector;
+import org.apache.nifi.components.connector.ConfigurationStep;
+import org.apache.nifi.components.connector.ConnectorPropertyDescriptor;
+import org.apache.nifi.components.connector.ConnectorPropertyGroup;
+import org.apache.nifi.components.connector.PropertyType;
+import org.apache.nifi.components.connector.components.FlowContext;
+import org.apache.nifi.flow.VersionedExternalFlow;
+import org.apache.nifi.flow.VersionedProcessGroup;
+import org.apache.nifi.migration.ConnectorPropertyConfiguration;
+import org.apache.nifi.migration.ConnectorStepPropertyConfiguration;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Post-migration counterpart to the fixture Connector of the same simple type name in the
+ * {@code nifi-system-test-extensions} bundle. The pre-migration fixture defines a single
+ * {@code "Legacy Step"} with legacy property names; this class defines the migrated {@code "Kafka Connection"} step and
+ * renames / removes / adds properties in {@link #migrateProperties(ConnectorPropertyConfiguration)} so that a NAR swap
+ * followed by NiFi restart exercises the full {@code Connector.migrateProperties} code path end-to-end.
+ */
+public class MigratePropertiesConnector extends AbstractConnector {
+
+    static final String LEGACY_STEP_NAME = "Legacy Step";
+    static final String MIGRATED_STEP_NAME = "Kafka Connection";
+
+    static final String LEGACY_BROKER_URL_NAME = "legacy-broker-url";
+    static final String LEGACY_CREDENTIALS_NAME = "legacy-credentials";
+    static final String LEGACY_OBSOLETE_NAME = "legacy-obsolete";
+
+    static final String BROKER_URL_NAME = "Broker URL";
+    static final String CREDENTIALS_NAME = "Credentials";
+    static final String CLIENT_ID_NAME = "Client Id";
+    static final String CLIENT_ID_MIGRATED_VALUE = "auto-migrated";
+
+    private static final ConnectorPropertyDescriptor BROKER_URL = new ConnectorPropertyDescriptor.Builder()
+        .name(BROKER_URL_NAME)
+        .description("Migrated string property.")
+        .required(false)
+        .type(PropertyType.STRING)
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .build();
+
+    private static final ConnectorPropertyDescriptor CREDENTIALS = new ConnectorPropertyDescriptor.Builder()
+        .name(CREDENTIALS_NAME)
+        .description("Migrated secret property.")
+        .required(false)
+        .type(PropertyType.SECRET)
+        .build();
+
+    private static final ConnectorPropertyDescriptor CLIENT_ID = new ConnectorPropertyDescriptor.Builder()
+        .name(CLIENT_ID_NAME)
+        .description("Added by migration when not already present.")
+        .required(false)
+        .type(PropertyType.STRING)
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .build();
+
+    private static final ConnectorPropertyGroup MIGRATED_PROPERTY_GROUP = new ConnectorPropertyGroup.Builder()
+        .name("Kafka Connection Properties")
+        .description("Migrated property group.")
+        .properties(List.of(BROKER_URL, CREDENTIALS, CLIENT_ID))
+        .build();
+
+    private static final ConfigurationStep MIGRATED_STEP = new ConfigurationStep.Builder()
+        .name(MIGRATED_STEP_NAME)
+        .propertyGroups(List.of(MIGRATED_PROPERTY_GROUP))
+        .build();
+
+    private final List<ConfigurationStep> configurationSteps = List.of(MIGRATED_STEP);
+
+    @Override
+    protected void onStepConfigured(final String stepName, final FlowContext workingContext) {
+    }
+
+    @Override
+    public VersionedExternalFlow getInitialFlow() {
+        final VersionedProcessGroup group = new VersionedProcessGroup();
+        group.setName("Migrate Properties Flow");
+
+        final VersionedExternalFlow flow = new VersionedExternalFlow();
+        flow.setFlowContents(group);
+        return flow;
+    }
+
+    @Override
+    public VersionedExternalFlow getActiveFlow(final FlowContext activeFlowContext) {
+        return getInitialFlow();
+    }
+
+    @Override
+    public List<ConfigVerificationResult> verifyConfigurationStep(final String stepName, final Map<String, String> propertyValueOverrides, final FlowContext flowContext) {
+        return List.of(new ConfigVerificationResult.Builder()
+            .outcome(Outcome.SUCCESSFUL)
+            .subject(stepName)
+            .verificationStepName("Migrate Properties Verification")
+            .explanation("Successful verification with properties: " + propertyValueOverrides)
+            .build());
+    }
+
+    @Override
+    public List<ConfigurationStep> getConfigurationSteps() {
+        return configurationSteps;
+    }
+
+    @Override
+    public void applyUpdate(final FlowContext workingFlowContext, final FlowContext activeFlowContext) {
+    }
+
+    @Override
+    public void migrateProperties(final ConnectorPropertyConfiguration config) {
+        config.renameStep(LEGACY_STEP_NAME, MIGRATED_STEP_NAME);
+        final ConnectorStepPropertyConfiguration step = config.forStep(MIGRATED_STEP_NAME);
+        step.renameProperty(LEGACY_BROKER_URL_NAME, BROKER_URL_NAME);
+        step.renameProperty(LEGACY_CREDENTIALS_NAME, CREDENTIALS_NAME);
+        step.removeProperty(LEGACY_OBSOLETE_NAME);
+        if (!step.hasProperty(CLIENT_ID_NAME)) {
+            step.setProperty(CLIENT_ID_NAME, CLIENT_ID_MIGRATED_VALUE);
+        }
+    }
+}

--- a/nifi-system-tests/nifi-alternate-config-extensions-bundle/nifi-alternate-config-extensions/src/main/java/org/apache/nifi/parameter/tests/system/PropertiesParameterProvider.java
+++ b/nifi-system-tests/nifi-alternate-config-extensions-bundle/nifi-alternate-config-extensions/src/main/java/org/apache/nifi/parameter/tests/system/PropertiesParameterProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.parameter.tests.system;
+
+import org.apache.nifi.annotation.behavior.DynamicProperty;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.parameter.AbstractParameterProvider;
+import org.apache.nifi.parameter.Parameter;
+import org.apache.nifi.parameter.ParameterGroup;
+import org.apache.nifi.parameter.ParameterProvider;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+/**
+ * Alternate-config-bundle copy of the pre-migration {@code PropertiesParameterProvider}. Preserving the same fully
+ * qualified class name here means that after the system-test NAR is swapped out for the alternate-config NAR, existing
+ * Parameter Provider instances (and any secret references pointing at their parameters) continue to resolve. Used by
+ * {@code ConnectorPropertyMigrationIT} so that a {@code SecretReference} carried through
+ * {@code Connector.migrateProperties} still resolves after the NAR swap.
+ */
+@DynamicProperty(name = "Parameter Group Name", value = "Parameters for the group",
+        expressionLanguageScope = ExpressionLanguageScope.NONE,
+        description = "Specifies parameters in a properties file format for the group")
+public class PropertiesParameterProvider extends AbstractParameterProvider implements ParameterProvider {
+
+    private static final PropertyDescriptor PARAMETERS = new PropertyDescriptor.Builder()
+            .name("parameters")
+            .displayName("Parameters")
+            .description("Specifies parameters in a properties file format")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .required(false)
+            .build();
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return Collections.singletonList(PARAMETERS);
+    }
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        return new PropertyDescriptor.Builder()
+                .name(propertyDescriptorName)
+                .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+                .dynamic(true)
+                .required(false)
+                .build();
+    }
+
+    @Override
+    public List<ParameterGroup> fetchParameters(final ConfigurationContext context) {
+        final List<ParameterGroup> groups = new ArrayList<>();
+
+        if (context.getProperty(PARAMETERS).isSet()) {
+            final List<Parameter> parameters = fetchParametersFromProperties(context.getProperty(PARAMETERS).getValue());
+            groups.add(new ParameterGroup("Parameters", parameters));
+        }
+
+        for (final Map.Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
+            if (entry.getKey().isDynamic()) {
+                final String groupName = entry.getKey().getName();
+                final List<Parameter> parameters = fetchParametersFromProperties(entry.getValue());
+                groups.add(new ParameterGroup(groupName, parameters));
+            }
+        }
+
+        return groups;
+    }
+
+    private List<Parameter> fetchParametersFromProperties(final String parametersPropertiesValue) {
+        final Properties parameters = new Properties();
+        try {
+            parameters.load(new ByteArrayInputStream(parametersPropertiesValue.getBytes(StandardCharsets.UTF_8)));
+        } catch (final IOException e) {
+            throw new RuntimeException("Could not parse parameters as properties: " + parametersPropertiesValue);
+        }
+        return parameters.entrySet().stream()
+                .map(entry -> new Parameter.Builder()
+                    .name(entry.getKey().toString())
+                    .value(entry.getValue().toString())
+                    .provided(true)
+                    .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/nifi-system-tests/nifi-alternate-config-extensions-bundle/nifi-alternate-config-extensions/src/main/resources/META-INF/services/org.apache.nifi.components.connector.Connector
+++ b/nifi-system-tests/nifi-alternate-config-extensions-bundle/nifi-alternate-config-extensions/src/main/resources/META-INF/services/org.apache.nifi.components.connector.Connector
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.nifi.connectors.tests.system.MigratePropertiesConnector

--- a/nifi-system-tests/nifi-alternate-config-extensions-bundle/nifi-alternate-config-extensions/src/main/resources/META-INF/services/org.apache.nifi.parameter.ParameterProvider
+++ b/nifi-system-tests/nifi-alternate-config-extensions-bundle/nifi-alternate-config-extensions/src/main/resources/META-INF/services/org.apache.nifi.parameter.ParameterProvider
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.nifi.parameter.tests.system.PropertiesParameterProvider

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/connectors/tests/system/MigratePropertiesConnector.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/connectors/tests/system/MigratePropertiesConnector.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.connectors.tests.system;
+
+import org.apache.nifi.components.ConfigVerificationResult;
+import org.apache.nifi.components.ConfigVerificationResult.Outcome;
+import org.apache.nifi.components.connector.AbstractConnector;
+import org.apache.nifi.components.connector.ConfigurationStep;
+import org.apache.nifi.components.connector.ConnectorPropertyDescriptor;
+import org.apache.nifi.components.connector.ConnectorPropertyGroup;
+import org.apache.nifi.components.connector.PropertyType;
+import org.apache.nifi.components.connector.components.FlowContext;
+import org.apache.nifi.flow.VersionedExternalFlow;
+import org.apache.nifi.flow.VersionedProcessGroup;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Pre-migration fixture for the Connector migrateProperties system test. Defines a single
+ * {@link ConfigurationStep} named {@code "Legacy Step"} with legacy property names. Paired with the post-migration
+ * counterpart of the same simple type name in the alternate-config extensions bundle, which renames the step and
+ * properties, removes the obsolete property, and adds a new property via {@code migrateProperties}.
+ */
+public class MigratePropertiesConnector extends AbstractConnector {
+
+    private static final ConnectorPropertyDescriptor LEGACY_BROKER_URL = new ConnectorPropertyDescriptor.Builder()
+        .name("legacy-broker-url")
+        .description("Legacy string property renamed by the post-migration connector.")
+        .required(false)
+        .type(PropertyType.STRING)
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .build();
+
+    private static final ConnectorPropertyDescriptor LEGACY_CREDENTIALS = new ConnectorPropertyDescriptor.Builder()
+        .name("legacy-credentials")
+        .description("Legacy secret property renamed by the post-migration connector.")
+        .required(false)
+        .type(PropertyType.SECRET)
+        .build();
+
+    private static final ConnectorPropertyDescriptor LEGACY_OBSOLETE = new ConnectorPropertyDescriptor.Builder()
+        .name("legacy-obsolete")
+        .description("Legacy property removed by the post-migration connector.")
+        .required(false)
+        .type(PropertyType.STRING)
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .build();
+
+    private static final ConnectorPropertyGroup LEGACY_PROPERTY_GROUP = new ConnectorPropertyGroup.Builder()
+        .name("Legacy Properties")
+        .description("Legacy properties migrated by the post-migration connector.")
+        .properties(List.of(LEGACY_BROKER_URL, LEGACY_CREDENTIALS, LEGACY_OBSOLETE))
+        .build();
+
+    private static final ConfigurationStep LEGACY_STEP = new ConfigurationStep.Builder()
+        .name("Legacy Step")
+        .propertyGroups(List.of(LEGACY_PROPERTY_GROUP))
+        .build();
+
+    private final List<ConfigurationStep> configurationSteps = List.of(LEGACY_STEP);
+
+    @Override
+    protected void onStepConfigured(final String stepName, final FlowContext workingContext) {
+    }
+
+    @Override
+    public VersionedExternalFlow getInitialFlow() {
+        final VersionedProcessGroup group = new VersionedProcessGroup();
+        group.setName("Migrate Properties Flow");
+
+        final VersionedExternalFlow flow = new VersionedExternalFlow();
+        flow.setFlowContents(group);
+        return flow;
+    }
+
+    @Override
+    public VersionedExternalFlow getActiveFlow(final FlowContext activeFlowContext) {
+        return getInitialFlow();
+    }
+
+    @Override
+    public List<ConfigVerificationResult> verifyConfigurationStep(final String stepName, final Map<String, String> propertyValueOverrides, final FlowContext flowContext) {
+        return List.of(new ConfigVerificationResult.Builder()
+            .outcome(Outcome.SUCCESSFUL)
+            .subject(stepName)
+            .verificationStepName("Migrate Properties Verification")
+            .explanation("Successful verification with properties: " + propertyValueOverrides)
+            .build());
+    }
+
+    @Override
+    public List<ConfigurationStep> getConfigurationSteps() {
+        return configurationSteps;
+    }
+
+    @Override
+    public void applyUpdate(final FlowContext workingFlowContext, final FlowContext activeFlowContext) {
+    }
+}

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.components.connector.Connector
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.components.connector.Connector
@@ -24,6 +24,7 @@ org.apache.nifi.connectors.tests.system.GatedDataQueuingConnector
 org.apache.nifi.connectors.tests.system.FailingConfigurationMigrationConnector
 org.apache.nifi.connectors.tests.system.FailingStateMigrationConnector
 org.apache.nifi.connectors.tests.system.MigrationTargetConnector
+org.apache.nifi.connectors.tests.system.MigratePropertiesConnector
 org.apache.nifi.connectors.tests.system.NestedProcessGroupConnector
 org.apache.nifi.connectors.tests.system.NonMigratingConnector
 org.apache.nifi.connectors.tests.system.NopConnector

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/AbstractNarSwapMigrationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/AbstractNarSwapMigrationIT.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.tests.system;
+
+import org.junit.jupiter.api.AfterEach;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Base class for system tests that exercise a component's migration path by swapping the
+ * {@code nifi-system-test-extensions} NARs for the {@code nifi-alternate-config-extensions} NAR between the
+ * pre-migration setup phase and the assertion phase. Subclasses call {@link #switchOutNars()} once NiFi has been
+ * stopped for the migration boundary, and this class restores the original layout via {@link #switchNarsBack()} in
+ * an {@link AfterEach} hook so subsequent tests see the default NAR set.
+ */
+public abstract class AbstractNarSwapMigrationIT extends NiFiSystemIT {
+
+    @Override
+    protected boolean isAllowFactoryReuse() {
+        return false;
+    }
+
+    @Override
+    protected boolean isDestroyEnvironmentAfterEachTest() {
+        return true;
+    }
+
+    @AfterEach
+    public void restoreNars() {
+        // Stop the NiFi instance, ensure that the nifi-system-test-extensions-nar and nifi-alternate-config-extensions bundles
+        // are where they need to be. Then, restart the instance so that everything is in the right state for the next test that
+        // will run
+        getNiFiInstance().stop();
+        switchNarsBack();
+        getNiFiInstance().start(true);
+    }
+
+    protected void switchOutNars() throws IOException {
+        final File instanceDir = getNiFiInstance().getInstanceDirectory();
+        final File lib = new File(instanceDir, "lib");
+        final File alternateConfig = new File(lib, "alternate-config");
+
+        // Move the nifi-system-test-extensions-nar out of the lib directory
+        moveNars(lib, "nifi-system-test-extensions-nar-.*", alternateConfig);
+
+        // Move the nifi-system-test-extensions-services-nar out of the lib directory
+        moveNars(lib, "nifi-system-test-extensions-services-nar-.*", alternateConfig);
+
+        // Move the nifi-system-test-extensions-services-api-nar out of the lib directory
+        moveNars(lib, "nifi-system-test-extensions-services-api-nar-.*", alternateConfig);
+
+        moveNars(alternateConfig, "nifi-alternate-config.*", lib);
+
+        final File workDir = new File(instanceDir, "work/nar/extensions");
+        deleteRecursively(workDir);
+    }
+
+    protected void switchNarsBack() {
+        final File instanceDir = getNiFiInstance().getInstanceDirectory();
+        final File lib = new File(instanceDir, "lib");
+        final File alternateConfig = new File(lib, "alternate-config");
+
+        // Move the nifi-system-test-extensions-nar back to the lib directory
+        moveNars(alternateConfig, "nifi-system-test-extensions-nar-.*", lib);
+
+        // Move the nifi-system-test-extensions-services-nar back to the lib directory
+        moveNars(alternateConfig, "nifi-system-test-extensions-services-nar-.*", lib);
+
+        // Move the nifi-system-test-extensions-services-api-nar back to the lib directory
+        moveNars(alternateConfig, "nifi-system-test-extensions-services-api-nar-.*", lib);
+
+        moveNars(lib, "nifi-alternate-config.*", alternateConfig);
+    }
+
+    private void deleteRecursively(final File file) throws IOException {
+        Files.walkFileTree(file.toPath(), new FileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(final Path visited, final BasicFileAttributes attrs) throws IOException {
+                Files.delete(visited);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(final Path visited, final IOException exc) {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private File findFile(final File dir, final String regex) {
+        final Pattern pattern = Pattern.compile(regex);
+        final File[] files = dir.listFiles(file -> pattern.matcher(file.getName()).find());
+        if (files == null || files.length != 1) {
+            return null;
+        }
+        return files[0];
+    }
+
+    private void moveNars(final File source, final String regex, final File target) {
+        final File libNar = findFile(source, regex);
+        assertNotNull(libNar);
+        final File libNarTarget = new File(target, libNar.getName());
+        assertTrue(libNar.renameTo(libNarTarget));
+    }
+}

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/connectors/ConnectorPropertyMigrationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/connectors/ConnectorPropertyMigrationIT.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.tests.system.connectors;
+
+import org.apache.nifi.tests.system.AbstractNarSwapMigrationIT;
+import org.apache.nifi.toolkit.client.NiFiClientException;
+import org.apache.nifi.web.api.dto.ConfigurationStepConfigurationDTO;
+import org.apache.nifi.web.api.dto.ConnectorConfigurationDTO;
+import org.apache.nifi.web.api.dto.ConnectorValueReferenceDTO;
+import org.apache.nifi.web.api.dto.PropertyGroupConfigurationDTO;
+import org.apache.nifi.web.api.entity.ConnectorEntity;
+import org.apache.nifi.web.api.entity.ParameterProviderEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end system test for {@code Connector.migrateProperties}. A pre-migration
+ * {@code MigratePropertiesConnector} fixture in {@code nifi-system-test-extensions-nar} is created and configured
+ * through the REST API using legacy step / property names. NiFi is then stopped, the system-test extensions NARs are
+ * swapped for {@code nifi-alternate-config-extensions-nar} (which contains a same-simple-typed-name fixture that
+ * implements {@code migrateProperties}), and NiFi is restarted. The framework's {@code StandardConnectorRepository}
+ * sync path invokes {@code StandardConnectorNode.inheritConfiguration}, which drives
+ * {@code Connector.migrateProperties}. The test asserts that the persisted active and working configurations both
+ * reflect the migrated step and property names / values.
+ */
+public class ConnectorPropertyMigrationIT extends AbstractNarSwapMigrationIT {
+
+    private static final String CONNECTOR_TYPE_SIMPLE_NAME = "MigratePropertiesConnector";
+
+    private static final String LEGACY_STEP_NAME = "Legacy Step";
+    private static final String LEGACY_BROKER_URL_NAME = "legacy-broker-url";
+    private static final String LEGACY_CREDENTIALS_NAME = "legacy-credentials";
+    private static final String LEGACY_OBSOLETE_NAME = "legacy-obsolete";
+
+    private static final String MIGRATED_STEP_NAME = "Kafka Connection";
+    private static final String BROKER_URL_NAME = "Broker URL";
+    private static final String CREDENTIALS_NAME = "Credentials";
+    private static final String CLIENT_ID_NAME = "Client Id";
+
+    private static final String BROKER_URL_VALUE = "kafka-broker:9092";
+    private static final String OBSOLETE_VALUE = "gone";
+    private static final String CLIENT_ID_MIGRATED_VALUE = "auto-migrated";
+
+    private static final String SECRET_NAME = "supersecret";
+    private static final String FULLY_QUALIFIED_SECRET_NAME = "PropertiesParameterProvider.Parameters.supersecret";
+    private static final String STRING_LITERAL_TYPE = "STRING_LITERAL";
+    private static final String SECRET_REFERENCE_TYPE = "SECRET_REFERENCE";
+
+    @Test
+    public void testConnectorPropertyMigration() throws NiFiClientException, IOException, InterruptedException {
+        // Stand up a Parameter Provider with a single secret so that the legacy secret property can be configured with
+        // a SECRET_REFERENCE that survives the migration.
+        final ParameterProviderEntity paramProvider = getClientUtil().createParameterProvider("PropertiesParameterProvider");
+        getClientUtil().updateParameterProviderProperties(paramProvider, Map.of("parameters", SECRET_NAME + "=" + SECRET_NAME));
+
+        // Create the pre-migration connector and configure the legacy step with a string literal, a secret reference,
+        // and an obsolete string literal that will be removed by migration.
+        final ConnectorEntity connector = getClientUtil().createConnector(CONNECTOR_TYPE_SIMPLE_NAME);
+        assertNotNull(connector);
+
+        final ConnectorValueReferenceDTO brokerUrlRef = createStringLiteralReference(BROKER_URL_VALUE);
+        final ConnectorValueReferenceDTO credentialsRef = getClientUtil().createSecretValueReference(paramProvider.getId(),
+            SECRET_NAME, FULLY_QUALIFIED_SECRET_NAME);
+        final ConnectorValueReferenceDTO obsoleteRef = createStringLiteralReference(OBSOLETE_VALUE);
+        final Map<String, ConnectorValueReferenceDTO> legacyProperties = Map.of(
+            LEGACY_BROKER_URL_NAME, brokerUrlRef,
+            LEGACY_CREDENTIALS_NAME, credentialsRef,
+            LEGACY_OBSOLETE_NAME, obsoleteRef
+        );
+        getClientUtil().configureConnectorWithReferences(connector.getId(), LEGACY_STEP_NAME, legacyProperties);
+        getClientUtil().applyConnectorUpdate(connector);
+
+        // Sanity check: pre-restart state still has the legacy schema before we swap NARs.
+        final ConnectorEntity beforeRestart = getNifiClient().getConnectorClient().getConnector(connector.getId());
+        final Map<String, ConnectorValueReferenceDTO> legacyActive = propertyValues(beforeRestart.getComponent().getActiveConfiguration(), LEGACY_STEP_NAME);
+        assertEquals(BROKER_URL_VALUE, legacyActive.get(LEGACY_BROKER_URL_NAME).getValue());
+        assertEquals(SECRET_REFERENCE_TYPE, legacyActive.get(LEGACY_CREDENTIALS_NAME).getValueType());
+        assertEquals(OBSOLETE_VALUE, legacyActive.get(LEGACY_OBSOLETE_NAME).getValue());
+
+        // Swap out the system-test-extensions NARs for the alternate-config NAR that defines the same simple-typed
+        // MigratePropertiesConnector with the migrated schema and a migrateProperties implementation.
+        getNiFiInstance().stop();
+        switchOutNars();
+        getNiFiInstance().start(true);
+
+        // On restart, StandardConnectorRepository.syncConnector -> StandardConnectorNode.inheritConfiguration invokes
+        // Connector.migrateProperties for both the active and working configurations. Assert that each context now
+        // reflects the renamed step, renamed / removed / added properties, and that typed value references survive.
+        final ConnectorEntity afterRestart = getNifiClient().getConnectorClient().getConnector(connector.getId());
+        assertMigratedConfiguration(afterRestart.getComponent().getActiveConfiguration(), "active");
+        assertMigratedConfiguration(afterRestart.getComponent().getWorkingConfiguration(), "working");
+
+        getClientUtil().waitForValidConnector(connector.getId());
+    }
+
+    private void assertMigratedConfiguration(final ConnectorConfigurationDTO config, final String label) {
+        final List<ConfigurationStepConfigurationDTO> steps = config.getConfigurationStepConfigurations();
+        assertNotNull(steps, label + " configuration is missing steps");
+        assertTrue(steps.stream().noneMatch(step -> LEGACY_STEP_NAME.equals(step.getConfigurationStepName())),
+            label + " configuration still contains legacy step");
+
+        final Map<String, ConnectorValueReferenceDTO> migrated = propertyValues(config, MIGRATED_STEP_NAME);
+
+        final ConnectorValueReferenceDTO brokerUrl = migrated.get(BROKER_URL_NAME);
+        assertNotNull(brokerUrl, label + " configuration is missing " + BROKER_URL_NAME);
+        assertEquals(STRING_LITERAL_TYPE, brokerUrl.getValueType());
+        assertEquals(BROKER_URL_VALUE, brokerUrl.getValue());
+
+        final ConnectorValueReferenceDTO credentials = migrated.get(CREDENTIALS_NAME);
+        assertNotNull(credentials, label + " configuration is missing " + CREDENTIALS_NAME);
+        assertEquals(SECRET_REFERENCE_TYPE, credentials.getValueType());
+        assertEquals(SECRET_NAME, credentials.getSecretName());
+
+        final ConnectorValueReferenceDTO clientId = migrated.get(CLIENT_ID_NAME);
+        assertNotNull(clientId, label + " configuration is missing " + CLIENT_ID_NAME);
+        assertEquals(STRING_LITERAL_TYPE, clientId.getValueType());
+        assertEquals(CLIENT_ID_MIGRATED_VALUE, clientId.getValue());
+
+        assertFalse(migrated.containsKey(LEGACY_OBSOLETE_NAME));
+        assertFalse(migrated.containsKey(LEGACY_BROKER_URL_NAME));
+        assertFalse(migrated.containsKey(LEGACY_CREDENTIALS_NAME));
+    }
+
+    private Map<String, ConnectorValueReferenceDTO> propertyValues(final ConnectorConfigurationDTO config, final String stepName) {
+        final ConfigurationStepConfigurationDTO step = config.getConfigurationStepConfigurations().stream()
+            .filter(s -> stepName.equals(s.getConfigurationStepName()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Configuration step not found: " + stepName));
+
+        final List<PropertyGroupConfigurationDTO> groups = step.getPropertyGroupConfigurations();
+        assertNotNull(groups, "No property groups on step " + stepName);
+        assertFalse(groups.isEmpty(), "No property groups on step " + stepName);
+        return groups.getFirst().getPropertyValues();
+    }
+
+    private ConnectorValueReferenceDTO createStringLiteralReference(final String value) {
+        final ConnectorValueReferenceDTO valueRef = new ConnectorValueReferenceDTO();
+        valueRef.setValueType(STRING_LITERAL_TYPE);
+        valueRef.setValue(value);
+        return valueRef;
+    }
+}

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/migration/PropertyMigrationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/migration/PropertyMigrationIT.java
@@ -18,7 +18,7 @@
 package org.apache.nifi.tests.system.migration;
 
 import org.apache.nifi.migration.StandardControllerServiceFactory;
-import org.apache.nifi.tests.system.NiFiSystemIT;
+import org.apache.nifi.tests.system.AbstractNarSwapMigrationIT;
 import org.apache.nifi.toolkit.client.ControllerServicesClient;
 import org.apache.nifi.toolkit.client.NiFiClientException;
 import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
@@ -27,51 +27,23 @@ import org.apache.nifi.web.api.entity.ControllerServiceEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupEntity;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
 import org.apache.nifi.web.api.entity.ReportingTaskEntity;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.FileVisitor;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class PropertyMigrationIT extends NiFiSystemIT {
+public class PropertyMigrationIT extends AbstractNarSwapMigrationIT {
     private static final String SERVICE = "Service";
-
-    @Override
-    protected boolean isAllowFactoryReuse() {
-        return false;
-    }
-
-    @Override
-    protected boolean isDestroyEnvironmentAfterEachTest() {
-        return true;
-    }
-
-    @AfterEach
-    public void restoreNars() {
-        // Stop the NiFi instance, ensure that the nifi-system-test-extensions-nar and nifi-alternate-config-extensions bundles
-        // are where they need to be. Then, restart the instance so that everything is in the right state for the next test that
-        // will run
-        getNiFiInstance().stop();
-        switchNarsBack();
-        getNiFiInstance().start(true);
-    }
 
     @Test
     public void testControllerServiceCreated() throws NiFiClientException, IOException {
@@ -237,85 +209,5 @@ public class PropertyMigrationIT extends NiFiSystemIT {
         final ReportingTaskEntity updatedReportingTask = getNifiClient().getReportingTasksClient().getReportingTask(reportingTask.getId());
         final Map<String, String> expectedReportingTaskProperties = Map.of("Initial Value", "15", "Invalid Property", "Invalid");
         assertEquals(expectedReportingTaskProperties, updatedReportingTask.getComponent().getProperties());
-    }
-
-    private void switchOutNars() throws IOException {
-        final File instanceDir = getNiFiInstance().getInstanceDirectory();
-        final File lib = new File(instanceDir, "lib");
-        final File alternateConfig = new File(lib, "alternate-config");
-
-        // Move the nifi-system-test-extensions-nar out of the lib directory
-        moveNars(lib, "nifi-system-test-extensions-nar-.*", alternateConfig);
-
-        // Move the nifi-system-test-extensions-services-nar out of the lib directory
-        moveNars(lib, "nifi-system-test-extensions-services-nar-.*", alternateConfig);
-
-        // Move the nifi-system-test-extensions-services-api-nar out of the lib directory
-        moveNars(lib, "nifi-system-test-extensions-services-api-nar-.*", alternateConfig);
-
-        moveNars(alternateConfig, "nifi-alternate-config.*", lib);
-
-        final File workDir = new File(instanceDir, "work/nar/extensions");
-        deleteRecursively(workDir);
-    }
-
-    private void deleteRecursively(final File file) throws IOException {
-        Files.walkFileTree(file.toPath(), new FileVisitor<>() {
-            @Override
-            public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) {
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFileFailed(final Path file, final IOException exc) {
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
-                Files.delete(dir);
-                return FileVisitResult.CONTINUE;
-            }
-        });
-
-    }
-
-    private void switchNarsBack() {
-        final File instanceDir = getNiFiInstance().getInstanceDirectory();
-        final File lib = new File(instanceDir, "lib");
-        final File alternateConfig = new File(lib, "alternate-config");
-
-        // Move the nifi-system-test-extensions-nar back to the lib directory
-        moveNars(alternateConfig, "nifi-system-test-extensions-nar-.*", lib);
-
-        // Move the nifi-system-test-extensions-services-nar back to the lib directory
-        moveNars(alternateConfig, "nifi-system-test-extensions-services-nar-.*", lib);
-
-        // Move the nifi-system-test-extensions-services-api-nar back to the lib directory
-        moveNars(alternateConfig, "nifi-system-test-extensions-services-api-nar-.*", lib);
-
-        moveNars(lib, "nifi-alternate-config.*", alternateConfig);
-    }
-
-    private File findFile(final File dir, final String regex) {
-        final Pattern pattern = Pattern.compile(regex);
-        final File[] files = dir.listFiles(file -> pattern.matcher(file.getName()).find());
-        if (files == null || files.length != 1) {
-            return null;
-        }
-        return files[0];
-    }
-
-    private void moveNars(File source, String regex, File target) {
-        final File libNar = findFile(source, regex);
-        assertNotNull(libNar);
-        final File libNarTarget = new File(target, libNar.getName());
-        assertTrue(libNar.renameTo(libNarTarget));
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16081](https://issues.apache.org/jira/browse/NIFI-16081)

Implement Migrate Connector Properties API
SEE [NIP-34](https://issues.apache.org/jira/projects/NIP/issues/NIP-34)

* Support for migrateProperties method in Connector
* Tests supporting Step and Connector Property updates

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
