### PR TITLE
NIFI-16103 add access to input/output port concurrent tasks to the UI

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/component-dialogs/edit-port/edit-port.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/component-dialogs/edit-port/edit-port.component.html
@@ -26,19 +26,17 @@
             </mat-form-field>
         </div>
         <div>
-            @if (request.entity.component.allowRemoteAccess) {
-                <mat-form-field>
-                    <mat-label>
-                        Concurrent Tasks
-                        <i
-                            class="fa fa-info-circle"
-                            nifiTooltip
-                            [tooltipComponentType]="TextTip"
-                            tooltipInputData="The number of tasks that should be concurrently scheduled for this port."></i>
-                    </mat-label>
-                    <input matInput formControlName="concurrentTasks" type="text" [readonly]="readonly" />
-                </mat-form-field>
-            }
+            <mat-form-field>
+                <mat-label>
+                    Concurrent Tasks
+                    <i
+                        class="fa fa-info-circle"_
+                        nifiTooltip
+                        [tooltipComponentType]="TextTip"
+                        tooltipInputData="The number of tasks that should be concurrently scheduled for this port."></i>
+                </mat-label>
+                <input matInput formControlName="concurrentTasks" type="text" [readonly]="readonly" />
+            </mat-form-field>
         </div>
         @if (portTypeLabel === 'Output Port') {
             <div class="mb-3.5">

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/component-dialogs/edit-port/edit-port.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/component-dialogs/edit-port/edit-port.component.html
@@ -30,7 +30,7 @@
                 <mat-label>
                     Concurrent Tasks
                     <i
-                        class="fa fa-info-circle"_
+                        class="fa fa-info-circle"
                         nifiTooltip
                         [tooltipComponentType]="TextTip"
                         tooltipInputData="The number of tasks that should be concurrently scheduled for this port."></i>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/component-dialogs/edit-port/edit-port.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/component-dialogs/edit-port/edit-port.component.ts
@@ -95,14 +95,10 @@ export class EditPort extends CloseOnEscapeDialog {
             component: {
                 id: this.request.entity.id,
                 name: this.editPortForm.get('name')?.value,
-                comments: this.editPortForm.get('comments')?.value
+                comments: this.editPortForm.get('comments')?.value,
+                concurrentlySchedulableTaskCount: this.editPortForm.get('concurrentTasks')?.value
             }
         };
-
-        // if this port allows remote access update the concurrent tasks
-        if (this.request.entity.component.allowRemoteAccess) {
-            payload.component.concurrentlySchedulableTaskCount = this.editPortForm.get('concurrentTasks')?.value;
-        }
 
         // if this port is an output port update the port function
         if (ComponentType.OutputPort == this.request.type) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Local Input and Output Ports support multiple concurrent tasks, but this attribute is not accessible via the UI. This PR adds a field in the local port configuration allowing the user to change concurrent tasks for any Local Port.

[NIFI-16103](https://issues.apache.org/jira/browse/NIFI-16103)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
