### PR TITLE
NIFI-16110 Improve MiNiFi C2 Asset File Name Validation

### DIFF
--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/command/UpdateAssetCommandHelper.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/command/UpdateAssetCommandHelper.java
@@ -25,8 +25,14 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.compile;
 
 public class UpdateAssetCommandHelper {
+
+    public static final Pattern ALLOWED_RESOURCE_PATH_PATTERN = compile("^(?:[^~<>:|\"?*./\\\\]+(?:[/\\\\][^~<>:|\"?*./\\\\]+)*)?$");
 
     private static final Logger LOG = LoggerFactory.getLogger(UpdateAssetCommandHelper.class);
 
@@ -45,26 +51,47 @@ public class UpdateAssetCommandHelper {
         }
     }
 
-    public boolean assetUpdatePrecondition(String assetFileName, Boolean forceDownload) {
-        Path assetPath = Paths.get(assetDirectory, assetFileName);
-        if (Files.exists(assetPath) && !forceDownload) {
-            LOG.info("Asset file already exists on path {}. Asset won't be downloaded", assetPath);
-            return false;
+    public boolean assetUpdatePrecondition(final String assetFileName, final Boolean forceDownload) {
+        final boolean downloadEnabled;
+
+        final Matcher assetFileNameMatcher = ALLOWED_RESOURCE_PATH_PATTERN.matcher(assetFileName);
+        if (assetFileNameMatcher.matches()) {
+            final Path assetPath = Paths.get(assetDirectory, assetFileName);
+            if (Files.exists(assetPath) && !forceDownload) {
+                LOG.info("Asset File found at [{}] Download disabled", assetPath);
+                downloadEnabled = false;
+            } else {
+                LOG.info("Asset File not found at [{}] or Force Download enabled", assetPath);
+                downloadEnabled = true;
+            }
+        } else {
+            LOG.warn("Asset File Name [{}] not allowed for downloading", assetFileName);
+            downloadEnabled = false;
         }
-        LOG.info("Asset file does not exist or force download is on. Asset will be downloaded to {}", assetPath);
-        return true;
+
+        return downloadEnabled;
     }
 
-    public boolean assetPersistFunction(String assetFileName, byte[] assetBinary) {
-        Path assetPath = Paths.get(assetDirectory, assetFileName);
-        try {
-            Files.deleteIfExists(assetPath);
-            Files.write(assetPath, assetBinary);
-            LOG.info("Asset was persisted to {}, {} bytes were written", assetPath, assetBinary.length);
-            return true;
-        } catch (IOException e) {
-            LOG.error("Persisting asset failed. File creation was not successful targeting {}", assetPath, e);
-            return false;
+    public boolean assetPersistFunction(final String assetFileName, final byte[] assetBinary) {
+        boolean persisted;
+
+        final Matcher assetFileNameMatcher = ALLOWED_RESOURCE_PATH_PATTERN.matcher(assetFileName);
+        if (assetFileNameMatcher.matches()) {
+            final Path assetPath = Paths.get(assetDirectory, assetFileName);
+            try {
+                Files.deleteIfExists(assetPath);
+                Files.write(assetPath, assetBinary);
+                LOG.info("Asset was persisted to {}, {} bytes were written", assetPath, assetBinary.length);
+                persisted = true;
+            } catch (final IOException e) {
+                LOG.error("Persisting asset failed. File creation was not successful targeting {}", assetPath, e);
+                persisted = false;
+            }
+        } else {
+            LOG.warn("Asset File Name [{}] not allowed for writing", assetFileName);
+            persisted = false;
         }
+
+        return persisted;
     }
 }

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/command/syncresource/DefaultSyncResourceStrategy.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/command/syncresource/DefaultSyncResourceStrategy.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 import static java.nio.file.Files.copy;
 import static java.nio.file.Files.createTempFile;
@@ -42,17 +41,16 @@ import static java.util.Map.entry;
 import static java.util.Optional.empty;
 import static java.util.UUID.randomUUID;
 import static java.util.function.Predicate.not;
-import static java.util.regex.Pattern.compile;
 import static org.apache.nifi.c2.protocol.api.C2OperationState.OperationState.FULLY_APPLIED;
 import static org.apache.nifi.c2.protocol.api.C2OperationState.OperationState.NOT_APPLIED;
 import static org.apache.nifi.c2.protocol.api.C2OperationState.OperationState.NO_OPERATION;
 import static org.apache.nifi.c2.protocol.api.C2OperationState.OperationState.PARTIALLY_APPLIED;
 import static org.apache.nifi.c2.protocol.api.ResourceType.ASSET;
+import static org.apache.nifi.minifi.c2.command.UpdateAssetCommandHelper.ALLOWED_RESOURCE_PATH_PATTERN;
 
 public class DefaultSyncResourceStrategy implements SyncResourceStrategy {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultSyncResourceStrategy.class);
-    private static final Pattern ALLOWED_RESOURCE_PATH_PATTERN = compile("^(?:[^~<>:\\|\\\"\\?\\*\\.\\/\\\\]+(?:[/\\\\][^~<>:\\|\\\"\\?\\*\\.\\/\\\\]+)*)?$");
 
     private static final Set<Entry<OperationState, OperationState>> SUCCESS_RESULT_PAIRS = Set.of(
         entry(NO_OPERATION, NO_OPERATION),

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/UpdateAssetCommandHelperTest.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/UpdateAssetCommandHelperTest.java
@@ -20,31 +20,43 @@ package org.apache.nifi.minifi.c2.command;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.nio.charset.Charset.defaultCharset;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.exists;
 import static java.nio.file.Files.isDirectory;
 import static java.nio.file.Files.readAllLines;
-import static java.nio.file.Files.write;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class UpdateAssetCommandHelperTest {
+class UpdateAssetCommandHelperTest {
+
+    private static final String[] INVALID_ASSET_FILE_NAMES = new String[]{
+            "~",
+            "./",
+            "../",
+            "./../",
+            "../sibling-directory",
+            "/tmp"
+    };
 
     private static final String ASSET_DIRECTORY = "asset_directory";
-    private static final String ASSET_FILE = "asset.file";
+    private static final String ASSET_FILE = "asset-file";
+    private static final byte[] CONTENT = String.class.getSimpleName().getBytes(StandardCharsets.UTF_8);
 
     @TempDir
     private File tempDir;
@@ -53,89 +65,88 @@ public class UpdateAssetCommandHelperTest {
     private UpdateAssetCommandHelper updateAssetCommandHelper;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         assetDirectory = Paths.get(tempDir.getAbsolutePath(), ASSET_DIRECTORY);
         updateAssetCommandHelper = new UpdateAssetCommandHelper(assetDirectory.toString());
     }
 
     @Test
-    public void testAssetDirectoryShouldBeCreated() {
-        // given + when
+    void testAssetDirectoryShouldBeCreated() {
         updateAssetCommandHelper.createAssetDirectory();
 
-        // then
         assertTrue(exists(assetDirectory));
         assertTrue(isDirectory(assetDirectory));
     }
 
     @Test
-    public void testAssetFileDoesNotExist() {
-        // given
+    void testAssetFileDoesNotExist() {
         updateAssetCommandHelper.createAssetDirectory();
 
-        // when
         boolean result = updateAssetCommandHelper.assetUpdatePrecondition(ASSET_FILE, FALSE);
 
-        // then
         assertTrue(result);
     }
 
     @Test
-    public void testAssetFileExistsAndForceDownloadOff() {
-        // given
+    void testAssetFileExistsAndForceDownloadOff() {
         updateAssetCommandHelper.createAssetDirectory();
         touchAssetFile();
 
-        // when
         boolean result = updateAssetCommandHelper.assetUpdatePrecondition(ASSET_FILE, FALSE);
 
-        // then
         assertFalse(result);
     }
 
     @Test
-    public void testAssetFileExistsAndForceDownloadOn() {
-        // given
+    void testAssetFileExistsAndForceDownloadOn() {
         updateAssetCommandHelper.createAssetDirectory();
         touchAssetFile();
 
-        // when
         boolean result = updateAssetCommandHelper.assetUpdatePrecondition(ASSET_FILE, TRUE);
 
-        // then
         assertTrue(result);
     }
 
     @Test
-    public void testAssetPersistedCorrectly() throws IOException {
-        // given
+    void testAssetPersistedCorrectly() throws IOException {
         updateAssetCommandHelper.createAssetDirectory();
         String testAssetContent = "test file content";
 
-        // when
         boolean result = updateAssetCommandHelper.assetPersistFunction(ASSET_FILE, testAssetContent.getBytes(defaultCharset()));
 
-        // then
         assertTrue(result);
         assertIterableEquals(singletonList(testAssetContent), readAllLines(assetDirectory.resolve(ASSET_FILE), defaultCharset()));
     }
 
     @Test
-    public void testAssetDirectoryDoesNotExistWhenPersistingAsset() {
-        // given
+    void testAssetDirectoryDoesNotExistWhenPersistingAsset() {
         String testAssetContent = "test file content";
 
-        // when
         boolean result = updateAssetCommandHelper.assetPersistFunction(ASSET_FILE, testAssetContent.getBytes(defaultCharset()));
 
-        // then
         assertFalse(result);
         assertFalse(exists(assetDirectory.resolve(ASSET_FILE)));
     }
 
+    @ParameterizedTest
+    @FieldSource("INVALID_ASSET_FILE_NAMES")
+    void testAssetUpdatePreconditionDirectoriesDisallowed(final String assetName) {
+        final boolean completed = updateAssetCommandHelper.assetUpdatePrecondition(assetName, true);
+
+        assertFalse(completed);
+    }
+
+    @ParameterizedTest
+    @FieldSource("INVALID_ASSET_FILE_NAMES")
+    void testAssetPersistFunctionDirectoriesDisallowed(final String assetName) {
+        final boolean completed = updateAssetCommandHelper.assetPersistFunction(assetName, CONTENT);
+
+        assertFalse(completed);
+    }
+
     private void touchAssetFile() {
         try {
-            write(Paths.get(assetDirectory.toString(), ASSET_FILE), EMPTY.getBytes(UTF_8));
+            Files.writeString(Paths.get(assetDirectory.toString(), ASSET_FILE), EMPTY);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to touch file", e);
         }


### PR DESCRIPTION
# Summary

[NIFI-16110](https://issues.apache.org/jira/browse/NIFI-16110) Improves the Asset File Name validation handling in MiNiFi C2 to use the same name pattern for both synchronization and update methods.

The implementation moves the existing name validation pattern to the `UpdateAssetCommandHelper` class and adds new unit tests to verify disallowing several representative file names.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
