### PR TITLE
NIFI-16104 Fix flaky ConnectorAssetsIT by polling for asset removal

### DIFF
--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
@@ -76,6 +76,7 @@ import org.apache.nifi.web.api.dto.status.ConnectionStatusSnapshotDTO;
 import org.apache.nifi.web.api.dto.status.ProcessGroupStatusSnapshotDTO;
 import org.apache.nifi.web.api.dto.status.ProcessorStatusSnapshotDTO;
 import org.apache.nifi.web.api.entity.ActivateControllerServicesEntity;
+import org.apache.nifi.web.api.entity.AssetsEntity;
 import org.apache.nifi.web.api.entity.ConfigurationStepEntity;
 import org.apache.nifi.web.api.entity.ConnectionEntity;
 import org.apache.nifi.web.api.entity.ConnectionStatusEntity;
@@ -520,6 +521,27 @@ public class NiFiClientUtil {
 
             if (iteration++ % 30 == 0) { // Every 3 seconds log status
                 logger.info("Connector with ID {} has state {} but waiting for state {}.", connectorId, state, desiredState);
+            }
+
+            Thread.sleep(100L);
+        }
+    }
+
+    public void waitForAssetRemoved(final String connectorId, final String assetId)
+            throws NiFiClientException, IOException, InterruptedException {
+        int iteration = 0;
+        while (true) {
+            final AssetsEntity assetsEntity = getConnectorClient().getAssets(connectorId);
+            final boolean assetStillPresent = assetsEntity.getAssets() != null
+                    && assetsEntity.getAssets().stream()
+                            .filter(a -> a.getAsset() != null)
+                            .anyMatch(a -> assetId.equals(a.getAsset().getId()));
+            if (!assetStillPresent) {
+                return;
+            }
+
+            if (iteration++ % 30 == 0) {
+                logger.info("Asset with ID {} is still present for Connector {} but waiting for removal.", assetId, connectorId);
             }
 
             Thread.sleep(100L);

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/connectors/ConnectorAssetsIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/connectors/ConnectorAssetsIT.java
@@ -188,15 +188,8 @@ public class ConnectorAssetsIT extends NiFiSystemIT {
 
         getClientUtil().waitForConnectorState(connectorId, ConnectorState.STOPPED);
 
-        // Verify that the Asset has been removed from the Connector's Assets list
-        final AssetsEntity assetsAfterRemoval = connectorClient.getAssets(connectorId);
-        assertNotNull(assetsAfterRemoval);
-
-        final boolean assetStillPresent = assetsAfterRemoval.getAssets() != null && assetsAfterRemoval.getAssets().stream()
-                .filter(a -> a.getAsset() != null)
-                .anyMatch(a -> uploadedAssetId.equals(a.getAsset().getId()));
-
-        assertFalse(assetStillPresent);
+        // Wait for the Asset to be removed from the Connector's Assets list
+        getClientUtil().waitForAssetRemoved(connectorId, uploadedAssetId);
 
         // Wait for Connector to stop before attempting to delete it.
         getClientUtil().waitForConnectorStopped(connectorAfterApply.getId());


### PR DESCRIPTION
# Summary

`ConnectorAssetsIT.testCreateConnectorAndUploadAsset` intermittently fails with:

```
ConnectorAssetsIT.testCreateConnectorAndUploadAsset:199 expected: <false> but was: <true>
```

The test asserts that an unreferenced asset is removed immediately after `waitForConnectorState(STOPPED)`. Asset cleanup is asynchronous and may not have completed by the time the connector reaches STOPPED state, making the single-shot assertion inherently racy.

# Changes

- **`NiFiClientUtil`** — add `waitForAssetRemoved(connectorId, assetId)` utility that polls every 100 ms (matching the `waitForConnectorState` pattern) until the specified asset is absent from the connector's asset list.
- **`ConnectorAssetsIT`** — replace the immediate one-shot `getAssets` / `assertFalse` check with a call to `waitForAssetRemoved`, tolerating the async cleanup delay.

# Tracking

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-16084) issue linked

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-16084`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-16084`

### Testing

- Existing `testCreateConnectorAndUploadAsset` now reliably passes because it waits for the async asset cleanup instead of checking exactly once.