### PR TITLE
NIFI-16138 - Resolve nifi-frontend transitive dependency security advisories via npm overrides

### DIFF
--- a/nifi-frontend/src/main/frontend/package-lock.json
+++ b/nifi-frontend/src/main/frontend/package-lock.json
@@ -3618,29 +3618,6 @@
                 "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
-        "node_modules/@eslint/config-array/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -3707,10 +3684,17 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5666,16 +5650,6 @@
                 "@module-federation/sdk": "2.5.1"
             }
         },
-        "node_modules/@module-federation/node/node_modules/adm-zip": {
-            "version": "0.5.10",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
-            "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
         "node_modules/@module-federation/node/node_modules/ajv": {
             "version": "8.18.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -6598,29 +6572,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/@npmcli/package-json/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "node_modules/@npmcli/package-json/node_modules/glob": {
             "version": "13.0.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -6999,31 +6950,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/@nx/module-federation/node_modules/body-parser": {
-            "version": "1.20.5",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "~3.1.2",
-                "content-type": "~1.0.5",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "~1.2.0",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.4.24",
-                "on-finished": "~2.4.1",
-                "qs": "~6.15.1",
-                "raw-body": "~2.5.3",
-                "type-is": "~1.6.18",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
         "node_modules/@nx/module-federation/node_modules/content-disposition": {
             "version": "0.5.4",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -7137,19 +7063,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/@nx/module-federation/node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@nx/module-federation/node_modules/media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -7209,22 +7122,6 @@
             "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@nx/module-federation/node_modules/raw-body": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-            "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "~3.1.2",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.4.24",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
         },
         "node_modules/@nx/module-federation/node_modules/send": {
             "version": "0.19.2",
@@ -7479,31 +7376,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/@nx/rspack/node_modules/body-parser": {
-            "version": "1.20.5",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "~3.1.2",
-                "content-type": "~1.0.5",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "~1.2.0",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.4.24",
-                "on-finished": "~2.4.1",
-                "qs": "~6.15.1",
-                "raw-body": "~2.5.3",
-                "type-is": "~1.6.18",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
         "node_modules/@nx/rspack/node_modules/content-disposition": {
             "version": "0.5.4",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -7653,19 +7525,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/@nx/rspack/node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@nx/rspack/node_modules/less-loader": {
             "version": "11.1.4",
             "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-11.1.4.tgz",
@@ -7765,22 +7624,6 @@
             "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@nx/rspack/node_modules/raw-body": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-            "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "~3.1.2",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.4.24",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
         },
         "node_modules/@nx/rspack/node_modules/send": {
             "version": "0.19.2",
@@ -9922,31 +9765,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/@rspack/dev-server/node_modules/body-parser": {
-            "version": "1.20.5",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "~3.1.2",
-                "content-type": "~1.0.5",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "~1.2.0",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.4.24",
-                "on-finished": "~2.4.1",
-                "qs": "~6.15.1",
-                "raw-body": "~2.5.3",
-                "type-is": "~1.6.18",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
         "node_modules/@rspack/dev-server/node_modules/chokidar": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -10098,44 +9916,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/@rspack/dev-server/node_modules/http-proxy-middleware": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-proxy": "^1.17.8",
-                "http-proxy": "^1.18.1",
-                "is-glob": "^4.0.1",
-                "is-plain-obj": "^3.0.0",
-                "micromatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "@types/express": "^4.17.13"
-            },
-            "peerDependenciesMeta": {
-                "@types/express": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@rspack/dev-server/node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@rspack/dev-server/node_modules/media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -10214,22 +9994,6 @@
             "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@rspack/dev-server/node_modules/raw-body": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-            "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "~3.1.2",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.4.24",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
         },
         "node_modules/@rspack/dev-server/node_modules/readdirp": {
             "version": "3.6.0",
@@ -10860,29 +10624,6 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/@tufjs/models/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@tufjs/models/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/@tufjs/models/node_modules/minimatch": {
@@ -11750,29 +11491,6 @@
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -12370,13 +12088,13 @@
             }
         },
         "node_modules/adm-zip": {
-            "version": "0.5.16",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-            "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+            "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=12.0"
+                "node": ">=14.0"
             }
         },
         "node_modules/agent-base": {
@@ -12701,15 +12419,43 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+            "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
                 "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/axios/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/axobject-query": {
@@ -12833,10 +12579,14 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "license": "MIT"
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -12955,22 +12705,36 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "debug": "^4.4.3",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.7.0",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.1",
-                "raw-body": "^3.0.1",
-                "type-is": "^2.0.1"
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
             },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -12998,12 +12762,16 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -13154,29 +12922,6 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/cacache/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/cacache/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/cacache/node_modules/glob": {
@@ -14231,14 +13976,14 @@
             }
         },
         "node_modules/css-tree": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "mdn-data": "2.0.30",
-                "source-map-js": "^1.0.1"
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -15210,9 +14955,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.11",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-            "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+            "version": "3.4.12",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optional": true,
             "optionalDependencies": {
@@ -15825,29 +15570,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "node_modules/eslint/node_modules/eslint-visitor-keys": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -16181,9 +15903,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+            "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
             "dev": true,
             "funding": [
                 {
@@ -16654,10 +16376,17 @@
                 "ajv": "^6.9.1"
             }
         },
+        "node_modules/fork-ts-checker-webpack-plugin/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17301,9 +17030,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.25",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-            "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+            "version": "4.12.31",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+            "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17572,9 +17301,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-            "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+            "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17586,7 +17315,7 @@
                 "micromatch": "^4.0.8"
             },
             "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+                "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/http-server": {
@@ -17724,29 +17453,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/ignore-walk/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/ignore-walk/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "node_modules/ignore-walk/node_modules/minimatch": {
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -17788,9 +17494,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
             "dev": true,
             "license": "MIT"
         },
@@ -18044,19 +17750,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-plain-obj": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-            "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-plain-object": {
@@ -18318,9 +18011,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+            "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
             "dev": true,
             "funding": [
                 {
@@ -18337,7 +18030,7 @@
                 "argparse": "^2.0.1"
             },
             "bin": {
-                "js-yaml": "bin/js-yaml.js"
+                "js-yaml": "bin/js-yaml.mjs"
             }
         },
         "node_modules/jsesc": {
@@ -19601,9 +19294,9 @@
             }
         },
         "node_modules/mdn-data": {
-            "version": "2.0.30",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
             "dev": true,
             "license": "CC0-1.0"
         },
