### PR TITLE
NIFI-16092 - Fix flaky TestStandardRecordProcessorBlocker.TimeoutBlock.testBlockAndUnblock

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/pause/TestStandardRecordProcessorBlocker.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/pause/TestStandardRecordProcessorBlocker.java
@@ -43,6 +43,7 @@ public class TestStandardRecordProcessorBlocker {
             blockerInspector.awaitBlockAwaited();
             assertTrue(thread.isAlive());
 
+            blockerInspector.awaitThreadParked(thread);
             recordProcessorBlocker.unblock();
             blockerInspector.awaitBlockExited();
         }
@@ -96,6 +97,7 @@ public class TestStandardRecordProcessorBlocker {
             blockerInspector.awaitBlockAwaited();
             assertTrue(thread.isAlive());
 
+            blockerInspector.awaitThreadParked(thread);
             recordProcessorBlocker.unblock();
             blockerInspector.awaitBlockExited();
         }
@@ -163,8 +165,8 @@ public class TestStandardRecordProcessorBlocker {
 
     private static class TestThreadInspector {
         private static final Duration BUSY_WAIT_MAX_DURATION = Duration.ofSeconds(5);
-        private boolean blockAwaited = false;
-        private boolean blockExited = false;
+        private volatile boolean blockAwaited = false;
+        private volatile boolean blockExited = false;
 
         public void onBlockAwaited() {
             blockAwaited = true;
@@ -180,6 +182,10 @@ public class TestStandardRecordProcessorBlocker {
 
         public void awaitBlockExited() {
             busyWait(() -> !blockExited);
+        }
+
+        public void awaitThreadParked(final Thread thread) {
+            busyWait(() -> thread.getState() != Thread.State.WAITING);
         }
 
         private void busyWait(final Supplier<Boolean> condition) {


### PR DESCRIPTION
# Summary

NIFI-16092 - Fix flaky TestStandardRecordProcessorBlocker.TimeoutBlock.testBlockAndUnblock

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
