### PR TITLE
NIFI-16108 Removed unnecessary calls of toString

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/compile/ExpressionCompiler.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/compile/ExpressionCompiler.java
@@ -1165,7 +1165,7 @@ public class ExpressionCompiler {
                         toStringEvaluator(argEvaluators.get(0), "first argument to trimDelimitedList")), "trimDelimitedList");
             }
             default:
-                throw new AttributeExpressionLanguageParsingException("Expected a Function-type expression but got " + tree.toString());
+                throw new AttributeExpressionLanguageParsingException("Expected a Function-type expression but got " + tree);
         }
     }
 
@@ -1251,7 +1251,7 @@ public class ExpressionCompiler {
                     case ANY_MATCHING_ATTRIBUTE ->
                         addToken(new MultiMatchAttributeEvaluator(attributeNames, ANY_MATCHING_ATTRIBUTE), "anyMatchingAttribute");
                     default ->
-                        throw new AssertionError("Illegal Multi-Attribute Reference: " + functionTypeTree.toString());
+                        throw new AssertionError("Illegal Multi-Attribute Reference: " + functionTypeTree);
                 };
             }
             case ATTR_NAME: {
@@ -1342,7 +1342,7 @@ public class ExpressionCompiler {
                 return addToken(new GetUriEvaluator(uriArgs), "getUri");
             }
             default:
-                throw new AttributeExpressionLanguageParsingException("Unexpected token: " + tree.toString());
+                throw new AttributeExpressionLanguageParsingException("Unexpected token: " + tree);
         }
     }
 
@@ -1467,7 +1467,7 @@ public class ExpressionCompiler {
             case TRUE -> addToken(new BooleanLiteralEvaluator(true), "true");
             case FALSE -> addToken(new BooleanLiteralEvaluator(false), "true");
             default ->
-                    throw new AttributeExpressionLanguageParsingException("Cannot build Boolean evaluator from tree " + tree.toString());
+                    throw new AttributeExpressionLanguageParsingException("Cannot build Boolean evaluator from tree " + tree);
         };
     }
 

--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/Unpackage.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/Unpackage.java
@@ -66,7 +66,7 @@ public class Unpackage {
                 continue;
             }
 
