### PR TITLE
NIFI-16056 Document single host format for Proxy Host Headers

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -2732,7 +2732,12 @@ X-ProxyPort - the port the proxy is listening on
 X-ProxyContextPath - the path configured to map to the NiFi instance
 ....
 
-* If NiFi is running securely, any proxy needs to be authorized to proxy user requests. These can be configured in the NiFi UI through the Global Menu. Once these permissions are in place, proxies
+* NiFi expects a single host or host and port combination in `X-ProxyHost` or `X-Forwarded-Host` header values. When routing requests through multiple servers, some proxy servers append to existing
+values, producing a comma-separated string composed of multiple hosts. NiFi rejects comma-separated values with an `HTTP 421` status. Reverse proxy servers must be configured to disable appending to
+existing values, or unset input values before forwarding requests. Servers as such Apache HTTP link:https://httpd.apache.org/docs/2.4/mod/mod_proxy.html[mod_proxy] should set `ProxyAddHeaders` to
+`Off` to avoid producing invalid comma-separated values.
+
+* When running with HTTPS enabled, all proxy servers must be authorized to proxy user requests. These can be configured in the NiFi UI through the Global Menu. Once these permissions are in place, proxies
 can begin proxying user requests. The end user identity must be relayed in a HTTP header. For example, if the end user sent a request to the proxy, the proxy must authenticate the user. Following
 this the proxy can send the request to NiFi. In this request an HTTP header should be added as follows.
 

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -2734,7 +2734,7 @@ X-ProxyContextPath - the path configured to map to the NiFi instance
 
 * NiFi expects a single host or host and port combination in `X-ProxyHost` or `X-Forwarded-Host` header values. When routing requests through multiple servers, some proxy servers append to existing
 values, producing a comma-separated string composed of multiple hosts. NiFi rejects comma-separated values with an `HTTP 421` status. Reverse proxy servers must be configured to disable appending to
-existing values, or unset input values before forwarding requests. Servers as such Apache HTTP link:https://httpd.apache.org/docs/2.4/mod/mod_proxy.html[mod_proxy] should set `ProxyAddHeaders` to
+existing values, or unset input values before forwarding requests. Servers such as Apache HTTP link:https://httpd.apache.org/docs/2.4/mod/mod_proxy.html[mod_proxy] should set `ProxyAddHeaders` to
 `Off` to avoid producing invalid comma-separated values.
 
 * When running with HTTPS enabled, all proxy servers must be authorized to proxy user requests. These can be configured in the NiFi UI through the Global Menu. Once these permissions are in place, proxies


### PR DESCRIPTION
# Summary

[NIFI-16056](https://issues.apache.org/jira/browse/NIFI-16056) Updates the Administrator's Guide documentation section on Proxy Configuration with an additional paragraph described the valid single host format for `X-ProxyHost` and `X-Forwarded-Host` HTTP headers.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
