### PR TITLE
NIFI-16140 - Bump Logback to 1.6.0, Okio to 3.18.0, Tika to 3.3.2, and others

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
-            <version>3.5.0</version>
+            <version>3.5.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>9.4.3</elasticsearch.client.version>
+        <elasticsearch.client.version>9.4.4</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>nifi-graph-test-clients</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <janusgraph.version>1.2.0-20260719-131347.d9158a6</janusgraph.version>
+        <janusgraph.version>1.2.0-20260723-164414.ac0eb23</janusgraph.version>
         <guava.version>33.6.0-jre</guava.version>
         <amqp-client.version>5.34.0</amqp-client.version>
     </properties>

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tika.version>3.3.1</tika.version>
+        <tika.version>3.3.2</tika.version>
     </properties>
     <dependencies>
         <dependency>

--- a/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
@@ -34,6 +34,6 @@
     </modules>
 
     <properties>
-        <mongo.driver.version>5.9.0</mongo.driver.version>
+        <mongo.driver.version>5.9.1</mongo.driver.version>
     </properties>
 </project>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <guava.version>33.6.0-jre</guava.version>
         <protobuf.version>4.35.1</protobuf.version>
-        <grpc.version>1.82.2</grpc.version>
+        <grpc.version>1.83.0</grpc.version>
         <snowflake-jdbc-thin.version>4.3.2</snowflake-jdbc-thin.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -34,7 +34,7 @@
         <module>nifi-standard-content-viewer-nar</module>
     </modules>
     <properties>
-        <tika.version>3.3.1</tika.version>
+        <tika.version>3.3.2</tika.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -115,7 +115,7 @@
             <dependency>
                 <groupId>org.codehaus.jettison</groupId>
                 <artifactId>jettison</artifactId>
-                <version>1.5.6</version>
+                <version>1.5.7</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.security</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>4.1.0</spring.boot.version>
-        <flyway.version>12.11.0</flyway.version>
+        <flyway.version>13.0.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.7.0.202606012155-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.48.3</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.49.2</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.7</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -169,7 +169,7 @@
 
         <!-- Logging and observability -->
         <log4j2.version>2.26.1</log4j2.version>
-        <logback.version>1.5.38</logback.version>
+        <logback.version>1.6.0</logback.version>
         <org.slf4j.version>2.0.18</org.slf4j.version>
         <prometheus.version>0.16.0</prometheus.version>
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
@@ -177,14 +177,14 @@
         <!-- Networking and transport -->
         <netty.4.version>4.2.16.Final</netty.4.version>
         <okhttp.version>5.4.0</okhttp.version>
-        <okio.version>3.17.0</okio.version>
+        <okio.version>3.18.0</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
         <org.apache.sshd.version>2.19.0</org.apache.sshd.version>
 
         <!-- Security -->
         <nimbus-jose-jwt.version>10.9.1</nimbus-jose-jwt.version>
-        <nimbus-oauth2-oidc.version>11.38.1</nimbus-oauth2-oidc.version>
+        <nimbus-oauth2-oidc.version>11.38.2</nimbus-oauth2-oidc.version>
         <org.bouncycastle.version>1.85</org.bouncycastle.version>
 
         <!-- Utilities -->
@@ -849,7 +849,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.5.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
# Summary

NIFI-16140 - Bump Logback to 1.6.0, Okio to 3.18.0, Tika to 3.3.2, and others

- AWS Kinesis Client from 3.5.0 to 3.5.1 - https://github.com/awslabs/amazon-kinesis-client/releases/tag/v3.5.1
- Elasticsearch Client from 9.4.3 to 9.4.4 - https://github.com/elastic/elasticsearch-java/releases/tag/v9.4.4
- JanusGraph from 1.2.0-20260719-131347.d9158a6 to 1.2.0-20260723-164414.ac0eb23 - https://github.com/JanusGraph/janusgraph
- Apache Tika from 3.3.1 to 3.3.2 - https://github.com/apache/tika/releases/tag/3.3.2
- MongoDB Driver from 5.9.0 to 5.9.1 - https://github.com/mongodb/mongo-java-driver/releases/tag/r5.9.1
- gRPC from 1.82.2 to 1.83.0 - https://github.com/grpc/grpc/releases/tag/v1.83.0
- Jettison from 1.5.6 to 1.5.7 - https://github.com/jettison-json/jettison/releases/tag/jettison-1.5.7
- FlywayDB from 12.11.0 to 13.0.0 - https://github.com/flyway/flyway/releases/tag/flyway-13.0.0
- AWS SDK BOM from 2.48.3 to 2.49.2 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.49.2
- Logback from 1.5.38 to 1.6.0 - https://github.com/qos-ch/logback/releases/tag/v_1.6.0
- Okio from 3.17.0 to 3.18.0 - https://lysine.dev/okio/changelog/#version-3180
- Nimbus OAuth2 OIDC from 11.38.1 to 11.38.2 - https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/master/CHANGELOG.txt
- Maven JAR Plugin from 3.5.0 to 3.5.1 - https://github.com/apache/maven-jar-plugin/releases/tag/maven-jar-plugin-3.5.1

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
