### PR TITLE
NIFI-16099: Controller Service Provider should be passed to Connectors

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
@@ -497,6 +497,7 @@ public class ExtensionBuilder {
         requireNonNull(identifier, "Connector ID");
         requireNonNull(type, "Connector Type");
         requireNonNull(bundleCoordinate, "Bundle Coordinate");
+        requireNonNull(serviceProvider, "Controller Service Provider");
         requireNonNull(extensionManager, "Extension Manager");
         requireNonNull(managedProcessGroup, "Managed Process Group");
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardFlowManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardFlowManager.java
@@ -776,6 +776,7 @@ public class StandardFlowManager extends AbstractFlowManager implements FlowMana
             .type(type)
             .bundleCoordinate(coordinate)
             .extensionManager(extensionManager)
+            .controllerServiceProvider(flowController.getControllerServiceProvider())
             .managedProcessGroup(managedRootGroup)
             .activeConfigurationContext(activeConfigurationContext)
             .flowContextFactory(flowContextFactory)


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16099](https://issues.apache.org/jira/browse/NIFI-16099)

StandardFlowManager.createConnector builds the connector via ExtensionBuilder, but the builder chain is missing the

.controllerServiceProvider(...)

every other builder in the same file uses this call.

Compare with, for example, buildProcessorNode, buildControllerServiceNode, buildReportingTaskNode, buildFlowAnalysisRuleNode, buildFlowRegistryClient — every one of them calls: .controllerServiceProvider(flowController.getControllerServiceProvider()).

ExtensionBuilder.buildConnector(...) also doesn't requireNonNull(serviceProvider, ...) (unlike every other builder in the file), so the null slips silently into the StandardConnectorNode constructor.
 
This is required for the connector code to use the ControllerServiceProvider which will be required for Migrations.  SEE https://github.com/apache/nifi/pull/11240



# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
