### PR TITLE
NIFI-16134 - Controller Service enable failure bulletins not attributed to the source component

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceProvider.java
@@ -35,7 +35,9 @@ import org.apache.nifi.nar.ExtensionDefinition;
 import org.apache.nifi.nar.ExtensionManager;
 import org.apache.nifi.registry.flow.FlowRegistryClientNode;
 import org.apache.nifi.registry.flow.mapping.VersionedComponentStateLookup;
+import org.apache.nifi.reporting.Bulletin;
 import org.apache.nifi.reporting.BulletinRepository;
+import org.apache.nifi.reporting.ComponentType;
 import org.apache.nifi.reporting.Severity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -286,8 +288,8 @@ public class StandardControllerServiceProvider implements ControllerServiceProvi
             } catch (Exception e) {
                 logger.error("Failed to enable {}", controllerServiceNode, e);
                 if (this.bulletinRepo != null) {
-                    this.bulletinRepo.addBulletin(BulletinFactory.createBulletin("Controller Service",
-                            Severity.ERROR.name(), "Could not start " + controllerServiceNode + " due to " + e));
+                    this.bulletinRepo.addBulletin(createControllerServiceBulletin(controllerServiceNode,
+                            "Could not start " + controllerServiceNode + " due to " + e, e));
                 }
             }
         }
@@ -369,8 +371,8 @@ public class StandardControllerServiceProvider implements ControllerServiceProvi
                         }
 
                         if (this.bulletinRepo != null) {
-                            this.bulletinRepo.addBulletin(BulletinFactory.createBulletin("Controller Service",
-                                Severity.ERROR.name(), "Could not enable " + controllerServiceNode + " due to " + e));
+                            this.bulletinRepo.addBulletin(createControllerServiceBulletin(controllerServiceNode,
+                                "Could not enable " + controllerServiceNode + " due to " + e, e));
                         }
 
                         break;
@@ -379,8 +381,8 @@ public class StandardControllerServiceProvider implements ControllerServiceProvi
             } catch (Exception e) {
                 logger.error("Failed to enable {}", controllerServiceNode, e);
                 if (this.bulletinRepo != null) {
-                    this.bulletinRepo.addBulletin(BulletinFactory.createBulletin("Controller Service",
-                        Severity.ERROR.name(), "Could not start " + controllerServiceNode + " due to " + e));
+                    this.bulletinRepo.addBulletin(createControllerServiceBulletin(controllerServiceNode,
+                        "Could not start " + controllerServiceNode + " due to " + e, e));
                 }
             }
         }
@@ -828,5 +830,13 @@ public class StandardControllerServiceProvider implements ControllerServiceProvi
     @Override
     public ExtensionManager getExtensionManager() {
         return extensionManager;
+    }
+
+    private Bulletin createControllerServiceBulletin(final ControllerServiceNode serviceNode, final String message, final Throwable t) {
+        final ProcessGroup processGroup = serviceNode.getProcessGroup();
+        final String groupId = processGroup == null ? null : processGroup.getIdentifier();
+        final String groupName = processGroup == null ? null : processGroup.getName();
+        return BulletinFactory.createBulletin(groupId, groupName, serviceNode.getIdentifier(),
+                ComponentType.CONTROLLER_SERVICE, serviceNode.getName(), "Controller Service", Severity.ERROR.name(), message, t);
     }
 }


### PR DESCRIPTION
# Summary

NIFI-16134 - Controller Service enable failure bulletins not attributed to the source component

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
