### PR TITLE
NIFI-16082 - Connection update is incorrectly rejected when the current destination is running

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/connectable/StandardConnection.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/connectable/StandardConnection.java
@@ -292,6 +292,27 @@ public final class StandardConnection implements Connection {
             return;
         }
 
+        verifyCanUpdateDestination();
+
+        if (newDestination instanceof Funnel && newDestination.equals(source)) {
+            throw new IllegalStateException("Funnels do not support self-looping connections.");
+        }
+
+        try {
+            previousDestination.removeConnection(this);
+            this.destination.set(newDestination);
+            getSource().updateConnection(this);
+            newDestination.addConnection(this);
+        } catch (final RuntimeException e) {
+            this.destination.set(previousDestination);
+            throw e;
+        }
+    }
+
+    @Override
+    public void verifyCanUpdateDestination() {
+        final Connectable previousDestination = destination.get();
+
         // Allow destination changes when the current destination is a Funnel, a LocalPort, or a
         // RemoteGroupPort. Funnels and LocalPorts cannot be stopped/started so they are exempt.
         // RemoteGroupPort represents an S2S ingress point: re-routing its incoming connections
@@ -309,20 +330,6 @@ public final class StandardConnection implements Connection {
 
         if (getFlowFileQueue().isUnacknowledgedFlowFile()) {
             throw new IllegalStateException("Cannot change destination of Connection because FlowFiles from this Connection are currently held by " + previousDestination);
-        }
-
-        if (newDestination instanceof Funnel && newDestination.equals(source)) {
-            throw new IllegalStateException("Funnels do not support self-looping connections.");
-        }
-
-        try {
-            previousDestination.removeConnection(this);
-            this.destination.set(newDestination);
-            getSource().updateConnection(this);
-            newDestination.addConnection(this);
-        } catch (final RuntimeException e) {
-            this.destination.set(previousDestination);
-            throw e;
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/connectable/StandardConnection.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/connectable/StandardConnection.java
@@ -309,6 +309,10 @@ public final class StandardConnection implements Connection {
         }
     }
 
+    /**
+     * @throws IllegalStateException if the current destination is running and is not exempt, or FlowFiles from this
+     * Connection are currently held by the destination
+     */
     @Override
     public void verifyCanUpdateDestination() {
         final Connectable previousDestination = destination.get();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/connectable/StandardConnectionTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/connectable/StandardConnectionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.connectable;
+
+import org.apache.nifi.controller.ProcessScheduler;
+import org.apache.nifi.controller.queue.FlowFileQueue;
+import org.apache.nifi.controller.queue.FlowFileQueueFactory;
+import org.apache.nifi.groups.ProcessGroup;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.remote.RemoteGroupPort;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class StandardConnectionTest {
+
+    private FlowFileQueue queue;
+
+    private StandardConnection connectionWithDestination(final Connectable source, final Connectable destination) {
+        queue = mock(FlowFileQueue.class);
+        final FlowFileQueueFactory queueFactory = mock(FlowFileQueueFactory.class);
+        when(queueFactory.createFlowFileQueue(any(), any(), any())).thenReturn(queue);
+
+        return new StandardConnection.Builder(mock(ProcessScheduler.class))
+                .id("connection-1")
+                .source(source)
+                .destination(destination)
+                .processGroup(mock(ProcessGroup.class))
+                .flowFileQueueFactory(queueFactory)
+                .relationships(List.of(Relationship.ANONYMOUS))
+                .build();
+    }
+
+    private StandardConnection connectionWithDestination(final Connectable destination) {
+        return connectionWithDestination(mock(Connectable.class), destination);
+    }
+
+    @Test
+    void testVerifyCanUpdateDestinationThrowsWhenCurrentDestinationRunning() {
+        final Connectable runningProcessor = mock(Connectable.class);
+        when(runningProcessor.isRunning()).thenReturn(true);
+        final StandardConnection connection = connectionWithDestination(runningProcessor);
+
+        assertThrows(IllegalStateException.class, connection::verifyCanUpdateDestination);
+    }
+
+    @Test
+    void testVerifyCanUpdateDestinationAllowsRunningFunnel() {
+        final Funnel runningFunnel = mock(Funnel.class);
+        when(runningFunnel.isRunning()).thenReturn(true);
+        final StandardConnection connection = connectionWithDestination(runningFunnel);
+
+        assertDoesNotThrow(connection::verifyCanUpdateDestination);
+    }
+
+    @Test
+    void testVerifyCanUpdateDestinationAllowsRunningLocalPort() {
+        final LocalPort runningLocalPort = mock(LocalPort.class);
+        when(runningLocalPort.isRunning()).thenReturn(true);
+        final StandardConnection connection = connectionWithDestination(runningLocalPort);
+
+        assertDoesNotThrow(connection::verifyCanUpdateDestination);
+    }
+
+    @Test
+    void testVerifyCanUpdateDestinationAllowsRunningRemoteGroupPort() {
+        final RemoteGroupPort runningRemotePort = mock(RemoteGroupPort.class);
+        when(runningRemotePort.isRunning()).thenReturn(true);
+        final StandardConnection connection = connectionWithDestination(runningRemotePort);
+
+        assertDoesNotThrow(connection::verifyCanUpdateDestination);
+    }
+
+    @Test
+    void testVerifyCanUpdateDestinationThrowsWhenFlowFilesHeld() {
+        final Funnel stoppedFunnel = mock(Funnel.class);
+        final StandardConnection connection = connectionWithDestination(stoppedFunnel);
+        when(queue.isUnacknowledgedFlowFile()).thenReturn(true);
+
+        assertThrows(IllegalStateException.class, connection::verifyCanUpdateDestination);
+    }
+
+    @Test
+    void testVerifyCanUpdateDestinationAllowsStoppedDestinationWithNoUnacknowledgedFlowFiles() {
+        final Connectable stoppedProcessor = mock(Connectable.class);
+        final StandardConnection connection = connectionWithDestination(stoppedProcessor);
+        when(queue.isUnacknowledgedFlowFile()).thenReturn(false);
+
+        assertDoesNotThrow(connection::verifyCanUpdateDestination);
+    }
+
+    @Test
+    void testSetDestinationNoOpWhenDestinationUnchanged() {
+        final Connectable runningProcessor = mock(Connectable.class);
+        when(runningProcessor.isRunning()).thenReturn(true);
+        final StandardConnection connection = connectionWithDestination(runningProcessor);
+
+        assertDoesNotThrow(() -> connection.setDestination(runningProcessor));
+    }
+
+    @Test
+    void testSetDestinationRejectsSelfLoopingFunnel() {
+        final Funnel funnel = mock(Funnel.class);
+        final Connectable currentDestination = mock(Connectable.class);
+        final StandardConnection connection = connectionWithDestination(funnel, currentDestination);
+
+        assertThrows(IllegalStateException.class, () -> connection.setDestination(funnel));
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/connectable/Connection.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/connectable/Connection.java
@@ -68,6 +68,16 @@ public interface Connection extends Authorizable, VersionedComponent {
 
     void setDestination(final Connectable newDestination);
 
+    /**
+     * Verifies that this Connection's destination may be changed, based solely on the current (existing) destination
+     * and the FlowFiles the Connection is holding. This applies the same guards as {@link #setDestination(Connectable)}
+     * so that a pre-check (e.g. the two-phase cluster verify) rejects exactly what the subsequent mutation would reject.
+     *
+     * @throws IllegalStateException if the current destination is running and is not exempt, or FlowFiles from this
+     * Connection are currently held by the destination
+     */
+    void verifyCanUpdateDestination() throws IllegalStateException;
+
     void setProcessGroup(ProcessGroup processGroup);
 
     ProcessGroup getProcessGroup();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/connectable/Connection.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/connectable/Connection.java
@@ -70,13 +70,9 @@ public interface Connection extends Authorizable, VersionedComponent {
 
     /**
      * Verifies that this Connection's destination may be changed, based solely on the current (existing) destination
-     * and the FlowFiles the Connection is holding. This applies the same guards as {@link #setDestination(Connectable)}
-     * so that a pre-check (e.g. the two-phase cluster verify) rejects exactly what the subsequent mutation would reject.
-     *
-     * @throws IllegalStateException if the current destination is running and is not exempt, or FlowFiles from this
-     * Connection are currently held by the destination
+     * and the FlowFiles the Connection is holding.
      */
-    void verifyCanUpdateDestination() throws IllegalStateException;
+    void verifyCanUpdateDestination();
 
     void setProcessGroup(ProcessGroup processGroup);
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardConnectionDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardConnectionDAO.java
@@ -519,17 +519,47 @@ public class StandardConnectionDAO extends ComponentDAO implements ConnectionDAO
                 throw new ValidationException(validationErrors);
             }
 
-            // If destination is changing, ensure that current destination is not running. This check is done here, rather than
-            // in the Connection object itself because the Connection object itself does not know which updates are to occur and
-            // we don't want to prevent updating things like the connection name or backpressure just because the destination is running
-            final Connectable destination = connection.getDestination();
-            if (destination != null && destination.isRunning() && destination.getConnectableType() != ConnectableType.FUNNEL && destination.getConnectableType() != ConnectableType.INPUT_PORT) {
-                throw new ValidationException(Collections.singletonList("Cannot change the destination of connection because the current destination is running"));
+            // If the destination is changing, ensure the current destination is in a state that allows it to be changed.
+            // The check lives on the Connection (shared with setDestination) so the verify phase rejects exactly what the
+            // subsequent mutation would reject. It is applied only for an actual destination change so that other updates
+            // (name, backpressure, etc.) are not blocked merely because the current destination is running.
+            if (isDestinationChanging(connection, connectionDTO.getDestination())) {
+                try {
+                    connection.verifyCanUpdateDestination();
+                } catch (final IllegalStateException e) {
+                    throw new ValidationException(Collections.singletonList(e.getMessage()));
+                }
             }
 
             // verify that this connection supports modification
             connection.verifyCanUpdate();
         }
+    }
+
+    /**
+     * Determines whether the proposed destination represents an actual change from the Connection's current destination.
+     * Mirrors the change-detection used by {@link #updateConnection(ConnectionDTO)} so the verify and commit phases agree
+     * on what constitutes a destination change — including a remote input port re-pointed to a different remote process group.
+     */
+    boolean isDestinationChanging(final Connection connection, final ConnectableDTO proposedDestination) {
+        if (proposedDestination == null) {
+            return false;
+        }
+
+        final Connectable currentDestination = connection.getDestination();
+        if (!proposedDestination.getId().equals(currentDestination.getIdentifier())) {
+            return true;
+        }
+
+        // Same destination id: for a remote input port, a different remote process group id is also a change.
+        if (ConnectableType.REMOTE_INPUT_PORT.name().equals(proposedDestination.getType())
+                && currentDestination.getConnectableType() == ConnectableType.REMOTE_INPUT_PORT) {
+            final RemoteGroupPort remotePort = (RemoteGroupPort) currentDestination;
+            return proposedDestination.getGroupId() != null
+                    && !proposedDestination.getGroupId().equals(remotePort.getRemoteProcessGroup().getIdentifier());
+        }
+
+        return false;
     }
 
     @Override
@@ -571,8 +601,6 @@ public class StandardConnectionDAO extends ComponentDAO implements ConnectionDAO
         // determine if the destination changed
         final ConnectableDTO proposedDestination = connectionDTO.getDestination();
         if (proposedDestination != null) {
-            final Connectable currentDestination = connection.getDestination();
-
             // handle remote input port differently
             if (ConnectableType.REMOTE_INPUT_PORT.name().equals(proposedDestination.getType())) {
                 // the group id must be specified
@@ -580,17 +608,8 @@ public class StandardConnectionDAO extends ComponentDAO implements ConnectionDAO
                     throw new IllegalArgumentException("When the destination is a remote input port its group id is required.");
                 }
 
-                // if the current destination is a remote input port
-                boolean isDifferentRemoteProcessGroup = false;
-                if (currentDestination.getConnectableType() == ConnectableType.REMOTE_INPUT_PORT) {
-                    RemoteGroupPort remotePort = (RemoteGroupPort) currentDestination;
-                    if (!proposedDestination.getGroupId().equals(remotePort.getRemoteProcessGroup().getIdentifier())) {
-                        isDifferentRemoteProcessGroup = true;
-                    }
-                }
-
                 // if the destination is changing or the previous destination was a different remote process group
-                if (!proposedDestination.getId().equals(currentDestination.getIdentifier()) || isDifferentRemoteProcessGroup) {
+                if (isDestinationChanging(connection, proposedDestination)) {
                     final ProcessGroup destinationParentGroup = locateProcessGroup(flowController, group.getIdentifier());
                     final RemoteProcessGroup remoteProcessGroup = destinationParentGroup.getRemoteProcessGroup(proposedDestination.getGroupId());
 
@@ -615,7 +634,7 @@ public class StandardConnectionDAO extends ComponentDAO implements ConnectionDAO
                 }
             } else {
                 // if there is a different destination id
-                if (!proposedDestination.getId().equals(currentDestination.getIdentifier())) {
+                if (isDestinationChanging(connection, proposedDestination)) {
                     // if the destination connectable's group id has not been set, its inferred to be the current group
                     if (proposedDestination.getGroupId() == null) {
                         proposedDestination.setGroupId(group.getIdentifier());

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/StandardConnectionDAOTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/StandardConnectionDAOTest.java
@@ -21,11 +21,18 @@ import org.apache.nifi.components.connector.ConnectorRepository;
 import org.apache.nifi.components.connector.ConnectorState;
 import org.apache.nifi.components.connector.ConnectorSyncMode;
 import org.apache.nifi.components.connector.FrameworkFlowContext;
+import org.apache.nifi.connectable.Connectable;
+import org.apache.nifi.connectable.ConnectableType;
 import org.apache.nifi.connectable.Connection;
 import org.apache.nifi.controller.FlowController;
+import org.apache.nifi.controller.exception.ValidationException;
 import org.apache.nifi.controller.flow.FlowManager;
 import org.apache.nifi.groups.ProcessGroup;
+import org.apache.nifi.groups.RemoteProcessGroup;
+import org.apache.nifi.remote.RemoteGroupPort;
 import org.apache.nifi.web.ResourceNotFoundException;
+import org.apache.nifi.web.api.dto.ConnectableDTO;
+import org.apache.nifi.web.api.dto.ConnectionDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,10 +44,14 @@ import org.mockito.quality.Strictness;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -198,5 +209,125 @@ class StandardConnectionDAOTest {
         final Connection result = connectorManagedComponentLookup.getConnection(secondConnectorConnectionId);
 
         assertEquals(connectionInSecondConnector, result);
+    }
+
+    private ConnectionDTO connectionDtoWithNameOnly() {
+        final ConnectionDTO dto = new ConnectionDTO();
+        dto.setId(ROOT_CONNECTION_ID);
+        dto.setName("renamed-connection");
+        return dto;
+    }
+
+    private ConnectionDTO connectionDtoChangingDestination(final String newDestinationId) {
+        final ConnectionDTO dto = new ConnectionDTO();
+        dto.setId(ROOT_CONNECTION_ID);
+        final ConnectableDTO newDestination = new ConnectableDTO();
+        newDestination.setId(newDestinationId);
+        newDestination.setType(ConnectableType.PROCESSOR.name());
+        dto.setDestination(newDestination);
+        return dto;
+    }
+
+    private void stubRootConnectionDestination(final String destinationId) {
+        final ProcessGroup group = mock(ProcessGroup.class);
+        when(group.getIdentifier()).thenReturn("group-id");
+        when(rootConnection.getProcessGroup()).thenReturn(group);
+
+        final Connectable currentDestination = mock(Connectable.class);
+        when(currentDestination.getIdentifier()).thenReturn(destinationId);
+        when(currentDestination.isRunning()).thenReturn(true);
+        when(currentDestination.getConnectableType()).thenReturn(ConnectableType.PROCESSOR);
+        when(rootConnection.getDestination()).thenReturn(currentDestination);
+    }
+
+    @Test
+    void testVerifyUpdateDoesNotCheckDestinationForNonDestinationEdit() {
+        stubRootConnectionDestination("current-destination-id");
+
+        assertDoesNotThrow(() -> connectionDAO.verifyUpdate(connectionDtoWithNameOnly()));
+        verify(rootConnection, never()).verifyCanUpdateDestination();
+    }
+
+    @Test
+    void testVerifyUpdateWrapsIllegalStateFromDestinationGuardAsValidationException() {
+        stubRootConnectionDestination("current-destination-id");
+        final String guardMessage = "Cannot change destination of Connection because the current destination ([proc]) is running";
+        org.mockito.Mockito.doThrow(new IllegalStateException(guardMessage))
+                .when(rootConnection).verifyCanUpdateDestination();
+
+        final ValidationException thrown = assertThrows(ValidationException.class,
+                () -> connectionDAO.verifyUpdate(connectionDtoChangingDestination("new-destination-id")));
+        assertTrue(thrown.getValidationErrors().contains(guardMessage),
+                "ValidationException should carry the guard's message; was: " + thrown.getValidationErrors());
+    }
+
+    @Test
+    void testVerifyUpdateChecksDestinationGuardWhenDestinationChanges() {
+        stubRootConnectionDestination("current-destination-id");
+
+        assertDoesNotThrow(() -> connectionDAO.verifyUpdate(connectionDtoChangingDestination("new-destination-id")));
+        verify(rootConnection).verifyCanUpdateDestination();
+    }
+
+    @Test
+    void testIsDestinationChangingReturnsFalseForSameDestinationId() {
+        final Connectable currentDestination = mock(Connectable.class);
+        when(currentDestination.getIdentifier()).thenReturn("dest-1");
+        when(rootConnection.getDestination()).thenReturn(currentDestination);
+
+        final ConnectableDTO proposed = new ConnectableDTO();
+        proposed.setId("dest-1");
+        proposed.setType(ConnectableType.PROCESSOR.name());
+
+        assertFalse(connectionDAO.isDestinationChanging(rootConnection, proposed));
+    }
+
+    @Test
+    void testIsDestinationChangingReturnsTrueForDifferentDestinationId() {
+        final Connectable currentDestination = mock(Connectable.class);
+        when(currentDestination.getIdentifier()).thenReturn("dest-1");
+        when(rootConnection.getDestination()).thenReturn(currentDestination);
+
+        final ConnectableDTO proposed = new ConnectableDTO();
+        proposed.setId("dest-2");
+        proposed.setType(ConnectableType.PROCESSOR.name());
+
+        assertTrue(connectionDAO.isDestinationChanging(rootConnection, proposed));
+    }
+
+    @Test
+    void testIsDestinationChangingRemoteInputPortSameGroupIsNotChanging() {
+        final RemoteGroupPort currentRemotePort = mock(RemoteGroupPort.class);
+        final RemoteProcessGroup currentRpg = mock(RemoteProcessGroup.class);
+        when(currentRemotePort.getIdentifier()).thenReturn("port-1");
+        when(currentRemotePort.getConnectableType()).thenReturn(ConnectableType.REMOTE_INPUT_PORT);
+        when(currentRemotePort.getRemoteProcessGroup()).thenReturn(currentRpg);
+        when(currentRpg.getIdentifier()).thenReturn("rpg-A");
+        when(rootConnection.getDestination()).thenReturn(currentRemotePort);
+
+        final ConnectableDTO proposed = new ConnectableDTO();
+        proposed.setId("port-1");
+        proposed.setType(ConnectableType.REMOTE_INPUT_PORT.name());
+        proposed.setGroupId("rpg-A");
+
+        assertFalse(connectionDAO.isDestinationChanging(rootConnection, proposed));
+    }
+
+    @Test
+    void testIsDestinationChangingRemoteInputPortDifferentGroupIsChanging() {
+        final RemoteGroupPort currentRemotePort = mock(RemoteGroupPort.class);
+        final RemoteProcessGroup currentRpg = mock(RemoteProcessGroup.class);
+        when(currentRemotePort.getIdentifier()).thenReturn("port-1");
+        when(currentRemotePort.getConnectableType()).thenReturn(ConnectableType.REMOTE_INPUT_PORT);
+        when(currentRemotePort.getRemoteProcessGroup()).thenReturn(currentRpg);
+        when(currentRpg.getIdentifier()).thenReturn("rpg-A");
+        when(rootConnection.getDestination()).thenReturn(currentRemotePort);
+
+        final ConnectableDTO proposed = new ConnectableDTO();
+        proposed.setId("port-1");
+        proposed.setType(ConnectableType.REMOTE_INPUT_PORT.name());
+        proposed.setGroupId("rpg-B");
+
+        assertTrue(connectionDAO.isDestinationChanging(rootConnection, proposed));
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/StandardConnectionDAOTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/StandardConnectionDAOTest.java
@@ -49,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -91,6 +92,14 @@ class StandardConnectionDAOTest {
     private static final String ROOT_CONNECTION_ID = "root-connection-id";
     private static final String CONNECTOR_CONNECTION_ID = "connector-connection-id";
     private static final String NON_EXISTENT_ID = "non-existent-id";
+    private static final String PROCESS_GROUP_ID = "group-id";
+    private static final String CURRENT_DESTINATION_ID = "current-destination-id";
+    private static final String NEW_DESTINATION_ID = "new-destination-id";
+    private static final String DESTINATION_ID = "dest-1";
+    private static final String ALTERNATIVE_DESTINATION_ID = "dest-2";
+    private static final String REMOTE_PORT_ID = "port-1";
+    private static final String REMOTE_PROCESS_GROUP_ID = "rpg-A";
+    private static final String ALTERNATIVE_REMOTE_PROCESS_GROUP_ID = "rpg-B";
 
     @BeforeEach
     void setUp() {
@@ -230,7 +239,7 @@ class StandardConnectionDAOTest {
 
     private void stubRootConnectionDestination(final String destinationId) {
         final ProcessGroup group = mock(ProcessGroup.class);
-        when(group.getIdentifier()).thenReturn("group-id");
+        when(group.getIdentifier()).thenReturn(PROCESS_GROUP_ID);
         when(rootConnection.getProcessGroup()).thenReturn(group);
 
         final Connectable currentDestination = mock(Connectable.class);
@@ -242,7 +251,7 @@ class StandardConnectionDAOTest {
 
     @Test
     void testVerifyUpdateDoesNotCheckDestinationForNonDestinationEdit() {
-        stubRootConnectionDestination("current-destination-id");
+        stubRootConnectionDestination(CURRENT_DESTINATION_ID);
 
         assertDoesNotThrow(() -> connectionDAO.verifyUpdate(connectionDtoWithNameOnly()));
         verify(rootConnection, never()).verifyCanUpdateDestination();
@@ -250,33 +259,33 @@ class StandardConnectionDAOTest {
 
     @Test
     void testVerifyUpdateWrapsIllegalStateFromDestinationGuardAsValidationException() {
-        stubRootConnectionDestination("current-destination-id");
+        stubRootConnectionDestination(CURRENT_DESTINATION_ID);
         final String guardMessage = "Cannot change destination of Connection because the current destination ([proc]) is running";
-        org.mockito.Mockito.doThrow(new IllegalStateException(guardMessage))
+        doThrow(new IllegalStateException(guardMessage))
                 .when(rootConnection).verifyCanUpdateDestination();
 
         final ValidationException thrown = assertThrows(ValidationException.class,
-                () -> connectionDAO.verifyUpdate(connectionDtoChangingDestination("new-destination-id")));
+                () -> connectionDAO.verifyUpdate(connectionDtoChangingDestination(NEW_DESTINATION_ID)));
         assertTrue(thrown.getValidationErrors().contains(guardMessage),
                 "ValidationException should carry the guard's message; was: " + thrown.getValidationErrors());
     }
 
     @Test
     void testVerifyUpdateChecksDestinationGuardWhenDestinationChanges() {
-        stubRootConnectionDestination("current-destination-id");
+        stubRootConnectionDestination(CURRENT_DESTINATION_ID);
 
-        assertDoesNotThrow(() -> connectionDAO.verifyUpdate(connectionDtoChangingDestination("new-destination-id")));
+        assertDoesNotThrow(() -> connectionDAO.verifyUpdate(connectionDtoChangingDestination(NEW_DESTINATION_ID)));
         verify(rootConnection).verifyCanUpdateDestination();
     }
 
     @Test
     void testIsDestinationChangingReturnsFalseForSameDestinationId() {
         final Connectable currentDestination = mock(Connectable.class);
-        when(currentDestination.getIdentifier()).thenReturn("dest-1");
+        when(currentDestination.getIdentifier()).thenReturn(DESTINATION_ID);
         when(rootConnection.getDestination()).thenReturn(currentDestination);
 
         final ConnectableDTO proposed = new ConnectableDTO();
-        proposed.setId("dest-1");
+        proposed.setId(DESTINATION_ID);
         proposed.setType(ConnectableType.PROCESSOR.name());
 
         assertFalse(connectionDAO.isDestinationChanging(rootConnection, proposed));
@@ -285,11 +294,11 @@ class StandardConnectionDAOTest {
     @Test
     void testIsDestinationChangingReturnsTrueForDifferentDestinationId() {
         final Connectable currentDestination = mock(Connectable.class);
-        when(currentDestination.getIdentifier()).thenReturn("dest-1");
+        when(currentDestination.getIdentifier()).thenReturn(DESTINATION_ID);
         when(rootConnection.getDestination()).thenReturn(currentDestination);
 
         final ConnectableDTO proposed = new ConnectableDTO();
-        proposed.setId("dest-2");
+        proposed.setId(ALTERNATIVE_DESTINATION_ID);
         proposed.setType(ConnectableType.PROCESSOR.name());
 
         assertTrue(connectionDAO.isDestinationChanging(rootConnection, proposed));
@@ -299,16 +308,16 @@ class StandardConnectionDAOTest {
     void testIsDestinationChangingRemoteInputPortSameGroupIsNotChanging() {
         final RemoteGroupPort currentRemotePort = mock(RemoteGroupPort.class);
         final RemoteProcessGroup currentRpg = mock(RemoteProcessGroup.class);
-        when(currentRemotePort.getIdentifier()).thenReturn("port-1");
+        when(currentRemotePort.getIdentifier()).thenReturn(REMOTE_PORT_ID);
         when(currentRemotePort.getConnectableType()).thenReturn(ConnectableType.REMOTE_INPUT_PORT);
         when(currentRemotePort.getRemoteProcessGroup()).thenReturn(currentRpg);
-        when(currentRpg.getIdentifier()).thenReturn("rpg-A");
+        when(currentRpg.getIdentifier()).thenReturn(REMOTE_PROCESS_GROUP_ID);
         when(rootConnection.getDestination()).thenReturn(currentRemotePort);
 
         final ConnectableDTO proposed = new ConnectableDTO();
-        proposed.setId("port-1");
+        proposed.setId(REMOTE_PORT_ID);
         proposed.setType(ConnectableType.REMOTE_INPUT_PORT.name());
-        proposed.setGroupId("rpg-A");
+        proposed.setGroupId(REMOTE_PROCESS_GROUP_ID);
 
         assertFalse(connectionDAO.isDestinationChanging(rootConnection, proposed));
     }
@@ -317,16 +326,16 @@ class StandardConnectionDAOTest {
     void testIsDestinationChangingRemoteInputPortDifferentGroupIsChanging() {
         final RemoteGroupPort currentRemotePort = mock(RemoteGroupPort.class);
         final RemoteProcessGroup currentRpg = mock(RemoteProcessGroup.class);
-        when(currentRemotePort.getIdentifier()).thenReturn("port-1");
+        when(currentRemotePort.getIdentifier()).thenReturn(REMOTE_PORT_ID);
         when(currentRemotePort.getConnectableType()).thenReturn(ConnectableType.REMOTE_INPUT_PORT);
         when(currentRemotePort.getRemoteProcessGroup()).thenReturn(currentRpg);
-        when(currentRpg.getIdentifier()).thenReturn("rpg-A");
+        when(currentRpg.getIdentifier()).thenReturn(REMOTE_PROCESS_GROUP_ID);
         when(rootConnection.getDestination()).thenReturn(currentRemotePort);
 
         final ConnectableDTO proposed = new ConnectableDTO();
-        proposed.setId("port-1");
+        proposed.setId(REMOTE_PORT_ID);
         proposed.setType(ConnectableType.REMOTE_INPUT_PORT.name());
-        proposed.setGroupId("rpg-B");
+        proposed.setGroupId(ALTERNATIVE_REMOTE_PROCESS_GROUP_ID);
 
         assertTrue(connectionDAO.isDestinationChanging(rootConnection, proposed));
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/StandardConnectionDAOTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/StandardConnectionDAOTest.java
@@ -21,11 +21,18 @@ import org.apache.nifi.components.connector.ConnectorRepository;
 import org.apache.nifi.components.connector.ConnectorState;
 import org.apache.nifi.components.connector.ConnectorSyncMode;
 import org.apache.nifi.components.connector.FrameworkFlowContext;
+import org.apache.nifi.connectable.Connectable;
+import org.apache.nifi.connectable.ConnectableType;
 import org.apache.nifi.connectable.Connection;
 import org.apache.nifi.controller.FlowController;
+import org.apache.nifi.controller.exception.ValidationException;
 import org.apache.nifi.controller.flow.FlowManager;
 import org.apache.nifi.groups.ProcessGroup;
+import org.apache.nifi.groups.RemoteProcessGroup;
+import org.apache.nifi.remote.RemoteGroupPort;
 import org.apache.nifi.web.ResourceNotFoundException;
+import org.apache.nifi.web.api.dto.ConnectableDTO;
+import org.apache.nifi.web.api.dto.ConnectionDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,11 +44,14 @@ import org.mockito.quality.Strictness;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -199,5 +209,125 @@ class StandardConnectionDAOTest {
         final Connection result = connectorManagedComponentLookup.getConnection(secondConnectorConnectionId);
 
         assertEquals(connectionInSecondConnector, result);
+    }
+
+    private ConnectionDTO connectionDtoWithNameOnly() {
+        final ConnectionDTO dto = new ConnectionDTO();
+        dto.setId(ROOT_CONNECTION_ID);
+        dto.setName("renamed-connection");
+        return dto;
+    }
+
+    private ConnectionDTO connectionDtoChangingDestination(final String newDestinationId) {
+        final ConnectionDTO dto = new ConnectionDTO();
+        dto.setId(ROOT_CONNECTION_ID);
+        final ConnectableDTO newDestination = new ConnectableDTO();
+        newDestination.setId(newDestinationId);
+        newDestination.setType(ConnectableType.PROCESSOR.name());
+        dto.setDestination(newDestination);
+        return dto;
+    }
+
+    private void stubRootConnectionDestination(final String destinationId) {
+        final ProcessGroup group = mock(ProcessGroup.class);
+        when(group.getIdentifier()).thenReturn("group-id");
+        when(rootConnection.getProcessGroup()).thenReturn(group);
+
+        final Connectable currentDestination = mock(Connectable.class);
+        when(currentDestination.getIdentifier()).thenReturn(destinationId);
+        when(currentDestination.isRunning()).thenReturn(true);
+        when(currentDestination.getConnectableType()).thenReturn(ConnectableType.PROCESSOR);
+        when(rootConnection.getDestination()).thenReturn(currentDestination);
+    }
+
+    @Test
+    void testVerifyUpdateDoesNotCheckDestinationForNonDestinationEdit() {
+        stubRootConnectionDestination("current-destination-id");
+
+        assertDoesNotThrow(() -> connectionDAO.verifyUpdate(connectionDtoWithNameOnly()));
+        verify(rootConnection, never()).verifyCanUpdateDestination();
+    }
+
+    @Test
+    void testVerifyUpdateWrapsIllegalStateFromDestinationGuardAsValidationException() {
+        stubRootConnectionDestination("current-destination-id");
+        final String guardMessage = "Cannot change destination of Connection because the current destination ([proc]) is running";
+        org.mockito.Mockito.doThrow(new IllegalStateException(guardMessage))
+                .when(rootConnection).verifyCanUpdateDestination();
+
+        final ValidationException thrown = assertThrows(ValidationException.class,
+                () -> connectionDAO.verifyUpdate(connectionDtoChangingDestination("new-destination-id")));
+        assertTrue(thrown.getValidationErrors().contains(guardMessage),
+                "ValidationException should carry the guard's message; was: " + thrown.getValidationErrors());
+    }
+
+    @Test
+    void testVerifyUpdateChecksDestinationGuardWhenDestinationChanges() {
+        stubRootConnectionDestination("current-destination-id");
+
+        assertDoesNotThrow(() -> connectionDAO.verifyUpdate(connectionDtoChangingDestination("new-destination-id")));
+        verify(rootConnection).verifyCanUpdateDestination();
+    }
+
+    @Test
+    void testIsDestinationChangingReturnsFalseForSameDestinationId() {
+        final Connectable currentDestination = mock(Connectable.class);
+        when(currentDestination.getIdentifier()).thenReturn("dest-1");
+        when(rootConnection.getDestination()).thenReturn(currentDestination);
+
+        final ConnectableDTO proposed = new ConnectableDTO();
+        proposed.setId("dest-1");
+        proposed.setType(ConnectableType.PROCESSOR.name());
+
+        assertFalse(connectionDAO.isDestinationChanging(rootConnection, proposed));
+    }
+
+    @Test
+    void testIsDestinationChangingReturnsTrueForDifferentDestinationId() {
+        final Connectable currentDestination = mock(Connectable.class);
+        when(currentDestination.getIdentifier()).thenReturn("dest-1");
+        when(rootConnection.getDestination()).thenReturn(currentDestination);
+
+        final ConnectableDTO proposed = new ConnectableDTO();
+        proposed.setId("dest-2");
+        proposed.setType(ConnectableType.PROCESSOR.name());
+
+        assertTrue(connectionDAO.isDestinationChanging(rootConnection, proposed));
+    }
+
+    @Test
+    void testIsDestinationChangingRemoteInputPortSameGroupIsNotChanging() {
+        final RemoteGroupPort currentRemotePort = mock(RemoteGroupPort.class);
+        final RemoteProcessGroup currentRpg = mock(RemoteProcessGroup.class);
+        when(currentRemotePort.getIdentifier()).thenReturn("port-1");
+        when(currentRemotePort.getConnectableType()).thenReturn(ConnectableType.REMOTE_INPUT_PORT);
+        when(currentRemotePort.getRemoteProcessGroup()).thenReturn(currentRpg);
+        when(currentRpg.getIdentifier()).thenReturn("rpg-A");
+        when(rootConnection.getDestination()).thenReturn(currentRemotePort);
+
+        final ConnectableDTO proposed = new ConnectableDTO();
+        proposed.setId("port-1");
+        proposed.setType(ConnectableType.REMOTE_INPUT_PORT.name());
+        proposed.setGroupId("rpg-A");
+
+        assertFalse(connectionDAO.isDestinationChanging(rootConnection, proposed));
+    }
+
+    @Test
+    void testIsDestinationChangingRemoteInputPortDifferentGroupIsChanging() {
+        final RemoteGroupPort currentRemotePort = mock(RemoteGroupPort.class);
+        final RemoteProcessGroup currentRpg = mock(RemoteProcessGroup.class);
+        when(currentRemotePort.getIdentifier()).thenReturn("port-1");
+        when(currentRemotePort.getConnectableType()).thenReturn(ConnectableType.REMOTE_INPUT_PORT);
+        when(currentRemotePort.getRemoteProcessGroup()).thenReturn(currentRpg);
+        when(currentRpg.getIdentifier()).thenReturn("rpg-A");
+        when(rootConnection.getDestination()).thenReturn(currentRemotePort);
+
+        final ConnectableDTO proposed = new ConnectableDTO();
+        proposed.setId("port-1");
+        proposed.setType(ConnectableType.REMOTE_INPUT_PORT.name());
+        proposed.setGroupId("rpg-B");
+
+        assertTrue(connectionDAO.isDestinationChanging(rootConnection, proposed));
     }
 }


### PR DESCRIPTION
# Summary

NIFI-16082 - Connection update is incorrectly rejected when the current destination is running

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
