### PR TITLE
NIFI-16120 Add caching for Kubernetes Leader Election Manager

### DIFF
--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-leader-election/src/main/java/org/apache/nifi/kubernetes/leader/election/KubernetesLeaderElectionManager.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-leader-election/src/main/java/org/apache/nifi/kubernetes/leader/election/KubernetesLeaderElectionManager.java
@@ -23,6 +23,7 @@ import org.apache.nifi.kubernetes.client.KubernetesClientProvider;
 import org.apache.nifi.kubernetes.client.NamespaceProvider;
 import org.apache.nifi.kubernetes.client.ServiceAccountNamespaceProvider;
 import org.apache.nifi.kubernetes.client.StandardKubernetesClientProvider;
+import org.apache.nifi.kubernetes.leader.election.command.CachingLeaderElectionCommandProvider;
 import org.apache.nifi.kubernetes.leader.election.command.LeaderElectionCommandProvider;
 import org.apache.nifi.kubernetes.leader.election.command.StandardLeaderElectionCommandProvider;
 import org.apache.nifi.util.NiFiProperties;
@@ -243,7 +244,8 @@ public class KubernetesLeaderElectionManager extends TrackedLeaderElectionManage
         final NamespaceProvider namespaceProvider = new ServiceAccountNamespaceProvider();
         final String namespace = namespaceProvider.getNamespace();
         final KubernetesClientProvider kubernetesClientProvider = new StandardKubernetesClientProvider();
