### PR TITLE
NIFI-16088 Add scheduling diagnostics for cron primary-node-only processors

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/CronSchedulingAgent.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/CronSchedulingAgent.java
@@ -129,8 +129,17 @@ public class CronSchedulingAgent extends AbstractTimeBasedSchedulingAgent {
                     try {
                         continuallyRunTask.invoke();
                     } catch (final RuntimeException re) {
+                        // Diagnostic: an exception here skips the rescheduling below. Because each cron trigger is a
+                        // one-shot scheduled task that reschedules only after a successful run, a throwable silently
+                        // terminates the scheduling chain: the component stays RUNNING but never fires again on its
+                        // schedule until it is stopped and started. Log it before propagating, since the executor
+                        // otherwise discards it with no record.
+                        logger.warn("Cron-scheduled trigger for {} threw an exception; its scheduling chain will terminate "
+                            + "and it will not run again on its schedule until it is stopped and started", connectable, re);
                         throw re;
                     } catch (final Exception e) {
+                        logger.warn("Cron-scheduled trigger for {} threw an exception; its scheduling chain will terminate "
+                            + "and it will not run again on its schedule until it is stopped and started", connectable, e);
                         throw new ProcessException(e);
                     }
 
@@ -138,9 +147,17 @@ public class CronSchedulingAgent extends AbstractTimeBasedSchedulingAgent {
                     final long delay = getDelay(nextSchedule);
 
                     logger.debug("Finished task for {}; next scheduled time is at {} after a delay of {} milliseconds", connectable, nextSchedule, delay);
-                    final ScheduledFuture<?> newFuture = flowEngine.schedule(this, delay, TimeUnit.MILLISECONDS);
-                    final ScheduledFuture<?> oldFuture = componentFuturesMap.put(taskNumber.get(), newFuture);
-                    scheduleState.replaceFuture(oldFuture, newFuture);
+                    try {
+                        final ScheduledFuture<?> newFuture = flowEngine.schedule(this, delay, TimeUnit.MILLISECONDS);
+                        final ScheduledFuture<?> oldFuture = componentFuturesMap.put(taskNumber.get(), newFuture);
+                        scheduleState.replaceFuture(oldFuture, newFuture);
+                    } catch (final RuntimeException re) {
+                        // Diagnostic: failing to schedule the next trigger (e.g. the engine is shutting down) also
+                        // silently terminates the scheduling chain, leaving the component RUNNING but unscheduled.
+                        logger.warn("Failed to reschedule the next cron trigger for {}; its scheduling chain will terminate "
+                            + "and it will not run again on its schedule until it is stopped and started", connectable, re);
+                        throw re;
+                    }
                 }
             };
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ConnectableTask.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ConnectableTask.java
@@ -49,6 +49,7 @@ import org.apache.nifi.processor.SimpleProcessLogger;
 import org.apache.nifi.processor.StandardProcessContext;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.exception.TerminatedTaskException;
