### PR TITLE
NIFI-16150 - Bump Logback to 1.6.1, Azure to 1.3.8, ActiveMQ to 6.3.0, and others

### DIFF
--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-standard-services/pom.xml
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-standard-services/pom.xml
@@ -27,7 +27,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <couchbase.version>3.12.1</couchbase.version>
+        <couchbase.version>3.12.2</couchbase.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <activemq.version>6.2.7</activemq.version>
+        <activemq.version>6.3.0</activemq.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>de.siegmar</groupId>
             <artifactId>fastcsv</artifactId>
-            <version>4.3.1</version>
+            <version>4.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.palindromicity</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -39,7 +39,7 @@
         <flyway.version>13.0.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
-        <jgit.version>7.7.0.202606012155-r</jgit.version>
+        <jgit.version>7.7.1.202607240634-r</jgit.version>
         <h2.version>2.4.240</h2.version>
     </properties>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <docker.jre.image.name>bellsoft/liberica-openjre-debian</docker.jre.image.name>
 
         <!-- Frontend tooling -->
-        <frontend.mvn.plugin.version>2.0.1</frontend.mvn.plugin.version>
+        <frontend.mvn.plugin.version>2.0.2</frontend.mvn.plugin.version>
         <node.version>v24.14.1</node.version>
 
         <!-- NiFi build -->
@@ -122,9 +122,9 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.49.2</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.49.5</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
-        <azure.sdk.bom.version>1.3.7</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
+        <azure.sdk.bom.version>1.3.8</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
         <!-- Apache Commons -->
         <org.apache.commons.cli.version>1.11.0</org.apache.commons.cli.version>
@@ -153,7 +153,7 @@
         <kafka-clients.version>4.3.1</kafka-clients.version>
         <avro.version>1.12.1</avro.version>
         <calcite.version>1.42.0</calcite.version>
-        <com.github.luben.zstd-jni.version>1.5.7-11</com.github.luben.zstd-jni.version>
+        <com.github.luben.zstd-jni.version>1.5.7-12</com.github.luben.zstd-jni.version>
         <com.jayway.jsonpath.version>3.0.0</com.jayway.jsonpath.version>
         <gson.version>2.14.0</gson.version>
         <jackson.annotations.version>2.22</jackson.annotations.version>
@@ -169,7 +169,7 @@
 
         <!-- Logging and observability -->
         <log4j2.version>2.26.1</log4j2.version>
-        <logback.version>1.6.0</logback.version>
+        <logback.version>1.6.1</logback.version>
         <org.slf4j.version>2.0.18</org.slf4j.version>
         <prometheus.version>0.16.0</prometheus.version>
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
@@ -177,7 +177,7 @@
         <!-- Networking and transport -->
         <netty.4.version>4.2.16.Final</netty.4.version>
         <okhttp.version>5.4.0</okhttp.version>
-        <okio.version>3.18.0</okio.version>
+        <okio.version>3.18.1</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
         <org.apache.sshd.version>2.19.0</org.apache.sshd.version>


### PR DESCRIPTION
# Summary

NIFI-16150 - Bump Logback to 1.6.1, Azure to 1.3.8, ActiveMQ to 6.3.0, and others

- Couchbase from 3.12.1 to 3.12.2 - https://github.com/couchbase/couchbase-jvm-clients/releases/tag/3.12.2
- Apache ActiveMQ from 6.2.7 to 6.3.0 - https://github.com/apache/activemq/releases/tag/activemq-6.3.0
- FastCSV from 4.3.1 to 4.4.0 - https://github.com/osiegmar/FastCSV/releases/tag/v4.4.0
- jGit from 7.7.0.202606012155-r to 7.7.1.202607240634-r - https://github.com/eclipse-jgit/jgit/releases/tag/v7.7.1.202607240634-r
- Frontend Maven Plugin from 2.0.1 to 2.0.2 - https://github.com/eirslett/frontend-maven-plugin/releases/tag/frontend-plugins-2.0.2
- AWS SDK BOM from 2.49.2 to 2.49.5 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.49.5
- Azure SDK BOM from 1.3.7 to 1.3.8 - https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/boms/azure-sdk-bom/README.md
- zstd from 1.5.7-11 to 1.5.7-12 - https://github.com/luben/zstd-jni/tags
- Logback from 1.6.0 to 1.6.1 - https://github.com/qos-ch/logback/releases/tag/v_1.6.1
- Okio from 3.18.0 to 3.18.1 - https://lysine.dev/okio/changelog/#version-3181

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
