### PR TITLE
NIFI-16145 - Branch creation with Flow Registry Clients

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
@@ -39,6 +39,7 @@ import {
     navigateToViewStatusHistoryForComponent,
     openChangeProcessorVersionDialog,
     openChangeVersionDialogRequest,
+    openCreateBranchDialogRequest,
     openCommitLocalChangesDialogRequest,
     openForceCommitLocalChangesDialogRequest,
     openRevertLocalChangesDialogRequest,
@@ -213,6 +214,28 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
                         processGroupId: pgId
                     };
                     this.store.dispatch(openChangeVersionDialogRequest({ request }));
+                }
+            },
+            {
+                condition: (selection: d3.Selection<any, any, any, any>) => {
+                    return this.canvasUtils.supportsCreateFlowBranch(selection);
+                },
+                clazz: 'fa fa-code-fork',
+                text: 'Create Branch',
+                action: (selection: d3.Selection<any, any, any, any>) => {
+                    let pgId;
+                    if (selection.empty()) {
+                        pgId = this.canvasUtils.getProcessGroupId();
+                    } else {
+                        pgId = selection.datum().id;
+                    }
+                    this.store.dispatch(
+                        openCreateBranchDialogRequest({
+                            request: {
+                                processGroupId: pgId
+                            }
+                        })
+                    );
                 }
             },
             {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.spec.ts
@@ -24,7 +24,12 @@ import * as fromFlow from '../state/flow/flow.reducer';
 import { transformFeatureKey } from '../state/transform';
 import * as fromTransform from '../state/transform/transform.reducer';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { selectConnections, selectCurrentProcessGroupId, selectFlowState } from '../state/flow/flow.selectors';
+import {
+    selectConnections,
+    selectCurrentProcessGroupId,
+    selectFlowState,
+    selectRegistryClients
+} from '../state/flow/flow.selectors';
 import { controllerServicesFeatureKey } from '../state/controller-services';
 import * as fromControllerServices from '../state/controller-services/controller-services.reducer';
 import { selectCurrentUser } from '../../../state/current-user/current-user.selectors';
@@ -128,6 +133,91 @@ describe('CanvasUtils', () => {
             };
             const selection = d3.select(document.createElement('div')).classed('process-group', true).datum(pgDatum);
             expect(service.getFlowVersionControlInformation(selection)).toBe(versionControlInformation);
+        });
+    });
+
+    describe('supportsCreateFlowBranch', () => {
+        const registryId = '324e0ab1-0197-1000-ffff-ffffb3123c5c';
+
+        function createProcessGroupSelection(versionControlInformation: any): d3.Selection<any, any, any, any> {
+            const pgDatum = {
+                id: '1',
+                type: ComponentType.ProcessGroup,
+                permissions: { canRead: true, canWrite: true },
+                component: {
+                    id: '1',
+                    name: 'Test Process Group',
+                    versionControlInformation
+                }
+            };
+            return d3.select(document.createElement('div')).classed('process-group', true).datum(pgDatum);
+        }
+
+        function configure(canVersionFlows: boolean, supportsBranching: boolean): void {
+            const store = TestBed.inject(MockStore);
+            store.overrideSelector(selectCurrentUser, { ...fromUser.initialState.user, canVersionFlows });
+            store.overrideSelector(selectRegistryClients, [
+                { id: registryId, component: { supportsBranching } }
+            ] as any);
+            store.refreshState();
+        }
+
+        it('should return false when the user cannot version flows', () => {
+            configure(false, true);
+            const selection = createProcessGroupSelection({ groupId: '1', registryId, state: 'UP_TO_DATE' });
+            expect(service.supportsCreateFlowBranch(selection)).toBe(false);
+        });
+
+        it('should return false when there is no version control information', () => {
+            configure(true, true);
+            const selection = createProcessGroupSelection(null);
+            expect(service.supportsCreateFlowBranch(selection)).toBe(false);
+        });
+
+        it('should return false when the registry id is missing', () => {
+            configure(true, true);
+            const selection = createProcessGroupSelection({ groupId: '1', state: 'UP_TO_DATE' });
+            expect(service.supportsCreateFlowBranch(selection)).toBe(false);
+        });
+
+        it('should return false when the flow is in a sync failure state', () => {
+            configure(true, true);
+            const selection = createProcessGroupSelection({ groupId: '1', registryId, state: 'SYNC_FAILURE' });
+            expect(service.supportsCreateFlowBranch(selection)).toBe(false);
+        });
+
+        it('should return false when the registry client does not support branching', () => {
+            configure(true, false);
+            const selection = createProcessGroupSelection({ groupId: '1', registryId, state: 'UP_TO_DATE' });
+            expect(service.supportsCreateFlowBranch(selection)).toBe(false);
+        });
+
+        it('should return true when version controlled and the registry client supports branching', () => {
+            configure(true, true);
+            const selection = createProcessGroupSelection({ groupId: '1', registryId, state: 'UP_TO_DATE' });
+            expect(service.supportsCreateFlowBranch(selection)).toBe(true);
+        });
+
+        it('should return true when the flow is locally modified', () => {
+            configure(true, true);
+            const selection = createProcessGroupSelection({ groupId: '1', registryId, state: 'LOCALLY_MODIFIED' });
+            expect(service.supportsCreateFlowBranch(selection)).toBe(true);
+        });
+
+        it('should return true when the flow is locally modified and stale', () => {
+            configure(true, true);
+            const selection = createProcessGroupSelection({
+                groupId: '1',
+                registryId,
+                state: 'LOCALLY_MODIFIED_AND_STALE'
+            });
+            expect(service.supportsCreateFlowBranch(selection)).toBe(true);
+        });
+
+        it('should return true when the flow is stale', () => {
+            configure(true, true);
+            const selection = createProcessGroupSelection({ groupId: '1', registryId, state: 'STALE' });
+            expect(service.supportsCreateFlowBranch(selection)).toBe(true);
         });
     });
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
@@ -26,13 +26,14 @@ import {
     selectConnections,
     selectCurrentParameterContext,
     selectCurrentProcessGroupId,
-    selectParentProcessGroupId
+    selectParentProcessGroupId,
+    selectRegistryClients
 } from '../state/flow/flow.selectors';
 import { initialState as initialFlowState } from '../state/flow/flow.reducer';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BulletinsTip } from '../../../ui/common/tooltips/bulletins-tip/bulletins-tip.component';
 import { Position } from '../state/shared';
