### PR TITLE
NIFI-16130 - Fix ReplayLastEventEndpointMerger to count per-node replays correctly

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ReplayLastEventEndpointMerger.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ReplayLastEventEndpointMerger.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,7 +50,7 @@ public class ReplayLastEventEndpointMerger extends AbstractSingleEntityEndpoint<
                                   final Set<NodeResponse> problematicResponses) {
 
         // Move all aggregate snapshots into the node snapshots.
-        final Set<Long> replayedEventIds = new HashSet<>();
+        final List<Long> replayedEventIds = new ArrayList<>();
         final Set<String> failureExplanations = new HashSet<>();
         boolean eventAvailable = false;
         for (final Map.Entry<NodeIdentifier, ReplayLastEventResponseEntity> entry : entityMap.entrySet()) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ReplayLastEventEndpointMergerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ReplayLastEventEndpointMergerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cluster.coordination.http.endpoints;
+
+import org.apache.nifi.cluster.protocol.NodeIdentifier;
+import org.apache.nifi.web.api.entity.ReplayLastEventResponseEntity;
+import org.apache.nifi.web.api.entity.ReplayLastEventSnapshotDTO;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ReplayLastEventEndpointMergerTest {
+
+    @Test
+    public void testCanHandle() {
+        final ReplayLastEventEndpointMerger merger = new ReplayLastEventEndpointMerger();
+        assertTrue(merger.canHandle(URI.create("/nifi-api/provenance-events/latest/replays"), "POST"));
+        assertFalse(merger.canHandle(URI.create("/nifi-api/provenance-events/latest/replays"), "GET"));
+        assertFalse(merger.canHandle(URI.create("/nifi-api/provenance-events"), "POST"));
+    }
+
+    /**
+     * Verifies that when two nodes each replay their last event and both happen to have the same
+     * local event ID (which is expected when both nodes have processed the same number of events),
+     * the merged aggregate correctly reports 2 events replayed rather than 1.
+     * Provenance event IDs are local counters per node, so ID collisions across nodes are normal.
+     */
+    @Test
+    public void testMergeResponsesWithIdenticalEventIds() {
+        final ReplayLastEventEndpointMerger merger = new ReplayLastEventEndpointMerger();
+
+        final ReplayLastEventResponseEntity clientEntity = createEntity(7L, null, true);
+
+        final NodeIdentifier node1 = new NodeIdentifier("node1", "host1", 8080, "host1", 8081, "host1", 8082, 8083, false);
+        final NodeIdentifier node2 = new NodeIdentifier("node2", "host2", 8080, "host2", 8081, "host2", 8082, 8083, false);
+
+        // Both nodes replay their last event; both happen to report local event ID 7
+        final Map<NodeIdentifier, ReplayLastEventResponseEntity> entityMap = new HashMap<>();
+        entityMap.put(node1, createEntity(7L, null, true));
+        entityMap.put(node2, createEntity(7L, null, true));
+
+        merger.mergeResponses(clientEntity, entityMap, Collections.emptySet(), Collections.emptySet());
+
+        assertEquals(2, clientEntity.getAggregateSnapshot().getEventsReplayed().size(),
+                "Both nodes replayed an event; aggregate must count them independently regardless of matching local event IDs");
+        assertTrue(clientEntity.getAggregateSnapshot().getEventAvailable());
+        assertNull(clientEntity.getAggregateSnapshot().getFailureExplanation());
+        assertEquals(2, clientEntity.getNodeSnapshots().size());
+    }
+
+    @Test
+    public void testMergeResponsesWithDistinctEventIds() {
+        final ReplayLastEventEndpointMerger merger = new ReplayLastEventEndpointMerger();
+
+        final ReplayLastEventResponseEntity clientEntity = createEntity(3L, null, true);
+
+        final NodeIdentifier node1 = new NodeIdentifier("node1", "host1", 8080, "host1", 8081, "host1", 8082, 8083, false);
+        final NodeIdentifier node2 = new NodeIdentifier("node2", "host2", 8080, "host2", 8081, "host2", 8082, 8083, false);
+
+        final Map<NodeIdentifier, ReplayLastEventResponseEntity> entityMap = new HashMap<>();
+        entityMap.put(node1, createEntity(3L, null, true));
+        entityMap.put(node2, createEntity(5L, null, true));
+
+        merger.mergeResponses(clientEntity, entityMap, Collections.emptySet(), Collections.emptySet());
+
+        assertEquals(2, clientEntity.getAggregateSnapshot().getEventsReplayed().size());
+        assertTrue(clientEntity.getAggregateSnapshot().getEventAvailable());
+        assertNull(clientEntity.getAggregateSnapshot().getFailureExplanation());
+    }
+
+    @Test
+    public void testMergeResponsesWithFailure() {
+        final ReplayLastEventEndpointMerger merger = new ReplayLastEventEndpointMerger();
+
+        final ReplayLastEventResponseEntity clientEntity = createEntity(1L, null, true);
+
+        final NodeIdentifier node1 = new NodeIdentifier("node1", "host1", 8080, "host1", 8081, "host1", 8082, 8083, false);
+        final NodeIdentifier node2 = new NodeIdentifier("node2", "host2", 8080, "host2", 8081, "host2", 8082, 8083, false);
+
+        final Map<NodeIdentifier, ReplayLastEventResponseEntity> entityMap = new HashMap<>();
+        entityMap.put(node1, createEntity(1L, null, true));
+        entityMap.put(node2, createEntity(null, "Source FlowFile Queue", false));
+
+        merger.mergeResponses(clientEntity, entityMap, Collections.emptySet(), Collections.emptySet());
+
+        assertEquals(1, clientEntity.getAggregateSnapshot().getEventsReplayed().size());
+        assertTrue(clientEntity.getAggregateSnapshot().getEventAvailable());
+        assertTrue(clientEntity.getAggregateSnapshot().getFailureExplanation().contains("Source FlowFile Queue"));
+    }
+
+    private ReplayLastEventResponseEntity createEntity(final Long eventId, final String failureExplanation, final boolean eventAvailable) {
+        final ReplayLastEventSnapshotDTO snapshot = new ReplayLastEventSnapshotDTO();
+        snapshot.setEventAvailable(eventAvailable);
+        snapshot.setFailureExplanation(failureExplanation);
+        if (eventId != null) {
+            snapshot.setEventsReplayed(Collections.singletonList(eventId));
+        }
+
+        final ReplayLastEventResponseEntity entity = new ReplayLastEventResponseEntity();
+        entity.setAggregateSnapshot(snapshot);
+        return entity;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ReplayLastEventEndpointMergerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ReplayLastEventEndpointMergerTest.java
@@ -31,10 +31,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ReplayLastEventEndpointMergerTest {
+class ReplayLastEventEndpointMergerTest {
+
+    private static final NodeIdentifier NODE_1 = new NodeIdentifier("node1", "host1", 8080, "host1", 8081, "host1", 8082, 8083, false);
+    private static final NodeIdentifier NODE_2 = new NodeIdentifier("node2", "host2", 8080, "host2", 8081, "host2", 8082, 8083, false);
+
+    private static final long EVENT_ID_1 = 7L;
+    private static final long EVENT_ID_2 = 5L;
 
     @Test
-    public void testCanHandle() {
+    void testCanHandle() {
         final ReplayLastEventEndpointMerger merger = new ReplayLastEventEndpointMerger();
         assertTrue(merger.canHandle(URI.create("/nifi-api/provenance-events/latest/replays"), "POST"));
         assertFalse(merger.canHandle(URI.create("/nifi-api/provenance-events/latest/replays"), "GET"));
@@ -48,18 +54,15 @@ public class ReplayLastEventEndpointMergerTest {
      * Provenance event IDs are local counters per node, so ID collisions across nodes are normal.
      */
     @Test
-    public void testMergeResponsesWithIdenticalEventIds() {
+    void testMergeResponsesWithIdenticalEventIds() {
         final ReplayLastEventEndpointMerger merger = new ReplayLastEventEndpointMerger();
 
-        final ReplayLastEventResponseEntity clientEntity = createEntity(7L, null, true);
+        final ReplayLastEventResponseEntity clientEntity = createEntity(EVENT_ID_1, null, true);
 
-        final NodeIdentifier node1 = new NodeIdentifier("node1", "host1", 8080, "host1", 8081, "host1", 8082, 8083, false);
-        final NodeIdentifier node2 = new NodeIdentifier("node2", "host2", 8080, "host2", 8081, "host2", 8082, 8083, false);
-
-        // Both nodes replay their last event; both happen to report local event ID 7
+        // Both nodes replay their last event; both happen to report the same local event ID
         final Map<NodeIdentifier, ReplayLastEventResponseEntity> entityMap = new HashMap<>();
-        entityMap.put(node1, createEntity(7L, null, true));
-        entityMap.put(node2, createEntity(7L, null, true));
+        entityMap.put(NODE_1, createEntity(EVENT_ID_1, null, true));
+        entityMap.put(NODE_2, createEntity(EVENT_ID_1, null, true));
 
         merger.mergeResponses(clientEntity, entityMap, Collections.emptySet(), Collections.emptySet());
 
@@ -71,17 +74,14 @@ public class ReplayLastEventEndpointMergerTest {
     }
 
     @Test
-    public void testMergeResponsesWithDistinctEventIds() {
+    void testMergeResponsesWithDistinctEventIds() {
         final ReplayLastEventEndpointMerger merger = new ReplayLastEventEndpointMerger();
 
-        final ReplayLastEventResponseEntity clientEntity = createEntity(3L, null, true);
-
-        final NodeIdentifier node1 = new NodeIdentifier("node1", "host1", 8080, "host1", 8081, "host1", 8082, 8083, false);
-        final NodeIdentifier node2 = new NodeIdentifier("node2", "host2", 8080, "host2", 8081, "host2", 8082, 8083, false);
+        final ReplayLastEventResponseEntity clientEntity = createEntity(EVENT_ID_1, null, true);
 
         final Map<NodeIdentifier, ReplayLastEventResponseEntity> entityMap = new HashMap<>();
-        entityMap.put(node1, createEntity(3L, null, true));
-        entityMap.put(node2, createEntity(5L, null, true));
+        entityMap.put(NODE_1, createEntity(EVENT_ID_1, null, true));
+        entityMap.put(NODE_2, createEntity(EVENT_ID_2, null, true));
 
         merger.mergeResponses(clientEntity, entityMap, Collections.emptySet(), Collections.emptySet());
 
@@ -91,17 +91,14 @@ public class ReplayLastEventEndpointMergerTest {
     }
 
     @Test
-    public void testMergeResponsesWithFailure() {
+    void testMergeResponsesWithFailure() {
         final ReplayLastEventEndpointMerger merger = new ReplayLastEventEndpointMerger();
 
-        final ReplayLastEventResponseEntity clientEntity = createEntity(1L, null, true);
-
-        final NodeIdentifier node1 = new NodeIdentifier("node1", "host1", 8080, "host1", 8081, "host1", 8082, 8083, false);
-        final NodeIdentifier node2 = new NodeIdentifier("node2", "host2", 8080, "host2", 8081, "host2", 8082, 8083, false);
+        final ReplayLastEventResponseEntity clientEntity = createEntity(EVENT_ID_1, null, true);
 
         final Map<NodeIdentifier, ReplayLastEventResponseEntity> entityMap = new HashMap<>();
-        entityMap.put(node1, createEntity(1L, null, true));
-        entityMap.put(node2, createEntity(null, "Source FlowFile Queue", false));
+        entityMap.put(NODE_1, createEntity(EVENT_ID_1, null, true));
+        entityMap.put(NODE_2, createEntity(null, "Source FlowFile Queue", false));
 
         merger.mergeResponses(clientEntity, entityMap, Collections.emptySet(), Collections.emptySet());
 


### PR DESCRIPTION
# Summary

NIFI-16130 - Fix ReplayLastEventEndpointMerger to count per-node replays correctly

Provenance event IDs are local counters per node, starting at 0 and incrementing independently. In a multi-node cluster two different nodes can legitimately have the same numeric event ID for entirely different physical provenance events.

`ReplayLastEventEndpointMerger` was using a `HashSet<Long>` to accumulate event IDs returned by each node after a "replay last event" request. Because both nodes in a 2-node cluster where each has processed the same number of events will return the same local event ID, the `HashSet` silently deduplicated them and reported `eventsReplayed.size() == 1` instead of `2`. This caused `ClusteredReplayProvenanceIT.testReplayLastEvent` (with `ReplayEventNodes.ALL`) to fail with `expected: <2> but was: <1>`.

**Change:** Replace `HashSet<Long>` with `ArrayList<Long>` for the event ID accumulator so each node's replay is counted independently regardless of matching local event IDs.

**Also adds:** `ReplayLastEventEndpointMergerTest` — there was no unit test for this merger class. The test covers the colliding-ID case (regression test for this fix), the distinct-ID case, and the partial-failure case.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files