### PR TITLE
NIFI-15546 correct active load balance glyph location in UI

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/connection-manager.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/connection-manager.service.ts
@@ -1868,7 +1868,7 @@ export class ConnectionManager implements OnDestroy {
                                 return true;
                             }
                         })
-                        .classed('load-balance-icon-active fa-rotate-90 success-color-variant', (d: any) => {
+                        .classed('load-balance-icon-active success-color-variant', (d: any) => {
                             return d.permissions.canRead && d.component.loadBalanceStatus === 'LOAD_BALANCE_ACTIVE';
                         })
                         .classed('primary-color', (d: any) => {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.scss
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.scss
@@ -271,6 +271,13 @@
         font-size: 12px;
     }
 
+    /* Rotate about the glyph itself, not the svg view box */
+    text.load-balance-icon-active {
+        transform: rotate(90deg);
+        transform-box: fill-box;
+        transform-origin: center;
+    }
+
     g.connection rect.backpressure-object > title > tspan,
     g.connection rect.backpressure-data-size > title > tspan {
         display: block;


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Fixed the issue in the UI where the active load balancing glyph appears in the wrong location. The glyph is the same as the inactive load balancing glyph (two-tone circle split horizontally), but it is rotated and color changed. The rotation - but same location - makes it appear like the icon has changed while load balancing is active. The problem was that the center of rotation was not at the center of the icon; it rotated the icon to an undesirable location no longer within the connection label.

This PR adjusts the center of rotation to be the center of the glyph keeping its location consistent whether it is the active or inactive load balance icon.

[NIFI-15546](https://issues.apache.org/jira/browse/NIFI-15546)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Testing requires a Cluster; it's the only way to activate load balancing. Queue up a relatively large number of FlowFiles (or few FlowFiles of large size.) Doing so will allow a refresh to display the active load balancing icon. Observe the active versus inactive state. The circle icon will appear to rotate (and change color) but will remain in the exact same location.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