-import { BreadcrumbEntity } from '../../../state/shared';
+import { BreadcrumbEntity, RegistryClientEntity } from '../../../state/shared';
 import { BulletinEntity, ComponentType, NiFiCommon, ParameterContextReferenceEntity, Permissions } from '@nifi/shared';
 import { CurrentUser } from '../../../state/current-user';
 import { initialState as initialUserState } from '../../../state/current-user/current-user.reducer';
@@ -89,6 +90,7 @@ export class CanvasUtils {
     private connections: any[] = [];
     private breadcrumbs: BreadcrumbEntity | null = null;
     private copiedSnippet: CopiedSnippet | null = null;
+    private registryClients: RegistryClientEntity[] = initialFlowState.registryClients;
 
     private readonly humanizeDuration: Humanizer;
 
@@ -157,6 +159,13 @@ export class CanvasUtils {
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe((scale) => {
                 this.scale = scale;
+            });
+
+        this.store
+            .select(selectRegistryClients)
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((registryClients) => {
+                this.registryClients = registryClients;
             });
     }
 
@@ -2170,6 +2179,32 @@ export class CanvasUtils {
             versionControlInformation.state !== 'LOCALLY_MODIFIED_AND_STALE' &&
             versionControlInformation.state !== 'SYNC_FAILURE'
         );
+    }
+
+    /**
+     * Returns whether the process group supports creating a new branch. This requires that the
+     * process group is under version control with a registry client that supports branching.
+     *
+     * @argument {d3.Selection} selection      The selection
+     * @return {boolean}                       Whether the selection supports creating a branch.
+     */
+    public supportsCreateFlowBranch(selection: d3.Selection<any, any, any, any>): boolean {
+        if (!this.canVersionFlows()) {
+            return false;
+        }
+
+        const versionControlInformation = this.getFlowVersionControlInformation(selection);
+
+        if (!versionControlInformation || !versionControlInformation.registryId) {
+            return false;
+        }
+
+        if (versionControlInformation.state === 'SYNC_FAILURE') {
+            return false;
+        }
+
+        const registryClient = this.registryClients.find((client) => client.id === versionControlInformation.registryId);
+        return !!registryClient?.component.supportsBranching;
     }
 
     /**

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/flow.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/flow.service.ts
@@ -25,6 +25,7 @@ import {
     CreateComponentRequest,
     CreateComponentResponse,
     CreateConnection,
+    CreateFlowBranchRequest,
     CreateLabelRequest,
     CreatePortRequest,
     CreateProcessGroupRequest,
@@ -50,6 +51,7 @@ import {
 } from '../state/flow';
 import { Client } from '../../../service/client.service';
 import { ComponentType, NiFiCommon } from '@nifi/shared';
+import { Revision } from '@nifi/shared';
 import { ClusterConnectionService } from '../../../service/cluster-connection.service';
 import {
     ClearBulletinsRequest,
@@ -412,6 +414,33 @@ export class FlowService implements PropertyDescriptorRetriever {
         return this.httpClient.post(
             `${FlowService.API}/versions/process-groups/${request.processGroupId}`,
             saveRequest
+        ) as Observable<VersionControlInformationEntity>;
+    }
+
+    createFlowBranch(request: CreateFlowBranchRequest): Observable<VersionControlInformationEntity> {
+        const payload: {
+            processGroupRevision: Revision;
+            branch: string;
+            disconnectedNodeAcknowledged: boolean;
+            sourceBranch?: string;
+            sourceVersion?: string;
+        } = {
+            processGroupRevision: request.revision,
+            branch: request.branch,
+            disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged()
+        };
+
+        if (request.sourceBranch) {
+            payload.sourceBranch = request.sourceBranch;
+        }
+
+        if (request.sourceVersion) {
+            payload.sourceVersion = request.sourceVersion;
+        }
+
+        return this.httpClient.post(
+            `${FlowService.API}/versions/process-groups/${request.processGroupId}/branches`,
+            payload
         ) as Observable<VersionControlInformationEntity>;
     }
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
@@ -16,6 +16,7 @@
  */
 
 import { createAction, props } from '@ngrx/store';