-        return new StandardLeaderElectionCommandProvider(kubernetesClientProvider, namespace);
+        final LeaderElectionCommandProvider standardProvider = new StandardLeaderElectionCommandProvider(kubernetesClientProvider, namespace);
+        return new CachingLeaderElectionCommandProvider(standardProvider);
     }
 
     private synchronized void registerLeaderElectionCommand(final String roleName, final LeaderElectionStateChangeListener listener, final String participantId) {

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-leader-election/src/main/java/org/apache/nifi/kubernetes/leader/election/command/CachingLeaderElectionCommandProvider.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-leader-election/src/main/java/org/apache/nifi/kubernetes/leader/election/command/CachingLeaderElectionCommandProvider.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kubernetes.leader.election.command;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * Leader Election Command Provider implementing caching of Leader status minimizing requests to Kubernetes
+ */
+public class CachingLeaderElectionCommandProvider implements LeaderElectionCommandProvider {
+    /** Expiration for cached Leader Identifiers shorter than the Lease Duration */
+    private static final Duration DEFAULT_CACHE_EXPIRATION = Duration.ofSeconds(5);
+
+    private final LeaderElectionCommandProvider provider;
+
+    private final Duration cacheExpiration;
+
+    private final Map<String, CachedLeader> cachedLeaders = new ConcurrentHashMap<>();
+
+    public CachingLeaderElectionCommandProvider(final LeaderElectionCommandProvider provider) {
+        this(provider, DEFAULT_CACHE_EXPIRATION);
+    }
+
+    CachingLeaderElectionCommandProvider(final LeaderElectionCommandProvider provider, final Duration cacheExpiration) {
+        this.provider = Objects.requireNonNull(provider, "Provider required");
+        this.cacheExpiration = Objects.requireNonNull(cacheExpiration, "Cache Expiration required");
+    }
+
+    @Override
+    public Runnable getCommand(
+            final String name,
+            final String identity,
+            final Runnable onStartLeading,
+            final Runnable onStopLeading,
+            final Consumer<String> onNewLeader
+    ) {
+        return provider.getCommand(name, identity, onStartLeading, onStopLeading, onNewLeader);
+    }
+
+    /**
+     * Find Leader Identifier for specified Election Name returning a cached result when available and not expired
+     *
+     * @param name Election Name
+     * @return Leader Identifier or empty when not found
+     */
+    @Override
+    public Optional<String> findLeader(final String name) {
+        final Optional<String> leader;
+
+        // Concurrent requests handled without locking
+        final CachedLeader cachedLeader = cachedLeaders.get(name);
+        if (cachedLeader == null || cachedLeader.isExpired()) {
+            leader = provider.findLeader(name);
+            final Instant expiration = Instant.now().plus(cacheExpiration);
+            cachedLeaders.put(name, new CachedLeader(leader.orElse(null), expiration));
+        } else {
+            leader = Optional.ofNullable(cachedLeader.leader);
+        }
+
+        return leader;
+    }
+
+    @Override
+    public void close() throws IOException {
+        cachedLeaders.clear();
+        provider.close();
+    }
+
+    private record CachedLeader(String leader, Instant expiration) {
+
+        private boolean isExpired() {
+            return Instant.now().isAfter(expiration);
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-leader-election/src/test/java/org/apache/nifi/kubernetes/leader/election/command/CachingLeaderElectionCommandProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-leader-election/src/test/java/org/apache/nifi/kubernetes/leader/election/command/CachingLeaderElectionCommandProviderTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kubernetes.leader.election.command;
+
+import org.apache.nifi.controller.leader.election.LeaderElectionRole;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CachingLeaderElectionCommandProviderTest {
+
+    private static final String CLUSTER_COORDINATOR = LeaderElectionRole.CLUSTER_COORDINATOR.getRoleName();
+
+    private static final String PRIMARY_NODE = LeaderElectionRole.PRIMARY_NODE.getRoleName();
+
+    private static final String LEADER = "Node-0";
+
+    @Mock
+    LeaderElectionCommandProvider mockProvider;
+
+    @Test
+    void testFindLeaderCachedWithinExpiration() {
+        when(mockProvider.findLeader(CLUSTER_COORDINATOR)).thenReturn(Optional.of(LEADER));
+        final CachingLeaderElectionCommandProvider provider = new CachingLeaderElectionCommandProvider(mockProvider);
+
+        final Optional<String> first = provider.findLeader(CLUSTER_COORDINATOR);
+        final Optional<String> second = provider.findLeader(CLUSTER_COORDINATOR);
+
+        assertEquals(Optional.of(LEADER), first);
+        assertEquals(Optional.of(LEADER), second);
+        verify(mockProvider, times(1)).findLeader(CLUSTER_COORDINATOR);
+    }
+
+    @Test
+    void testFindLeaderRefreshedAfterExpiration() {
+        when(mockProvider.findLeader(CLUSTER_COORDINATOR)).thenReturn(Optional.of(LEADER));
+        final Duration negativeExpiration = Duration.ofSeconds(-5);
+        final CachingLeaderElectionCommandProvider provider = new CachingLeaderElectionCommandProvider(mockProvider, negativeExpiration);
+
+        provider.findLeader(CLUSTER_COORDINATOR);
+        provider.findLeader(CLUSTER_COORDINATOR);
+
+        verify(mockProvider, times(2)).findLeader(CLUSTER_COORDINATOR);
+    }
+
+    @Test
+    void testFindLeaderCachedPerName() {
+        when(mockProvider.findLeader(CLUSTER_COORDINATOR)).thenReturn(Optional.of(LEADER));
+        when(mockProvider.findLeader(PRIMARY_NODE)).thenReturn(Optional.empty());
+        final CachingLeaderElectionCommandProvider provider = new CachingLeaderElectionCommandProvider(mockProvider);
+
+        assertEquals(Optional.of(LEADER), provider.findLeader(CLUSTER_COORDINATOR));
+        assertEquals(Optional.empty(), provider.findLeader(PRIMARY_NODE));
+        assertEquals(Optional.of(LEADER), provider.findLeader(CLUSTER_COORDINATOR));
+
+        verify(mockProvider, times(1)).findLeader(CLUSTER_COORDINATOR);
+        verify(mockProvider, times(1)).findLeader(PRIMARY_NODE);
+    }
+
+    @Test
+    void testGetCommandDelegates() {
+        final Runnable command = () -> { };
+        final Runnable onStartLeading = () -> { };
+        final Runnable onStopLeading = () -> { };
+        final Consumer<String> onNewLeader = leader -> { };
+        when(mockProvider.getCommand(CLUSTER_COORDINATOR, LEADER, onStartLeading, onStopLeading, onNewLeader)).thenReturn(command);
+        final CachingLeaderElectionCommandProvider provider = new CachingLeaderElectionCommandProvider(mockProvider);
+
+        final Runnable returned = provider.getCommand(CLUSTER_COORDINATOR, LEADER, onStartLeading, onStopLeading, onNewLeader);
+
+        assertSame(command, returned);
+    }
+
+    @Test
+    void testCloseClearsCacheAndClosesDelegatedProvider() throws IOException {
+        when(mockProvider.findLeader(CLUSTER_COORDINATOR)).thenReturn(Optional.of(LEADER));
+        final CachingLeaderElectionCommandProvider provider = new CachingLeaderElectionCommandProvider(mockProvider);
+
+        provider.findLeader(CLUSTER_COORDINATOR);
+        provider.close();
+        provider.findLeader(CLUSTER_COORDINATOR);
+
+        verify(mockProvider).close();
+        verify(mockProvider, times(2)).findLeader(CLUSTER_COORDINATOR);
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-16120](https://issues.apache.org/jira/browse/NIFI-16120) Adds caching of current leader status for each role name to the `KubernetesLeaderElectionManager` using a delegated implementation class.

The caching strategy has a 5 second timeout, aligning with the approach in the ZooKeeper implementation. The cached leader status reduces repeated requests to the Kubernetes REST API when running large numbers of Processors on the Primary Node. The 5 second timeout is less than the current 15 second lease duration, and less than the 10 second renew deadline to avoid artificial extension of existing lease expiration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [X] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
