### PR TITLE
NIFI-16153 - Avoid FlowController read lock when reading clustered state

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -406,11 +406,10 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
      */
     private volatile NodeIdentifier nodeId;
 
-    // guarded by rwLock
     /**
      * true if controller is connected or trying to connect to the cluster
      */
-    private boolean clustered;
+    private volatile boolean clustered;
 
     // guarded by rwLock
     private volatile NodeConnectionStatus connectionStatus;
@@ -3006,12 +3005,7 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
      */
     @Override
     public boolean isClustered() {
-        readLock.lock();
-        try {
-            return clustered;
-        } finally {
-            readLock.unlock("isClustered");
-        }
+        return clustered;
     }
 
     @Override


### PR DESCRIPTION
# Summary

NIFI-16153 - Avoid FlowController read lock when reading clustered state

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
