### PR TITLE
NIFI-16105 - Bump NiFi API to 2.10.0

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/facades/standalone/StandaloneConnectionFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/facades/standalone/StandaloneConnectionFacade.java
@@ -19,6 +19,7 @@ package org.apache.nifi.components.connector.facades.standalone;
 
 import org.apache.nifi.components.connector.DropFlowFileSummary;
 import org.apache.nifi.components.connector.components.ConnectionFacade;
+import org.apache.nifi.components.connector.components.QueueSnapshot;
 import org.apache.nifi.connectable.Connection;
 import org.apache.nifi.controller.queue.QueueSize;
 import org.apache.nifi.flow.VersionedConnection;
@@ -56,6 +57,11 @@ public class StandaloneConnectionFacade implements ConnectionFacade {
     @Override
     public DropFlowFileSummary dropFlowFiles(final Predicate<FlowFile> predicate) throws IOException {
         return connection.getFlowFileQueue().dropFlowFiles(predicate);
+    }
+
+    @Override
+    public QueueSnapshot getQueueSnapshot() {
+        throw new UnsupportedOperationException("Queue snapshots not yet implemented");
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/facades/standalone/StandaloneProcessorFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/facades/standalone/StandaloneProcessorFacade.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.nifi.asset.AssetManager;
+import org.apache.nifi.components.Backlog;
+import org.apache.nifi.components.BacklogReportingException;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
@@ -49,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public class StandaloneProcessorFacade implements ProcessorFacade {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
@@ -207,6 +210,16 @@ public class StandaloneProcessorFacade implements ProcessorFacade {
         } catch (final JsonProcessingException e) {
             throw new InvocationFailedException("Failed to deserialize return value from Connector Method '" + methodName + "'", e);
         }
+    }
+
+    @Override
+    public boolean reportsBacklog() {
+        return false;
+    }
+
+    @Override
+    public Optional<Backlog> getBacklog() throws BacklogReportingException {
+        return Optional.empty();
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/connector/authorization/AuthorizingConnectionFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/connector/authorization/AuthorizingConnectionFacade.java
@@ -18,6 +18,7 @@ package org.apache.nifi.web.connector.authorization;
 
 import org.apache.nifi.components.connector.DropFlowFileSummary;
 import org.apache.nifi.components.connector.components.ConnectionFacade;
+import org.apache.nifi.components.connector.components.QueueSnapshot;
 import org.apache.nifi.controller.queue.QueueSize;
 import org.apache.nifi.flow.VersionedConnection;
 import org.apache.nifi.flowfile.FlowFile;
@@ -62,6 +63,12 @@ public class AuthorizingConnectionFacade implements ConnectionFacade {
     public DropFlowFileSummary dropFlowFiles(final Predicate<FlowFile> predicate) throws IOException {
         authContext.authorizeWrite();
         return delegate.dropFlowFiles(predicate);
+    }
+
+    @Override
+    public QueueSnapshot getQueueSnapshot() {
+        authContext.authorizeRead();
+        return delegate.getQueueSnapshot();
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/connector/authorization/AuthorizingProcessorFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/connector/authorization/AuthorizingProcessorFacade.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.web.connector.authorization;
 
+import org.apache.nifi.components.Backlog;
+import org.apache.nifi.components.BacklogReportingException;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.connector.InvocationFailedException;
@@ -28,6 +30,7 @@ import org.apache.nifi.flow.VersionedProcessor;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A wrapper around {@link ProcessorFacade} that enforces authorization before delegating
@@ -95,6 +98,18 @@ public class AuthorizingProcessorFacade implements ProcessorFacade {
     public <T> T invokeConnectorMethod(final String methodName, final Map<String, Object> arguments, final Class<T> returnType) throws InvocationFailedException {
         authContext.authorizeWrite();
         return delegate.invokeConnectorMethod(methodName, arguments, returnType);
+    }
+
+    @Override
+    public boolean reportsBacklog() {
+        authContext.authorizeRead();
+        return delegate.reportsBacklog();
+    }
+
+    @Override
+    public Optional<Backlog> getBacklog() throws BacklogReportingException {
+        authContext.authorizeRead();
+        return delegate.getBacklog();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <node.version>v24.14.1</node.version>
 
         <!-- NiFi build -->
-        <nifi-api.version>2.9.0</nifi-api.version>
+        <nifi-api.version>2.10.0</nifi-api.version>
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->


### PR DESCRIPTION
# Summary

NIFI-16105 - Bump NiFi API to 2.10.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