-            final File tempFile = new File(outputDir, ".temp." + UUID.randomUUID().toString() + ".unpackage");
+            final File tempFile = new File(outputDir, ".temp." + UUID.randomUUID() + ".unpackage");
             inputFileCount++;
             try (final FileInputStream fis = new FileInputStream(inFile);
                     final BufferedInputStream bufferedIn = new BufferedInputStream(fis)) {

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/socket/EndpointConnectionPool.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/socket/EndpointConnectionPool.java
@@ -253,11 +253,11 @@ public class EndpointConnectionPool implements PeerStatusProvider {
                         } else if (protocol.isPortInvalid()) {
                             peerSelector.penalize(peer, penalizationMillis);
                             cleanup(protocol, peer);
-                            throw new PortNotRunningException(peer + " indicates that port " + portId + " is not running");
+                            throw new PortNotRunningException(String.format("%s indicates that port %s is not running", peer, portId));
                         } else if (protocol.isPortUnknown()) {
                             peerSelector.penalize(peer, penalizationMillis);
                             cleanup(protocol, peer);
-                            throw new UnknownPortException(peer + " indicates that port " + portId + " is not known");
+                            throw new UnknownPortException(String.format("%s indicates that port %s is not known", peer, portId));
                         }
 
                         // negotiate the FlowFileCodec to use

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/socket/EndpointConnectionPool.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/socket/EndpointConnectionPool.java
@@ -253,11 +253,11 @@ public class EndpointConnectionPool implements PeerStatusProvider {
                         } else if (protocol.isPortInvalid()) {
                             peerSelector.penalize(peer, penalizationMillis);
                             cleanup(protocol, peer);
-                            throw new PortNotRunningException(peer.toString() + " indicates that port " + portId + " is not running");
+                            throw new PortNotRunningException(peer + " indicates that port " + portId + " is not running");
                         } else if (protocol.isPortUnknown()) {
                             peerSelector.penalize(peer, penalizationMillis);
                             cleanup(protocol, peer);
-                            throw new UnknownPortException(peer.toString() + " indicates that port " + portId + " is not known");
+                            throw new UnknownPortException(peer + " indicates that port " + portId + " is not known");
                         }
 
                         // negotiate the FlowFileCodec to use
@@ -270,7 +270,7 @@ public class EndpointConnectionPool implements PeerStatusProvider {
                         peerSelector.penalize(peer, penalizationMillis);
                         cleanup(protocol, peer);
 
-                        final String message = String.format("%s failed to communicate with %s due to %s", this, peer == null ? clusterUrl : peer, e.toString());
+                        final String message = String.format("%s failed to communicate with %s due to %s", this, peer == null ? clusterUrl : peer, e);
                         error(logger, eventReporter, message);
                         if (logger.isDebugEnabled()) {
                             logger.error("", e);
@@ -406,7 +406,7 @@ public class EndpointConnectionPool implements PeerStatusProvider {
         try {
             clientProtocol.shutdown(peer);
         } catch (final IOException e) {
-            final String message = String.format("%s Failed to shutdown protocol when updating list of peers due to %s", this, e.toString());
+            final String message = String.format("%s Failed to shutdown protocol when updating list of peers due to %s", this, e);
             warn(logger, eventReporter, message);
             if (logger.isDebugEnabled()) {
                 logger.warn("", e);
@@ -416,7 +416,7 @@ public class EndpointConnectionPool implements PeerStatusProvider {
         try {
             peer.close();
         } catch (final IOException e) {
-            final String message = String.format("%s Failed to close resources when updating list of peers due to %s", this, e.toString());
+            final String message = String.format("%s Failed to close resources when updating list of peers due to %s", this, e);
             warn(logger, eventReporter, message);
             if (logger.isDebugEnabled()) {
                 logger.warn("", e);

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/text/RegexDateTimeMatcher.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/text/RegexDateTimeMatcher.java
@@ -64,7 +64,7 @@ public class RegexDateTimeMatcher implements DateTimeMatcher {
                 sb.append(subPatterns.get(i));
             }
 
-            final String regex = "^" + sb.toString();
+            final String regex = sb.insert(0, "^").toString();
             final Pattern pattern = Pattern.compile(regex);
             final Matcher matcher = pattern.matcher(text);
             final boolean found = matcher.find();

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/monitor/TestCompoundUpdateMonitor.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/monitor/TestCompoundUpdateMonitor.java
@@ -38,7 +38,7 @@ public class TestCompoundUpdateMonitor {
         final DigestUpdateMonitor updateMonitor = new DigestUpdateMonitor();
         final CompoundUpdateMonitor compound = new CompoundUpdateMonitor(lastModified, updateMonitor);
 
-        final File file = new File("target/" + UUID.randomUUID().toString());
+        final File file = new File("target/" + UUID.randomUUID());
         if (file.exists()) {
             assertTrue(file.delete());
         }

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -219,7 +219,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
             final Map<String, String> attributes = buildAttributes(amqpProperties, envelope, context);
             flowFile = session.putAllAttributes(flowFile, attributes);
 
-            session.getProvenanceReporter().receive(flowFile, connection.toString() + "/" + context.getProperty(QUEUE).getValue());
+            session.getProvenanceReporter().receive(flowFile, connection + "/" + context.getProperty(QUEUE).getValue());
             session.transfer(flowFile, REL_SUCCESS);
             lastReceived = response;
         }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/validation/StandardValidationError.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/validation/StandardValidationError.java
@@ -92,7 +92,11 @@ public class StandardValidationError implements ValidationError {
                     }
                     sb.append("]");
 
-                    return sb.toString() + " is not a valid value for " + fieldName.get() + ": " + explanation;
+                    return sb.append(" is not a valid value for ")
+                            .append(fieldName.get())
+                            .append(": ")
+                            .append(explanation)
+                            .toString();
                 } else {
                     return inputValue.get() + " is not a valid value for " + fieldName.get() + ": " + explanation;
                 }

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
@@ -358,7 +358,7 @@ public class PutHDFS extends AbstractHadoopProcessor {
                     try {
                         final FileStatus fileStatus = hdfs.getFileStatus(dirPath);
                         if (!fileStatus.isDirectory()) {
-                            throw new IOException(dirPath.toString() + " already exists and is not a directory");
+                            throw new IOException(dirPath + " already exists and is not a directory");
                         }
                         if (fileStatus.hasAcl()) {
                             checkAclStatus(getAclStatus(dirPath));
@@ -366,7 +366,7 @@ public class PutHDFS extends AbstractHadoopProcessor {
                     } catch (FileNotFoundException fe) {
                         targetDirCreated = hdfs.mkdirs(dirPath);
                         if (!targetDirCreated) {
-                            throw new IOException(dirPath.toString() + " could not be created");
+                            throw new IOException(dirPath + " could not be created");
                         }
                         final FileStatus fileStatus = hdfs.getFileStatus(dirPath);
                         if (fileStatus.hasAcl()) {

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongo.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongo.java
@@ -149,7 +149,7 @@ public class GetMongo extends AbstractMongoQueryProcessor {
                     .append((documents.size() > 1 && index + 1 < documents.size()) ? ", " : "");
         }
 
-        return "[" + builder.toString() + "]";
+        return "[" + builder + "]";
     }
 
     private ObjectWriter getObjectWriter(ObjectMapper mapper, String ppSetting) {

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/engine/ClojureScriptEngine.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/engine/ClojureScriptEngine.java
@@ -42,7 +42,7 @@ public class ClojureScriptEngine extends AbstractScriptEngine {
     public static final String ENGINE_VERSION = "1.8.0";
 
     private volatile ScriptEngineFactory scriptEngineFactory;
-    private final String uuid = "ns-" + UUID.randomUUID().toString();
+    private final String uuid = "ns-" + UUID.randomUUID();
     private final Symbol namespaceSymbol = Symbol.create(uuid);
 
     protected ClojureScriptEngine(ScriptEngineFactory scriptEngineFactory) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
@@ -354,9 +354,9 @@ public class FetchFile extends AbstractProcessor {
                         final String simpleFilename = targetFile.getName();
                         final String newName;
                         if (simpleFilename.contains(".")) {
-                            newName = StringUtils.substringBeforeLast(simpleFilename, ".") + "-" + UUID.randomUUID().toString() + "." + StringUtils.substringAfterLast(simpleFilename, ".");
+                            newName = StringUtils.substringBeforeLast(simpleFilename, ".") + "-" + UUID.randomUUID() + "." + StringUtils.substringAfterLast(simpleFilename, ".");
                         } else {
-                            newName = simpleFilename + "-" + UUID.randomUUID().toString();
+                            newName = simpleFilename + "-" + UUID.randomUUID();
                         }
 
                         move(file, new File(targetDirectory, newName), false);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFile.java
@@ -414,9 +414,9 @@ public class GetFile extends AbstractProcessor {
                 final File file = itr.next();
                 final Path filePath = file.toPath();
                 final Path relativePath = directoryPath.relativize(filePath.getParent());
-                String relativePathString = relativePath.toString() + "/";
+                String relativePathString = relativePath + "/";
                 final Path absPath = filePath.toAbsolutePath();
-                final String absPathString = absPath.getParent().toString() + "/";
+                final String absPathString = absPath.getParent() + "/";
 
                 flowFile = session.create();
                 final long importStart = System.nanoTime();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateRecord.java
@@ -393,7 +393,7 @@ public class ValidateRecord extends AbstractProcessor {
                     final StringBuilder errorBuilder = new StringBuilder();
                     errorBuilder.append("Records in this FlowFile were invalid for the following reasons: ");
                     if (!missingFields.isEmpty()) {
-                        errorBuilder.append("The following ").append(missingFields.size()).append(" fields were missing: ").append(missingFields.toString());
+                        errorBuilder.append("The following ").append(missingFields.size()).append(" fields were missing: ").append(missingFields);
                     }
 
                     if (!extraFields.isEmpty()) {
@@ -402,7 +402,7 @@ public class ValidateRecord extends AbstractProcessor {
                         }
 
                         errorBuilder.append("The following ").append(extraFields.size())
-                            .append(" fields were present in the Record but not in the schema: ").append(extraFields.toString());
+                            .append(" fields were present in the Record but not in the schema: ").append(extraFields);
                     }
 
                     if (!invalidFields.isEmpty()) {
@@ -411,7 +411,7 @@ public class ValidateRecord extends AbstractProcessor {
                         }
 
                         errorBuilder.append("The following ").append(invalidFields.size())
-                            .append(" fields had values whose type did not match the schema: ").append(invalidFields.toString());
+                            .append(" fields had values whose type did not match the schema: ").append(invalidFields);
                     }
 
                     if (!otherProblems.isEmpty()) {
@@ -420,7 +420,7 @@ public class ValidateRecord extends AbstractProcessor {
                         }
 
                         errorBuilder.append("The following ").append(otherProblems.size())
-                            .append(" additional problems were encountered: ").append(otherProblems.toString());
+                            .append(" additional problems were encountered: ").append(otherProblems);
                     }
 
                     final String validationErrorString = errorBuilder.toString();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ftp/filesystem/VirtualFileSystemView.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ftp/filesystem/VirtualFileSystemView.java
@@ -64,7 +64,7 @@ public class VirtualFileSystemView implements FileSystemView {
         VirtualPath filePath = currentDirectory.resolve(fileName);
         VirtualPath parent = filePath.getParent();
         if ((parent != null) && !fileSystem.exists(filePath.getParent())) {
-            throw new FtpException(String.format("Parent directory does not exist for %s", filePath.toString()));
+            throw new FtpException(String.format("Parent directory does not exist for %s", filePath));
         }
         return new VirtualFtpFile(filePath, fileSystem);
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/AbstractTestTailFileScenario.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/AbstractTestTailFileScenario.java
@@ -144,7 +144,7 @@ public class AbstractTestTailFileScenario {
         assertEquals(
             expected.stream().collect(Collectors.joining()),
             actual.stream().collect(Collectors.joining()),
-            stopAfterEachTrigger + " " + actions.toString()
+            stopAfterEachTrigger + " " + actions
         );
     }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
@@ -176,11 +176,11 @@ public class DatabaseRecordLookupService extends AbstractDatabaseLookupService i
                 }
 
             } catch (SQLException se) {
-                throw new LookupFailureException("Error executing SQL statement: " + selectQuery + "for value " + key
-                        + " : " + (se.getCause() == null ? se.getMessage() : se.getCause().getMessage()), se);
+                throw new LookupFailureException(String.format("Error executing SQL statement: %s for value %s : %s",
+                        selectQuery, key, (se.getCause() == null ? se.getMessage() : se.getCause().getMessage())), se);
             } catch (IOException ioe) {
-                throw new LookupFailureException("Error retrieving result set for SQL statement: " + selectQuery + "for value " + key
-                        + " : " + (ioe.getCause() == null ? ioe.getMessage() : ioe.getCause().getMessage()), ioe);
+                throw new LookupFailureException( String.format("Error retrieving result set for SQL statement: %s for value %s : %s",
+                        selectQuery, key, (ioe.getCause() == null ? ioe.getMessage() : ioe.getCause().getMessage())), ioe);
             }
         }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
@@ -179,7 +179,7 @@ public class DatabaseRecordLookupService extends AbstractDatabaseLookupService i
                 throw new LookupFailureException(String.format("Error executing SQL statement: %s for value %s : %s",
                         selectQuery, key, (se.getCause() == null ? se.getMessage() : se.getCause().getMessage())), se);
             } catch (IOException ioe) {
-                throw new LookupFailureException( String.format("Error retrieving result set for SQL statement: %s for value %s : %s",
+                throw new LookupFailureException(String.format("Error retrieving result set for SQL statement: %s for value %s : %s",
                         selectQuery, key, (ioe.getCause() == null ? ioe.getMessage() : ioe.getCause().getMessage())), ioe);
             }
         }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
@@ -176,10 +176,10 @@ public class DatabaseRecordLookupService extends AbstractDatabaseLookupService i
                 }
 
             } catch (SQLException se) {
-                throw new LookupFailureException("Error executing SQL statement: " + selectQuery + "for value " + key.toString()
+                throw new LookupFailureException("Error executing SQL statement: " + selectQuery + "for value " + key
                         + " : " + (se.getCause() == null ? se.getMessage() : se.getCause().getMessage()), se);
             } catch (IOException ioe) {
-                throw new LookupFailureException("Error retrieving result set for SQL statement: " + selectQuery + "for value " + key.toString()
+                throw new LookupFailureException("Error retrieving result set for SQL statement: " + selectQuery + "for value " + key
                         + " : " + (ioe.getCause() == null ? ioe.getMessage() : ioe.getCause().getMessage()), ioe);
             }
         }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/SimpleDatabaseLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/SimpleDatabaseLookupService.java
@@ -159,8 +159,9 @@ public class SimpleDatabaseLookupService extends AbstractDatabaseLookupService i
                 }
 
             } catch (SQLException se) {
-                throw new LookupFailureException("Error executing SQL statement: " + selectQuery + "for value " + key.toString()
-                        + " : " + (se.getCause() == null ? se.getMessage() : se.getCause().getMessage()), se);
+                final String message = String.format("Error executing SQL statement: %s for value %s : %s",
+                        selectQuery, key, (se.getCause() == null ? se.getMessage() : se.getCause().getMessage()));
+                throw new LookupFailureException(message, se);
             }
         }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/SimpleDatabaseLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/SimpleDatabaseLookupService.java
@@ -159,9 +159,8 @@ public class SimpleDatabaseLookupService extends AbstractDatabaseLookupService i
                 }
 
             } catch (SQLException se) {
-                final String message = String.format("Error executing SQL statement: %s for value %s : %s",
-                        selectQuery, key, (se.getCause() == null ? se.getMessage() : se.getCause().getMessage()));
-                throw new LookupFailureException(message, se);
+                throw new LookupFailureException(String.format("Error executing SQL statement: %s for value %s : %s",
+                        selectQuery, key, (se.getCause() == null ? se.getMessage() : se.getCause().getMessage())), se);
             }
         }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/schema/inference/VolatileSchemaCache.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/schema/inference/VolatileSchemaCache.java
@@ -99,7 +99,7 @@ public class VolatileSchemaCache extends AbstractControllerService implements Re
 
         // Schemas hashed to same value but do not equal one another. Append a randomly generated UUID
         // and add that to the cache.
-        final String updatedIdentifier = identifier + "-" + UUID.randomUUID().toString();
+        final String updatedIdentifier = identifier + "-" + UUID.randomUUID();
         cache.put(updatedIdentifier, schema);
 
         getLogger().debug("Schema with ID {} conflicted with new Schema. Resolved by using generated identifier {}", identifier, updatedIdentifier);

--- a/nifi-extension-bundles/nifi-update-attribute-bundle/nifi-update-attribute-ui/src/main/java/org/apache/nifi/update/attributes/UpdateAttributeModelFactory.java
+++ b/nifi-extension-bundles/nifi-update-attribute-bundle/nifi-update-attribute-ui/src/main/java/org/apache/nifi/update/attributes/UpdateAttributeModelFactory.java
@@ -117,7 +117,7 @@ public class UpdateAttributeModelFactory {
         try {
             Query.validateExpression(dto.getValue(), true);
         } catch (final AttributeExpressionLanguageParsingException e) {
-            throw new IllegalArgumentException("Invalid Expression: " + e.toString(), e);
+            throw new IllegalArgumentException("Invalid Expression: " + e, e);
         }
 
         final Action action = new Action();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -1123,7 +1123,7 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
             }
         } catch (final Throwable t) {
             LOG.error("Failed to perform validation", t);
-            results.add(new ValidationResult.Builder().explanation("Failed to run validation due to " + t.toString())
+            results.add(new ValidationResult.Builder().explanation("Failed to run validation due to " + t)
                     .valid(false).build());
         }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -1091,7 +1091,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
         final StandardRepositoryRecord repoRecord = getRecord(flowFile);
         if (repoRecord == null) {
-            throw new FlowFileHandlingException(flowFile + " is not known in this session (" + toString() + ")");
+            throw new FlowFileHandlingException(String.format("%s is not known in this session (%s)", flowFile, this));
         }
 
         final ProvenanceEventBuilder recordBuilder = context.createProvenanceEventBuilder().fromEvent(rawEvent);
@@ -1564,7 +1564,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
                 final StandardRepositoryRecord record = getRecord(flowFile);
                 if (record == null) {
-                    throw new FlowFileHandlingException(flowFile + " is not known in this session (" + toString() + ")");
+                    throw new FlowFileHandlingException(String.format("%s is not known in this session (%s)", flowFile, this));
                 }
             }
 
@@ -2750,7 +2750,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             ensureNotAppending(record.getCurrentClaim());
             claimCache.flush(record.getCurrentClaim());
         } catch (final IOException e) {
-            throw new FlowFileAccessException("Failed to access ContentClaim for " + source.toString(), e);
+            throw new FlowFileAccessException("Failed to access ContentClaim for " + source, e);
         }
 
         try (final InputStream rawIn = getInputStream(source, record.getCurrentClaim(), record.getCurrentClaimOffset(), true);
@@ -2785,7 +2785,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         } catch (final ContentNotFoundException nfe) {
             handleContentNotFound(nfe, record);
         } catch (final IOException ex) {
-            throw new ProcessException("IOException thrown from " + connectableDescription + ": " + ex.toString(), ex);
+            throw new ProcessException(String.format("IOException thrown from %s : %s", connectableDescription, ex), ex);
         }
     }
 
@@ -2801,7 +2801,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             ensureNotAppending(currentClaim);
             claimCache.flush(currentClaim);
         } catch (final IOException e) {
-            throw new FlowFileAccessException("Failed to access ContentClaim for " + source.toString(), e);
+            throw new FlowFileAccessException("Failed to access ContentClaim for " + source, e);
         }
 
         final InputStream rawIn;
@@ -2959,7 +2959,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
                 ensureNotAppending(record.getCurrentClaim());
                 claimCache.flush(record.getCurrentClaim());
             } catch (final IOException e) {
-                throw new FlowFileAccessException("Unable to read from source " + source + " due to " + e.toString(), e);
+                throw new FlowFileAccessException(String.format("Unable to read from source %s due to %s", source, e), e);
             }
         }
 
@@ -2970,7 +2970,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             newClaim = contentRepo.create(context.getConnectable().isLossTolerant());
             claimLog.debug("Creating ContentClaim {} for 'merge' for {}", newClaim, destinationRecord.getCurrent());
         } catch (final IOException e) {
-            throw new FlowFileAccessException("Unable to create ContentClaim due to " + e.toString(), e);
+            throw new FlowFileAccessException("Unable to create ContentClaim due to " + e, e);
         }
 
         long readCount = 0L;
@@ -3016,7 +3016,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             handleContentNotFound(nfe, sourceRecords);
         } catch (final IOException ioe) {
             destroyContent(newClaim, destinationRecord);
-            throw new FlowFileAccessException("Failed to merge " + sources.size() + " into " + destination + " due to " + ioe.toString(), ioe);
+            throw new FlowFileAccessException(String.format("Failed to merge %s into %s due to %s", sources.size(), destination, ioe), ioe);
         } catch (final Throwable t) {
             destroyContent(newClaim, destinationRecord);
             throw t;
@@ -3180,7 +3180,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         } catch (final IOException ioe) {
             resetWriteClaims(); // need to reset write claim before we can remove the claim
             destroyContent(newClaim, record);
-            throw new ProcessException("IOException thrown from " + connectableDescription + ": " + ioe.toString(), ioe);
+            throw new ProcessException(String.format("IOException thrown from %s: %s", connectableDescription, ioe), ioe);
         } catch (final Throwable t) {
             resetWriteClaims(); // need to reset write claim before we can remove the claim
             destroyContent(newClaim, record);
@@ -3229,7 +3229,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         } catch (final IOException ioe) {
             resetWriteClaims(); // need to reset write claim before we can remove the claim
             destroyContent(newClaim, record);
-            throw new ProcessException("IOException thrown from " + connectableDescription + ": " + ioe.toString(), ioe);
+            throw new ProcessException(String.format("IOException thrown from %s: %s", connectableDescription, ioe), ioe);
         } catch (final Throwable t) {
             resetWriteClaims(); // need to reset write claim before we can remove the claim
             destroyContent(newClaim, record);
@@ -3352,7 +3352,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
                 destroyContent(newClaim, record);
             }
 