@@ -19831,6 +19524,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minimatch/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "license": "MIT"
+        },
+        "node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/minimist": {
@@ -21591,9 +21299,9 @@
             }
         },
         "node_modules/piscina": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
-            "integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.3.0.tgz",
+            "integrity": "sha512-9D3tPBayfoal6l9l4Y8NrMn1jkV718qJoYrla6P51+hh9h0Q+9/1c8KgEnoBQqhguyfgjay4biADI8HJG3pkoA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -24113,9 +23821,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+            "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -24763,39 +24471,29 @@
             }
         },
         "node_modules/svgo": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-            "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+            "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "commander": "^7.2.0",
+                "commander": "^11.1.0",
                 "css-select": "^5.1.0",
-                "css-tree": "^2.3.1",
+                "css-tree": "^3.0.1",
                 "css-what": "^6.1.0",
                 "csso": "^5.0.5",
-                "picocolors": "^1.0.0",
+                "picocolors": "^1.1.1",
                 "sax": "^1.5.0"
             },
             "bin": {
-                "svgo": "bin/svgo"
+                "svgo": "bin/svgo.js"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/svgo"
-            }
-        },
-        "node_modules/svgo/node_modules/commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
             }
         },
         "node_modules/svgo/node_modules/css-select": {
@@ -24889,9 +24587,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+            "version": "7.5.21",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+            "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -25500,18 +25198,36 @@
             }
         },
         "node_modules/type-is": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "media-typer": "^1.1.0",
                 "mime-types": "^3.0.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/typed-assert": {
@@ -25567,13 +25283,13 @@
             "optional": true
         },
         "node_modules/undici": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-            "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-8.8.0.tgz",
