### PR TITLE
NIFI-16093 - Fix flaky PutCouchbaseIT.testPutDocument

### DIFF
--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/integration/AbstractCouchbaseIT.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/integration/AbstractCouchbaseIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processors.couchbase.integration;
 
+import com.couchbase.client.java.Cluster;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.services.couchbase.StandardCouchbaseConnectionService;
 import org.apache.nifi.util.TestRunner;
@@ -23,6 +24,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.couchbase.BucketDefinition;
 import org.testcontainers.couchbase.CouchbaseContainer;
+
+import java.time.Duration;
 
 import static org.apache.nifi.services.couchbase.StandardCouchbaseConnectionService.CONNECTION_STRING;
 import static org.apache.nifi.services.couchbase.StandardCouchbaseConnectionService.PASSWORD;
@@ -59,6 +62,9 @@ public class AbstractCouchbaseIT {
     @BeforeAll
     public static void start() {
         container.start();
+        try (Cluster cluster = Cluster.connect(container.getConnectionString(), container.getUsername(), container.getPassword())) {
+            cluster.bucket(TEST_BUCKET_NAME).waitUntilReady(Duration.ofSeconds(60));
+        }
     }
 
     @AfterAll


### PR DESCRIPTION
# Summary

NIFI-16093 - Wait for Couchbase KV service readiness in AbstractCouchbaseIT to stabilize integration tests

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