-            throw new ProcessException("IOException thrown from " + connectableDescription + ": " + ioe.toString(), ioe);
+            throw new ProcessException(String.format("IOException thrown from %s: %s", connectableDescription, ioe), ioe);
         } catch (final Throwable t) {
             resetWriteClaims(); // need to reset write claim before we can remove the claim
 
@@ -3541,7 +3541,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             handleContentNotFound(nfe, record);
         } catch (final IOException ioe) {
             destroyContent(newClaim, record);
-            throw new ProcessException("IOException thrown from " + connectableDescription + ": " + ioe.toString(), ioe);
+            throw new ProcessException(String.format("IOException thrown from %s: %s", connectableDescription, ioe), ioe);
         } catch (final Throwable t) {
             destroyContent(newClaim, record);
             throw t;
@@ -3594,7 +3594,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             newClaim = context.getContentRepository().create(context.getConnectable().isLossTolerant());
             claimLog.debug("Creating ContentClaim {} for 'importFrom' for {}", newClaim, destination);
         } catch (final IOException e) {
-            throw new FlowFileAccessException("Unable to create ContentClaim due to " + e.toString(), e);
+            throw new FlowFileAccessException("Unable to create ContentClaim due to " + e, e);
         }
 
         claimOffset = 0L;
@@ -3605,7 +3605,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             bytesRead += newSize;
         } catch (final Throwable t) {
             destroyContent(newClaim, record);
-            throw new FlowFileAccessException("Failed to import data from " + source + " for " + destination + " due to " + t.toString(), t);
+            throw new FlowFileAccessException(String.format("Failed to import data from %s for %s due to %s", source, destination, t), t);
         }
 
         removeTemporaryClaim(record);