+            "integrity": "sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=20.18.1"
+                "node": ">=22.19.0"
             }
         },
         "node_modules/undici-types": {
@@ -25783,13 +25499,13 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-            "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+            "version": "7.3.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+            "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.27.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "fdir": "^6.5.0",
                 "picomatch": "^4.0.3",
                 "postcss": "^8.5.6",
@@ -26190,31 +25906,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/webpack-dev-server/node_modules/body-parser": {
-            "version": "1.20.5",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "~3.1.2",
-                "content-type": "~1.0.5",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "~1.2.0",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.4.24",
-                "on-finished": "~2.4.1",
-                "qs": "~6.15.1",
-                "raw-body": "~2.5.3",
-                "type-is": "~1.6.18",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
         "node_modules/webpack-dev-server/node_modules/chokidar": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -26366,44 +26057,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-proxy": "^1.17.8",
-                "http-proxy": "^1.18.1",
-                "is-glob": "^4.0.1",
-                "is-plain-obj": "^3.0.0",
-                "micromatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "@types/express": "^4.17.13"
-            },
-            "peerDependenciesMeta": {
-                "@types/express": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/webpack-dev-server/node_modules/media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -26482,22 +26135,6 @@
             "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/webpack-dev-server/node_modules/raw-body": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-            "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "~3.1.2",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.4.24",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
         },
         "node_modules/webpack-dev-server/node_modules/readdirp": {
             "version": "3.6.0",
@@ -26723,9 +26360,9 @@
             }
         },
         "node_modules/websocket-driver": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+            "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/nifi-frontend/src/main/frontend/package.json
+++ b/nifi-frontend/src/main/frontend/package.json
@@ -128,18 +128,32 @@
         "@nx/devkit": {
             "minimatch": "9.0.9"
         },
-        "undici": ">=7.24.0",
+        "undici": ">=7.28.0",
         "flatted": "3.4.2",
         "picomatch": "^4.0.4",
         "lodash-es": "^4.18.0",
         "@babel/core": ">=7.29.7",
-        "js-yaml": ">=4.2.0",
+        "js-yaml": ">=4.3.0",
         "postcss": "^8.5.10",
         "sockjs": {
             "uuid": ">=11.1.1"
         },
         "webpack-dev-server": ">=5.2.5",
