### PR TITLE
NIFI-16021 Improved JoltTransformJSON error message when specified JOLT spec is invalid and ensured leading single and multi-line Java comments are supported when the Jolt spec is specified as text. 

### DIFF
--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/AbstractJoltTransform.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/AbstractJoltTransform.java
@@ -256,7 +256,7 @@ public abstract class AbstractJoltTransform extends AbstractProcessor {
         try (final BufferedReader reader = new BufferedReader(new InputStreamReader(resourceReference.read(), StandardCharsets.UTF_8))) {
             return reader.lines().collect(Collectors.joining(System.lineSeparator()));
         } catch (final IOException e) {
-            throw new UncheckedIOException("Read JOLT Transform failed", e);
+            throw new UncheckedIOException("Read JOLT Transform failed, reason: " + e.getMessage(), e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/AbstractJoltTransform.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/AbstractJoltTransform.java
@@ -190,8 +190,15 @@ public abstract class AbstractJoltTransform extends AbstractProcessor {
                     }
                 }
             } catch (final Exception e) {
-                String message = String.format("Specification not valid for the selected transformation: %s",
-                        (e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));
+                final String reason;
+                final Throwable cause = e.getCause();
+                if (cause == null) {
+                    reason = e.getMessage();
+                } else {
+                    reason = "%s [%s]".formatted(cause.getMessage(), e.getMessage());
+                }
+
+                final String message = "Specification not valid... %s".formatted(reason);
                 results.add(new ValidationResult.Builder()
                         .valid(false)
                         .subject(JOLT_SPEC.getDisplayName())

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/AbstractJoltTransform.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/AbstractJoltTransform.java
@@ -198,7 +198,7 @@ public abstract class AbstractJoltTransform extends AbstractProcessor {
                     reason = "%s [%s]".formatted(cause.getMessage(), e.getMessage());
                 }
 
-                final String message = "Specification not valid... %s".formatted(reason);
+                final String message = "Specification not valid: %s".formatted(reason);
                 results.add(new ValidationResult.Builder()
                         .valid(false)
                         .subject(JOLT_SPEC.getDisplayName())

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/AbstractJoltTransform.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/AbstractJoltTransform.java
@@ -190,7 +190,8 @@ public abstract class AbstractJoltTransform extends AbstractProcessor {
                     }
                 }
             } catch (final Exception e) {
-                String message = String.format("Specification not valid for the selected transformation: %s", e.getMessage());
+                String message = String.format("Specification not valid for the selected transformation: %s",
+                        (e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));
                 results.add(new ValidationResult.Builder()
                         .valid(false)
                         .subject(JOLT_SPEC.getDisplayName())
@@ -256,7 +257,7 @@ public abstract class AbstractJoltTransform extends AbstractProcessor {
         try (final BufferedReader reader = new BufferedReader(new InputStreamReader(resourceReference.read(), StandardCharsets.UTF_8))) {
             return reader.lines().collect(Collectors.joining(System.lineSeparator()));
         } catch (final IOException e) {
-            throw new UncheckedIOException("Read JOLT Transform failed, reason: " + e.getMessage(), e);
+            throw new UncheckedIOException("Read JOLT Transform failed", e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/test/java/org/apache/nifi/processors/jolt/TestJoltTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/test/java/org/apache/nifi/processors/jolt/TestJoltTransformJSON.java
@@ -211,10 +211,9 @@ class TestJoltTransformJSON {
     }
 
     @ParameterizedTest()
-    @MethodSource("getChainrArguments")
-    void testTransformInputWithChainr(Path specPath) throws IOException {
-        final String spec = Files.readString(specPath);
-        runner.setProperty(JoltTransformJSON.JOLT_SPEC, spec);
+    @MethodSource("getChainrArgumentContents")
+    void testTransformInputWithChainrContents(String chainrSpecContents) throws IOException {
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC, chainrSpecContents);
         runner.enqueue(JSON_INPUT);
         runner.run();
 
@@ -615,9 +614,50 @@ class TestJoltTransformJSON {
         );
     }
 
-    private static Stream<Arguments> getChainrArguments() {
+    private static Stream<Arguments> getChainrArgumentContents() throws IOException {
+        final String chainrSpecWithLeadingMultLineJavaComment = """
+                /*
+                    Multiline Java comment
+                */
+                [
+                  {
+                    "operation": "shift",
+                    "spec": {
+                      "rating": {
+                        "primary": {
+                          "value": "Rating",
+                          "max": "RatingRange"
+                        },
+                        "*": {
+                          "max": "SecondaryRatings.&1.Range",
+                          "value": "SecondaryRatings.&1.Value",
+                          "$": "SecondaryRatings.&1.Id"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "operation": "default",
+                    "spec": {
+                      "Range": 5,
+                      "SecondaryRatings": {
+                        "*": {
+                          "Range": 5
+                        }
+                      }
+                    }
+                  }
+                ]
+                """;
+
+        final Path chainrSpecWithoutCommentsPath = Paths.get(CHAINR_SPEC_PATH);
+        final String chainrSpecWithoutComments = Files.readString(chainrSpecWithoutCommentsPath);
+        final Path chainrSpecWithLeadingSingleLineCommentPath = Paths.get("src/test/resources/specs/chainrSpecWithSingleLineComment.json");
+        final String chainrSpecWithLeadingSingleLineComment = Files.readString(chainrSpecWithLeadingSingleLineCommentPath);
+
         return Stream.of(
-                Arguments.argumentSet("has no single line comments", Paths.get(CHAINR_SPEC_PATH)),
-                Arguments.argumentSet("has a single line comment", Paths.get("src/test/resources/specs/chainrSpecWithSingleLineComment.json")));
+                Arguments.argumentSet("No Java comments", chainrSpecWithoutComments),
+                Arguments.argumentSet("Leading single line Java comment", chainrSpecWithLeadingSingleLineComment),
+                Arguments.argumentSet("Leading multi-line Java comment", chainrSpecWithLeadingMultLineJavaComment));
     }
 }

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/test/java/org/apache/nifi/processors/jolt/TestJoltTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/test/java/org/apache/nifi/processors/jolt/TestJoltTransformJSON.java
@@ -18,6 +18,7 @@ package org.apache.nifi.processors.jolt;
 
 import io.joltcommunity.jolt.Diffy;
 import io.joltcommunity.jolt.JsonUtils;
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.jolt.util.JoltTransformStrategy;
 import org.apache.nifi.processor.Processor;
@@ -40,6 +41,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -107,6 +109,19 @@ class TestJoltTransformJSON {
 
         runner.setProperty(JoltTransformJSON.JOLT_SPEC, chainrSpecContents);
         runner.assertValid();
+    }
+
+    @Test
+    void testNonExistingJOLTSpec() throws IOException {
+        final Path testResourcesDir = Paths.get("src/test/resources");
+        final Path nonexistingSpec = testResourcesDir.resolve("nonExistingSpec.json");
+        runner.setProperty(JoltTransformJSON.JOLT_SPEC, nonexistingSpec.toAbsolutePath().toString());
+        runner.enqueue(JSON_INPUT);
+        runner.assertNotValid();
+
+        final Collection<ValidationResult> validationResults = runner.validate();
+        final String explanation = validationResults.iterator().next().getExplanation();
+        assertTrue(explanation.contains("file"));
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/test/resources/specs/chainrSpecWithSingleLineComment.json
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/test/resources/specs/chainrSpecWithSingleLineComment.json
@@ -1,5 +1,5 @@
+// Single line comment
 [
-  // Single line comment
   {
     "operation": "shift",
     "spec": {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateJson.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateJson.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processors.standard;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.json.schema.JsonSchema;
 import org.apache.nifi.json.schema.SchemaVersion;
@@ -250,6 +251,120 @@ class TestValidateJson {
         }
 
         runner.clearTransferState();
+    }
+
+    @ParameterizedTest
+    @MethodSource("schemasWithLeadingComments")
+    void testSchemaContentWithLeadingComments(String schema) {
+        runner.setProperty(ValidateJson.SCHEMA_CONTENT, schema);
+        runner.setProperty(JsonSchemaRegistryComponent.SCHEMA_VERSION, SCHEMA_VERSION);
+        runner.enqueue(getFileContent("simple-example-with-comments.json"));
+        runner.assertValid();
+
+        final AssertionFailedError assertionFailedError = assertThrows(AssertionFailedError.class, () -> runner.run());
+        final String stackTrace = ExceptionUtils.getStackTrace(assertionFailedError);
+        assertTrue(stackTrace.contains("JsonParseException") && !stackTrace.contains("FileNotFoundException"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("schemasWithEmbeddedComments")
+    void testSchemaContentWithEmbeddedComments(String schema) {
+        runner.setProperty(ValidateJson.SCHEMA_CONTENT, schema);
+        runner.setProperty(JsonSchemaRegistryComponent.SCHEMA_VERSION, SCHEMA_VERSION);
+        runner.enqueue(getFileContent("simple-example-with-comments.json"));
+        runner.assertValid();
+
+        final AssertionFailedError assertionFailedError = assertThrows(AssertionFailedError.class, () -> runner.run());
+        final String stackTrace = ExceptionUtils.getStackTrace(assertionFailedError);
+        assertTrue(stackTrace.contains("JsonParseException"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("schemasWithTrailingComments")
+    void testSchemaContentWithTrailingCommentsIgnored(String schema) {
+        runner.setProperty(ValidateJson.SCHEMA_CONTENT, schema);
+        runner.setProperty(JsonSchemaRegistryComponent.SCHEMA_VERSION, SCHEMA_VERSION);
+        runner.enqueue(getFileContent("simple-example-with-comments.json"));
+        runner.assertValid();
+
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(ValidateJson.REL_VALID);
+    }
+
+    private static Stream<Arguments> schemasWithLeadingComments() {
+        final String schemasWithSingleLineComment = """
+                 // Single line Java comment
+                {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "type": "object",
+                    "additionalProperties": true
+                }
+                """;
+        final String schemaWithMultiLineComment = """
+                /*
+                    Multi-line Java comment
+                */
+                {
+                   "$schema": "http://json-schema.org/draft-07/schema#",
+                   "type": "object",
+                   "additionalProperties": true
+                }
+                """;
+        return Stream.of(
+                Arguments.argumentSet("Leading Java single line comment", schemasWithSingleLineComment),
+                Arguments.argumentSet("Leading Java multi-line comment", schemaWithMultiLineComment)
+        );
+    }
+
+    private static Stream<Arguments> schemasWithEmbeddedComments() {
+        final String schemasWithSingleLineComment = """
+                {
+                    // Single line Java comment
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "type": "object",
+                    "additionalProperties": true
+                }
+                """;
+        final String schemaWithMultiLineComment = """
+                {
+                    /*
+                        Multi-line Java comment
+                    */
+                   "$schema": "http://json-schema.org/draft-07/schema#",
+                   "type": "object",
+                   "additionalProperties": true
+                }
+                """;
+        return Stream.of(
+                Arguments.argumentSet("Embedded Java single line comment", schemasWithSingleLineComment),
+                Arguments.argumentSet("Embedded Java multi-line comment", schemaWithMultiLineComment)
+        );
+    }
+
+    private static Stream<Arguments> schemasWithTrailingComments() {
+        final String schemasWithSingleLineComment = """
+                {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "type": "object",
+                    "additionalProperties": true
+                }
+                // Single line Java comment
+                """;
+        final String schemaWithMultiLineComment = """
+                {
+                   "$schema": "http://json-schema.org/draft-07/schema#",
+                   "type": "object",
+                   "additionalProperties": true
+                }
+                 /*
+                        Multi-line Java comment
+                  */
+                """;
+        return Stream.of(
+                Arguments.argumentSet("Trailing Java single line comment", schemasWithSingleLineComment),
+                Arguments.argumentSet("Trailing Java multi-line comment", schemaWithMultiLineComment)
+        );
     }
 
     private void assertValidationErrors(Relationship relationship, boolean expected) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16021](https://issues.apache.org/jira/browse/NIFI-16021)

Also added tests to ensure ValidateJson causes Json parsing exception when any Java comments is specified before or inside a schema.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