@@ -3659,14 +3659,14 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
                 newSize = context.getContentRepository().importFrom(createTaskTerminationStream(source), newClaim);
                 bytesWritten += newSize;
             } catch (final IOException e) {
-                throw new FlowFileAccessException("Unable to create ContentClaim due to " + e.toString(), e);
+                throw new FlowFileAccessException("Unable to create ContentClaim due to " + e, e);
             }
         } catch (final Throwable t) {
             if (newClaim != null) {
                 destroyContent(newClaim, record);
             }
 
-            throw new FlowFileAccessException("Failed to import data from " + source + " for " + destination + " due to " + t.toString(), t);
+            throw new FlowFileAccessException(String.format("Failed to import data from %s for %s due to %s", source, destination, t), t);
         }
 
         removeTemporaryClaim(record);
@@ -3708,7 +3708,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         } catch (final ContentNotFoundException nfe) {
             handleContentNotFound(nfe, record);
         } catch (final Throwable t) {
-            throw new FlowFileAccessException("Failed to export " + source + " to " + destination + " due to " + t.toString(), t);
+            throw new FlowFileAccessException(String.format("Failed to export %s to %s due to %s", source, destination, t), t);
         }
     }
 
@@ -3726,7 +3726,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             ensureNotAppending(record.getCurrentClaim());
             claimCache.flush(record.getCurrentClaim());
         } catch (final IOException e) {
-            throw new FlowFileAccessException("Failed to access ContentClaim for " + source.toString(), e);
+            throw new FlowFileAccessException("Failed to access ContentClaim for " + source, e);
         }
 
         try (final InputStream rawIn = getInputStream(source, record.getCurrentClaim(), record.getCurrentClaimOffset(), true);
@@ -3762,7 +3762,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         } catch (final ContentNotFoundException nfe) {
             handleContentNotFound(nfe, record);
         } catch (final IOException ex) {
-            throw new ProcessException("IOException thrown from " + connectableDescription + ": " + ex.toString(), ex);
+            throw new ProcessException(String.format("IOException thrown from %s: %s", connectableDescription, ex), ex);
         }
     }
 
