### PR TITLE
NIFI-16106 - Bump Bouncycastle to 1.85, Logback to 1.5.38, Jackson to 3.2.1, and others

### DIFF
--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
@@ -20,7 +20,7 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <amqp-client.version>5.33.1</amqp-client.version>
+        <amqp-client.version>5.34.0</amqp-client.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.box</groupId>
                 <artifactId>box-java-sdk</artifactId>
-                <version>5.13.0</version>
+                <version>5.14.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-github-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-github-bundle/pom.xml
@@ -26,7 +26,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <github-api.version>2.0-rc.6</github-api.version>
+        <github-api.version>2.0-rc.7</github-api.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <janusgraph.version>1.2.0-20260703-225631.5361a02</janusgraph.version>
         <guava.version>33.6.0-jre</guava.version>
-        <amqp-client.version>5.33.1</amqp-client.version>
+        <amqp-client.version>5.34.0</amqp-client.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.hivemq</groupId>
             <artifactId>hivemq-mqtt-client</artifactId>
-            <version>1.3.16</version>
+            <version>1.3.17</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <guava.version>33.6.0-jre</guava.version>
         <protobuf.version>4.35.1</protobuf.version>
-        <grpc.version>1.82.1</grpc.version>
+        <grpc.version>1.82.2</grpc.version>
         <snowflake-jdbc-thin.version>4.3.1</snowflake-jdbc-thin.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -106,7 +106,7 @@
             <dependency>
                 <groupId>net.sf.saxon</groupId>
                 <artifactId>Saxon-HE</artifactId>
-                <version>12.9</version>
+                <version>12.10</version>
             </dependency>
             <dependency>
                 <groupId>javax.jms</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>4.1.0</spring.boot.version>
-        <flyway.version>12.10.0</flyway.version>
+        <flyway.version>12.11.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.7.0.202606012155-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.47.3</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.47.5</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.7</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -158,7 +158,7 @@
         <gson.version>2.14.0</gson.version>
         <jackson.annotations.version>2.22</jackson.annotations.version>
         <jackson.bom.version>2.22.1</jackson.bom.version>
-        <jackson3.bom.version>3.2.0</jackson3.bom.version>
+        <jackson3.bom.version>3.2.1</jackson3.bom.version>
         <json.smart.version>2.6.0</json.smart.version>
         <snakeyaml.version>2.6</snakeyaml.version>
 
@@ -169,7 +169,7 @@
 
         <!-- Logging and observability -->
         <log4j2.version>2.26.1</log4j2.version>
-        <logback.version>1.5.37</logback.version>
+        <logback.version>1.5.38</logback.version>
         <org.slf4j.version>2.0.18</org.slf4j.version>
         <prometheus.version>0.16.0</prometheus.version>
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
@@ -180,12 +180,12 @@
         <okio.version>3.17.0</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
-        <org.apache.sshd.version>2.18.0</org.apache.sshd.version>
+        <org.apache.sshd.version>2.19.0</org.apache.sshd.version>
 
         <!-- Security -->
         <nimbus-jose-jwt.version>10.9.1</nimbus-jose-jwt.version>
-        <nimbus-oauth2-oidc.version>11.37.2</nimbus-oauth2-oidc.version>
-        <org.bouncycastle.version>1.84</org.bouncycastle.version>
+        <nimbus-oauth2-oidc.version>11.38.1</nimbus-oauth2-oidc.version>
+        <org.bouncycastle.version>1.85</org.bouncycastle.version>
 
         <!-- Utilities -->
         <caffeine.version>3.2.4</caffeine.version>
@@ -206,7 +206,7 @@
         <swagger.annotations.version>2.2.52</swagger.annotations.version>
 
         <!-- Testing and quality -->
-        <junit.version>6.1.1</junit.version>
+        <junit.version>6.1.2</junit.version>
         <mockito.version>5.23.0</mockito.version>
         <pmd.version>7.25.0</pmd.version>
         <checkstyle.version>13.7.0</checkstyle.version>


### PR DESCRIPTION
# Summary

NIFI-16106 - Bump Bouncycastle to 1.85, Logback to 1.5.38, Jackson to 3.2.1, and others

- RabbitMQ Client from 5.33.1 to 5.34.0 - https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.34.0
- Box Java SDK from 5.13.0 to 5.14.1 - https://github.com/box/box-java-sdk/releases/tag/v5.14.1
- Github Client from 2.0-rc.6 to 2.0-rc.7 - https://github.com/hub4j/github-api/releases/tag/github-api-2.0-rc.7
- HiveMQ MQTT Client from 1.3.16 to 1.3.17 - https://github.com/hivemq/hivemq-mqtt-client/releases/tag/v1.3.17
- gRPC from 1.82.1 to 1.82.2 - https://github.com/grpc/grpc
- Saxon-HE from 12.9 to 12.10 - https://blog.saxonica.com/announcements/2026/07/saxon-12.10.html
- FlywayDB from 12.10.0 to 12.11.0 - https://github.com/flyway/flyway/releases/tag/flyway-12.11.0
- AWS SDK from 2.47.3 to 2.47.5 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.47.5
- Jackson 3 from 3.2.0 to 3.2.1 - https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.2.1
- Logback from 1.5.37 to 1.5.38 - https://github.com/qos-ch/logback/releases/tag/v_1.5.38
- Apache Mina SSHd from 2.18.0 to 2.19.0 - https://github.com/apache/mina-sshd/releases/tag/sshd-2.19.0
- Nimbus OAuth2 OIDC from 11.37.2 to 11.38.1 - https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/master/CHANGELOG.txt
- Bouncycastle from 1.84 to 1.85 - https://www.bouncycastle.org/download/bouncy-castle-java/#release-notes
- JUnit from 6.1.1 to 6.1.2 - https://github.com/junit-team/junit-framework/releases/tag/r6.1.2

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