+import { HttpErrorResponse } from '@angular/common/http';
 import {
     CenterComponentRequest,
     ChangeColorRequest,
@@ -28,6 +29,8 @@ import {
     CreateComponentResponse,
     CreateConnection,
     CreateConnectionRequest,
+    CreateBranchDialogRequest,
+    CreateFlowBranchRequest,
     CreatePortRequest,
     CreateProcessGroupDialogRequest,
     CreateProcessGroupRequest,
@@ -71,6 +74,7 @@ import {
     NavigateToQueueListing,
     OpenChangeVersionDialogRequest,
     OpenComponentDialogRequest,
+    OpenCreateBranchDialogRequest,
     OpenGroupComponentsDialogRequest,
     OpenLocalChangesDialogRequest,
     OpenSaveVersionDialogRequest,
@@ -845,6 +849,31 @@ export const saveToFlowRegistry = createAction(
 export const saveToFlowRegistrySuccess = createAction(
     `${CANVAS_PREFIX} Save To Version Control Success`,
     props<{ response: VersionControlInformationEntity }>()
+);
+
+export const openCreateBranchDialogRequest = createAction(
+    `${CANVAS_PREFIX} Open Create Branch Dialog Request`,
+    props<{ request: OpenCreateBranchDialogRequest }>()
+);
+
+export const openCreateBranchDialog = createAction(
+    `${CANVAS_PREFIX} Open Create Branch Dialog`,
+    props<{ request: CreateBranchDialogRequest }>()
+);
+
+export const createFlowBranch = createAction(
+    `${CANVAS_PREFIX} Create Flow Branch`,
+    props<{ request: CreateFlowBranchRequest }>()
+);
+
+export const createFlowBranchSuccess = createAction(
+    `${CANVAS_PREFIX} Create Flow Branch Success`,
+    props<{ response: VersionControlInformationEntity }>()
+);
+
+export const createFlowBranchFailure = createAction(
+    `${CANVAS_PREFIX} Create Flow Branch Failure`,
+    props<{ errorResponse: HttpErrorResponse }>()
 );
 
 export const stopVersionControlRequest = createAction(

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -52,6 +52,7 @@ import {
 } from 'rxjs';
 import {
     ComponentEntity,
+    CreateBranchDialogRequest,
     CreateConnectionDialogRequest,
     CreateProcessGroupDialogRequest,
     DeleteComponentResponse,
@@ -154,6 +155,7 @@ import { selectPrioritizerTypes } from '../../../../state/extension-types/extens
 import { NoRegistryClientsDialog } from '../../ui/common/no-registry-clients-dialog/no-registry-clients-dialog.component';
 import { EditRemoteProcessGroup } from '../../../../ui/common/component-dialogs/edit-remote-process-group/edit-remote-process-group.component';
 import { HttpErrorResponse } from '@angular/common/http';
+import { CreateBranchDialog } from '../../ui/canvas/items/flow/create-branch-dialog/create-branch-dialog.component';
 import { SaveVersionDialog } from '../../ui/canvas/items/flow/save-version-dialog/save-version-dialog.component';
 import { ChangeVersionDialog } from '../../ui/canvas/items/flow/change-version-dialog/change-version-dialog';
 import { ChangeVersionProgressDialog } from '../../ui/canvas/items/flow/change-version-progress-dialog/change-version-progress-dialog';
@@ -3998,6 +4000,118 @@ export class FlowEffects {
                 this.dialog.closeAll();
             }),
             switchMap(() => of(FlowActions.reloadFlow()))
+        )
+    );
+
+    /////////////////////////////////
+    // Create branch effects
+    /////////////////////////////////
+
+    openCreateBranchDialogRequest$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(FlowActions.openCreateBranchDialogRequest),
+            map((action) => action.request),
+            switchMap((request) =>
+                from(this.flowService.getVersionInformation(request.processGroupId)).pipe(
+                    map((response) => {
+                        const versionControlInformation = response.versionControlInformation;
+                        if (!versionControlInformation) {
+                            return FlowActions.showOkDialog({
+                                title: 'Create Branch',
+                                message: 'Process Group is no longer under version control.'
+                            });
+                        }
+
+                        return FlowActions.openCreateBranchDialog({
+                            request: {
+                                processGroupId: request.processGroupId,
+                                revision: response.processGroupRevision,
+                                versionControlInformation
+                            }
+                        });
+                    }),
+                    catchError((errorResponse: HttpErrorResponse) => of(this.snackBarOrFullScreenError(errorResponse)))
+                )
+            )
+        )
+    );
+
+    openCreateBranchDialog$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(FlowActions.openCreateBranchDialog),
+                map((action) => action.request),
+                tap((request: CreateBranchDialogRequest) => {
+                    const dialogReference = this.dialog.open(CreateBranchDialog, {
+                        ...MEDIUM_DIALOG,
+                        data: request,
+                        autoFocus: true
+                    });
+
+                    dialogReference.componentInstance.saving = this.store.selectSignal(selectVersionSaving);
+
+                    dialogReference.componentInstance.createBranch
+                        .pipe(takeUntil(dialogReference.afterClosed()))
+                        .subscribe((branch: string) => {
+                            this.store.dispatch(
+                                FlowActions.createFlowBranch({
+                                    request: {
+                                        processGroupId: request.processGroupId,
+                                        revision: request.revision,
+                                        branch,
+                                        sourceBranch: request.versionControlInformation.branch,
+                                        sourceVersion: request.versionControlInformation.version
+                                    }
+                                })
+                            );
+                        });
+                })
+            ),
+        { dispatch: false }
+    );
+
+    createFlowBranch$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(FlowActions.createFlowBranch),
+            map((action) => action.request),
+            switchMap((request) =>
+                from(this.flowService.createFlowBranch(request)).pipe(
+                    map((response) => FlowActions.createFlowBranchSuccess({ response })),
+                    catchError((errorResponse: HttpErrorResponse) =>
+                        of(FlowActions.createFlowBranchFailure({ errorResponse }))
+                    )
+                )
+            )
+        )
+    );
+
+    createFlowBranchSuccess$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(FlowActions.createFlowBranchSuccess),
+            map((action) => action.response),
+            tap((response) => {
+                this.dialog.closeAll();
+                const branch = response.versionControlInformation?.branch;
+                const message = branch
+                    ? `Process Group is now tracking branch ${branch}.`
+                    : 'Branch creation completed successfully.';
+
+                this.store.dispatch(
+                    FlowActions.showOkDialog({
+                        title: 'Create Branch',
+                        message
+                    })
+                );
+            }),
+            switchMap(() => of(FlowActions.reloadFlow()))
+        )
+    );
+
+    createFlowBranchFailure$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(FlowActions.createFlowBranchFailure),
+            map((action) => action.errorResponse),
+            switchMap((errorResponse) => of(this.bannerOrFullScreenError(errorResponse, ErrorContextKey.FLOW_BRANCH)))
         )
     );
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.reducer.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.reducer.ts
@@ -24,6 +24,9 @@ import {
     createComponentSuccess,
     createConnection,
     createFunnel,
+    createFlowBranch,
+    createFlowBranchFailure,
+    createFlowBranchSuccess,
     createLabel,
     createPort,
     createProcessGroup,
@@ -604,9 +607,34 @@ export const flowReducer = createReducer(
             draftState.saving = false;
         });
     }),