@@ -3810,7 +3810,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         final StandardRepositoryRecord record = getRecord(flowFile);
         if (record == null) {
             rollback();
-            throw new FlowFileHandlingException(flowFile + " is not known in this session (" + toString() + ")");
+            throw new FlowFileHandlingException(String.format("%s is not known in this session (%s)", flowFile, this));
         }
         if (record.getTransferRelationship() != null) {
             rollback();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -3482,7 +3482,7 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
                     return "Content is no longer available in Content Repository";
                 }
             } catch (final IOException ioe) {
-                return "Failed to determine whether or not content was available in Content Repository due to " + ioe.toString();
+                return "Failed to determine whether or not content was available in Content Repository due to " + ioe;
             }
         }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
@@ -649,7 +649,7 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
         } catch (final Exception ex) {
             // disconnect controller
             if (controller.isClustered()) {
-                disconnect("Failed to properly handle Reconnection request due to " + ex.toString());
+                disconnect("Failed to properly handle Reconnection request due to " + ex);
             }
 
             logger.error("Handling reconnection request failed", ex);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
@@ -826,7 +826,7 @@ public class SwappablePriorityQueue {
                 } catch (final IOException ioe) {
                     logger.error("Failed to drop the FlowFiles from queue {}", getQueueIdentifier(), ioe);
 
-                    dropRequest.setState(DropFlowFileState.FAILURE, "Failed to drop FlowFiles due to " + ioe.toString());
+                    dropRequest.setState(DropFlowFileState.FAILURE, "Failed to drop FlowFiles due to " + ioe);
                     return;
                 }
 
@@ -848,7 +848,7 @@ public class SwappablePriorityQueue {
                 } catch (final IOException ioe) {
                     logger.error("Failed to drop the FlowFiles from queue {}", getQueueIdentifier(), ioe);
 
-                    dropRequest.setState(DropFlowFileState.FAILURE, "Failed to drop FlowFiles due to " + ioe.toString());
+                    dropRequest.setState(DropFlowFileState.FAILURE, "Failed to drop FlowFiles due to " + ioe);
                     return;
                 }
 
@@ -891,7 +891,7 @@ public class SwappablePriorityQueue {
                                 + ". The FlowFiles contained in this Swap File will not be dropped from the queue");
                         }
 