+import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.apache.nifi.util.Connectables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -177,7 +178,14 @@ public class ConnectableTask {
 
         // make sure that either we're not clustered or this processor runs on all nodes or that this is the primary node
         if (!isRunOnCluster(flowController)) {
-            logger.debug("Will not trigger {} because this is not the primary node", connectable);
+            // Diagnostic: a cron-driven primary-node-only component triggers comparatively rarely, so log at INFO to
+            // make a skipped scheduled fire visible (e.g. a component that stops firing on its schedule after a
+            // primary-node change). Timer-driven components trigger frequently, so keep those at DEBUG to avoid noise.
+            if (connectable.getSchedulingStrategy() == SchedulingStrategy.CRON_DRIVEN) {
+                logger.info("Will not trigger {} because this is not the primary node; the cron-scheduled fire is being skipped", connectable);
+            } else {
+                logger.debug("Will not trigger {} because this is not the primary node", connectable);
+            }
             return InvocationResult.yield("This node is not the primary node");
         }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/CronSchedulingAgentTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/CronSchedulingAgentTest.java
@@ -27,14 +27,20 @@ import org.apache.nifi.reporting.ReportingTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -91,6 +97,36 @@ class CronSchedulingAgentTest {
         when(flowController.getGarbageCollectionLog()).thenReturn(mock(GarbageCollectionLog.class));
 
         schedulingAgent.doSchedule(connectable, lifecycleState);
+    }
+
+    @Test
+    void testCronTaskExceptionPropagatesRatherThanSilentlyStoppingChain() {
+        // A cron trigger is a one-shot task that reschedules only after a successful run. If the triggered task
+        // throws, the exception must still propagate (it is also logged as a diagnostic) rather than being silently
+        // swallowed in a way that could leave the component RUNNING but unscheduled. This guards that propagation.
+        final String componentId = UUID.randomUUID().toString();
+        final LifecycleState lifecycleState = new LifecycleState(componentId);
+
+        when(connectable.evaluateParameters(eq(DEFAULT_CRON_EXPRESSION))).thenReturn(DEFAULT_CRON_EXPRESSION);
+        when(connectable.getSchedulingPeriod()).thenReturn(DEFAULT_CRON_EXPRESSION);
+        when(connectable.getMaxConcurrentTasks()).thenReturn(CONCURRENT_TASKS);
+        when(connectable.getIdentifier()).thenReturn(componentId);
+        when(flowController.getStateManagerProvider()).thenReturn(stateManagerProvider);
+        when(stateManagerProvider.getStateManager(eq(componentId))).thenReturn(stateManager);
+        when(flowController.getGarbageCollectionLog()).thenReturn(mock(GarbageCollectionLog.class));
+
+        schedulingAgent.doSchedule(connectable, lifecycleState);
+
+        // Capture the self-rescheduling command submitted to the engine and run it with a triggered task that throws.
+        final ArgumentCaptor<Runnable> commandCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(flowEngine).schedule(commandCaptor.capture(), anyLong(), any(TimeUnit.class));
+        final Runnable command = commandCaptor.getValue();
+
+        final RuntimeException failure = new RuntimeException("trigger failure");
+        when(connectable.getYieldExpiration()).thenThrow(failure);
+
+        final RuntimeException thrown = assertThrows(RuntimeException.class, command::run);
+        assertEquals(failure, thrown);
     }
 
     @Test


### PR DESCRIPTION
# Summary

Relates to [NIFI-16088](https://issues.apache.org/jira/browse/NIFI-16088).

Cron triggers are scheduled as one-shot tasks that reschedule only after a successful run (`CronSchedulingAgent`). If the triggered task throws, or scheduling the next trigger fails, the scheduling chain silently terminates: the component stays `RUNNING` but never fires again on its schedule until it is stopped and started — with nothing in the logs, because the exception is discarded by the scheduled executor.

This adds **diagnostics only** (no scheduling or lifecycle behavior is changed):

- `CronSchedulingAgent`: log a WARN (before propagating) when a cron-scheduled trigger throws, or when rescheduling the next trigger fails, noting the component will not run again on its schedule until it is stopped and started.
- `ConnectableTask`: log at INFO (was DEBUG) when a cron-driven, Primary-Node-Only component's fire is skipped because the node is not the primary node; timer-driven components stay at DEBUG to avoid noise, since cron fires are comparatively rare.

Motivated by a case where Primary-Node-Only cron processors silently stopped firing after a heartbeat-induced disconnect/reconnect and had to be manually stopped/started; the existing logs gave no signal as to why.

# Verification

- New unit test in `CronSchedulingAgentTest` asserting a triggered exception still propagates (is not silently swallowed).
- `./mvnw -pl nifi-framework-bundle/nifi-framework/nifi-framework-core -am test -Dtest=CronSchedulingAgentTest` — green (4 tests).
- `checkstyle:check` clean for the module.