-    on(saveToFlowRegistry, stopVersionControl, (state) => ({
+    on(saveToFlowRegistry, stopVersionControl, createFlowBranch, (state) => ({
         ...state,
         versionSaving: true
+    })),
+    on(createFlowBranchSuccess, (state, { response }) => {
+        return produce(state, (draftState) => {
+            const collection: any[] | null = getComponentCollection(draftState, ComponentType.ProcessGroup);
+
+            if (collection) {
+                const componentIndex: number = collection.findIndex(
+                    (f: any) => response.versionControlInformation?.groupId === f.id
+                );
+                if (componentIndex > -1) {
+                    collection[componentIndex].revision = response.processGroupRevision;
+                    collection[componentIndex].versionedFlowState = response.versionControlInformation?.state;
+                    if (collection[componentIndex].component) {
+                        collection[componentIndex].component.versionControlInformation =
+                            response.versionControlInformation;
+                    }
+                }
+            }
+
+            draftState.versionSaving = false;
+        });
+    }),
+    on(createFlowBranchFailure, (state) => ({
+        ...state,
+        versionSaving: false
     })),
     on(saveToFlowRegistrySuccess, (state, { response }) => {
         return produce(state, (draftState) => {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/index.ts
@@ -160,11 +160,21 @@ export interface OpenChangeVersionDialogRequest {
     processGroupId: string;
 }
 
+export interface OpenCreateBranchDialogRequest {
+    processGroupId: string;
+}
+
 export interface ChangeVersionDialogRequest {
     processGroupId: string;
     revision: Revision;
     versionControlInformation: VersionControlInformation;
     versions: VersionedFlowSnapshotMetadataEntity[];
+}
+
+export interface CreateBranchDialogRequest {
+    processGroupId: string;
+    revision: Revision;
+    versionControlInformation: VersionControlInformation;
 }
 
 export interface SaveVersionDialogRequest {
@@ -188,6 +198,14 @@ export interface ConfirmStopVersionControlRequest {
 export interface StopVersionControlRequest {
     revision: Revision;
     processGroupId: string;
+}
+
+export interface CreateFlowBranchRequest {
+    processGroupId: string;
+    revision: Revision;
+    branch: string;
+    sourceBranch?: string;
+    sourceVersion?: string;
 }
 
 export interface StopVersionControlResponse {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/create-branch-dialog/create-branch-dialog.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/create-branch-dialog/create-branch-dialog.component.html
@@ -1,0 +1,57 @@
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one or more
+~ contributor license agreements.  See the NOTICE file distributed with
+~ this work for additional information regarding copyright ownership.
+~ The ASF licenses this file to You under the Apache License, Version 2.0
+~ (the "License"); you may not use this file except in compliance with
+~ the License.  You may obtain a copy of the License at
+~
+~    http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<h2 mat-dialog-title>Create Branch</h2>
+<form class="create-branch-form" [formGroup]="createBranchForm">
+    <context-error-banner [context]="ErrorContextKey.FLOW_BRANCH"></context-error-banner>
+    <mat-dialog-content>
+        <div class="flex flex-col gap-y-4 mb-6">
+            <div>
+                <div>Current branch</div>
+                <div class="tertiary-color font-medium">{{ currentBranch || 'Not specified' }}</div>
+            </div>
+
+            <div class="w-full">
+                <mat-form-field>
+                    <mat-label>Branch name</mat-label>
+                    <input matInput formControlName="branch" type="text" />
+                    @if (createBranchForm.controls['branch'].hasError('required')) {
+                        <mat-error>Branch name is required.</mat-error>
+                    }
+                    @if (createBranchForm.controls['branch'].hasError('pattern')) {
+                        <mat-error>Branch name cannot start with a space.</mat-error>
+                    }
+                    @if (createBranchForm.controls['branch'].hasError('branchConflicts')) {
+                        <mat-error>Must differ from current branch.</mat-error>
+                    }
+                </mat-form-field>
+            </div>
+        </div>
+    </mat-dialog-content>
+
+    <mat-dialog-actions align="end">
+        <button mat-button aria-label="Cancel" mat-dialog-close>Cancel</button>
+        <button
+            [disabled]="createBranchForm.invalid || saving() || createBranchForm.pending"
+            type="button"
+            mat-flat-button
+            aria-label="Create"
+            (click)="submitForm()">
+            <span *nifiSpinner="saving()">Create</span>
+        </button>
+    </mat-dialog-actions>
+</form>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/create-branch-dialog/create-branch-dialog.component.scss
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/create-branch-dialog/create-branch-dialog.component.scss
@@ -1,0 +1,26 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '@angular/material' as mat;
+
+.create-branch-form {
+    @include mat.button-density(-1);
+
+    .mat-mdc-form-field {
+        width: 100%;
+    }
+}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/create-branch-dialog/create-branch-dialog.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/create-branch-dialog/create-branch-dialog.component.spec.ts
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Signal, signal } from '@angular/core';
+import { CreateBranchDialog } from './create-branch-dialog.component';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { CreateBranchDialogRequest } from '../../../../../state/flow';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialState } from '../../../../../state/flow/flow.reducer';
+import { canvasFeatureKey, flowFeatureKey } from '../../../../../state';
+import { errorFeatureKey } from '../../../../../../../state/error';
+import { initialState as errorInitialState } from '../../../../../../../state/error/error.reducer';
+
+describe('CreateBranchDialog', () => {
+    let component: CreateBranchDialog;
+    let fixture: ComponentFixture<CreateBranchDialog>;
+
+    const data: CreateBranchDialogRequest = {
+        processGroupId: '5752a5ae-018d-1000-0990-c3709f5466f3',
+        revision: {
+            version: 0
+        },
+        versionControlInformation: {
+            groupId: '5752a5ae-018d-1000-0990-c3709f5466f3',
+            registryId: '324e0ab1-0197-1000-ffff-ffffb3123c5c',
+            registryName: 'ConnectorFlowRegistryClient',
+            branch: 'main',
+            bucketId: 'connectors',
+            bucketName: 'connectors',
+            flowId: 'kafka',
+            flowName: 'kafka',
+            flowDescription: '',
+            version: '0.1.0',
+            state: 'UP_TO_DATE',
+            stateExplanation: 'Flow version is current'
+        }
+    };
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [CreateBranchDialog, MatDialogModule, NoopAnimationsModule],
+            providers: [
+                {
+                    provide: MAT_DIALOG_DATA,
+                    useValue: data
+                },
+                provideMockStore({
+                    initialState: {
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        },
+                        [errorFeatureKey]: errorInitialState
+                    }
+                }),
+                { provide: MatDialogRef, useValue: null }
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(CreateBranchDialog);
+        component = fixture.componentInstance;
+        component.saving = (() => false) as Signal<boolean>;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+        expect(component.currentBranch).toBe('main');
+    });
+
+    it('should be invalid when the branch name is empty', () => {
+        component.createBranchForm.controls['branch'].setValue('');
+        expect(component.createBranchForm.invalid).toBe(true);
+        expect(component.createBranchForm.controls['branch'].hasError('required')).toBe(true);
+    });
+
+    it('should be invalid when the branch name starts with whitespace', () => {
+        component.createBranchForm.controls['branch'].setValue(' feature');
+        expect(component.createBranchForm.controls['branch'].hasError('pattern')).toBe(true);
+    });
+
+    it('should be invalid when the branch name matches the current branch', () => {
+        component.createBranchForm.controls['branch'].setValue('main');
+        expect(component.createBranchForm.controls['branch'].hasError('branchConflicts')).toBe(true);
+    });
+
+    it('should show an error and disable Create when the branch name matches the current branch', () => {
+        component.createBranchForm.controls['branch'].setValue('main');
+        fixture.detectChanges();
+
+        const error: HTMLElement = fixture.nativeElement.querySelector('mat-error');
+        const btn: HTMLButtonElement = fixture.nativeElement.querySelector('button[aria-label="Create"]');
+
+        expect(error.textContent).toContain('Must differ from current branch.');
+        expect(btn.disabled).toBe(true);
+    });
+
+    it('should emit the trimmed branch name when the form is valid', () => {
+        const emitted: string[] = [];
+        component.createBranch.subscribe((branch) => emitted.push(branch));
+
+        component.createBranchForm.controls['branch'].setValue('feature-branch');
+        component.submitForm();
+
+        expect(emitted).toEqual(['feature-branch']);
+    });
+
+    it('should not emit when the form is invalid', () => {
+        const emitted: string[] = [];
+        component.createBranch.subscribe((branch) => emitted.push(branch));
+
+        component.createBranchForm.controls['branch'].setValue('main');
+        component.submitForm();
+
+        expect(emitted).toEqual([]);
+    });
+
+    it('should disable the Create button while a request is in flight', () => {
+        const saving = signal(true);
+        component.saving = saving;
+        component.createBranchForm.controls['branch'].setValue('feature-branch');
+        fixture.detectChanges();
+        const btn: HTMLButtonElement = fixture.nativeElement.querySelector('button[aria-label="Create"]');
+        expect(btn.disabled).toBe(true);
+    });
+
+    it('should re-enable the Create button when the request completes', () => {
+        const saving = signal(true);
+        component.saving = saving;
+        component.createBranchForm.controls['branch'].setValue('feature-branch');
+        fixture.detectChanges();
+        saving.set(false);
+        fixture.detectChanges();
+        const btn: HTMLButtonElement = fixture.nativeElement.querySelector('button[aria-label="Create"]');
+        expect(btn.disabled).toBe(false);
+    });
+});

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/create-branch-dialog/create-branch-dialog.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/create-branch-dialog/create-branch-dialog.component.ts
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, DestroyRef, EventEmitter, Input, Output, Signal, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+    MAT_DIALOG_DATA,
+    MatDialogActions,
+    MatDialogClose,
+    MatDialogContent,
+    MatDialogTitle
+} from '@angular/material/dialog';
+import {
+    AbstractControl,
+    FormBuilder,
+    FormGroup,
+    ReactiveFormsModule,
+    ValidationErrors,
+    Validators
+} from '@angular/forms';
+import { MatButton } from '@angular/material/button';
+import { MatError, MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { CloseOnEscapeDialog, NifiSpinnerDirective } from '@nifi/shared';
+import { CreateBranchDialogRequest } from '../../../../../state/flow';
+import { ErrorContextKey } from '../../../../../../../state/error';
+import { ContextErrorBanner } from '../../../../../../../ui/common/context-error-banner/context-error-banner.component';
+
+@Component({
+    selector: 'create-branch-dialog',
+    imports: [
+        MatDialogTitle,
+        MatDialogContent,
+        MatDialogActions,
+        MatDialogClose,
+        ReactiveFormsModule,
+        MatButton,
+        MatFormField,
+        MatLabel,
+        MatError,
+        MatInput,
+        ContextErrorBanner,
+        NifiSpinnerDirective
+    ],
+    templateUrl: './create-branch-dialog.component.html',
+    styleUrl: './create-branch-dialog.component.scss'
+})
+export class CreateBranchDialog extends CloseOnEscapeDialog {
+    private dialogRequest = inject<CreateBranchDialogRequest>(MAT_DIALOG_DATA);
+    private formBuilder = inject(FormBuilder);
+    private destroyRef = inject(DestroyRef);
+
+    @Output() createBranch: EventEmitter<string> = new EventEmitter<string>();
+
+    @Input({ required: true }) saving!: Signal<boolean>;
+
+    protected readonly ErrorContextKey = ErrorContextKey;
+
+    currentBranch = this.dialogRequest.versionControlInformation.branch;
+
+    createBranchForm: FormGroup;
+
+    constructor() {
+        super();
+        this.createBranchForm = this.formBuilder.group({
+            branch: [
+                '',
+                [Validators.required, Validators.pattern(/^(?!\s).*$/), this.branchNotCurrentValidator.bind(this)]
+            ]
+        });
+
+        const branchControl = this.createBranchForm.controls['branch'];
+        branchControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+            if (branchControl.hasError('branchConflicts')) {
+                branchControl.markAsTouched({ onlySelf: true });
+            }
+        });
+    }
+
+    submitForm(): void {
+        if (this.createBranchForm.invalid) {
+            this.createBranchForm.markAllAsTouched();
+            return;
+        }
+
+        this.createBranch.emit(this.createBranchForm.controls['branch'].value.trim());
+    }
+
+    private branchNotCurrentValidator(control: AbstractControl): ValidationErrors | null {
+        const value = control.value;
+        if (!value) {
+            return null;
+        }
+
+        if (this.currentBranch && value.trim() === this.currentBranch) {
+            return { branchConflicts: true };
+        }
+
+        return null;
+    }
+}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/error/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/error/index.ts
@@ -46,6 +46,7 @@ export enum ErrorContextKey {
     REGISTRY_IMPORT = 'registry-import',
     LABEL = 'label',
     FLOW_VERSION = 'flow-version',
+    FLOW_BRANCH = 'flow-branch',
     FUNNEL = 'funnel',
     LOCAL_EXTENSIONS = 'local-extensions',
     LINEAGE = 'lineage',


### PR DESCRIPTION
# Summary

NIFI-16145 - Branch creation with Flow Registry Clients

<img width="520" height="177" alt="Screenshot 2026-07-24 at 23 52 28" src="https://github.com/user-attachments/assets/03cf5214-843e-46d9-8d3d-64b14c074ce5" />

<img width="522" height="299" alt="Screenshot 2026-07-24 at 23 52 15" src="https://github.com/user-attachments/assets/5973c56b-b958-45d3-a102-a45a6d5da3ec" />

<img width="504" height="286" alt="Screenshot 2026-07-24 at 23 52 08" src="https://github.com/user-attachments/assets/a572cc80-5153-4a02-8dee-d2e79e8226d0" />

<img width="544" height="187" alt="Screenshot 2026-07-24 at 23 52 01" src="https://github.com/user-attachments/assets/07f3c760-f8f3-4779-9781-f1a11e465505" />


# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
