### PR TITLE
NIFI-16146 Fix FileUtils sanitization of UTF-16 in filenames

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/FileUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/FileUtils.java
@@ -586,6 +586,8 @@ public class FileUtils {
     private static final int[] INVALID_CHARS = {34, 60, 62, 124, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
             16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 58, 42, 63, 92, 47};
 
+    private static final char REPLACEMENT_CHARACTER = '_';
+
     static {
         Arrays.sort(INVALID_CHARS);
     }
@@ -597,7 +599,7 @@ public class FileUtils {
      * @param filename The filename to clean
      * @return sanitized filename
      */
-    public static String getSanitizedFilename(String filename) {
+    public static String getSanitizedFilename(final String filename) {
         if (filename == null) {
             return null;
         }
@@ -605,15 +607,17 @@ public class FileUtils {
             return "";
         }
 
-        final int codePointCount = filename.codePointCount(0, filename.length());
+        final int filenameLength = filename.length();
         final StringBuilder cleanName = new StringBuilder();
-        for (int i = 0; i < codePointCount; i++) {
+        for (int i = 0; i < filenameLength;) {
             final int c = filename.codePointAt(i);
             if (Arrays.binarySearch(INVALID_CHARS, c) < 0) {
                 cleanName.appendCodePoint(c);
             } else {
-                cleanName.append('_');
+                cleanName.append(REPLACEMENT_CHARACTER);
             }
+            // Advance index based on character count to handle UTF-16
+            i += Character.charCount(c);
         }
         return cleanName.toString();
     }

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/FileUtilsTest.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/FileUtilsTest.java
@@ -50,4 +50,18 @@ class FileUtilsTest {
         assertEquals("report...", FileUtils.getSanitizedFilename("report..."));
         assertEquals(".env", FileUtils.getSanitizedFilename(".env"));
     }
+
+    @Test
+    void testGetSanitizedFilenamePreservesSupplementaryCodePoints() {
+        // U+1F4C4 PAGE FACING UP - encoded as a UTF-16 surrogate pair
+        final int pageFacingUpCharacter = 0x1F4C4;
+        final String pageFacingUp = new String(Character.toChars(pageFacingUpCharacter));
+
+        final String complexFilename = "a" + pageFacingUp + "b";
+        assertEquals(complexFilename, FileUtils.getSanitizedFilename(complexFilename));
+
+        // Test standard character replacements
+        assertEquals(pageFacingUp + "_file.txt", FileUtils.getSanitizedFilename(pageFacingUp + "/file.txt"));
+        assertEquals("report " + pageFacingUp + ".txt", FileUtils.getSanitizedFilename("report " + pageFacingUp + ".txt"));
+    }
 }


### PR DESCRIPTION
# Summary

[NIFI-16146](https://issues.apache.org/jira/browse/NIFI-16146) Corrects `FIleUtils.getSanitizedFilename()` handling of UTF-16 character code points and adds a new test method to validate corrected behavior.

The previous implementation iterated over every indexed number based on character code point, which did not properly handle UTF-16 characters, corrupting subsequent characters in output filenames.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