-                        dropRequest.setState(DropFlowFileState.FAILURE, "Failed to swap in FlowFiles from Swap File " + swapLocation + " due to " + ioe.toString());
+                        dropRequest.setState(DropFlowFileState.FAILURE, String.format("Failed to swap in FlowFiles from Swap File %s due to %s", swapLocation, ioe));
                         if (swapContents != null) {
                             activeQueue.addAll(swapContents.getFlowFiles()); // ensure that we don't lose the FlowFiles from our queue.
                         }
@@ -915,7 +915,7 @@ public class SwappablePriorityQueue {
                 dropRequest.setState(DropFlowFileState.COMPLETE);
             } catch (final Exception e) {
                 logger.error("Failed to drop FlowFiles from Connection with ID {}", getQueueIdentifier(), e);
-                dropRequest.setState(DropFlowFileState.FAILURE, "Failed to drop FlowFiles due to " + e.toString());
+                dropRequest.setState(DropFlowFileState.FAILURE, "Failed to drop FlowFiles due to " + e);
             }
         } finally {
             writeLock.unlock("Drop FlowFiles");

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/client/async/nio/NioAsyncLoadBalanceClientTask.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/client/async/nio/NioAsyncLoadBalanceClientTask.java
@@ -84,7 +84,7 @@ public class NioAsyncLoadBalanceClientTask implements Runnable {
                         }
                     } catch (final Exception e) {
                         eventReporter.reportEvent(Severity.ERROR, EVENT_CATEGORY, "Failed to communicate with Peer "
-                            + client.getNodeIdentifier() + " while trying to load balance data across the cluster due to " + e.toString());
+                            + client.getNodeIdentifier() + " while trying to load balance data across the cluster due to " + e);
                         logger.error("Failed to communicate with Peer {} while trying to load balance data across the cluster.", client.getNodeIdentifier(), e);
                     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