-        "ws": ">=8.21.0"
+        "ws": ">=8.21.0",
+        "tar": ">=7.5.19",
+        "websocket-driver": ">=0.7.5",
+        "adm-zip": ">=0.6.0",
+        "axios": ">=1.18.0",
+        "fast-uri": ">=3.1.4",
+        "http-proxy-middleware": ">=3.0.7 <4",
+        "immutable": ">=5.1.8",
+        "piscina": ">=5.2.0",
+        "shell-quote": ">=1.8.5",
+        "svgo": ">=3.3.4",
+        "vite": "^7.3.5",
+        "hono": ">=4.12.27",
+        "body-parser": ">=2.3.0",
+        "dompurify": ">=3.4.12"
     },
     "browser": {
         "fs": false,


### PR DESCRIPTION

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

[NIFI-16138](https://issues.apache.org/jira/browse/NIFI-16138)

## Summary

Resolves 26 of 32 open npm security advisories in `nifi-frontend` by adding and tightening
`overrides` entries in `package.json`. No direct dependency versions are modified and no
production code changes are made. The browser-shipped artifact is unaffected.

All 2 critical and all 23 high advisories are cleared. The 6 remaining advisories are
moderate severity and are confined to dev-only build tooling; they are deferred because
their fixes require major-version bumps that carry unknown compatibility risk with the
current Angular/Nx build toolchain.

This PR supersedes the following open Dependabot PRs, which can be closed:

- #11459 (fast-uri), #11458 (dompurify), #11457 (hono), #11454 (immutable),
  #11447 (axios), #11444 (adm-zip / @nx/angular), #11438 (websocket-driver)

## Vulnerability Counts

| Severity | Before | After |
|----------|--------|-------|
| Critical | 2 | 0 |
| High | 23 | 0 |
| Moderate | 5 | 6 |
| Low | 2 | 0 |
| **Total** | **32** | **6** |

## Changes

All changes are `overrides` entries in `nifi-frontend/src/main/frontend/package.json`.
The `package-lock.json` is regenerated to reflect resolved transitive versions. No other
files are modified.

### Updated existing overrides (floor was too permissive)

| Package | Old override | New override | Reason |
|---------|-------------|-------------|--------|
| `undici` | `>=7.24.0` | `>=7.28.0` | Installed 7.24.4 still falls within the advisory range 7.0.0–7.27.2 |
| `js-yaml` | `>=4.2.0` | `>=4.3.0` | Installed 4.2.0 is the exact upper bound of the advisory range |

### New overrides added

| Package | Constraint | Semver delta | Severity | Scope |
|---------|-----------|-------------|----------|-------|
| `tar` | `>=7.5.19` | patch | critical | dev |
| `websocket-driver` | `>=0.7.5` | patch | critical | dev |
| `adm-zip` | `>=0.6.0` | minor | high | dev |
| `axios` | `>=1.18.0` | minor | high | dev |
| `fast-uri` | `>=3.1.4` | patch | high | dev |
| `http-proxy-middleware` | `>=3.0.7 <4` | patch | high | dev |
| `immutable` | `>=5.1.8` | patch | high | dev |
| `piscina` | `>=5.2.0` | minor | high | dev |
| `shell-quote` | `>=1.8.5` | patch | high | dev |
| `svgo` | `>=3.3.4` | patch | high | dev |
| `vite` | `^7.3.5` | patch | high | dev |
| `hono` | `>=4.12.27` | patch | moderate | dev |
| `body-parser` | `>=2.3.0` | minor | low | dev |
| `dompurify` | `>=3.4.12` | patch | low | prod (transitive) |

### Cascade resolutions

Several high advisories were cleared indirectly rather than by a direct override:

- The `adm-zip` and `undici` overrides resolved the entire `@module-federation/*` cluster
  (`@module-federation/dts-plugin`, `cli`, `manifest`, `rspack`, `enhanced`, `node`) and
  consequently cleared the `@nx/module-federation`, `@nx/rspack`, and `@nx/angular` HIGH
  advisories.
- The `http-proxy-middleware`, `piscina`, and `vite` overrides cleared the `@angular/build`
  HIGH advisory and partially cleared `@angular-devkit/build-angular`.
- `brace-expansion` self-resolved to 5.0.8 (outside all advisory ranges) as a side effect
  of dependency tree re-resolution; no explicit override was needed.

## Remaining Vulnerabilities

Six moderate advisories are intentionally deferred:

**webpack-dev-server cluster** (GHSA-f5vj-f2hx-8m93, GHSA-m28w-2pqf-7qgj): No 5.x fix
exists. Remediation requires upgrading to webpack-dev-server 6.x, which is a major version
boundary and depends on an Angular build toolchain upgrade.

**@hono/node-server cluster** (GHSA-frvp-7c67-39w9): `@angular/cli` pulls in
`@modelcontextprotocol/sdk`, which requires `@hono/node-server@^1` (vulnerable below 2.0.5).
The fix requires a 1.x→2.x major bump whose compatibility with the current
`@modelcontextprotocol/sdk` version is untested.

Both clusters are dev/build-tooling only and do not affect any artifact shipped to the browser.

## Verification

`nx run-many -t lint` exits 0 across all 6 projects in `nifi-frontend` with these overrides
applied.