### PR TITLE
NIFI-16095 - Bump Jetty to 12.1.11, Jackson to 2.22.1, and others

### DIFF
--- a/nifi-extension-bom/pom.xml
+++ b/nifi-extension-bom/pom.xml
@@ -224,13 +224,13 @@
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-jsp</artifactId>
-                <version>11.0.22</version>
+                <version>11.0.23</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-el</artifactId>
-                <version>11.0.22</version>
+                <version>11.0.23</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-standard-services/pom.xml
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-standard-services/pom.xml
@@ -27,7 +27,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <couchbase.version>3.12.0</couchbase.version>
+        <couchbase.version>3.12.1</couchbase.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.84.0</google.libraries.version>
+        <google.libraries.version>26.85.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-iotdb-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-iotdb-bundle/pom.xml
@@ -30,7 +30,7 @@
     </modules>
 
     <properties>
-        <iotdb.sdk.version>2.0.8</iotdb.sdk.version>
+        <iotdb.sdk.version>2.0.10</iotdb.sdk.version>
     </properties>
 </project>
 

--- a/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
@@ -34,6 +34,6 @@
     </modules>
 
     <properties>
-        <mongo.driver.version>5.8.0</mongo.driver.version>
+        <mongo.driver.version>5.9.0</mongo.driver.version>
     </properties>
 </project>

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
@@ -56,7 +56,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -214,7 +214,7 @@
             <dependency>
                 <groupId>com.networknt</groupId>
                 <artifactId>json-schema-validator</artifactId>
-                <version>2.0.3</version>
+                <version>2.0.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-registry/nifi-registry-core/nifi-registry-jetty/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-jetty/pom.xml
@@ -101,13 +101,13 @@
         <dependency>
             <groupId>org.mortbay.jasper</groupId>
             <artifactId>mortbay-apache-jsp</artifactId>
-            <version>11.0.22</version>
+            <version>11.0.23</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mortbay.jasper</groupId>
             <artifactId>mortbay-apache-el</artifactId>
-            <version>11.0.22</version>
+            <version>11.0.23</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -118,13 +118,13 @@
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-jsp</artifactId>
-                <version>11.0.22</version>
+                <version>11.0.23</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-el</artifactId>
-                <version>11.0.22</version>
+                <version>11.0.23</version>
                 <scope>compile</scope>
                 <exclusions>
                     <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.47.1</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.47.3</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.7</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.47.0</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.47.1</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.7</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -157,7 +157,7 @@
         <com.jayway.jsonpath.version>3.0.0</com.jayway.jsonpath.version>
         <gson.version>2.14.0</gson.version>
         <jackson.annotations.version>2.22</jackson.annotations.version>
-        <jackson.bom.version>2.22.0</jackson.bom.version>
+        <jackson.bom.version>2.22.1</jackson.bom.version>
         <jackson3.bom.version>3.2.0</jackson3.bom.version>
         <json.smart.version>2.6.0</json.smart.version>
         <snakeyaml.version>2.6</snakeyaml.version>
@@ -199,7 +199,7 @@
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jaxb.runtime.version>4.0.9</jaxb.runtime.version>
         <jersey.bom.version>4.0.2</jersey.bom.version>
-        <jetty.version>12.1.10</jetty.version>
+        <jetty.version>12.1.11</jetty.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.security.version>7.1.0</spring.security.version>
         <spring.version>7.0.8</spring.version>


### PR DESCRIPTION
# Summary

NIFI-16095 - Bump Jetty to 12.1.11, Jackson to 2.22.1, and others

- Mortbay from 11.0.22 to 11.0.23 - https://github.com/jetty-project/jasper-jsp/tree/jasper-jsp-11.0.23
- Apache IoTDB from 2.0.8 to 2.0.10 - https://github.com/apache/iotdb/releases/tag/v2.0.10
- MongoDB Driver from 5.8.0 to 5.9.0 - https://github.com/mongodb/mongo-java-driver/releases/tag/r5.9.0
- JSON Schema Validator from 2.0.3 to 2.0.4 - https://github.com/networknt/json-schema-validator/releases/tag/2.0.4
- AWS SDK from 2.47.0 to 2.47.1 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.47.1
- Jackson from 2.22.0 to 2.22.1 - https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.22.1
- Jetty from 12.1.10 to 12.1.11 - https://github.com/jetty/jetty.project/releases/tag/jetty-12.1.11

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