@@ -327,7 +327,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
 
                     LOG.error("Failed to invoke the On-Scheduled Lifecycle methods of {} due to {}; administratively yielding this "
                             + "ReportingTask and will attempt to schedule it again after {}",
-                            reportingTask, e.toString(), administrativeYieldDuration, e);
+                            reportingTask, e, administrativeYieldDuration, e);
 
                     try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(extensionManager, reportingTask.getClass(), reportingTask.getIdentifier())) {
                         ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnUnscheduled.class, reportingTask, taskNode.getConfigurationContext());

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/MockSwapManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/MockSwapManager.java
@@ -83,7 +83,7 @@ public class MockSwapManager implements FlowFileSwapManager {
             throw ioe;
         }
 
-        final String location = UUID.randomUUID().toString() + "." + partitionName;
+        final String location = UUID.randomUUID() + "." + partitionName;
         swappedOut.put(location, new ArrayList<>(flowFiles));
         return location;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
@@ -238,14 +238,14 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
             throw new ProcessException(e);
         } catch (final UnreachableClusterException e) {
             context.yield();
-            final String message = String.format("%s failed to communicate with %s due to %s", this, url, e.toString());
+            final String message = String.format("%s failed to communicate with %s due to %s", this, url, e);
             logger.error(message);
             remoteGroup.getEventReporter().reportEvent(Severity.ERROR, CATEGORY, message);
             throw new ProcessException(e);
         } catch (final IOException e) {
             // we do not yield here because the 'peer' will be penalized, and we won't communicate with that particular nifi instance
             // for a while due to penalization, but we can continue to talk to other nifi instances
-            final String message = String.format("%s failed to communicate with %s due to %s", this, url, e.toString());
+            final String message = String.format("%s failed to communicate with %s due to %s", this, url, e);
             logger.error(message);
             if (logger.isDebugEnabled()) {
                 logger.error("", e);
@@ -273,7 +273,7 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
 
             session.commitAsync();
         } catch (final Throwable t) {
-            final String message = String.format("%s failed to communicate with remote NiFi instance due to %s", this, t.toString());
+            final String message = String.format("%s failed to communicate with remote NiFi instance due to %s", this, t);
 
             // If Exception is a TransmissionDisabledException, it's because the user explicitly terminated the connection in the middle.
             // No need to log errors for this, just debug log and move on. Otherwise, log the error.
@@ -505,7 +505,7 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
             .findFirst();
 
         if (resultOption.isPresent()) {
-            throw new IllegalStateException("Remote Process Group is not valid: " + resultOption.get().toString());
+            throw new IllegalStateException("Remote Process Group is not valid: " + resultOption.get());
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -409,7 +409,7 @@ public final class DtoFactory {
             purgeDetails.setEndDate(((PurgeDetails) actionDetails).getEndDate());
             return purgeDetails;
         } else {
-            throw new WebApplicationException(new IllegalArgumentException(String.format("Unrecognized type of action details encountered %s during serialization.", actionDetails.toString())));
+            throw new WebApplicationException(new IllegalArgumentException(String.format("Unrecognized type of action details encountered %s during serialization.", actionDetails)));
         }
     }
 
@@ -433,7 +433,7 @@ public final class DtoFactory {
             remoteProcessGroupDetails.setUri(((RemoteProcessGroupDetails) componentDetails).getUri());
             return remoteProcessGroupDetails;
         } else {
-            throw new WebApplicationException(new IllegalArgumentException(String.format("Unrecognized type of component details encountered %s during serialization. ", componentDetails.toString())));
+            throw new WebApplicationException(new IllegalArgumentException(String.format("Unrecognized type of component details encountered %s during serialization. ", componentDetails)));
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/ComponentDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/ComponentDAO.java
@@ -142,7 +142,7 @@ public abstract class ComponentDAO {
         if (bundle != null) {
             final BundleCoordinate coordinate = new BundleCoordinate(bundle.getGroup(), bundle.getArtifact(), bundle.getVersion());
             if (bundles.stream().filter(b -> b.getBundleDetails().getCoordinate().equals(coordinate)).count() == 0) {
-                throw new IllegalStateException(String.format("%s is not known to this NiFi instance.", coordinate.toString()));
+                throw new IllegalStateException(String.format("%s is not known to this NiFi instance.", coordinate));
             }
         } else {
             if (bundles.isEmpty()) {

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
@@ -273,7 +273,7 @@ public class MockProcessSession implements ProcessSession {
     public MockFlowFile clone(FlowFile flowFile, final long offset, final long size) {
         flowFile = validateState(flowFile);
         if (offset + size > flowFile.getSize()) {
-            throw new FlowFileHandlingException("Specified offset of " + offset + " and size " + size + " exceeds size of " + flowFile.toString());
+            throw new FlowFileHandlingException("Specified offset of " + offset + " and size " + size + " exceeds size of " + flowFile);
         }
 
         final MockFlowFile newFlowFile = new MockFlowFile(sharedState.nextFlowFileId(), flowFile);

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
@@ -273,7 +273,7 @@ public class MockProcessSession implements ProcessSession {
     public MockFlowFile clone(FlowFile flowFile, final long offset, final long size) {
         flowFile = validateState(flowFile);
         if (offset + size > flowFile.getSize()) {
-            throw new FlowFileHandlingException("Specified offset of " + offset + " and size " + size + " exceeds size of " + flowFile);
+            throw new FlowFileHandlingException(String.format("Specified offset of %s and size %s exceeds size of %s", offset, size, flowFile));
         }
 
         final MockFlowFile newFlowFile = new MockFlowFile(sharedState.nextFlowFileId(), flowFile);

--- a/nifi-registry/nifi-registry-core/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/BootstrapCodec.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/BootstrapCodec.java
@@ -57,7 +57,7 @@ public class BootstrapCodec {
         try {
             processRequest(cmd, args);
         } catch (final InvalidCommandException ice) {
-            throw new IOException("Received invalid command from NiFi Registry: " + line + (ice.getMessage() == null ? "" : " - Details: " + ice.toString()));
+            throw new IOException("Received invalid command from NiFi Registry: " + line + (ice.getMessage() == null ? "" : " - Details: " + ice));
         }
     }
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/composite/QuickImport.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/composite/QuickImport.java
@@ -161,7 +161,7 @@ public class QuickImport extends AbstractCompositeCommand<StringResult> {
     private String createQuickImportFlow(final NiFiRegistryClient registryClient, final String quickImportBucketId, final boolean isInteractive)
             throws ParseException, IOException, NiFiRegistryException {
         final String flowName = FLOW_NAME + System.currentTimeMillis();
-        final String flowDescription = FLOW_DESC + (new Date()).toString();
+        final String flowDescription = FLOW_DESC + (new Date());
 
         final Properties createFlowProps = new Properties();
         createFlowProps.setProperty(CommandOption.FLOW_NAME.getLongName(), flowName);
@@ -233,7 +233,7 @@ public class QuickImport extends AbstractCompositeCommand<StringResult> {
         if (registryClientId == null) {
             final Properties createRegClientProps = new Properties();
             createRegClientProps.setProperty(CommandOption.REGISTRY_CLIENT_NAME.getLongName(), REG_CLIENT_NAME);
-            createRegClientProps.setProperty(CommandOption.REGISTRY_CLIENT_DESC.getLongName(), REG_CLIENT_DESC + new Date().toString());
+            createRegClientProps.setProperty(CommandOption.REGISTRY_CLIENT_DESC.getLongName(), REG_CLIENT_DESC + new Date());
             createRegClientProps.setProperty(CommandOption.REGISTRY_CLIENT_URL.getLongName(), registryClientBaseUrl);
 
             final StringResult createdRegClient = createRegistryClient.doExecute(nifiClient, createRegClientProps);

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/extension/UploadBundle.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/extension/UploadBundle.java
@@ -66,8 +66,7 @@ public class UploadBundle extends AbstractNiFiRegistryCommand<BundleVersionResul
         try {
             bundleType = BundleType.fromString(getRequiredArg(properties, CommandOption.EXT_BUNDLE_TYPE));
         } catch (Exception e) {
-            throw new NiFiRegistryException("Invalid bundle type, should be one of "
-                    + BundleType.NIFI_NAR.toString() + " or " + BundleType.MINIFI_CPP.toString());
+            throw new NiFiRegistryException(String.format("Invalid bundle type, should be one of %s or %s", BundleType.NIFI_NAR, BundleType.MINIFI_CPP));
         }
 
         final File bundleFile = new File(getRequiredArg(properties, CommandOption.EXT_BUNDLE_FILE));

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/extension/UploadBundles.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/extension/UploadBundles.java
@@ -74,8 +74,7 @@ public class UploadBundles extends AbstractNiFiRegistryCommand<StringResult> {
         try {
             bundleType = BundleType.fromString(getRequiredArg(properties, CommandOption.EXT_BUNDLE_TYPE));
         } catch (IllegalArgumentException e) {
-            throw new NiFiRegistryException("Invalid bundle type, should be one of "
-                    + BundleType.NIFI_NAR.toString() + " or " + BundleType.MINIFI_CPP.toString());
+            throw new NiFiRegistryException(String.format("Invalid bundle type, should be one of %s or %s", BundleType.NIFI_NAR, BundleType.MINIFI_CPP));
         }
 
         final BundleVersionClient bundleVersionClient = client.getBundleVersionClient();


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16108](https://issues.apache.org/jira/browse/NIFI-16108)
This PR removed unnecessary toString calls and simplified the building of specific exception messages to use `String.format` instead of multiple concatenations.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
