### PR TITLE
NIFI-16147 Removed unnecessary fully qualified names and implemented PMD rule UnnecessaryFullyQualifiedName

### DIFF
--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/FileChangeIngestorTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/FileChangeIngestorTest.java
@@ -25,7 +25,6 @@ import org.apache.nifi.minifi.properties.BootstrapProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
@@ -42,7 +41,10 @@ import static org.apache.nifi.minifi.bootstrap.configuration.ingestors.PullHttpC
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +62,7 @@ public class FileChangeIngestorTest {
     @BeforeEach
     public void setUp() {
         mockWatchService = mock(WatchService.class);
-        notifierSpy = Mockito.spy(new FileChangeIngestor());
+        notifierSpy = spy(new FileChangeIngestor());
         mockDifferentiator = mock(Differentiator.class);
         testNotifier = mock(ConfigurationChangeNotifier.class);
         testProperties = mock(BootstrapProperties.class);
@@ -104,18 +106,18 @@ public class FileChangeIngestorTest {
     /* Verify handleChange events */
     @Test
     public void testTargetChangedNoModification() throws Exception {
-        when(mockDifferentiator.isNew(Mockito.any(ByteBuffer.class))).thenReturn(false);
+        when(mockDifferentiator.isNew(any(ByteBuffer.class))).thenReturn(false);
         final ConfigurationChangeNotifier testNotifier = mock(ConfigurationChangeNotifier.class);
 
         // In this case the WatchKey is null because there were no events found
         establishMockEnvironmentForChangeTests(null);
 
-        verify(testNotifier, Mockito.never()).notifyListeners(Mockito.any(ByteBuffer.class));
+        verify(testNotifier, never()).notifyListeners(any(ByteBuffer.class));
     }
 
     @Test
     public void testTargetChangedWithModificationEventNonConfigFile() throws Exception {
-        when(mockDifferentiator.isNew(Mockito.any(ByteBuffer.class))).thenReturn(false);
+        when(mockDifferentiator.isNew(any(ByteBuffer.class))).thenReturn(false);
         final ConfigurationChangeNotifier testNotifier = mock(ConfigurationChangeNotifier.class);
 
         // In this case, we receive a trigger event for the directory monitored, but it was another file not being monitored
@@ -125,12 +127,12 @@ public class FileChangeIngestorTest {
 
         notifierSpy.targetFileChanged();
 
-        verify(testNotifier, Mockito.never()).notifyListeners(Mockito.any(ByteBuffer.class));
+        verify(testNotifier, never()).notifyListeners(any(ByteBuffer.class));
     }
 
     @Test
     public void testTargetChangedWithModificationEvent() throws Exception {
-        when(mockDifferentiator.isNew(Mockito.any(ByteBuffer.class))).thenReturn(true);
+        when(mockDifferentiator.isNew(any(ByteBuffer.class))).thenReturn(true);
 
         final WatchKey mockWatchKey = createMockWatchKeyForPath(CONFIG_FILENAME);
         // Provided as a spy to allow injection of mock objects for some tests when dealing with the finalized FileSystems class
@@ -145,8 +147,8 @@ public class FileChangeIngestorTest {
         // Invoke the method of interest
         notifierSpy.run();
 
-        verify(mockWatchService, Mockito.atLeastOnce()).poll();
-        verify(testNotifier, Mockito.atLeastOnce()).notifyListeners(Mockito.any(ByteBuffer.class));
+        verify(mockWatchService, atLeastOnce()).poll();
+        verify(testNotifier, atLeastOnce()).notifyListeners(any(ByteBuffer.class));
     }
 
     /* Helper methods to establish mock environment */

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/RestChangeIngestorCommonTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/RestChangeIngestorCommonTest.java
@@ -28,13 +28,18 @@ import org.apache.nifi.minifi.bootstrap.configuration.ListenerHandleResult;
 import org.apache.nifi.minifi.bootstrap.configuration.differentiators.Differentiator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,15 +51,15 @@ public abstract class RestChangeIngestorCommonTest {
     public static RestChangeIngestor restChangeIngestor;
     public static final MediaType MEDIA_TYPE_MARKDOWN = MediaType.parse("text/x-markdown; charset=utf-8");
     public static String url;
-    public static ConfigurationChangeNotifier testNotifier = Mockito.mock(ConfigurationChangeNotifier.class);
-    public static Differentiator<ByteBuffer> mockDifferentiator = Mockito.mock(Differentiator.class);
+    public static ConfigurationChangeNotifier testNotifier = mock(ConfigurationChangeNotifier.class);
+    public static Differentiator<ByteBuffer> mockDifferentiator = mock(Differentiator.class);
 
     @BeforeEach
     public void setListener() {
-        Mockito.reset(testNotifier);
-        ConfigurationChangeListener testListener = Mockito.mock(ConfigurationChangeListener.class);
+        reset(testNotifier);
+        ConfigurationChangeListener testListener = mock(ConfigurationChangeListener.class);
         when(testListener.getDescriptor()).thenReturn("MockChangeListener");
-        Mockito.when(testNotifier.notifyListeners(Mockito.any())).thenReturn(Collections.singleton(new ListenerHandleResult(testListener)));
+        when(testNotifier.notifyListeners(any())).thenReturn(Collections.singleton(new ListenerHandleResult(testListener)));
     }
 
     @Test
@@ -69,13 +74,13 @@ public abstract class RestChangeIngestorCommonTest {
             }
 
             assertEquals(RestChangeIngestor.GET_TEXT, response.body().string());
-            verify(testNotifier, Mockito.never()).notifyListeners(Mockito.any(ByteBuffer.class));
+            verify(testNotifier, never()).notifyListeners(any(ByteBuffer.class));
         }
     }
 
     @Test
     public void testFileUploadNewConfig() throws Exception {
-        when(mockDifferentiator.isNew(Mockito.any(ByteBuffer.class))).thenReturn(true);
+        when(mockDifferentiator.isNew(any(ByteBuffer.class))).thenReturn(true);
 
         Request request = new Request.Builder()
             .url(url)
@@ -90,13 +95,13 @@ public abstract class RestChangeIngestorCommonTest {
 
             assertEquals("The result of notifying listeners:\nMockChangeListener successfully handled the configuration change\n", response.body().string());
 
-            verify(testNotifier, Mockito.times(1)).notifyListeners(Mockito.eq(ByteBuffer.wrap(testString.getBytes())));
+            verify(testNotifier, times(1)).notifyListeners(eq(ByteBuffer.wrap(testString.getBytes())));
         }
     }
 
     @Test
     public void testFileUploadSameConfig() throws Exception {
-        when(mockDifferentiator.isNew(Mockito.any(ByteBuffer.class))).thenReturn(false);
+        when(mockDifferentiator.isNew(any(ByteBuffer.class))).thenReturn(false);
 
         Request request = new Request.Builder()
             .url(url)
@@ -111,7 +116,7 @@ public abstract class RestChangeIngestorCommonTest {
 
             assertEquals("Request received but instance is already running this config.", response.body().string());
 
-            verify(testNotifier, Mockito.never()).notifyListeners(Mockito.any());
+            verify(testNotifier, never()).notifyListeners(any());
         }
     }
 }

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/RestChangeIngestorTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/RestChangeIngestorTest.java
@@ -23,7 +23,6 @@ import org.apache.nifi.minifi.bootstrap.configuration.ConfigurationChangeNotifie
 import org.apache.nifi.minifi.properties.BootstrapProperties;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.mockito.Mockito;
 
 import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
@@ -48,9 +47,9 @@ public class RestChangeIngestorTest extends RestChangeIngestorCommonTest {
         when(properties.getProperty(eq(HOST_KEY), any())).thenReturn("localhost");
         restChangeIngestor = new RestChangeIngestor();
 
-        testNotifier = Mockito.mock(ConfigurationChangeNotifier.class);
+        testNotifier = mock(ConfigurationChangeNotifier.class);
 
-        ConfigurationFileHolder configurationFileHolder = Mockito.mock(ConfigurationFileHolder.class);
+        ConfigurationFileHolder configurationFileHolder = mock(ConfigurationFileHolder.class);
         when(configurationFileHolder.getConfigFileReference()).thenReturn(new AtomicReference<>(ByteBuffer.wrap(new byte[0])));
 
         restChangeIngestor.initialize(properties, configurationFileHolder, testNotifier);

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/status/reporters/StatusLoggerTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/status/reporters/StatusLoggerTest.java
@@ -37,8 +37,10 @@ import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.NIFI_MINIFI_ST
 import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.NIFI_MINIFI_STATUS_REPORTER_LOG_QUERY;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class StatusLoggerTest {
 
@@ -58,15 +60,15 @@ public class StatusLoggerTest {
     public void init() throws IOException {
         statusLogger = Mockito.spy(new StatusLogger());
 
-        logger = Mockito.mock(Logger.class);
+        logger = mock(Logger.class);
         StatusLogger.logger = logger;
 
-        queryableStatusAggregator = Mockito.mock(QueryableStatusAggregator.class);
-        flowStatusReport = Mockito.mock(FlowStatusReport.class);
+        queryableStatusAggregator = mock(QueryableStatusAggregator.class);
+        flowStatusReport = mock(FlowStatusReport.class);
 
-        Mockito.when(flowStatusReport.toString()).thenReturn(MOCK_STATUS);
+        when(flowStatusReport.toString()).thenReturn(MOCK_STATUS);
 
-        Mockito.when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenReturn(flowStatusReport);
+        when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenReturn(flowStatusReport);
     }
 
     @Test
@@ -103,7 +105,7 @@ public class StatusLoggerTest {
         statusLogger.setScheduledExecutorService(new RunOnceScheduledExecutorService(1));
         statusLogger.start();
 
-        verify(logger, Mockito.atLeastOnce()).trace(MOCK_STATUS, (Throwable) null);
+        verify(logger, atLeastOnce()).trace(MOCK_STATUS, (Throwable) null);
     }
 
     @Test
@@ -112,7 +114,7 @@ public class StatusLoggerTest {
         statusLogger.setScheduledExecutorService(new RunOnceScheduledExecutorService(1));
         statusLogger.start();
 
-        verify(logger, Mockito.atLeastOnce()).debug(MOCK_STATUS, (Throwable) null);
+        verify(logger, atLeastOnce()).debug(MOCK_STATUS, (Throwable) null);
     }
 
     @Test
@@ -121,7 +123,7 @@ public class StatusLoggerTest {
         statusLogger.setScheduledExecutorService(new RunOnceScheduledExecutorService(1));
         statusLogger.start();
 
-        verify(logger, Mockito.atLeastOnce()).info(MOCK_STATUS, (Throwable) null);
+        verify(logger, atLeastOnce()).info(MOCK_STATUS, (Throwable) null);
     }
 
     @Test
@@ -130,7 +132,7 @@ public class StatusLoggerTest {
         statusLogger.setScheduledExecutorService(new RunOnceScheduledExecutorService(1));
         statusLogger.start();
 
-        verify(logger, Mockito.atLeastOnce()).warn(MOCK_STATUS, (Throwable) null);
+        verify(logger, atLeastOnce()).warn(MOCK_STATUS, (Throwable) null);
     }
 
     @Test
@@ -139,7 +141,7 @@ public class StatusLoggerTest {
         statusLogger.setScheduledExecutorService(new RunOnceScheduledExecutorService(1));
         statusLogger.start();
 
-        verify(logger, Mockito.atLeastOnce()).error(MOCK_STATUS, (Throwable) null);
+        verify(logger, atLeastOnce()).error(MOCK_STATUS, (Throwable) null);
     }
 
     @Test
@@ -147,61 +149,61 @@ public class StatusLoggerTest {
         BootstrapProperties properties = getProperties(LogLevel.TRACE);
 
         IOException ioException = new IOException("This is an expected test exception");
-        Mockito.when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenThrow(ioException);
+        when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenThrow(ioException);
 
         statusLogger.initialize(properties, queryableStatusAggregator);
         statusLogger.setScheduledExecutorService(new RunOnceScheduledExecutorService(1));
         statusLogger.start();
 
-        verify(logger, Mockito.atLeastOnce()).trace(ENCOUNTERED_IO_EXCEPTION, ioException);
+        verify(logger, atLeastOnce()).trace(ENCOUNTERED_IO_EXCEPTION, ioException);
     }
 
     @Test
     public void testDebugException() throws IOException {
         IOException ioException = new IOException("This is an expected test exception");
-        Mockito.when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenThrow(ioException);
+        when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenThrow(ioException);
 
         statusLogger.initialize(getProperties(LogLevel.DEBUG), queryableStatusAggregator);
         statusLogger.setScheduledExecutorService(new RunOnceScheduledExecutorService(1));
         statusLogger.start();
 
-        verify(logger, Mockito.atLeastOnce()).debug(ENCOUNTERED_IO_EXCEPTION, ioException);
+        verify(logger, atLeastOnce()).debug(ENCOUNTERED_IO_EXCEPTION, ioException);
     }
 
     @Test
     public void testInfoException() throws IOException {
         IOException ioException = new IOException("This is an expected test exception");
-        Mockito.when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenThrow(ioException);
+        when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenThrow(ioException);
 
         statusLogger.initialize(getProperties(LogLevel.INFO), queryableStatusAggregator);
         statusLogger.setScheduledExecutorService(new RunOnceScheduledExecutorService(1));
         statusLogger.start();
 
-        verify(logger, Mockito.atLeastOnce()).info(ENCOUNTERED_IO_EXCEPTION, ioException);
+        verify(logger, atLeastOnce()).info(ENCOUNTERED_IO_EXCEPTION, ioException);
     }
 
     @Test
     public void testWarnException() throws IOException {
         IOException ioException = new IOException("This is an expected test exception");
-        Mockito.when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenThrow(ioException);
+        when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenThrow(ioException);
 
         statusLogger.initialize(getProperties(LogLevel.WARN), queryableStatusAggregator);
         statusLogger.setScheduledExecutorService(new RunOnceScheduledExecutorService(1));
         statusLogger.start();
 
-        verify(logger, Mockito.atLeastOnce()).warn(ENCOUNTERED_IO_EXCEPTION, ioException);
+        verify(logger, atLeastOnce()).warn(ENCOUNTERED_IO_EXCEPTION, ioException);
     }
 
     @Test
     public void testErrorException() throws IOException {
         IOException ioException = new IOException("This is an expected test exception");
-        Mockito.when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenThrow(ioException);
+        when(queryableStatusAggregator.statusReport(MOCK_QUERY)).thenThrow(ioException);
 
         statusLogger.initialize(getProperties(LogLevel.ERROR), queryableStatusAggregator);
         statusLogger.setScheduledExecutorService(new RunOnceScheduledExecutorService(1));
         statusLogger.start();
 
-        verify(logger, Mockito.atLeastOnce()).error(ENCOUNTERED_IO_EXCEPTION, ioException);
+        verify(logger, atLeastOnce()).error(ENCOUNTERED_IO_EXCEPTION, ioException);
     }
 
     private static BootstrapProperties getProperties(LogLevel logLevel) {

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/FlowStatusReport.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/FlowStatusReport.java
@@ -28,10 +28,11 @@ import org.apache.nifi.minifi.commons.status.rpg.RemoteProcessGroupStatusBean;
 import org.apache.nifi.minifi.commons.status.system.SystemDiagnosticsStatus;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.List;
 
-public class FlowStatusReport implements java.io.Serializable {
+public class FlowStatusReport implements Serializable {
     private List<ControllerServiceStatus> controllerServiceStatusList;
     private List<ProcessorStatusBean> processorStatusList;
     private List<ConnectionStatusBean> connectionStatusList;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/common/BulletinStatus.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/common/BulletinStatus.java
@@ -17,9 +17,10 @@
 
 package org.apache.nifi.minifi.commons.status.common;
 
+import java.io.Serializable;
 import java.util.Date;
 
-public class BulletinStatus implements java.io.Serializable {
+public class BulletinStatus implements Serializable {
     private Date timestamp;
     private String message;
 

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/common/ValidationError.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/common/ValidationError.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.common;
 
-public class ValidationError implements java.io.Serializable {
+import java.io.Serializable;
+
+public class ValidationError implements Serializable {
     private String subject;
     private String input;
     private String reason;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/connection/ConnectionHealth.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/connection/ConnectionHealth.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.connection;
 
-public class ConnectionHealth implements java.io.Serializable {
+import java.io.Serializable;
+
+public class ConnectionHealth implements Serializable {
     private int queuedCount;
     private long queuedBytes;
 

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/connection/ConnectionStats.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/connection/ConnectionStats.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.connection;
 
-public class ConnectionStats implements java.io.Serializable {
+import java.io.Serializable;
+
+public class ConnectionStats implements Serializable {
     private int inputCount;
     private long inputBytes;
     private int outputCount;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/controllerservice/ControllerServiceHealth.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/controllerservice/ControllerServiceHealth.java
@@ -19,9 +19,10 @@ package org.apache.nifi.minifi.commons.status.controllerservice;
 
 import org.apache.nifi.minifi.commons.status.common.ValidationError;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class ControllerServiceHealth implements java.io.Serializable {
+public class ControllerServiceHealth implements Serializable {
     private String state;
     private boolean hasBulletins;
     private List<ValidationError> validationErrorList;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/controllerservice/ControllerServiceStatus.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/controllerservice/ControllerServiceStatus.java
@@ -19,9 +19,10 @@ package org.apache.nifi.minifi.commons.status.controllerservice;
 
 import org.apache.nifi.minifi.commons.status.common.BulletinStatus;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class ControllerServiceStatus implements java.io.Serializable {
+public class ControllerServiceStatus implements Serializable {
     private String name;
     private ControllerServiceHealth controllerServiceHealth;
     private List<BulletinStatus> bulletinList;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/instance/InstanceHealth.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/instance/InstanceHealth.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.instance;
 
-public class InstanceHealth implements java.io.Serializable {
+import java.io.Serializable;
+
+public class InstanceHealth implements Serializable {
 
     private int queuedCount;
     private double queuedContentSize;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/instance/InstanceStats.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/instance/InstanceStats.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.instance;
 
-public class InstanceStats implements java.io.Serializable {
+import java.io.Serializable;
+
+public class InstanceStats implements Serializable {
     private long bytesRead;
     private long bytesWritten;
     private long bytesSent;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/instance/InstanceStatus.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/instance/InstanceStatus.java
@@ -19,9 +19,10 @@ package org.apache.nifi.minifi.commons.status.instance;
 
 import org.apache.nifi.minifi.commons.status.common.BulletinStatus;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class InstanceStatus implements java.io.Serializable {
+public class InstanceStatus implements Serializable {
 
     private InstanceHealth instanceHealth;
     private List<BulletinStatus> bulletinList;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/processor/ProcessorHealth.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/processor/ProcessorHealth.java
@@ -19,9 +19,10 @@ package org.apache.nifi.minifi.commons.status.processor;
 
 import org.apache.nifi.minifi.commons.status.common.ValidationError;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class ProcessorHealth implements java.io.Serializable {
+public class ProcessorHealth implements Serializable {
     private String runStatus;
     private boolean hasBulletins;
     private List<ValidationError> validationErrorList;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/processor/ProcessorStats.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/processor/ProcessorStats.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.processor;
 
-public class ProcessorStats implements java.io.Serializable {
+import java.io.Serializable;
+
+public class ProcessorStats implements Serializable {
 
     private int activeThreads;
     private int flowfilesReceived;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/reportingTask/ReportingTaskHealth.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/reportingTask/ReportingTaskHealth.java
@@ -19,9 +19,10 @@ package org.apache.nifi.minifi.commons.status.reportingTask;
 
 import org.apache.nifi.minifi.commons.status.common.ValidationError;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class ReportingTaskHealth implements java.io.Serializable {
+public class ReportingTaskHealth implements Serializable {
     private String scheduledState;
     private boolean hasBulletins;
     private int activeThreads;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/reportingTask/ReportingTaskStatus.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/reportingTask/ReportingTaskStatus.java
@@ -19,9 +19,10 @@ package org.apache.nifi.minifi.commons.status.reportingTask;
 
 import org.apache.nifi.minifi.commons.status.common.BulletinStatus;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class ReportingTaskStatus implements java.io.Serializable {
+public class ReportingTaskStatus implements Serializable {
     private String name;
     private ReportingTaskHealth reportingTaskHealth;
     private List<BulletinStatus> bulletinList;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/rpg/PortStatus.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/rpg/PortStatus.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.rpg;
 
-public class PortStatus implements java.io.Serializable {
+import java.io.Serializable;
+
+public class PortStatus implements Serializable {
     private String name;
     private boolean targetExists;
     private boolean targetRunning;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/rpg/RemoteProcessGroupHealth.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/rpg/RemoteProcessGroupHealth.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.rpg;
 
-public class RemoteProcessGroupHealth implements java.io.Serializable {
+import java.io.Serializable;
+
+public class RemoteProcessGroupHealth implements Serializable {
     private String transmissionStatus;
     private boolean hasBulletins;
     private int activePortCount;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/rpg/RemoteProcessGroupStats.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/rpg/RemoteProcessGroupStats.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.rpg;
 
-public class RemoteProcessGroupStats implements java.io.Serializable {
+import java.io.Serializable;
+
+public class RemoteProcessGroupStats implements Serializable {
     private int activeThreads;
     private int sentCount;
     private long sentContentSize;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/ContentRepositoryUsage.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/ContentRepositoryUsage.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.system;
 
-public class ContentRepositoryUsage implements java.io.Serializable {
+import java.io.Serializable;
+
+public class ContentRepositoryUsage implements Serializable {
 
     private String name;
     private long freeSpace;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/FlowfileRepositoryUsage.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/FlowfileRepositoryUsage.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.system;
 
-public class FlowfileRepositoryUsage implements java.io.Serializable {
+import java.io.Serializable;
+
+public class FlowfileRepositoryUsage implements Serializable {
 
     private long freeSpace;
     private long totalSpace;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/GarbageCollectionStatus.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/GarbageCollectionStatus.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.system;
 
-public class GarbageCollectionStatus implements java.io.Serializable {
+import java.io.Serializable;
+
+public class GarbageCollectionStatus implements Serializable {
 
     private String name;
     private long collectionCount;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/HeapStatus.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/HeapStatus.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.system;
 
-public class HeapStatus implements java.io.Serializable {
+import java.io.Serializable;
+
+public class HeapStatus implements Serializable {
 
     private long totalHeap;
     private long maxHeap;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/SystemDiagnosticsStatus.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/SystemDiagnosticsStatus.java
@@ -17,9 +17,10 @@
 
 package org.apache.nifi.minifi.commons.status.system;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class SystemDiagnosticsStatus implements java.io.Serializable {
+public class SystemDiagnosticsStatus implements Serializable {
     private List<GarbageCollectionStatus> garbageCollectionStatusList;
     private HeapStatus heapStatus;
     private SystemProcessorStats systemProcessorStats;

--- a/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/SystemProcessorStats.java
+++ b/minifi/minifi-commons/minifi-flow-status-report/src/main/java/org/apache/nifi/minifi/commons/status/system/SystemProcessorStats.java
@@ -17,7 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status.system;
 
-public class SystemProcessorStats implements java.io.Serializable {
+import java.io.Serializable;
+
+public class SystemProcessorStats implements Serializable {
 
     private double loadAverage;
     private int availableProcessors;

--- a/nifi-commons/nifi-calcite-utils/src/main/java/org/apache/nifi/sql/CalciteDatabase.java
+++ b/nifi-commons/nifi-calcite-utils/src/main/java/org/apache/nifi/sql/CalciteDatabase.java
@@ -20,6 +20,7 @@ package org.apache.nifi.sql;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.jdbc.Driver;
 import org.apache.calcite.schema.FunctionContext;
 import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 import org.slf4j.Logger;
@@ -76,7 +77,7 @@ public class CalciteDatabase implements Closeable {
 
     static {
         try {
-            DriverManager.registerDriver(new org.apache.calcite.jdbc.Driver());
+            DriverManager.registerDriver(new Driver());
         } catch (final Exception e) {
             throw new RuntimeException("Could not initialize Calcite JDBC Driver");
         }

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IsValidInstantEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IsValidInstantEvaluator.java
@@ -29,7 +29,7 @@ import java.time.format.DateTimeParseException;
 
 /**
  * Evaluator for the {@code isValidInstant()} Expression Language function.
- * Returns {@code true} if the subject parses as a valid {@link java.time.Instant} using
+ * Returns {@code true} if the subject parses as a valid {@link Instant} using
  * ISO_INSTANT, ISO_OFFSET_DATE_TIME, or RFC_1123_DATE_TIME formats; {@code false} otherwise.
  */
 public class IsValidInstantEvaluator extends BooleanEvaluator {

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -28,7 +28,6 @@ import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.parameter.Parameter;
 import org.apache.nifi.parameter.ParameterDescriptor;
 import org.apache.nifi.parameter.ParameterLookup;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -454,7 +454,7 @@ public class TestQuery {
 
         // Unquoted parameter used within a function argument
         parameters.put("Date Format", "yyyy");
-        final String expectedYear = String.valueOf(java.time.LocalDate.now().getYear());
+        final String expectedYear = String.valueOf(LocalDate.now().getYear());
         verifyEquals("${now():format(#{Date Format})}", attributes, stateValues, parameters, expectedYear);
     }
 
@@ -2670,7 +2670,7 @@ public class TestQuery {
 
         AttributeExpressionLanguageException thrown = assertThrows(AttributeExpressionLanguageException.class,
                 () -> verifyEquals("${getUri('https', 'admin:admin', 'nifi.apache.org', 'notANumber', '/path/data ', 'key=value&key2=value2', 'frag1')}", null, ""));
-        Assertions.assertEquals("Could not evaluate 'getUri' function with argument 'notANumber' which is not a number", thrown.getMessage());
+        assertEquals("Could not evaluate 'getUri' function with argument 'notANumber' which is not a number", thrown.getMessage());
     }
 
     private void verifyEquals(final String expression, final Map<String, String> attributes, final Object expectedResult) {

--- a/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
+++ b/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
@@ -827,9 +827,9 @@ public class TestRecordPath {
                 final List<T> expectedUnchangedValues,
                 final List<Object> expectedAdjustedValues) {
             final Stream<Map.Entry<Object, Object>> expectedValues = Stream.concat(
-                    expectedUnchangedValues.stream().map(value -> Map.entry(value, value)),
+                    expectedUnchangedValues.stream().map(value -> entry(value, value)),
                     expectedAdjustedValues.stream().map(
-                            value -> Map.entry(value, DataTypeUtils.convertType(value, expectedType, "field"))
+                            value -> entry(value, DataTypeUtils.convertType(value, expectedType, "field"))
                     )
             );
 

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -31,6 +31,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Date;
@@ -434,13 +436,13 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
             if (valueToLookAt instanceof BigInteger) {
                 return RecordFieldType.BIGINT.getDataType();
             }
-            if (valueToLookAt instanceof java.sql.Time) {
+            if (valueToLookAt instanceof Time) {
                 return getDataType(RecordFieldType.TIME, useLogicalTypes);
             }
             if (valueToLookAt instanceof java.sql.Date) {
                 return getDataType(RecordFieldType.DATE, useLogicalTypes);
             }
-            if (valueToLookAt instanceof java.sql.Timestamp) {
+            if (valueToLookAt instanceof Timestamp) {
                 return getDataType(TIMESTAMP, useLogicalTypes);
             }
             if (valueToLookAt instanceof final Record record) {

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteToSiteClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/SiteToSiteClient.java
@@ -107,10 +107,10 @@ public interface SiteToSiteClient extends Closeable {
      *
      * @return a Transaction to use for sending or receiving data, or
      * <code>null</code> if all nodes are penalized.
-     * @throws org.apache.nifi.remote.exception.HandshakeException he
-     * @throws org.apache.nifi.remote.exception.PortNotRunningException pnre
+     * @throws HandshakeException he
+     * @throws PortNotRunningException pnre
      * @throws IOException ioe
-     * @throws org.apache.nifi.remote.exception.UnknownPortException upe
+     * @throws UnknownPortException upe
      */
     Transaction createTransaction(TransferDirection direction) throws HandshakeException, PortNotRunningException, ProtocolException, UnknownPortException, IOException;
 

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/remote/io/CompressionInputStream.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/remote/io/CompressionInputStream.java
@@ -177,7 +177,7 @@ public class CompressionInputStream extends InputStream {
      * Calls {@link Inflater#end()} to free acquired memory to prevent OutOfMemory error.
      * However, does NOT close underlying InputStream.
      *
-     * @throws java.io.IOException for any issues closing underlying stream
+     * @throws IOException for any issues closing underlying stream
      */
     @Override
     public void close() throws IOException {

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/monitor/SynchronousFileWatcher.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/monitor/SynchronousFileWatcher.java
@@ -23,7 +23,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * Allows the user to configure a {@link java.nio.file.Path Path} to watch for modifications and periodically poll to check if the file has been modified
+ * Allows the user to configure a {@link Path Path} to watch for modifications and periodically poll to check if the file has been modified
  */
 public class SynchronousFileWatcher {
 

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/locale/TestLocaleOfTestSuite.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/locale/TestLocaleOfTestSuite.java
@@ -26,13 +26,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
- * Testing of the test suite environment {@link java.util.Locale}.  The locales specified
+ * Testing of the test suite environment {@link Locale}.  The locales specified
  * in ".github/workflows/build.yml" are exercised.  This test is inert when run in alternate locales.
  */
 public class TestLocaleOfTestSuite {
 
     /**
-     * Test behaviors associated with non-standard ".github/workflows/build.yml" {@link java.util.Locale} "en-AU".
+     * Test behaviors associated with non-standard ".github/workflows/build.yml" {@link Locale} "en-AU".
      */
     @Test
     public void testLocaleCI_EN_AU() {
@@ -44,7 +44,7 @@ public class TestLocaleOfTestSuite {
     }
 
     /**
-     * Test behaviors associated with ".github/workflows/build.yml" {@link java.util.Locale#JAPAN}.
+     * Test behaviors associated with ".github/workflows/build.yml" {@link Locale#JAPAN}.
      */
     @Test
     public void testLocaleCI_JA_JP() {
@@ -56,7 +56,7 @@ public class TestLocaleOfTestSuite {
     }
 
     /**
-     * Test behaviors associated with ".github/workflows/build.yml" {@link java.util.Locale#FRANCE}.
+     * Test behaviors associated with ".github/workflows/build.yml" {@link Locale#FRANCE}.
      */
     @Test
     public void testLocaleCI_FR_FR() {

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/validator/InstrumentedStandardValidator.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/validator/InstrumentedStandardValidator.java
@@ -21,10 +21,10 @@ import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
 
 /**:
- * InstrumentedStandardValidator wraps a {@link org.apache.nifi.components.Validator} and provides statistics on it's interactions.
- * Because many of the {@link org.apache.nifi.components.Validator} instances returned from {@link org.apache.nifi.processor.util.StandardValidators}
+ * InstrumentedStandardValidator wraps a {@link Validator} and provides statistics on it's interactions.
+ * Because many of the {@link Validator} instances returned from {@link org.apache.nifi.processor.util.StandardValidators}
  * are not mockable with mockito, this is required to know, when running a test, if a
- * {@link org.apache.nifi.components.Validator} was in fact called, for example.
+ * {@link Validator} was in fact called, for example.
  */
 public class InstrumentedStandardValidator implements Validator {
 
@@ -43,7 +43,7 @@ public class InstrumentedStandardValidator implements Validator {
     /**
      * Constructs a new InstrumentedStandardValidator.
      *
-     * @param mockedValidator the {@link org.apache.nifi.components.Validator} to wrap.
+     * @param mockedValidator the {@link Validator} to wrap.
      */
     public InstrumentedStandardValidator(Validator mockedValidator) {
         this(mockedValidator, false);
@@ -52,7 +52,7 @@ public class InstrumentedStandardValidator implements Validator {
     /**
      * Constructs a new InstrumentedStandardValidator.
      *
-     * @param mockedValidator the {@link org.apache.nifi.components.Validator} to wrap.
+     * @param mockedValidator the {@link Validator} to wrap.
      */
     public InstrumentedStandardValidator(Validator mockedValidator, boolean resetOnGet) {
         this.mockedValidator = mockedValidator;

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/validator/TestStandardValidators.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/validator/TestStandardValidators.java
@@ -22,7 +22,6 @@ import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -54,7 +53,7 @@ public class TestStandardValidators {
     public void testNonEmptyELValidator() {
         Validator val = StandardValidators.NON_EMPTY_EL_VALIDATOR;
         ValidationContext vc = mock(ValidationContext.class);
-        Mockito.when(vc.isExpressionLanguageSupported("foo")).thenReturn(true);
+        when(vc.isExpressionLanguageSupported("foo")).thenReturn(true);
 
         ValidationResult vr = val.validate("foo", "", vc);
         assertFalse(vr.isValid());
@@ -62,7 +61,7 @@ public class TestStandardValidators {
         vr = val.validate("foo", "    h", vc);
         assertTrue(vr.isValid());
 
-        Mockito.when(vc.isExpressionLanguagePresent("${test}")).thenReturn(true);
+        when(vc.isExpressionLanguagePresent("${test}")).thenReturn(true);
         vr = val.validate("foo", "${test}", vc);
         assertTrue(vr.isValid());
 
@@ -74,7 +73,7 @@ public class TestStandardValidators {
     public void testHostnamePortListValidator() {
         Validator val = StandardValidators.HOSTNAME_PORT_LIST_VALIDATOR;
         ValidationContext vc = mock(ValidationContext.class);
-        Mockito.when(vc.isExpressionLanguageSupported("foo")).thenReturn(true);
+        when(vc.isExpressionLanguageSupported("foo")).thenReturn(true);
 
         ValidationResult vr = val.validate("foo", "", vc);
         assertFalse(vr.isValid());
@@ -97,7 +96,7 @@ public class TestStandardValidators {
         vr = val.validate("foo", "test:65535,localhost:666,127.0.0.1:8989", vc);
         assertTrue(vr.isValid());
 
-        Mockito.when(vc.isExpressionLanguagePresent("${test}")).thenReturn(true);
+        when(vc.isExpressionLanguagePresent("${test}")).thenReturn(true);
         vr = val.validate("foo", "${test}", vc);
         assertTrue(vr.isValid());
 
@@ -111,7 +110,7 @@ public class TestStandardValidators {
             .createTimePeriodValidator(1L, TimeUnit.SECONDS, Long.MAX_VALUE, TimeUnit.NANOSECONDS);
         ValidationResult vr;
 
-        final ValidationContext validationContext = Mockito.mock(ValidationContext.class);
+        final ValidationContext validationContext = mock(ValidationContext.class);
 
         vr = val.validate("TimePeriodTest", "0 sense made", validationContext);
         assertFalse(vr.isValid());
@@ -137,7 +136,7 @@ public class TestStandardValidators {
         Validator val = StandardValidators.createDataSizeBoundsValidator(100, 1000);
         ValidationResult vr;
 
-        final ValidationContext validationContext = Mockito.mock(ValidationContext.class);
+        final ValidationContext validationContext = mock(ValidationContext.class);
         vr = val.validate("DataSizeBounds", "5 GB", validationContext);
         assertFalse(vr.isValid());
 
@@ -173,7 +172,7 @@ public class TestStandardValidators {
         Validator val = StandardValidators.createListValidator(true, false, mockValidator);
         ValidationResult vr;
 
-        final ValidationContext validationContext = Mockito.mock(ValidationContext.class);
+        final ValidationContext validationContext = mock(ValidationContext.class);
 
         vr = val.validate("List", null, validationContext);
         assertFalse(vr.isValid());
@@ -323,7 +322,7 @@ public class TestStandardValidators {
         Validator val = StandardValidators.createListValidator(true, false, mockValidator, true);
         ValidationResult vr;
 
-        final ValidationContext validationContext = Mockito.mock(ValidationContext.class);
+        final ValidationContext validationContext = mock(ValidationContext.class);
 
         vr = val.validate("List", null, validationContext);
         assertFalse(vr.isValid());

--- a/nifi-commons/nifi-write-ahead-log/src/main/java/org/wali/WriteAheadRepository.java
+++ b/nifi-commons/nifi-write-ahead-log/src/main/java/org/wali/WriteAheadRepository.java
@@ -107,7 +107,7 @@ public interface WriteAheadRepository<T> {
      *
      *
      * @return the number of records that were written to the new snapshot
-     * @throws java.io.IOException if failure during checkpoint
+     * @throws IOException if failure during checkpoint
      */
     int checkpoint() throws IOException;
 

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
@@ -416,8 +416,8 @@ public class ConsumeAMQPTest {
                     throw new IllegalStateException("Consumer already created");
                 }
 
-                consumer = new AMQPConsumer(connection, context.getProperty(ConsumeAMQP.QUEUE).getValue(),
-                        context.getProperty(ConsumeAMQP.AUTO_ACKNOWLEDGE).asBoolean(), context.getProperty(ConsumeAMQP.PREFETCH_COUNT).asInteger(),
+                consumer = new AMQPConsumer(connection, context.getProperty(QUEUE).getValue(),
+                        context.getProperty(AUTO_ACKNOWLEDGE).asBoolean(), context.getProperty(PREFETCH_COUNT).asInteger(),
                         getLogger());
                 return consumer;
             } catch (IOException e) {

--- a/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/main/java/org/apache/nifi/jasn1/JASN1Reader.java
+++ b/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/main/java/org/apache/nifi/jasn1/JASN1Reader.java
@@ -18,6 +18,7 @@ package org.apache.nifi.jasn1;
 
 import antlr.RecognitionException;
 import antlr.TokenStreamException;
+import com.beanit.asn1bean.ber.types.BerType;
 import com.beanit.asn1bean.compiler.BerClassWriter;
 import com.beanit.asn1bean.compiler.BerClassWriterFactory;
 import com.beanit.asn1bean.compiler.model.AsnModel;
@@ -327,7 +328,7 @@ public class JASN1Reader extends AbstractConfigurableComponent implements Record
         JavaCompiler javaCompiler = ToolProvider.getSystemJavaCompiler();
         StandardJavaFileManager fileManager = javaCompiler.getStandardFileManager(null, null, null);
 
-        List<String> optionList = new ArrayList<>(Arrays.asList("-classpath", com.beanit.asn1bean.ber.types.BerType.class.getProtectionDomain().getCodeSource().getLocation().getFile()));
+        List<String> optionList = new ArrayList<>(Arrays.asList("-classpath", BerType.class.getProtectionDomain().getCodeSource().getLocation().getFile()));
 
         Iterable<? extends JavaFileObject> units;
         units = fileManager.getJavaFileObjectsFromFiles(javaFiles);

--- a/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/JASN1ReaderTest.java
+++ b/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/JASN1ReaderTest.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-import static org.apache.nifi.jasn1.JASN1Reader.ASN_FILES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -87,8 +86,8 @@ public class JASN1ReaderTest {
     @Test
     public void testCanLoadClassCompiledFromAsn() throws Exception {
         ConfigurationContext context = mock(ConfigurationContext.class, RETURNS_DEEP_STUBS);
-        when(context.getProperty(ASN_FILES).isSet()).thenReturn(true);
-        when(context.getProperty(ASN_FILES).evaluateAttributeExpressions().getValue()).thenReturn(Paths.get("src", "test", "resources", "test.asn").toString());
+        when(context.getProperty(JASN1Reader.ASN_FILES).isSet()).thenReturn(true);
+        when(context.getProperty(JASN1Reader.ASN_FILES).evaluateAttributeExpressions().getValue()).thenReturn(Paths.get("src", "test", "resources", "test.asn").toString());
 
         testSubject.onEnabled(context);
 
@@ -102,8 +101,8 @@ public class JASN1ReaderTest {
     @Test
     public void testAsnFileDoesntExist() {
         ConfigurationContext context = mock(ConfigurationContext.class, RETURNS_DEEP_STUBS);
-        when(context.getProperty(ASN_FILES).isSet()).thenReturn(true);
-        when(context.getProperty(ASN_FILES).evaluateAttributeExpressions().getValue()).thenReturn(
+        when(context.getProperty(JASN1Reader.ASN_FILES).isSet()).thenReturn(true);
+        when(context.getProperty(JASN1Reader.ASN_FILES).evaluateAttributeExpressions().getValue()).thenReturn(
                 new StringJoiner(",")
                         .add(Paths.get("src", "test", "resources", "test.asn").toString())
                         .add(Paths.get("src", "test", "resources", "doesnt_exist.asn").toString())
@@ -198,8 +197,8 @@ public class JASN1ReaderTest {
 
     private void testParseError(String asnFile, List<String> expectedErrorMessages) {
         ConfigurationContext context = mock(ConfigurationContext.class, RETURNS_DEEP_STUBS);
-        when(context.getProperty(ASN_FILES).isSet()).thenReturn(true);
-        when(context.getProperty(ASN_FILES).evaluateAttributeExpressions().getValue())
+        when(context.getProperty(JASN1Reader.ASN_FILES).isSet()).thenReturn(true);
+        when(context.getProperty(JASN1Reader.ASN_FILES).evaluateAttributeExpressions().getValue())
                 .thenReturn(asnFile);
 
         assertThrows(
@@ -217,8 +216,8 @@ public class JASN1ReaderTest {
 
     private void testCompileError(String asnFiles, List<String> expectedErrorMessages) {
         ConfigurationContext context = mock(ConfigurationContext.class, RETURNS_DEEP_STUBS);
-        when(context.getProperty(ASN_FILES).isSet()).thenReturn(true);
-        when(context.getProperty(ASN_FILES).evaluateAttributeExpressions().getValue())
+        when(context.getProperty(JASN1Reader.ASN_FILES).isSet()).thenReturn(true);
+        when(context.getProperty(JASN1Reader.ASN_FILES).evaluateAttributeExpressions().getValue())
                 .thenReturn(asnFiles);
 
         assertThrows(

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/main/java/org/apache/nifi/processors/aws/kinesis/ConsumeKinesis.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/main/java/org/apache/nifi/processors/aws/kinesis/ConsumeKinesis.java
@@ -59,6 +59,7 @@ import org.apache.nifi.serialization.RecordSetWriter;
 import org.apache.nifi.serialization.RecordSetWriterFactory;
 import org.apache.nifi.serialization.SimpleRecordSchema;
 import org.apache.nifi.serialization.record.MapRecord;
+import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
@@ -1114,7 +1115,7 @@ public class ConsumeKinesis extends AbstractProcessor implements BacklogReportin
                             writer.beginRecordSet();
 
                             int recordIndex = 0;
-                            org.apache.nifi.serialization.record.Record nifiRecord;
+                            Record nifiRecord;
                             while ((nifiRecord = reader.nextRecord()) != null) {
                                 final UserRecord record = records.get(recordIndex++);
                                 nifiRecord = decorateRecord(nifiRecord, record, record.shardId(), streamName, outputStrategy, writeSchema);
@@ -1191,12 +1192,12 @@ public class ConsumeKinesis extends AbstractProcessor implements BacklogReportin
                 }
 
                 RecordSchema readSchema = null;
-                final List<org.apache.nifi.serialization.record.Record> parsedRecords = new ArrayList<>();
+                final List<Record> parsedRecords = new ArrayList<>();
                 RecordReader reader = null;
                 try {
                     reader = readerFactory.createRecordReader(Map.of(), new ByteArrayInputStream(record.data()), record.data().length, getLogger());
                     readSchema = reader.getSchema();
-                    org.apache.nifi.serialization.record.Record nifiRecord;
+                    Record nifiRecord;
                     while ((nifiRecord = reader.nextRecord()) != null) {
                         parsedRecords.add(nifiRecord);
                     }
@@ -1242,9 +1243,8 @@ public class ConsumeKinesis extends AbstractProcessor implements BacklogReportin
 
                 batch.updateRecordRange(record);
 
-                for (final org.apache.nifi.serialization.record.Record parsed : parsedRecords) {
-                    final org.apache.nifi.serialization.record.Record decorated =
-                            decorateRecord(parsed, record, record.shardId(), streamName, outputStrategy, currentWriteSchema);
+                for (final Record parsed : parsedRecords) {
+                    final Record decorated = decorateRecord(parsed, record, record.shardId(), streamName, outputStrategy, currentWriteSchema);
                     currentWriter.write(decorated);
                     batch.incrementRecordCount();
                 }
@@ -1310,8 +1310,8 @@ public class ConsumeKinesis extends AbstractProcessor implements BacklogReportin
     /**
      * Attaches Kinesis metadata to a NiFi record according to the configured OutputStrategy.
      */
-    private static org.apache.nifi.serialization.record.Record decorateRecord(
-            final org.apache.nifi.serialization.record.Record nifiRecord,
+    private static Record decorateRecord(
+            final Record nifiRecord,
             final UserRecord kinesisRecord, final String shardId,
             final String streamName, final OutputStrategy outputStrategy,
             final RecordSchema writeSchema) {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/main/java/org/apache/nifi/processors/aws/kinesis/PollingKinesisClient.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/src/main/java/org/apache/nifi/processors/aws/kinesis/PollingKinesisClient.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
 import software.amazon.awssdk.services.kinesis.model.LimitExceededException;
 import software.amazon.awssdk.services.kinesis.model.ProvisionedThroughputExceededException;
+import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.kinesis.model.Shard;
 import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
@@ -262,7 +263,7 @@ final class PollingKinesisClient extends KinesisConsumerClient {
                         continue;
                     }
 
-                    final List<software.amazon.awssdk.services.kinesis.model.Record> records = response.records();
+                    final List<Record> records = response.records();
                     final Long millisBehindLatest = response.millisBehindLatest();
                     if (millisBehindLatest != null) {
                         // Notify the backlog tracker on every successful poll, including empty polls. Empty

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/factory/strategies/AccessKeyPairCredentialsStrategy.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/factory/strategies/AccessKeyPairCredentialsStrategy.java
@@ -21,6 +21,7 @@ import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 /**
  * Supports AWS credentials defined by an Access Key and Secret Key pair.
@@ -41,7 +42,7 @@ public class AccessKeyPairCredentialsStrategy extends AbstractCredentialsStrateg
     public AwsCredentialsProvider getAwsCredentialsProvider(final PropertyContext propertyContext) {
         final String accessKey = propertyContext.getProperty(AWSCredentialsProviderControllerService.ACCESS_KEY_ID).evaluateAttributeExpressions().getValue();
         final String secretKey = propertyContext.getProperty(AWSCredentialsProviderControllerService.SECRET_KEY).evaluateAttributeExpressions().getValue();
-        return software.amazon.awssdk.auth.credentials.StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+        return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
     }
 
 }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/factory/strategies/NamedProfileCredentialsStrategy.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/factory/strategies/NamedProfileCredentialsStrategy.java
@@ -20,6 +20,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 
 /**
  * Supports AWS Credentials using a named profile configured in the credentials file (typically ~/.aws/credentials).
@@ -38,6 +39,6 @@ public class NamedProfileCredentialsStrategy extends AbstractCredentialsStrategy
     @Override
     public AwsCredentialsProvider getAwsCredentialsProvider(final PropertyContext propertyContext) {
         final String profileName = propertyContext.getProperty(AWSCredentialsProviderControllerService.PROFILE_NAME).evaluateAttributeExpressions().getValue();
-        return software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider.create(profileName);
+        return ProfileCredentialsProvider.create(profileName);
     }
 }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/cloudwatch/TestPutCloudWatchMetric.java
@@ -42,7 +42,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static org.apache.nifi.processors.aws.region.RegionUtil.REGION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestPutCloudWatchMetric {
@@ -293,7 +292,7 @@ public class TestPutCloudWatchMetric {
     @Test
     void testMigration() {
         final Map<String, String> expectedRenamed = Map.ofEntries(
-                Map.entry("aws-region", REGION.getName()),
+                Map.entry("aws-region", RegionUtil.REGION.getName()),
                 Map.entry(AbstractAwsProcessor.OBSOLETE_AWS_CREDENTIALS_PROVIDER_SERVICE_PROPERTY_NAME, AbstractAwsProcessor.AWS_CREDENTIALS_PROVIDER_SERVICE.getName()),
                 Map.entry(ProxyConfigurationService.OBSOLETE_PROXY_CONFIGURATION_SERVICE, AbstractAwsProcessor.PROXY_CONFIGURATION_SERVICE.getName()),
                 Map.entry("MetricName", PutCloudWatchMetric.METRIC_NAME.getName()),

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/credentials/provider/service/AWSCredentialsProviderControllerServiceTest.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/credentials/provider/service/AWSCredentialsProviderControllerServiceTest.java
@@ -38,18 +38,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.ACCESS_KEY_ID;
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.ASSUME_ROLE_EXTERNAL_ID;
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.ASSUME_ROLE_PROXY_CONFIGURATION_SERVICE;
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.ASSUME_ROLE_SSL_CONTEXT_SERVICE;
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.ASSUME_ROLE_STS_ENDPOINT;
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.ASSUME_ROLE_STS_REGION;
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.CREDENTIALS_FILE;
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.MAX_SESSION_TIME;
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.PROFILE_NAME;
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.SECRET_KEY;
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.USE_ANONYMOUS_CREDENTIALS;
-import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.USE_DEFAULT_CREDENTIALS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -80,8 +68,8 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
         runner.enableControllerService(serviceImpl);
 
         runner.assertValid(serviceImpl);
@@ -97,8 +85,8 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_STS_REGION, Region.US_WEST_1.id());
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_ARN, "Role");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_NAME, "RoleName");
@@ -119,8 +107,8 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_STS_REGION, Region.US_WEST_1.id());
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_ARN, "Role");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_NAME, "RoleName");
@@ -142,8 +130,8 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_STS_REGION, Region.US_WEST_1.id());
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_ARN, "Role");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_NAME, "RoleName");
@@ -158,8 +146,8 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_STS_REGION, Region.US_WEST_1.id());
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_ARN, "Role");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_NAME, "RoleName");
@@ -174,8 +162,8 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_ARN, "Role");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_NAME, "RoleName");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.MAX_SESSION_TIME, "899");
@@ -187,8 +175,8 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_ARN, "Role");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_NAME, "RoleName");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.MAX_SESSION_TIME, "899");
@@ -200,8 +188,8 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_ARN, "Role");
 
         runner.assertNotValid(serviceImpl);
@@ -212,7 +200,7 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, CREDENTIALS_FILE, "src/test/resources/mock-aws-credentials.properties");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.CREDENTIALS_FILE, "src/test/resources/mock-aws-credentials.properties");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_STS_REGION, Region.US_WEST_1.id());
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_ARN, "Role");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_NAME, "RoleName");
@@ -233,7 +221,7 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, CREDENTIALS_FILE,
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.CREDENTIALS_FILE,
                 "src/test/resources/mock-aws-credentials.properties");
         runner.enableControllerService(serviceImpl);
 
@@ -252,7 +240,7 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, CREDENTIALS_FILE,
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.CREDENTIALS_FILE,
                 "src/test/resources/bad-mock-aws-credentials.properties");
 
         runner.assertNotValid(serviceImpl);
@@ -263,10 +251,10 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, CREDENTIALS_FILE,
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.CREDENTIALS_FILE,
                 "src/test/resources/mock-aws-credentials.properties");
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
 
         runner.assertNotValid(serviceImpl);
     }
@@ -276,9 +264,9 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, CREDENTIALS_FILE,
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.CREDENTIALS_FILE,
                 "src/test/resources/mock-aws-credentials.properties");
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
 
         runner.assertNotValid(serviceImpl);
     }
@@ -288,9 +276,9 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, CREDENTIALS_FILE,
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.CREDENTIALS_FILE,
                 "src/test/resources/mock-aws-credentials.properties");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
 
         runner.assertNotValid(serviceImpl);
     }
@@ -300,7 +288,7 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
 
         runner.assertNotValid(serviceImpl);
     }
@@ -310,7 +298,7 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
 
         runner.assertNotValid(serviceImpl);
     }
@@ -320,8 +308,8 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "${literal(\"awsAccessKey\")}");
-        runner.setProperty(serviceImpl, SECRET_KEY, "${literal(\"awsSecretKey\")}");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "${literal(\"awsAccessKey\")}");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "${literal(\"awsSecretKey\")}");
         runner.enableControllerService(serviceImpl);
 
         runner.assertValid(serviceImpl);
@@ -331,10 +319,10 @@ public class AWSCredentialsProviderControllerServiceTest {
 
         assertEquals(
                 "awsAccessKey", service.getAwsCredentialsProvider().resolveCredentials().accessKeyId(),
-            "Expression language should be supported for " + ACCESS_KEY_ID.getName());
+            "Expression language should be supported for " + AWSCredentialsProviderControllerService.ACCESS_KEY_ID.getName());
         assertEquals(
                 "awsSecretKey", service.getAwsCredentialsProvider().resolveCredentials().secretAccessKey(),
-            "Expression language should be supported for " + SECRET_KEY.getName());
+            "Expression language should be supported for " + AWSCredentialsProviderControllerService.SECRET_KEY.getName());
     }
 
     @Test
@@ -435,8 +423,8 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
         runner.enableControllerService(serviceImpl);
 
         final AwsCredentialsProviderService service = (AwsCredentialsProviderService) runner.getProcessContext()
@@ -457,8 +445,8 @@ public class AWSCredentialsProviderControllerServiceTest {
         final TestRunner runner = TestRunners.newTestRunner(FetchS3Object.class);
         final AWSCredentialsProviderControllerService serviceImpl = new AWSCredentialsProviderControllerService();
         runner.addControllerService("awsCredentialsProvider", serviceImpl);
-        runner.setProperty(serviceImpl, ACCESS_KEY_ID, "awsAccessKey");
-        runner.setProperty(serviceImpl, SECRET_KEY, "awsSecretKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ACCESS_KEY_ID, "awsAccessKey");
+        runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.SECRET_KEY, "awsSecretKey");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_STS_REGION, Region.US_WEST_1.id());
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_ARN, "Role");
         runner.setProperty(serviceImpl, AWSCredentialsProviderControllerService.ASSUME_ROLE_NAME, "RoleName");
@@ -486,17 +474,17 @@ public class AWSCredentialsProviderControllerServiceTest {
         final MockPropertyConfiguration configuration = new MockPropertyConfiguration(propertyValues);
         final AWSCredentialsProviderControllerService awsCredentialsProviderControllerService = new AWSCredentialsProviderControllerService();
         final Map<String, String> expectedRenamed = Map.ofEntries(
-                Map.entry("default-credentials", USE_DEFAULT_CREDENTIALS.getName()),
-                Map.entry("profile-name", PROFILE_NAME.getName()),
-                Map.entry("Access Key", ACCESS_KEY_ID.getName()),
-                Map.entry("Secret Key", SECRET_KEY.getName()),
-                Map.entry("anonymous-credentials", USE_ANONYMOUS_CREDENTIALS.getName()),
-                Map.entry("assume-role-sts-region", ASSUME_ROLE_STS_REGION.getName()),
-                Map.entry("assume-role-external-id", ASSUME_ROLE_EXTERNAL_ID.getName()),
-                Map.entry("assume-role-ssl-context-service", ASSUME_ROLE_SSL_CONTEXT_SERVICE.getName()),
-                Map.entry("assume-role-proxy-configuration-service", ASSUME_ROLE_PROXY_CONFIGURATION_SERVICE.getName()),
-                Map.entry("assume-role-sts-endpoint", ASSUME_ROLE_STS_ENDPOINT.getName()),
-                Map.entry("Session Time", MAX_SESSION_TIME.getName()),
+                Map.entry("default-credentials", AWSCredentialsProviderControllerService.USE_DEFAULT_CREDENTIALS.getName()),
+                Map.entry("profile-name", AWSCredentialsProviderControllerService.PROFILE_NAME.getName()),
+                Map.entry("Access Key", AWSCredentialsProviderControllerService.ACCESS_KEY_ID.getName()),
+                Map.entry("Secret Key", AWSCredentialsProviderControllerService.SECRET_KEY.getName()),
+                Map.entry("anonymous-credentials", AWSCredentialsProviderControllerService.USE_ANONYMOUS_CREDENTIALS.getName()),
+                Map.entry("assume-role-sts-region", AWSCredentialsProviderControllerService.ASSUME_ROLE_STS_REGION.getName()),
+                Map.entry("assume-role-external-id", AWSCredentialsProviderControllerService.ASSUME_ROLE_EXTERNAL_ID.getName()),
+                Map.entry("assume-role-ssl-context-service", AWSCredentialsProviderControllerService.ASSUME_ROLE_SSL_CONTEXT_SERVICE.getName()),
+                Map.entry("assume-role-proxy-configuration-service", AWSCredentialsProviderControllerService.ASSUME_ROLE_PROXY_CONFIGURATION_SERVICE.getName()),
+                Map.entry("assume-role-sts-endpoint", AWSCredentialsProviderControllerService.ASSUME_ROLE_STS_ENDPOINT.getName()),
+                Map.entry("Session Time", AWSCredentialsProviderControllerService.MAX_SESSION_TIME.getName()),
                 Map.entry(ProxyServiceMigration.OBSOLETE_PROXY_CONFIGURATION_SERVICE, ProxyServiceMigration.PROXY_CONFIGURATION_SERVICE)
         );
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/credentials/provider/service/TestAWSCredentialsProviderControllerServiceStrategies.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/credentials/provider/service/TestAWSCredentialsProviderControllerServiceStrategies.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -133,6 +134,6 @@ public class TestAWSCredentialsProviderControllerServiceStrategies {
 
         final AwsCredentialsProvider credentialsProvider = service.getAwsCredentialsProvider();
         assertNotNull(credentialsProvider);
-        assertEquals(software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider.class, credentialsProvider.getClass());
+        assertEquals(ProfileCredentialsProvider.class, credentialsProvider.getClass());
     }
 }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/dynamodb/PutDynamoDBRecordTest.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/dynamodb/PutDynamoDBRecordTest.java
@@ -27,7 +27,6 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.PropertyMigrationResult;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -146,7 +145,7 @@ public class PutDynamoDBRecordTest {
         runner.run();
 
         final List<BatchWriteItemRequest> results = captor.getAllValues();
-        Assertions.assertEquals(2, results.size());
+        assertEquals(2, results.size());
 
         final BatchWriteItemRequest result1 = results.getFirst();
         assertTrue(result1.hasRequestItems());
@@ -160,7 +159,7 @@ public class PutDynamoDBRecordTest {
 
         runner.assertAllFlowFilesTransferred(PutDynamoDBRecord.REL_SUCCESS, 1);
         final MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutDynamoDBRecord.REL_SUCCESS).getFirst();
-        Assertions.assertEquals("2", flowFile.getAttribute(PutDynamoDBRecord.DYNAMODB_CHUNKS_PROCESSED_ATTRIBUTE));
+        assertEquals("2", flowFile.getAttribute(PutDynamoDBRecord.DYNAMODB_CHUNKS_PROCESSED_ATTRIBUTE));
     }
 
     @Test
@@ -173,7 +172,7 @@ public class PutDynamoDBRecordTest {
 
         runner.assertAllFlowFilesTransferred(PutDynamoDBRecord.REL_UNPROCESSED, 1);
         final MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutDynamoDBRecord.REL_UNPROCESSED).getFirst();
-        Assertions.assertEquals("1", flowFile.getAttribute(PutDynamoDBRecord.DYNAMODB_CHUNKS_PROCESSED_ATTRIBUTE));
+        assertEquals("1", flowFile.getAttribute(PutDynamoDBRecord.DYNAMODB_CHUNKS_PROCESSED_ATTRIBUTE));
     }
 
     @Test
@@ -183,12 +182,12 @@ public class PutDynamoDBRecordTest {
         runner.enqueue(new FileInputStream("src/test/resources/dynamodb/multipleChunks.json"), Collections.singletonMap(PutDynamoDBRecord.DYNAMODB_CHUNKS_PROCESSED_ATTRIBUTE, "1"));
         runner.run();
 
-        Assertions.assertEquals(1, captor.getAllValues().size());
-        Assertions.assertEquals(4, captor.getValue().requestItems().get(TABLE_NAME).size());
+        assertEquals(1, captor.getAllValues().size());
+        assertEquals(4, captor.getValue().requestItems().get(TABLE_NAME).size());
 
         runner.assertAllFlowFilesTransferred(PutDynamoDBRecord.REL_SUCCESS, 1);
         final MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutDynamoDBRecord.REL_SUCCESS).getFirst();
-        Assertions.assertEquals("2", flowFile.getAttribute(PutDynamoDBRecord.DYNAMODB_CHUNKS_PROCESSED_ATTRIBUTE));
+        assertEquals("2", flowFile.getAttribute(PutDynamoDBRecord.DYNAMODB_CHUNKS_PROCESSED_ATTRIBUTE));
     }
 
     @Test
@@ -201,7 +200,7 @@ public class PutDynamoDBRecordTest {
 
         runner.assertAllFlowFilesTransferred(PutDynamoDBRecord.REL_FAILURE, 1);
         final MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutDynamoDBRecord.REL_FAILURE).getFirst();
-        Assertions.assertEquals("0", flowFile.getAttribute(PutDynamoDBRecord.DYNAMODB_CHUNKS_PROCESSED_ATTRIBUTE));
+        assertEquals("0", flowFile.getAttribute(PutDynamoDBRecord.DYNAMODB_CHUNKS_PROCESSED_ATTRIBUTE));
     }
 
     @Test
@@ -214,11 +213,11 @@ public class PutDynamoDBRecordTest {
         runner.run();
 
         final BatchWriteItemRequest result = captor.getValue();
-        Assertions.assertEquals(1, result.requestItems().get(TABLE_NAME).size());
+        assertEquals(1, result.requestItems().get(TABLE_NAME).size());
 
         final Map<String, AttributeValue> item = result.requestItems().get(TABLE_NAME).getFirst().putRequest().item();
-        Assertions.assertEquals(4, item.size());
-        Assertions.assertEquals(string("P0"), item.get("partition"));
+        assertEquals(4, item.size());
+        assertEquals(string("P0"), item.get("partition"));
         assertTrue(item.containsKey("generated"));
 
         runner.assertAllFlowFilesTransferred(PutDynamoDBRecord.REL_SUCCESS, 1);
@@ -239,11 +238,11 @@ public class PutDynamoDBRecordTest {
                 .map(PutRequest::item)
                 .forEach(items::add));
 
-        Assertions.assertEquals(29, items.size());
+        assertEquals(29, items.size());
 
         for (int sortKeyValue = 0; sortKeyValue < 29; sortKeyValue++) {
             final AttributeValue expectedValue = AttributeValue.builder().n(String.valueOf(sortKeyValue + 1)).build();
-            Assertions.assertEquals(expectedValue, items.get(sortKeyValue).get("sort"));
+            assertEquals(expectedValue, items.get(sortKeyValue).get("sort"));
         }
     }
 
@@ -336,18 +335,18 @@ public class PutDynamoDBRecordTest {
     }
 
     private void assertItemsConvertedProperly(final Collection<WriteRequest> writeRequests, final int expectedNumberOfItems) {
-        Assertions.assertEquals(expectedNumberOfItems, writeRequests.size());
+        assertEquals(expectedNumberOfItems, writeRequests.size());
         int index = 0;
 
         for (final WriteRequest writeRequest : writeRequests) {
             final PutRequest putRequest = writeRequest.putRequest();
             assertNotNull(putRequest);
             final Map<String, AttributeValue> item = putRequest.item();
-            Assertions.assertEquals(3, item.size());
-            Assertions.assertEquals(string("new"), item.get("value"));
+            assertEquals(3, item.size());
+            assertEquals(string("new"), item.get("value"));
 
-            Assertions.assertEquals(number(index), item.get("size"));
-            Assertions.assertEquals(string("P" + index), item.get("partition"));
+            assertEquals(number(index), item.get("size"));
+            assertEquals(string("P" + index), item.get("partition"));
             index++;
         }
     }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/dynamodb/RecordToItemConverterTest.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/dynamodb/RecordToItemConverterTest.java
@@ -23,12 +23,14 @@ import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -36,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -72,9 +75,9 @@ class RecordToItemConverterTest {
         values.put("double", Double.valueOf(1234.5678D));
         values.put("bigint", BigInteger.TEN);
         values.put("decimal", new BigDecimal("12345678901234567890.123456789012345678901234567890"));
-        values.put("timestamp", new java.sql.Timestamp(37293723L));
-        values.put("date", java.sql.Date.valueOf("1970-01-01"));
-        values.put("time", new java.sql.Time(37293723L));
+        values.put("timestamp", new Timestamp(37293723L));
+        values.put("date", Date.valueOf("1970-01-01"));
+        values.put("time", new Time(37293723L));
         values.put("char", 'c');
         values.put("enum", Component.Controller);
         values.put("array", new Integer[] {0, 1, 10});
@@ -112,7 +115,7 @@ class RecordToItemConverterTest {
         assertEquals(string(Component.Controller.name()), item.get("enum"));
 
         // DynamoDB uses lists and still keeps the payload datatype
-        Assertions.assertIterableEquals(Arrays.asList(number(BigDecimal.ZERO), number(BigDecimal.ONE), number(BigDecimal.TEN)),
+        assertIterableEquals(Arrays.asList(number(BigDecimal.ZERO), number(BigDecimal.ONE), number(BigDecimal.TEN)),
                 item.get("array").l());
 
         // DynamoDB cannot handle choice, all values enveloped into choice are handled as strings
@@ -262,7 +265,7 @@ class RecordToItemConverterTest {
         final Map<String, AttributeValue> resultMap = result.m();
         assertEquals(1, resultMap.size());
         final AttributeValue fieldResult = resultMap.get("starType");
-        Assertions.assertNotNull(fieldResult.m());
+        assertNotNull(fieldResult.m());
         final Map<String, AttributeValue> fieldResultMap = fieldResult.m();
         assertEquals(bool(false), fieldResultMap.get("isDwarf"));
         assertEquals(string("G"), fieldResultMap.get("type"));

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/TestConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/TestConsumeKinesisStream.java
@@ -26,7 +26,6 @@ import org.apache.nifi.processors.aws.AbstractAwsProcessor;
 import org.apache.nifi.processors.aws.ObsoleteAbstractAwsProcessorProperties;
 import org.apache.nifi.processors.aws.credentials.provider.AwsCredentialsProviderService;
 import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService;
-import org.apache.nifi.processors.aws.region.RegionUtil;
 import org.apache.nifi.proxy.ProxyConfigurationService;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.serialization.record.RecordFieldType;
@@ -325,7 +324,7 @@ public class TestConsumeKinesisStream {
         mockConsumeKinesisStreamRunner.setProperty(ConsumeKinesisStream.GRACEFUL_SHUTDOWN_TIMEOUT, "50 millis");
         mockConsumeKinesisStreamRunner.setProperty(ConsumeKinesisStream.KINESIS_STREAM_NAME, "test-stream");
         mockConsumeKinesisStreamRunner.setProperty(ConsumeKinesisStream.APPLICATION_NAME, "test-application");
-        mockConsumeKinesisStreamRunner.setProperty(RegionUtil.REGION, Region.EU_WEST_2.id());
+        mockConsumeKinesisStreamRunner.setProperty(REGION, Region.EU_WEST_2.id());
         mockConsumeKinesisStreamRunner.setProperty(ConsumeKinesisStream.TIMEOUT, "5 secs");
         mockConsumeKinesisStreamRunner.setProperty(ConsumeKinesisStream.INITIAL_STREAM_POSITION, "TRIM_HORIZON");
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import software.amazon.kinesis.exceptions.InvalidStateException;
 import software.amazon.kinesis.exceptions.ShutdownException;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
@@ -356,7 +355,7 @@ public class TestKinesisRecordProcessorRecord {
                 .peek(it -> {
                     parsableRecord1.data().rewind();
                     parsableRecord3.data().rewind();
-                    Mockito.reset(unparsableRecordMock);
+                    reset(unparsableRecordMock);
                 });
     }
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/ml/polly/GetAwsPollyStatusTest.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/ml/polly/GetAwsPollyStatusTest.java
@@ -41,8 +41,6 @@ import software.amazon.awssdk.services.polly.model.TaskStatus;
 
 import java.util.Map;
 
-import static org.apache.nifi.processors.aws.AbstractAwsProcessor.AWS_CREDENTIALS_PROVIDER_SERVICE;
-import static org.apache.nifi.processors.aws.AbstractAwsProcessor.OBSOLETE_AWS_CREDENTIALS_PROVIDER_SERVICE_PROPERTY_NAME;
 import static org.apache.nifi.processors.aws.ml.AbstractAwsMachineLearningJobStatusProcessor.AWS_TASK_OUTPUT_LOCATION;
 import static org.apache.nifi.processors.aws.ml.AbstractAwsMachineLearningJobStatusProcessor.REL_FAILURE;
 import static org.apache.nifi.processors.aws.ml.AbstractAwsMachineLearningJobStatusProcessor.REL_ORIGINAL;
@@ -114,7 +112,7 @@ public class GetAwsPollyStatusTest {
         assertEquals(TEST_TASK_ID, requestCaptor.getValue().taskId());
 
         final MockFlowFile flowFile = runner.getFlowFilesForRelationship(REL_SUCCESS).iterator().next();
-        assertEquals(uri, flowFile.getAttribute(GetAwsPollyJobStatus.AWS_TASK_OUTPUT_LOCATION));
+        assertEquals(uri, flowFile.getAttribute(AWS_TASK_OUTPUT_LOCATION));
         assertEquals("bucket", flowFile.getAttribute("PollyS3OutputBucket"));
         assertEquals("object", flowFile.getAttribute("filename"));
     }
@@ -144,7 +142,7 @@ public class GetAwsPollyStatusTest {
         final PropertyMigrationResult propertyMigrationResult = runner.migrateProperties();
         final Map<String, String> expected = Map.of("aws-region", REGION.getName(),
                 "awsTaskId", TASK_ID.getName(),
-                OBSOLETE_AWS_CREDENTIALS_PROVIDER_SERVICE_PROPERTY_NAME, AWS_CREDENTIALS_PROVIDER_SERVICE.getName(),
+                AbstractAwsProcessor.OBSOLETE_AWS_CREDENTIALS_PROVIDER_SERVICE_PROPERTY_NAME, AbstractAwsProcessor.AWS_CREDENTIALS_PROVIDER_SERVICE.getName(),
                 ProxyConfigurationService.OBSOLETE_PROXY_CONFIGURATION_SERVICE, AbstractAwsProcessor.PROXY_CONFIGURATION_SERVICE.getName());
 
         assertEquals(expected, propertyMigrationResult.getPropertiesRenamed());

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/AbstractS3IT.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/AbstractS3IT.java
@@ -24,7 +24,6 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
@@ -287,7 +286,7 @@ public abstract class AbstractS3IT {
         try {
             setSecureProperties(runner);
         } catch (InitializationException e) {
-            Assertions.fail("Could not set security properties");
+            fail("Could not set security properties");
         }
 
         runner.setProperty(RegionUtil.REGION, getRegion());

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
@@ -434,7 +434,7 @@ public class ITPutS3Object extends AbstractS3IT {
         runner.setProperty(PutS3Object.FULL_CONTROL_USER_LIST, "28545acd76c35c7e91f8409b95fd1aa0c0914bfa1ac60975d9f48bc3c5e090b5");
         runner.setProperty(PutS3Object.MULTIPART_PART_SIZE, TEST_PARTSIZE_STRING);
         runner.setProperty(PutS3Object.BUCKET_WITHOUT_DEFAULT_VALUE, BUCKET_NAME);
-        runner.setProperty(PutS3Object.KEY, AbstractS3IT.SAMPLE_FILE_RESOURCE_NAME);
+        runner.setProperty(PutS3Object.KEY, SAMPLE_FILE_RESOURCE_NAME);
 
         assertEquals(BUCKET_NAME, context.getProperty(PutS3Object.BUCKET_WITHOUT_DEFAULT_VALUE).evaluateAttributeExpressions((FlowFile) null).toString());
         assertEquals(SAMPLE_FILE_RESOURCE_NAME, context.getProperty(PutS3Object.KEY).evaluateAttributeExpressions(Collections.emptyMap()).toString());

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestFetchS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestFetchS3Object.java
@@ -72,7 +72,7 @@ public class TestFetchS3Object {
     @BeforeEach
     public void setUp() {
         mockS3Client = mock(S3Client.class);
-        Mockito.when(mockS3Client.utilities()).thenReturn(S3Utilities.builder().region(Region.US_WEST_2).build());
+        when(mockS3Client.utilities()).thenReturn(S3Utilities.builder().region(Region.US_WEST_2).build());
         mockFetchS3Object = new FetchS3Object() {
             @Override
             protected S3Client getClient(final ProcessContext context, final Map<String, String> attributes) {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestListS3.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestListS3.java
@@ -66,7 +66,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.apache.nifi.processors.aws.region.RegionUtil.REGION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -1167,7 +1166,7 @@ public class TestListS3 {
                         Map.entry("encryption-service", AbstractS3Processor.ENCRYPTION_SERVICE.getName()),
                         Map.entry("use-chunked-encoding", AbstractS3Processor.USE_CHUNKED_ENCODING.getName()),
                         Map.entry("use-path-style-access", AbstractS3Processor.USE_PATH_STYLE_ACCESS.getName()),
-                        Map.entry("aws-region", REGION.getName()),
+                        Map.entry("aws-region", RegionUtil.REGION.getName()),
                         Map.entry(AbstractAwsProcessor.OBSOLETE_AWS_CREDENTIALS_PROVIDER_SERVICE_PROPERTY_NAME, AbstractAwsProcessor.AWS_CREDENTIALS_PROVIDER_SERVICE.getName()),
                         Map.entry(ListedEntityTracker.OLD_TRACKING_STATE_CACHE_PROPERTY_NAME, ListS3.TRACKING_STATE_CACHE.getName()),
                         Map.entry(ListedEntityTracker.OLD_TRACKING_TIME_WINDOW_PROPERTY_NAME, ListS3.TRACKING_TIME_WINDOW.getName()),

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
@@ -72,7 +72,7 @@ public class TestPutS3Object {
     @BeforeEach
     public void setUp() {
         mockS3Client = mock(S3Client.class);
-        Mockito.when(mockS3Client.utilities()).thenReturn(S3Utilities.builder().region(Region.US_WEST_2).build());
+        when(mockS3Client.utilities()).thenReturn(S3Utilities.builder().region(Region.US_WEST_2).build());
         putS3Object = new PutS3Object() {
             @Override
             protected S3Client getClient(final ProcessContext context, final Map<String, String> attributes) {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureDataLakeStorageProcessor.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureDataLakeStorageProcessor.java
@@ -34,8 +34,6 @@ import org.apache.nifi.services.azure.storage.ADLSCredentialsService;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ADLS_CREDENTIALS_SERVICE;
-
 public abstract class AbstractAzureDataLakeStorageProcessor extends AbstractProcessor {
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -74,7 +72,7 @@ public abstract class AbstractAzureDataLakeStorageProcessor extends AbstractProc
     public DataLakeServiceClient getStorageClient(PropertyContext context, FlowFile flowFile) {
         final Map<String, String> attributes = flowFile != null ? flowFile.getAttributes() : Map.of();
 
-        final ADLSCredentialsService credentialsService = context.getProperty(ADLS_CREDENTIALS_SERVICE)
+        final ADLSCredentialsService credentialsService = context.getProperty(AzureStorageUtils.ADLS_CREDENTIALS_SERVICE)
                 .asControllerService(ADLSCredentialsService.class);
         final ADLSCredentialsDetails credentialsDetails = credentialsService.getCredentialsDetails(attributes);
 

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/AbstractAzureCosmosDBProcessor.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/AbstractAzureCosmosDBProcessor.java
@@ -237,15 +237,15 @@ public abstract class AbstractAzureCosmosDBProcessor extends AbstractProcessor {
             validationResults.add(new ValidationResult.Builder().valid(false).explanation(msg).build());
         }
         if (!databaseIsSet) {
-            final String msg = AbstractAzureCosmosDBProcessor.DATABASE_NAME.getDisplayName() + " must be set.";
+            final String msg = DATABASE_NAME.getDisplayName() + " must be set.";
             validationResults.add(new ValidationResult.Builder().valid(false).explanation(msg).build());
         }
         if (!collectionIsSet) {
-            final String msg = AbstractAzureCosmosDBProcessor.CONTAINER_ID.getDisplayName() + " must be set.";
+            final String msg = CONTAINER_ID.getDisplayName() + " must be set.";
             validationResults.add(new ValidationResult.Builder().valid(false).explanation(msg).build());
         }
         if (!partitionIsSet) {
-            final String msg = AbstractAzureCosmosDBProcessor.PARTITION_KEY.getDisplayName() + " must be set.";
+            final String msg = PARTITION_KEY.getDisplayName() + " must be set.";
             validationResults.add(new ValidationResult.Builder().valid(false).explanation(msg).build());
         }
         return validationResults;

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
@@ -151,8 +151,8 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .build();
     static final PropertyDescriptor SERVICE_BUS_ENDPOINT = AzureEventHubUtils.SERVICE_BUS_ENDPOINT;
     static final PropertyDescriptor AUTHENTICATION_STRATEGY = AzureEventHubComponent.AUTHENTICATION_STRATEGY;
-    static final PropertyDescriptor EVENT_HUB_OAUTH2_ACCESS_TOKEN_PROVIDER = AzureEventHubComponent.OAUTH2_ACCESS_TOKEN_PROVIDER;
-    static final PropertyDescriptor EVENT_HUB_IDENTITY_FEDERATION_TOKEN_PROVIDER = AzureEventHubComponent.IDENTITY_FEDERATION_TOKEN_PROVIDER;
+    static final PropertyDescriptor EVENT_HUB_OAUTH2_ACCESS_TOKEN_PROVIDER = OAUTH2_ACCESS_TOKEN_PROVIDER;
+    static final PropertyDescriptor EVENT_HUB_IDENTITY_FEDERATION_TOKEN_PROVIDER = IDENTITY_FEDERATION_TOKEN_PROVIDER;
     static final PropertyDescriptor ACCESS_POLICY_NAME = new PropertyDescriptor.Builder()
             .name("Shared Access Policy Name")
             .description("The name of the shared access policy. This policy must have Listen claims.")

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
@@ -117,8 +117,8 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
             .build();
     static final PropertyDescriptor SERVICE_BUS_ENDPOINT = AzureEventHubUtils.SERVICE_BUS_ENDPOINT;
     static final PropertyDescriptor AUTHENTICATION_STRATEGY = AzureEventHubComponent.AUTHENTICATION_STRATEGY;
-    static final PropertyDescriptor EVENT_HUB_OAUTH2_ACCESS_TOKEN_PROVIDER = AzureEventHubComponent.OAUTH2_ACCESS_TOKEN_PROVIDER;
-    static final PropertyDescriptor EVENT_HUB_IDENTITY_FEDERATION_TOKEN_PROVIDER = AzureEventHubComponent.IDENTITY_FEDERATION_TOKEN_PROVIDER;
+    static final PropertyDescriptor EVENT_HUB_OAUTH2_ACCESS_TOKEN_PROVIDER = OAUTH2_ACCESS_TOKEN_PROVIDER;
+    static final PropertyDescriptor EVENT_HUB_IDENTITY_FEDERATION_TOKEN_PROVIDER = IDENTITY_FEDERATION_TOKEN_PROVIDER;
     static final PropertyDescriptor ACCESS_POLICY = new PropertyDescriptor.Builder()
             .name("Shared Access Policy Name")
             .description("The name of the shared access policy. This policy must have Listen claims.")

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
@@ -90,8 +90,8 @@ public class PutAzureEventHub extends AbstractProcessor implements AzureEventHub
             .build();
     static final PropertyDescriptor SERVICE_BUS_ENDPOINT = AzureEventHubUtils.SERVICE_BUS_ENDPOINT;
     static final PropertyDescriptor AUTHENTICATION_STRATEGY = AzureEventHubComponent.AUTHENTICATION_STRATEGY;
-    static final PropertyDescriptor EVENT_HUB_OAUTH2_ACCESS_TOKEN_PROVIDER = AzureEventHubComponent.OAUTH2_ACCESS_TOKEN_PROVIDER;
-    static final PropertyDescriptor EVENT_HUB_IDENTITY_FEDERATION_TOKEN_PROVIDER = AzureEventHubComponent.IDENTITY_FEDERATION_TOKEN_PROVIDER;
+    static final PropertyDescriptor EVENT_HUB_OAUTH2_ACCESS_TOKEN_PROVIDER = OAUTH2_ACCESS_TOKEN_PROVIDER;
+    static final PropertyDescriptor EVENT_HUB_IDENTITY_FEDERATION_TOKEN_PROVIDER = IDENTITY_FEDERATION_TOKEN_PROVIDER;
     static final PropertyDescriptor ACCESS_POLICY = new PropertyDescriptor.Builder()
             .name("Shared Access Policy Name")
             .description("The name of the shared access policy. This policy must have Send claims.")

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/checkpoint/ComponentStateCheckpointStore.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/checkpoint/ComponentStateCheckpointStore.java
@@ -59,16 +59,16 @@ import static org.apache.nifi.processors.azure.eventhub.checkpoint.ComponentStat
 import static org.apache.nifi.processors.azure.eventhub.checkpoint.ComponentStateCheckpointStoreUtils.ownershipToString;
 
 /**
- * The {@link com.azure.messaging.eventhubs.CheckpointStore} is responsible for managing the storage of partition ownership and checkpoint information for Azure Event Hubs consumers.
+ * The {@link CheckpointStore} is responsible for managing the storage of partition ownership and checkpoint information for Azure Event Hubs consumers.
  * The underlying storage has to be persistent and centralized (shared across the consumer clients in the consumer group).
  * <p>
- * There exist one ownership entry and one checkpoint entry for each partition in the store. They represent {@link com.azure.messaging.eventhubs.models.PartitionOwnership}
- * and {@link com.azure.messaging.eventhubs.models.Checkpoint} entities in a storage-specific serialized form.
+ * There exist one ownership entry and one checkpoint entry for each partition in the store. They represent {@link PartitionOwnership}
+ * and {@link Checkpoint} entities in a storage-specific serialized form.
  * <p>
  * The checkpoint store is plugged into {@link com.azure.messaging.eventhubs.EventProcessorClient} and directly used by the load balancer algorithm running in each consumer client instance.
  * <p>
  * {@code ComponentStateCheckpointStore} stores the partition ownership and checkpoint information in the component's (that is {@link org.apache.nifi.processors.azure.eventhub.ConsumeAzureEventHub}
- * processor's) state using NiFi's {@link org.apache.nifi.components.state.StateManager} in the background.
+ * processor's) state using NiFi's {@link StateManager} in the background.
  * <p>
  * The format of the ownership entry in the state map:
  * <pre>    ownership/event-hub-namespace/event-hub-name/consumer-group/partition-id -> client-id/last-modified-time/etag</pre>
@@ -77,16 +77,16 @@ import static org.apache.nifi.processors.azure.eventhub.checkpoint.ComponentStat
  * <pre>    checkpoint/event-hub-namespace/event-hub-name/consumer-group/partition-id -> offset/sequence-number</pre>
  * <p>
  * The checkpoint store is required to provide optimistic locking mechanism in order to avoid concurrent updating of the same ownership entry and therefore owning the same partition
- * by multiple client instances at the same time. The optimistic locking is supposed to be based on the <code>eTag</code> field of {@link com.azure.messaging.eventhubs.models.PartitionOwnership}
+ * by multiple client instances at the same time. The optimistic locking is supposed to be based on the <code>eTag</code> field of {@link PartitionOwnership}
  * and should be supported at entry level (only updating the same partition ownership is conflicting, claiming ownership of 2 different partitions or updating 2 checkpoints in parallel are
  * valid operations as they are independent changes).
  * <p>
- * {@link org.apache.nifi.components.state.StateManager#replace(StateMap, Map, Scope)} method supports optimistic locking but only globally, in the scope of the whole state map (which may or may not
+ * {@link StateManager#replace(StateMap, Map, Scope)} method supports optimistic locking but only globally, in the scope of the whole state map (which may or may not
  * contain conflicting changes after update). For this reason, the state update had to be implemented in 2 phases in {@link ComponentStateCheckpointStore#claimOwnership(List)}:
  * <ul>
  *     <li>in the 1st phase the algorithm gets the current state and tries to set the ownership in memory based on <code>eTag</code>, the claim request is skipped if <code>eTag</code>
  *     does not match (the original <code>eTag</code> was retrieved in {@link ComponentStateCheckpointStore#listOwnership(String, String, String)})</li>
- *     <li>in the 2nd phase {@link org.apache.nifi.components.state.StateManager#replace(StateMap, Map, Scope)} is called to persist the new state and if it is not successful - meaning
+ *     <li>in the 2nd phase {@link StateManager#replace(StateMap, Map, Scope)} is called to persist the new state and if it is not successful - meaning
  *     that another client instance changed the state in the meantime which may or may not be conflicting -, then the whole process needs to be started over with the 1st phase</li>
  * </ul>
  */

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureBlobStorage_v12.java
@@ -39,7 +39,6 @@ import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_BLOBNAME;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_CONTAINER;
 
@@ -74,7 +73,7 @@ public class DeleteAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            BLOB_STORAGE_CREDENTIALS_SERVICE,
+            AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE,
             CONTAINER,
             BLOB_NAME,
             DELETE_SNAPSHOTS_OPTION,
@@ -126,7 +125,7 @@ public class DeleteAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
     @Override
     public void migrateProperties(PropertyConfiguration config) {
         super.migrateProperties(config);
-        config.renameProperty(AbstractAzureBlobProcessor_v12.OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, BLOB_NAME.getName());
+        config.renameProperty(OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, BLOB_NAME.getName());
         config.renameProperty("delete-snapshots-option", DELETE_SNAPSHOTS_OPTION.getName());
         config.renameProperty(AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, CONTAINER.getName());
         config.renameProperty(AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.getName());

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureDataLakeStorage.java
@@ -40,9 +40,6 @@ import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 import java.time.Duration;
 import java.util.List;
 
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ADLS_CREDENTIALS_SERVICE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.DIRECTORY;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.FILESYSTEM;
 import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateDirectoryProperty;
 import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateFileProperty;
 import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateFileSystemProperty;
@@ -70,10 +67,10 @@ public class DeleteAzureDataLakeStorage extends AbstractAzureDataLakeStorageProc
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            ADLS_CREDENTIALS_SERVICE,
-            FILESYSTEM,
+            AzureStorageUtils.ADLS_CREDENTIALS_SERVICE,
+            AzureStorageUtils.FILESYSTEM,
             FILESYSTEM_OBJECT_TYPE,
-            DIRECTORY,
+            AzureStorageUtils.DIRECTORY,
             FILE,
             AzureStorageUtils.PROXY_CONFIGURATION_SERVICE
     );
@@ -88,10 +85,10 @@ public class DeleteAzureDataLakeStorage extends AbstractAzureDataLakeStorageProc
             final boolean isFile = context.getProperty(FILESYSTEM_OBJECT_TYPE).getValue().equals(FS_TYPE_FILE.getValue());
             final DataLakeServiceClient storageClient = getStorageClient(context, flowFile);
 
-            final String fileSystem = evaluateFileSystemProperty(FILESYSTEM, context, flowFile);
+            final String fileSystem = evaluateFileSystemProperty(AzureStorageUtils.FILESYSTEM, context, flowFile);
             final DataLakeFileSystemClient fileSystemClient = storageClient.getFileSystemClient(fileSystem);
 
-            final String directory = evaluateDirectoryProperty(DIRECTORY, context, flowFile);
+            final String directory = evaluateDirectoryProperty(AzureStorageUtils.DIRECTORY, context, flowFile);
             final DataLakeDirectoryClient directoryClient = fileSystemClient.getDirectoryClient(directory);
 
             if (isFile) {
@@ -116,7 +113,7 @@ public class DeleteAzureDataLakeStorage extends AbstractAzureDataLakeStorageProc
     public void migrateProperties(PropertyConfiguration config) {
         super.migrateProperties(config);
         config.renameProperty(AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName());
-        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, DIRECTORY.getName());
+        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, AzureStorageUtils.DIRECTORY.getName());
         config.renameProperty("filesystem-object-type", FILESYSTEM_OBJECT_TYPE.getName());
         config.renameProperty(AzureStorageUtils.OLD_FILE_DESCRIPTOR_NAME, FILE.getName());
     }

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureBlobStorage_v12.java
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBNAME;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBTYPE;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_CONTAINER;
@@ -140,7 +139,7 @@ public class FetchAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 im
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            BLOB_STORAGE_CREDENTIALS_SERVICE,
+            AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE,
             CONTAINER,
             BLOB_NAME,
             RANGE_START,
@@ -207,7 +206,7 @@ public class FetchAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 im
     @Override
     public void migrateProperties(PropertyConfiguration config) {
         super.migrateProperties(config);
-        config.renameProperty(AbstractAzureBlobProcessor_v12.OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, BLOB_NAME.getName());
+        config.renameProperty(OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, BLOB_NAME.getName());
         config.renameProperty(AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, CONTAINER.getName());
         config.renameProperty(AzureStorageUtils.OLD_BLOB_STORAGE_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.getName());
         config.renameProperty("range-start", RANGE_START.getName());

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureDataLakeStorage.java
@@ -48,14 +48,6 @@ import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ADLS_CREDENTIALS_SERVICE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.DIRECTORY;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.FILE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.FILESYSTEM;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateDirectoryProperty;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateFileProperty;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateFileSystemProperty;
-
 @Tags({"azure", "microsoft", "cloud", "storage", "adlsgen2", "datalake"})
 @SeeAlso({PutAzureDataLakeStorage.class, DeleteAzureDataLakeStorage.class, ListAzureDataLakeStorage.class})
 @CapabilityDescription("Fetch the specified file from Azure Data Lake Storage")
@@ -124,10 +116,10 @@ public class FetchAzureDataLakeStorage extends AbstractAzureDataLakeStorageProce
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            ADLS_CREDENTIALS_SERVICE,
-            FILESYSTEM,
-            DIRECTORY,
-            FILE,
+            AzureStorageUtils.ADLS_CREDENTIALS_SERVICE,
+            AzureStorageUtils.FILESYSTEM,
+            AzureStorageUtils.DIRECTORY,
+            AzureStorageUtils.FILE,
             RANGE_START,
             RANGE_LENGTH,
             NUM_RETRIES,
@@ -155,16 +147,16 @@ public class FetchAzureDataLakeStorage extends AbstractAzureDataLakeStorageProce
             final DownloadRetryOptions retryOptions = new DownloadRetryOptions();
             retryOptions.setMaxRetryRequests(numRetries);
 
-            final String fileSystem = evaluateFileSystemProperty(FILESYSTEM, context, flowFile);
-            final String directory = evaluateDirectoryProperty(DIRECTORY, context, flowFile);
-            final String fileName = evaluateFileProperty(context, flowFile);
+            final String fileSystem = AzureStorageUtils.evaluateFileSystemProperty(AzureStorageUtils.FILESYSTEM, context, flowFile);
+            final String directory = AzureStorageUtils.evaluateDirectoryProperty(AzureStorageUtils.DIRECTORY, context, flowFile);
+            final String fileName = AzureStorageUtils.evaluateFileProperty(context, flowFile);
             final DataLakeServiceClient storageClient = getStorageClient(context, flowFile);
             final DataLakeFileSystemClient fileSystemClient = storageClient.getFileSystemClient(fileSystem);
             final DataLakeDirectoryClient directoryClient = fileSystemClient.getDirectoryClient(directory);
             final DataLakeFileClient fileClient = directoryClient.getFileClient(fileName);
 
             if (fileClient.getProperties().isDirectory()) {
-                throw new ProcessException(FILE.getDisplayName() + " (" + fileName + ") points to a directory. Full path: " + fileClient.getFilePath());
+                throw new ProcessException(AzureStorageUtils.FILE.getDisplayName() + " (" + fileName + ") points to a directory. Full path: " + fileClient.getFilePath());
             }
 
             flowFile = session.write(flowFile, os -> fileClient.readWithResponse(os, fileRange, retryOptions, null, false, null, Context.NONE));
@@ -193,8 +185,8 @@ public class FetchAzureDataLakeStorage extends AbstractAzureDataLakeStorageProce
     public void migrateProperties(PropertyConfiguration config) {
         super.migrateProperties(config);
         config.renameProperty(AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName());
-        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, DIRECTORY.getName());
-        config.renameProperty(AzureStorageUtils.OLD_FILE_DESCRIPTOR_NAME, FILE.getName());
+        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, AzureStorageUtils.DIRECTORY.getName());
+        config.renameProperty(AzureStorageUtils.OLD_FILE_DESCRIPTOR_NAME, AzureStorageUtils.FILE.getName());
         config.renameProperty("number-of-retries", NUM_RETRIES.getName());
         config.renameProperty("range-start", RANGE_START.getName());
         config.renameProperty("range-length", RANGE_LENGTH.getName());

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureBlobStorage_v12.java
@@ -60,8 +60,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.getProxyOptions;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBNAME;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBTYPE;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_CONTAINER;
@@ -135,7 +133,7 @@ public class ListAzureBlobStorage_v12 extends AbstractListAzureProcessor<BlobInf
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            BLOB_STORAGE_CREDENTIALS_SERVICE,
+            AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE,
             CONTAINER,
             BLOB_NAME_PREFIX,
             RECORD_WRITER,
@@ -159,7 +157,7 @@ public class ListAzureBlobStorage_v12 extends AbstractListAzureProcessor<BlobInf
 
     @OnScheduled
     public void onScheduled(ProcessContext context) {
-        clientFactory = new BlobServiceClientFactory(getLogger(), getProxyOptions(context));
+        clientFactory = new BlobServiceClientFactory(getLogger(), AzureStorageUtils.getProxyOptions(context));
     }
 
     @OnStopped
@@ -213,7 +211,7 @@ public class ListAzureBlobStorage_v12 extends AbstractListAzureProcessor<BlobInf
 
     @Override
     protected boolean isListingResetNecessary(final PropertyDescriptor property) {
-        return BLOB_STORAGE_CREDENTIALS_SERVICE.equals(property)
+        return AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE.equals(property)
                 || CONTAINER.equals(property)
                 || BLOB_NAME_PREFIX.equals(property)
                 || LISTING_STRATEGY.equals(property);
@@ -223,7 +221,7 @@ public class ListAzureBlobStorage_v12 extends AbstractListAzureProcessor<BlobInf
     protected List<BlobInfo> performListing(final ProcessContext context, final Long minTimestamp, final ListingMode listingMode) throws IOException {
         final BlobServiceClientFactory currentClientFactory;
         if (ListingMode.CONFIGURATION_VERIFICATION == listingMode) {
-            currentClientFactory = new BlobServiceClientFactory(getLogger(), getProxyOptions(context));
+            currentClientFactory = new BlobServiceClientFactory(getLogger(), AzureStorageUtils.getProxyOptions(context));
         } else {
             currentClientFactory = clientFactory;
         }
@@ -235,7 +233,8 @@ public class ListAzureBlobStorage_v12 extends AbstractListAzureProcessor<BlobInf
         try {
             final List<BlobInfo> listing = new ArrayList<>();
 
-            final AzureStorageCredentialsService_v12 credentialsService = context.getProperty(BLOB_STORAGE_CREDENTIALS_SERVICE).asControllerService(AzureStorageCredentialsService_v12.class);
+            final AzureStorageCredentialsService_v12 credentialsService =
+                    context.getProperty(AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE).asControllerService(AzureStorageCredentialsService_v12.class);
             final AzureStorageCredentialsDetails_v12 credentialsDetails = credentialsService.getCredentialsDetails(Collections.emptyMap());
             final BlobServiceClient storageClient = currentClientFactory.getStorageClient(credentialsDetails);
 

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureDataLakeStorage.java
@@ -61,9 +61,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import static org.apache.nifi.processor.util.list.ListedEntityTracker.INITIAL_LISTING_TARGET;
-import static org.apache.nifi.processor.util.list.ListedEntityTracker.TRACKING_STATE_CACHE;
-import static org.apache.nifi.processor.util.list.ListedEntityTracker.TRACKING_TIME_WINDOW;
 import static org.apache.nifi.processors.azure.AbstractAzureDataLakeStorageProcessor.TEMP_FILE_DIRECTORY;
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_DESCRIPTION_DIRECTORY;
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_DESCRIPTION_ETAG;
@@ -79,12 +76,6 @@ import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_FILE_PATH;
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_LAST_MODIFIED;
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_LENGTH;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ADLS_CREDENTIALS_SERVICE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.DIRECTORY;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.FILESYSTEM;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateDirectoryProperty;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateFileSystemProperty;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.getProxyOptions;
 
 @PrimaryNodeOnly
 @TriggerSerially
@@ -141,18 +132,18 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            ADLS_CREDENTIALS_SERVICE,
-            FILESYSTEM,
-            DIRECTORY,
+            AzureStorageUtils.ADLS_CREDENTIALS_SERVICE,
+            AzureStorageUtils.FILESYSTEM,
+            AzureStorageUtils.DIRECTORY,
             RECURSE_SUBDIRECTORIES,
             FILE_FILTER,
             PATH_FILTER,
             INCLUDE_TEMPORARY_FILES,
             RECORD_WRITER,
             LISTING_STRATEGY,
-            TRACKING_STATE_CACHE,
-            TRACKING_TIME_WINDOW,
-            INITIAL_LISTING_TARGET,
+            ListedEntityTracker.TRACKING_STATE_CACHE,
+            ListedEntityTracker.TRACKING_TIME_WINDOW,
+            ListedEntityTracker.INITIAL_LISTING_TARGET,
             MIN_AGE,
             MAX_AGE,
             MIN_SIZE,
@@ -161,9 +152,9 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
     );
 
     private static final Set<PropertyDescriptor> LISTING_RESET_PROPERTIES = Set.of(
-            ADLS_CREDENTIALS_SERVICE,
-            FILESYSTEM,
-            DIRECTORY,
+            AzureStorageUtils.ADLS_CREDENTIALS_SERVICE,
+            AzureStorageUtils.FILESYSTEM,
+            AzureStorageUtils.DIRECTORY,
             RECURSE_SUBDIRECTORIES,
             FILE_FILTER,
             PATH_FILTER,
@@ -199,14 +190,14 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
         super.migrateProperties(config);
         config.renameProperty(AzureStorageUtils.OLD_ADLS_CREDENTIALS_SERVICE_DESCRIPTOR_NAME, AzureStorageUtils.ADLS_CREDENTIALS_SERVICE.getName());
         config.renameProperty(AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName());
-        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, DIRECTORY.getName());
+        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, AzureStorageUtils.DIRECTORY.getName());
         config.renameProperty("recurse-subdirectories", RECURSE_SUBDIRECTORIES.getName());
         config.renameProperty("file-filter", FILE_FILTER.getName());
         config.renameProperty("path-filter", PATH_FILTER.getName());
         config.renameProperty("include-temporary-files", INCLUDE_TEMPORARY_FILES.getName());
-        config.renameProperty(ListedEntityTracker.OLD_TRACKING_STATE_CACHE_PROPERTY_NAME, TRACKING_STATE_CACHE.getName());
-        config.renameProperty(ListedEntityTracker.OLD_TRACKING_TIME_WINDOW_PROPERTY_NAME, TRACKING_TIME_WINDOW.getName());
-        config.renameProperty(ListedEntityTracker.OLD_INITIAL_LISTING_TARGET_PROPERTY_NAME, INITIAL_LISTING_TARGET.getName());
+        config.renameProperty(ListedEntityTracker.OLD_TRACKING_STATE_CACHE_PROPERTY_NAME, ListedEntityTracker.TRACKING_STATE_CACHE.getName());
+        config.renameProperty(ListedEntityTracker.OLD_TRACKING_TIME_WINDOW_PROPERTY_NAME, ListedEntityTracker.TRACKING_TIME_WINDOW.getName());
+        config.renameProperty(ListedEntityTracker.OLD_INITIAL_LISTING_TARGET_PROPERTY_NAME, ListedEntityTracker.INITIAL_LISTING_TARGET.getName());
     }
 
     @Override
@@ -242,7 +233,7 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
 
     @Override
     protected String getPath(final ProcessContext context) {
-        final String directory = context.getProperty(DIRECTORY).evaluateAttributeExpressions().getValue();
+        final String directory = context.getProperty(AzureStorageUtils.DIRECTORY).evaluateAttributeExpressions().getValue();
         return directory != null ? directory : ".";
     }
 
@@ -280,20 +271,20 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
                                               final boolean applyFilters) throws IOException {
         final DataLakeServiceClientFactory currentClientFactory;
         if (ListingMode.CONFIGURATION_VERIFICATION == listingMode) {
-            currentClientFactory = new DataLakeServiceClientFactory(getLogger(), getProxyOptions(context));
+            currentClientFactory = new DataLakeServiceClientFactory(getLogger(), AzureStorageUtils.getProxyOptions(context));
         } else {
             currentClientFactory = clientFactory;
         }
 
         try {
-            final String fileSystem = evaluateFileSystemProperty(FILESYSTEM, context);
-            final String baseDirectory = evaluateDirectoryProperty(DIRECTORY, context);
+            final String fileSystem = AzureStorageUtils.evaluateFileSystemProperty(AzureStorageUtils.FILESYSTEM, context);
+            final String baseDirectory = AzureStorageUtils.evaluateDirectoryProperty(AzureStorageUtils.DIRECTORY, context);
             final boolean recurseSubdirectories = context.getProperty(RECURSE_SUBDIRECTORIES).asBoolean();
 
             final Pattern filePattern = listingMode == ListingMode.EXECUTION ? this.filePattern : getPattern(context, FILE_FILTER);
             final Pattern pathPattern = listingMode == ListingMode.EXECUTION ? this.pathPattern : getPattern(context, PATH_FILTER);
 
-            final ADLSCredentialsService credentialsService = context.getProperty(ADLS_CREDENTIALS_SERVICE).asControllerService(ADLSCredentialsService.class);
+            final ADLSCredentialsService credentialsService = context.getProperty(AzureStorageUtils.ADLS_CREDENTIALS_SERVICE).asControllerService(ADLSCredentialsService.class);
 
             final ADLSCredentialsDetails credentialsDetails = credentialsService.getCredentialsDetails(Collections.emptyMap());
 

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage_v12.java
@@ -68,9 +68,6 @@ import java.util.stream.Collectors;
 
 import static com.azure.core.http.ContentType.APPLICATION_OCTET_STREAM;
 import static com.azure.core.util.FluxUtil.toFluxByteBuffer;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.CONTENT_MD5;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.convertMd5ToBytes;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBNAME;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_BLOBTYPE;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_DESCRIPTION_CONTAINER;
@@ -146,12 +143,12 @@ public class PutAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 impl
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            BLOB_STORAGE_CREDENTIALS_SERVICE,
+            AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE,
             AzureStorageUtils.CONTAINER,
             AzureStorageUtils.CREATE_CONTAINER,
             AzureStorageUtils.CONFLICT_RESOLUTION,
             BLOB_NAME,
-            CONTENT_MD5,
+            AzureStorageUtils.CONTENT_MD5,
             BLOB_TAG_PREFIX,
             REMOVE_TAG_PREFIX,
             RESOURCE_TRANSFER_SOURCE,
@@ -243,9 +240,9 @@ public class PutAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 impl
                         blobParallelUploadOptions.setMetadata(userMetadata);
                     }
 
-                    final String contentMd5 = context.getProperty(CONTENT_MD5).evaluateAttributeExpressions(sourceFlowFile).getValue();
+                    final String contentMd5 = context.getProperty(AzureStorageUtils.CONTENT_MD5).evaluateAttributeExpressions(sourceFlowFile).getValue();
                     if (contentMd5 != null) {
-                        final byte[] md5Bytes = convertMd5ToBytes(contentMd5);
+                        final byte[] md5Bytes = AzureStorageUtils.convertMd5ToBytes(contentMd5);
                         final BlobHttpHeaders blobHttpHeaders = new BlobHttpHeaders().setContentMd5(md5Bytes);
                         blobParallelUploadOptions.setHeaders(blobHttpHeaders);
                     }
@@ -292,7 +289,7 @@ public class PutAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 impl
     @Override
     public void migrateProperties(PropertyConfiguration config) {
         super.migrateProperties(config);
-        config.renameProperty(AbstractAzureBlobProcessor_v12.OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, BLOB_NAME.getName());
+        config.renameProperty(OLD_BLOB_NAME_PROPERTY_DESCRIPTOR_NAME, BLOB_NAME.getName());
         config.renameProperty(AzureStorageUtils.OLD_CONFLICT_RESOLUTION_DESCRIPTOR_NAME, AzureStorageUtils.CONFLICT_RESOLUTION.getName());
         config.renameProperty(AzureStorageUtils.OLD_CREATE_CONTAINER_DESCRIPTOR_NAME, AzureStorageUtils.CREATE_CONTAINER.getName());
         config.renameProperty(AzureStorageUtils.OLD_CONTAINER_DESCRIPTOR_NAME, AzureStorageUtils.CONTAINER.getName());

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
@@ -67,13 +67,6 @@ import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_FILESYSTEM;
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_LENGTH;
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_PRIMARY_URI;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ADLS_CREDENTIALS_SERVICE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.DIRECTORY;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.FILE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.FILESYSTEM;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateDirectoryProperty;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateFileProperty;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateFileSystemProperty;
 import static org.apache.nifi.processors.transfer.ResourceTransferProperties.FILE_RESOURCE_SERVICE;
 import static org.apache.nifi.processors.transfer.ResourceTransferProperties.RESOURCE_TRANSFER_SOURCE;
 import static org.apache.nifi.processors.transfer.ResourceTransferUtils.getFileResource;
@@ -123,10 +116,10 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            ADLS_CREDENTIALS_SERVICE,
-            FILESYSTEM,
-            DIRECTORY,
-            FILE,
+            AzureStorageUtils.ADLS_CREDENTIALS_SERVICE,
+            AzureStorageUtils.FILESYSTEM,
+            AzureStorageUtils.DIRECTORY,
+            AzureStorageUtils.FILE,
             WRITING_STRATEGY,
             BASE_TEMPORARY_PATH,
             CONFLICT_RESOLUTION,
@@ -149,9 +142,9 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
 
         final long startNanos = System.nanoTime();
         try {
-            final String fileSystem = evaluateFileSystemProperty(FILESYSTEM, context, flowFile);
-            final String directory = evaluateDirectoryProperty(DIRECTORY, context, flowFile);
-            final String fileName = evaluateFileProperty(context, flowFile);
+            final String fileSystem = AzureStorageUtils.evaluateFileSystemProperty(AzureStorageUtils.FILESYSTEM, context, flowFile);
+            final String directory = AzureStorageUtils.evaluateDirectoryProperty(AzureStorageUtils.DIRECTORY, context, flowFile);
+            final String fileName = AzureStorageUtils.evaluateFileProperty(context, flowFile);
 
             final DataLakeFileSystemClient fileSystemClient = getFileSystemClient(context, flowFile, fileSystem);
             final DataLakeDirectoryClient directoryClient = fileSystemClient.getDirectoryClient(directory);
@@ -165,7 +158,7 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
             final DataLakeFileClient fileClient;
 
             if (writingStrategy == WritingStrategy.WRITE_AND_RENAME) {
-                final String tempPath = evaluateDirectoryProperty(BASE_TEMPORARY_PATH, context, flowFile);
+                final String tempPath = AzureStorageUtils.evaluateDirectoryProperty(BASE_TEMPORARY_PATH, context, flowFile);
                 final String tempDirectory = createPath(tempPath, TEMP_FILE_DIRECTORY);
                 final String tempFilePrefix = UUID.randomUUID().toString();
 
@@ -206,8 +199,8 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
     public void migrateProperties(PropertyConfiguration config) {
         super.migrateProperties(config);
         config.renameProperty(AzureStorageUtils.OLD_FILESYSTEM_DESCRIPTOR_NAME, AzureStorageUtils.FILESYSTEM.getName());
-        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, DIRECTORY.getName());
-        config.renameProperty(AzureStorageUtils.OLD_FILE_DESCRIPTOR_NAME, FILE.getName());
+        config.renameProperty(AzureStorageUtils.OLD_DIRECTORY_DESCRIPTOR_NAME, AzureStorageUtils.DIRECTORY.getName());
+        config.renameProperty(AzureStorageUtils.OLD_FILE_DESCRIPTOR_NAME, AzureStorageUtils.FILE.getName());
         config.renameProperty("conflict-resolution-strategy", CONFLICT_RESOLUTION.getName());
         config.renameProperty("writing-strategy", WRITING_STRATEGY.getName());
         config.renameProperty("base-temporary-path", BASE_TEMPORARY_PATH.getName());

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/ADLSCredentialsControllerService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/ADLSCredentialsControllerService.java
@@ -35,12 +35,6 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.CREDENTIALS_TYPE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID;
-
 /**
  * Provides credentials details for ADLS
  *
@@ -76,19 +70,19 @@ public class ADLSCredentialsControllerService extends AbstractControllerService 
 
     public static final PropertyDescriptor PROXY_CONFIGURATION_SERVICE = new PropertyDescriptor.Builder()
             .fromPropertyDescriptor(AzureStorageUtils.PROXY_CONFIGURATION_SERVICE)
-            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL, AzureStorageCredentialsType.MANAGED_IDENTITY)
+            .dependsOn(AzureStorageUtils.CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL, AzureStorageCredentialsType.MANAGED_IDENTITY)
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ACCOUNT_NAME,
             ENDPOINT_SUFFIX,
-            CREDENTIALS_TYPE,
+            AzureStorageUtils.CREDENTIALS_TYPE,
             ACCOUNT_KEY,
             SAS_TOKEN,
-            MANAGED_IDENTITY_CLIENT_ID,
-            SERVICE_PRINCIPAL_TENANT_ID,
-            SERVICE_PRINCIPAL_CLIENT_ID,
-            SERVICE_PRINCIPAL_CLIENT_SECRET,
+            AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID,
+            AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID,
+            AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID,
+            AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET,
             AzureStorageUtils.IDENTITY_FEDERATION_TOKEN_PROVIDER,
             PROXY_CONFIGURATION_SERVICE
     );
@@ -107,24 +101,24 @@ public class ADLSCredentialsControllerService extends AbstractControllerService 
         config.renameProperty(AzureStorageUtils.STORAGE_ACCOUNT_NAME_PROPERTY_DESCRIPTOR_NAME, ACCOUNT_NAME.getName());
         config.renameProperty(AzureStorageUtils.STORAGE_ENDPOINT_SUFFIX_PROPERTY_DESCRIPTOR_NAME, ENDPOINT_SUFFIX.getName());
         config.renameProperty(AzureStorageUtils.STORAGE_SAS_TOKEN_PROPERTY_DESCRIPTOR_NAME, SAS_TOKEN.getName());
-        config.renameProperty(AzureStorageUtils.OLD_MANAGED_IDENTITY_CLIENT_ID_DESCRIPTOR_NAME, MANAGED_IDENTITY_CLIENT_ID.getName());
-        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_TENANT_ID_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_TENANT_ID.getName());
-        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_ID_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_CLIENT_ID.getName());
-        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_SECRET_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_CLIENT_SECRET.getName());
+        config.renameProperty(AzureStorageUtils.OLD_MANAGED_IDENTITY_CLIENT_ID_DESCRIPTOR_NAME, AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_TENANT_ID_DESCRIPTOR_NAME, AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_ID_DESCRIPTOR_NAME, AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_SECRET_DESCRIPTOR_NAME, AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET.getName());
 
-        if (!config.hasProperty(CREDENTIALS_TYPE)) {
+        if (!config.hasProperty(AzureStorageUtils.CREDENTIALS_TYPE)) {
             final String propNameUseManagedIdentity = "storage-use-managed-identity";
 
             if (config.isPropertySet(ACCOUNT_KEY)) {
-                config.setProperty(CREDENTIALS_TYPE, AzureStorageCredentialsType.ACCOUNT_KEY.getValue());
+                config.setProperty(AzureStorageUtils.CREDENTIALS_TYPE, AzureStorageCredentialsType.ACCOUNT_KEY.getValue());
             } else if (config.isPropertySet(SAS_TOKEN)) {
-                config.setProperty(CREDENTIALS_TYPE, AzureStorageCredentialsType.SAS_TOKEN.getValue());
-            } else if (config.isPropertySet(SERVICE_PRINCIPAL_TENANT_ID)) {
-                config.setProperty(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL.getValue());
+                config.setProperty(AzureStorageUtils.CREDENTIALS_TYPE, AzureStorageCredentialsType.SAS_TOKEN.getValue());
+            } else if (config.isPropertySet(AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID)) {
+                config.setProperty(AzureStorageUtils.CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL.getValue());
             } else {
                 config.getPropertyValue(propNameUseManagedIdentity).ifPresent(value -> {
                     if ("true".equals(value)) {
-                        config.setProperty(CREDENTIALS_TYPE, AzureStorageCredentialsType.MANAGED_IDENTITY.getValue());
+                        config.setProperty(AzureStorageUtils.CREDENTIALS_TYPE, AzureStorageCredentialsType.MANAGED_IDENTITY.getValue());
                     }
                 });
             }
@@ -148,14 +142,14 @@ public class ADLSCredentialsControllerService extends AbstractControllerService 
         setValue(credentialsBuilder, ACCOUNT_KEY, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setAccountKey, attributes);
         setValue(credentialsBuilder, SAS_TOKEN, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setSasToken, attributes);
         setValue(credentialsBuilder, ENDPOINT_SUFFIX, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setEndpointSuffix, attributes);
-        setValue(credentialsBuilder, CREDENTIALS_TYPE, property -> property.asAllowableValue(AzureStorageCredentialsType.class) == AzureStorageCredentialsType.MANAGED_IDENTITY,
+        setValue(credentialsBuilder, AzureStorageUtils.CREDENTIALS_TYPE, property -> property.asAllowableValue(AzureStorageCredentialsType.class) == AzureStorageCredentialsType.MANAGED_IDENTITY,
                 ADLSCredentialsDetails.Builder::setUseManagedIdentity, attributes);
-        setValue(credentialsBuilder, MANAGED_IDENTITY_CLIENT_ID, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setManagedIdentityClientId, attributes);
-        setValue(credentialsBuilder, SERVICE_PRINCIPAL_TENANT_ID, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setServicePrincipalTenantId, attributes);
-        setValue(credentialsBuilder, SERVICE_PRINCIPAL_CLIENT_ID, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setServicePrincipalClientId, attributes);
-        setValue(credentialsBuilder, SERVICE_PRINCIPAL_CLIENT_SECRET, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setServicePrincipalClientSecret, attributes);
+        setValue(credentialsBuilder, AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setManagedIdentityClientId, attributes);
+        setValue(credentialsBuilder, AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setServicePrincipalTenantId, attributes);
+        setValue(credentialsBuilder, AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setServicePrincipalClientId, attributes);
+        setValue(credentialsBuilder, AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setServicePrincipalClientSecret, attributes);
 
-        if (context.getProperty(CREDENTIALS_TYPE).asAllowableValue(AzureStorageCredentialsType.class) == AzureStorageCredentialsType.IDENTITY_FEDERATION) {
+        if (context.getProperty(AzureStorageUtils.CREDENTIALS_TYPE).asAllowableValue(AzureStorageCredentialsType.class) == AzureStorageCredentialsType.IDENTITY_FEDERATION) {
             final AzureIdentityFederationTokenProvider identityTokenProvider = context.getProperty(AzureStorageUtils.IDENTITY_FEDERATION_TOKEN_PROVIDER)
                     .asControllerService(AzureIdentityFederationTokenProvider.class);
             credentialsBuilder.setIdentityTokenProvider(identityTokenProvider);

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureBlobStorageFileResourceService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureBlobStorageFileResourceService.java
@@ -42,8 +42,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.getProxyOptions;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_BLOBNAME;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_CONTAINER;
 import static org.apache.nifi.util.StringUtils.isBlank;
@@ -74,7 +72,7 @@ public class AzureBlobStorageFileResourceService extends AbstractControllerServi
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            BLOB_STORAGE_CREDENTIALS_SERVICE,
+            AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE,
             CONTAINER,
             BLOB_NAME
     );
@@ -89,7 +87,7 @@ public class AzureBlobStorageFileResourceService extends AbstractControllerServi
 
     @OnEnabled
     public void onEnabled(final ConfigurationContext context) {
-        this.clientFactory = new BlobServiceClientFactory(getLogger(), getProxyOptions(context));
+        this.clientFactory = new BlobServiceClientFactory(getLogger(), AzureStorageUtils.getProxyOptions(context));
         this.context = context;
     }
 
@@ -117,7 +115,7 @@ public class AzureBlobStorageFileResourceService extends AbstractControllerServi
     }
 
     protected BlobServiceClient getStorageClient(Map<String, String> attributes) {
-        final AzureStorageCredentialsService_v12 credentialsService = context.getProperty(BLOB_STORAGE_CREDENTIALS_SERVICE)
+        final AzureStorageCredentialsService_v12 credentialsService = context.getProperty(AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE)
                 .asControllerService(AzureStorageCredentialsService_v12.class);
         return clientFactory.getStorageClient(credentialsService.getCredentialsDetails(attributes));
     }

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureDataLakeStorageFileResourceService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureDataLakeStorageFileResourceService.java
@@ -44,12 +44,6 @@ import java.util.Map;
 
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_DIRECTORY;
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_FILESYSTEM;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ADLS_CREDENTIALS_SERVICE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.FILE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateDirectoryProperty;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateFileProperty;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.evaluateFileSystemProperty;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.getProxyOptions;
 
 @Tags({"azure", "microsoft", "cloud", "storage", "adlsgen2", "file", "resource", "datalake"})
 @SeeAlso({FetchAzureDataLakeStorage.class})
@@ -78,10 +72,10 @@ public class AzureDataLakeStorageFileResourceService extends AbstractControllerS
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            ADLS_CREDENTIALS_SERVICE,
+            AzureStorageUtils.ADLS_CREDENTIALS_SERVICE,
             FILESYSTEM,
             DIRECTORY,
-            FILE
+            AzureStorageUtils.FILE
     );
 
     private volatile DataLakeServiceClientFactory clientFactory;
@@ -94,7 +88,7 @@ public class AzureDataLakeStorageFileResourceService extends AbstractControllerS
 
     @OnEnabled
     public void onEnabled(final ConfigurationContext context) {
-        this.clientFactory = new DataLakeServiceClientFactory(getLogger(), getProxyOptions(context));
+        this.clientFactory = new DataLakeServiceClientFactory(getLogger(), AzureStorageUtils.getProxyOptions(context));
         this.context = context;
     }
 
@@ -122,7 +116,7 @@ public class AzureDataLakeStorageFileResourceService extends AbstractControllerS
     }
 
     protected DataLakeServiceClient getStorageClient(Map<String, String> attributes) {
-        final ADLSCredentialsService credentialsService = context.getProperty(ADLS_CREDENTIALS_SERVICE)
+        final ADLSCredentialsService credentialsService = context.getProperty(AzureStorageUtils.ADLS_CREDENTIALS_SERVICE)
                 .asControllerService(ADLSCredentialsService.class);
         return clientFactory.getStorageClient(credentialsService.getCredentialsDetails(attributes));
     }
@@ -136,16 +130,16 @@ public class AzureDataLakeStorageFileResourceService extends AbstractControllerS
      * @throws IOException exception caused by missing parameters or blob not found
      */
     private FileResource fetchFile(final DataLakeServiceClient storageClient, final Map<String, String> attributes) throws IOException {
-        final String fileSystem = evaluateFileSystemProperty(FILESYSTEM, context, attributes);
-        final String directory = evaluateDirectoryProperty(DIRECTORY, context, attributes);
-        final String file = evaluateFileProperty(context, attributes);
+        final String fileSystem = AzureStorageUtils.evaluateFileSystemProperty(FILESYSTEM, context, attributes);
+        final String directory = AzureStorageUtils.evaluateDirectoryProperty(DIRECTORY, context, attributes);
+        final String file = AzureStorageUtils.evaluateFileProperty(context, attributes);
 
         final DataLakeFileSystemClient fileSystemClient = storageClient.getFileSystemClient(fileSystem);
         final DataLakeDirectoryClient directoryClient = fileSystemClient.getDirectoryClient(directory);
         final DataLakeFileClient fileClient = directoryClient.getFileClient(file);
 
         if (fileClient.getProperties().isDirectory()) {
-            throw new ProcessException(FILE.getDisplayName() + " (" + file + ") points to a directory. Full path: " + fileClient.getFilePath());
+            throw new ProcessException(AzureStorageUtils.FILE.getDisplayName() + " (" + file + ") points to a directory. Full path: " + fileClient.getFilePath());
         }
 
         if (!fileClient.exists()) {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureStorageCredentialsControllerService_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureStorageCredentialsControllerService_v12.java
@@ -32,16 +32,6 @@ import org.apache.nifi.services.azure.AzureIdentityFederationTokenProvider;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ACCOUNT_KEY;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ACCOUNT_NAME;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.CREDENTIALS_TYPE;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.IDENTITY_FEDERATION_TOKEN_PROVIDER;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SAS_TOKEN;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET;
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID;
-
 /**
  * Provides credentials details for Azure Storage processors
  *
@@ -58,20 +48,20 @@ public class AzureStorageCredentialsControllerService_v12 extends AbstractContro
 
     public static final PropertyDescriptor PROXY_CONFIGURATION_SERVICE = new PropertyDescriptor.Builder()
             .fromPropertyDescriptor(AzureStorageUtils.PROXY_CONFIGURATION_SERVICE)
-            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL, AzureStorageCredentialsType.MANAGED_IDENTITY)
+            .dependsOn(AzureStorageUtils.CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL, AzureStorageCredentialsType.MANAGED_IDENTITY)
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            ACCOUNT_NAME,
+            AzureStorageUtils.ACCOUNT_NAME,
             ENDPOINT_SUFFIX,
-            CREDENTIALS_TYPE,
-            ACCOUNT_KEY,
-            SAS_TOKEN,
-            MANAGED_IDENTITY_CLIENT_ID,
-            SERVICE_PRINCIPAL_TENANT_ID,
-            SERVICE_PRINCIPAL_CLIENT_ID,
-            SERVICE_PRINCIPAL_CLIENT_SECRET,
-            IDENTITY_FEDERATION_TOKEN_PROVIDER,
+            AzureStorageUtils.CREDENTIALS_TYPE,
+            AzureStorageUtils.ACCOUNT_KEY,
+            AzureStorageUtils.SAS_TOKEN,
+            AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID,
+            AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID,
+            AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID,
+            AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET,
+            AzureStorageUtils.IDENTITY_FEDERATION_TOKEN_PROVIDER,
             PROXY_CONFIGURATION_SERVICE
     );
 
@@ -89,29 +79,29 @@ public class AzureStorageCredentialsControllerService_v12 extends AbstractContro
 
     @Override
     public AzureStorageCredentialsDetails_v12 getCredentialsDetails(Map<String, String> attributes) {
-        String accountName = context.getProperty(ACCOUNT_NAME).getValue();
+        String accountName = context.getProperty(AzureStorageUtils.ACCOUNT_NAME).getValue();
         String endpointSuffix = context.getProperty(ENDPOINT_SUFFIX).getValue();
-        AzureStorageCredentialsType credentialsType = context.getProperty(CREDENTIALS_TYPE).asAllowableValue(AzureStorageCredentialsType.class);
+        AzureStorageCredentialsType credentialsType = context.getProperty(AzureStorageUtils.CREDENTIALS_TYPE).asAllowableValue(AzureStorageCredentialsType.class);
         ProxyOptions proxyOptions = AzureStorageUtils.getProxyOptions(context);
 
         switch (credentialsType) {
             case ACCOUNT_KEY:
-                String accountKey = context.getProperty(ACCOUNT_KEY).getValue();
+                String accountKey = context.getProperty(AzureStorageUtils.ACCOUNT_KEY).getValue();
                 return AzureStorageCredentialsDetails_v12.createWithAccountKey(accountName, endpointSuffix, accountKey);
             case SAS_TOKEN:
-                String sasToken = context.getProperty(SAS_TOKEN).getValue();
+                String sasToken = context.getProperty(AzureStorageUtils.SAS_TOKEN).getValue();
                 return AzureStorageCredentialsDetails_v12.createWithSasToken(accountName, endpointSuffix, sasToken);
             case MANAGED_IDENTITY:
-                String managedIdentityClientId = context.getProperty(MANAGED_IDENTITY_CLIENT_ID).getValue();
+                String managedIdentityClientId = context.getProperty(AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID).getValue();
                 return AzureStorageCredentialsDetails_v12.createWithManagedIdentity(accountName, endpointSuffix, managedIdentityClientId, proxyOptions);
             case SERVICE_PRINCIPAL:
-                String servicePrincipalTenantId = context.getProperty(SERVICE_PRINCIPAL_TENANT_ID).getValue();
-                String servicePrincipalClientId = context.getProperty(SERVICE_PRINCIPAL_CLIENT_ID).getValue();
-                String servicePrincipalClientSecret = context.getProperty(SERVICE_PRINCIPAL_CLIENT_SECRET).getValue();
+                String servicePrincipalTenantId = context.getProperty(AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID).getValue();
+                String servicePrincipalClientId = context.getProperty(AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID).getValue();
+                String servicePrincipalClientSecret = context.getProperty(AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET).getValue();
                 return AzureStorageCredentialsDetails_v12.createWithServicePrincipal(accountName, endpointSuffix,
                         servicePrincipalTenantId, servicePrincipalClientId, servicePrincipalClientSecret, proxyOptions);
             case IDENTITY_FEDERATION:
-                final AzureIdentityFederationTokenProvider identityTokenProvider = context.getProperty(IDENTITY_FEDERATION_TOKEN_PROVIDER)
+                final AzureIdentityFederationTokenProvider identityTokenProvider = context.getProperty(AzureStorageUtils.IDENTITY_FEDERATION_TOKEN_PROVIDER)
                         .asControllerService(AzureIdentityFederationTokenProvider.class);
                 return AzureStorageCredentialsDetails_v12.createWithIdentityTokenProvider(
                         accountName,
@@ -125,14 +115,14 @@ public class AzureStorageCredentialsControllerService_v12 extends AbstractContro
     @Override
     public void migrateProperties(PropertyConfiguration config) {
         config.renameProperty(AzureStorageUtils.OLD_CREDENTIALS_TYPE_DESCRIPTOR_NAME, AzureStorageUtils.CREDENTIALS_TYPE.getName());
-        config.renameProperty(AzureStorageUtils.STORAGE_ACCOUNT_KEY_PROPERTY_DESCRIPTOR_NAME, ACCOUNT_KEY.getName());
-        config.renameProperty(AzureStorageUtils.STORAGE_ACCOUNT_NAME_PROPERTY_DESCRIPTOR_NAME, ACCOUNT_NAME.getName());
+        config.renameProperty(AzureStorageUtils.STORAGE_ACCOUNT_KEY_PROPERTY_DESCRIPTOR_NAME, AzureStorageUtils.ACCOUNT_KEY.getName());
+        config.renameProperty(AzureStorageUtils.STORAGE_ACCOUNT_NAME_PROPERTY_DESCRIPTOR_NAME, AzureStorageUtils.ACCOUNT_NAME.getName());
         config.renameProperty(AzureStorageUtils.STORAGE_ENDPOINT_SUFFIX_PROPERTY_DESCRIPTOR_NAME, ENDPOINT_SUFFIX.getName());
-        config.renameProperty(AzureStorageUtils.STORAGE_SAS_TOKEN_PROPERTY_DESCRIPTOR_NAME, SAS_TOKEN.getName());
-        config.renameProperty(AzureStorageUtils.OLD_MANAGED_IDENTITY_CLIENT_ID_DESCRIPTOR_NAME, MANAGED_IDENTITY_CLIENT_ID.getName());
-        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_TENANT_ID_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_TENANT_ID.getName());
-        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_ID_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_CLIENT_ID.getName());
-        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_SECRET_DESCRIPTOR_NAME, SERVICE_PRINCIPAL_CLIENT_SECRET.getName());
+        config.renameProperty(AzureStorageUtils.STORAGE_SAS_TOKEN_PROPERTY_DESCRIPTOR_NAME, AzureStorageUtils.SAS_TOKEN.getName());
+        config.renameProperty(AzureStorageUtils.OLD_MANAGED_IDENTITY_CLIENT_ID_DESCRIPTOR_NAME, AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_TENANT_ID_DESCRIPTOR_NAME, AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_ID_DESCRIPTOR_NAME, AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID.getName());
+        config.renameProperty(AzureStorageUtils.OLD_SERVICE_PRINCIPAL_CLIENT_SECRET_DESCRIPTOR_NAME, AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET.getName());
         ProxyServiceMigration.renameProxyConfigurationServiceProperty(config);
     }
 }

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestPutAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/TestPutAzureBlobStorage_v12.java
@@ -47,7 +47,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE;
 import static org.apache.nifi.processors.azure.storage.utils.BlobAttributes.ATTR_NAME_USER_METADATA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -132,7 +131,7 @@ public class TestPutAzureBlobStorage_v12 {
                 @Override
                 protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
                     return super.getSupportedPropertyDescriptors().stream()
-                            .filter(pd -> !pd.equals(BLOB_STORAGE_CREDENTIALS_SERVICE))
+                            .filter(pd -> !pd.equals(AzureStorageUtils.BLOB_STORAGE_CREDENTIALS_SERVICE))
                             .toList();
                 }
             };

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/services/azure/util/TestAzureWorkloadIdentityCredentialUtils.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/services/azure/util/TestAzureWorkloadIdentityCredentialUtils.java
@@ -22,6 +22,8 @@ import org.apache.nifi.oauth2.AccessToken;
 import org.apache.nifi.oauth2.OAuth2AccessTokenProvider;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.Supplier;
+
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -67,7 +69,7 @@ public class TestAzureWorkloadIdentityCredentialUtils {
     @Test
     public void testCreateCredentialWithNullSupplier() {
         assertThrows(NullPointerException.class, () ->
-                AzureWorkloadIdentityCredentialUtils.createCredential(TENANT_ID, CLIENT_ID, (java.util.function.Supplier<String>) null));
+                AzureWorkloadIdentityCredentialUtils.createCredential(TENANT_ID, CLIENT_ID, (Supplier<String>) null));
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/util/ProxyOptionsUtils.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/util/ProxyOptionsUtils.java
@@ -21,7 +21,7 @@ import com.azure.core.http.ProxyOptions;
 import java.util.Objects;
 
 /**
- * Utility class implementing equals and hashCode methods for {@link com.azure.core.http.ProxyOptions}.
+ * Utility class implementing equals and hashCode methods for {@link ProxyOptions}.
  */
 public final class ProxyOptionsUtils {
 

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/CreateBoxMetadataTemplate.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/CreateBoxMetadataTemplate.java
@@ -204,7 +204,7 @@ public class CreateBoxMetadataTemplate extends AbstractBoxProcessor {
             attributes.put("box.template.name", templateName);
             attributes.put("box.template.key", templateKey);
             attributes.put("box.template.scope", SCOPE_ENTERPRISE);
-            attributes.put("box.template.fields.count", String.valueOf(fields.size()));
+            attributes.put("box.template.fields.count", valueOf(fields.size()));
             flowFile = session.putAllAttributes(flowFile, attributes);
 
             session.getProvenanceReporter().create(flowFile, "Created Box metadata template: " + templateName);
@@ -298,7 +298,7 @@ public class CreateBoxMetadataTemplate extends AbstractBoxProcessor {
                                              final List<MetadataTemplate.Field> fields) {
         MetadataTemplate.createMetadataTemplate(
                 boxAPIConnection,
-                CreateBoxMetadataTemplate.SCOPE_ENTERPRISE,
+                SCOPE_ENTERPRISE,
                 templateKey,
                 templateName,
                 isHidden,

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ListBoxFileInfo.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ListBoxFileInfo.java
@@ -222,7 +222,7 @@ public class ListBoxFileInfo extends AbstractBoxProcessor {
                 }
 
                 final Map<String, String> recordAttributes = new HashMap<>(writeResult.getAttributes());
-                recordAttributes.put("record.count", String.valueOf(writeResult.getRecordCount()));
+                recordAttributes.put("record.count", valueOf(writeResult.getRecordCount()));
                 recordAttributes.put(CoreAttributes.MIME_TYPE.key(), mimeType);
                 flowFile = session.putAllAttributes(flowFile, recordAttributes);
 

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ListBoxFileMetadataInstances.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ListBoxFileMetadataInstances.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.lang.String.join;
 import static java.lang.String.valueOf;
 import static org.apache.nifi.processors.box.BoxFileAttributes.ERROR_CODE;
 import static org.apache.nifi.processors.box.BoxFileAttributes.ERROR_CODE_DESC;
@@ -170,11 +171,11 @@ public class ListBoxFileMetadataInstances extends AbstractBoxProcessor {
                 }
 
                 final Map<String, String> recordAttributes = new HashMap<>();
-                recordAttributes.put("record.count", String.valueOf(instanceList.size()));
+                recordAttributes.put("record.count", valueOf(instanceList.size()));
                 recordAttributes.put(CoreAttributes.MIME_TYPE.key(), "application/json");
                 recordAttributes.put("box.id", fileId);
-                recordAttributes.put("box.metadata.instances.names", String.join(",", templateNames));
-                recordAttributes.put("box.metadata.instances.count", String.valueOf(instanceList.size()));
+                recordAttributes.put("box.metadata.instances.names", join(",", templateNames));
+                recordAttributes.put("box.metadata.instances.count", valueOf(instanceList.size()));
                 flowFile = session.putAllAttributes(flowFile, recordAttributes);
 
                 session.getProvenanceReporter().receive(flowFile, BoxFileUtils.BOX_URL + fileId + "/metadata");

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ListBoxFileMetadataTemplates.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ListBoxFileMetadataTemplates.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.lang.String.join;
 import static java.lang.String.valueOf;
 import static org.apache.nifi.processors.box.BoxFileAttributes.ERROR_CODE;
 import static org.apache.nifi.processors.box.BoxFileAttributes.ERROR_CODE_DESC;
@@ -183,11 +184,11 @@ public class ListBoxFileMetadataTemplates extends AbstractBoxProcessor {
                 }
 
                 final Map<String, String> recordAttributes = new HashMap<>();
-                recordAttributes.put("record.count", String.valueOf(templatesList.size()));
+                recordAttributes.put("record.count", valueOf(templatesList.size()));
                 recordAttributes.put(CoreAttributes.MIME_TYPE.key(), "application/json");
                 recordAttributes.put("box.file.id", fileId);
-                recordAttributes.put("box.metadata.templates.names", String.join(",", templateNames));
-                recordAttributes.put("box.metadata.templates.count", String.valueOf(templatesList.size()));
+                recordAttributes.put("box.metadata.templates.names", join(",", templateNames));
+                recordAttributes.put("box.metadata.templates.count", valueOf(templatesList.size()));
                 flowFile = session.putAllAttributes(flowFile, recordAttributes);
 
                 session.getProvenanceReporter().receive(flowFile, BoxFileUtils.BOX_URL + fileId);

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/PutBoxFile.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/PutBoxFile.java
@@ -419,14 +419,14 @@ public class PutBoxFile extends AbstractBoxProcessor {
     }
 
     private void handleUnexpectedError(final ProcessSession session, FlowFile flowFile, final Exception e) {
-        flowFile = session.putAttribute(flowFile, BoxFileAttributes.ERROR_MESSAGE, e.getMessage());
+        flowFile = session.putAttribute(flowFile, ERROR_MESSAGE, e.getMessage());
         flowFile = session.penalize(flowFile);
         session.transfer(flowFile, REL_FAILURE);
     }
 
     private void handleExpectedError(final ProcessSession session, FlowFile flowFile, final BoxAPIResponseException e) {
-        flowFile = session.putAttribute(flowFile, BoxFileAttributes.ERROR_MESSAGE, e.getMessage());
-        flowFile = session.putAttribute(flowFile, BoxFileAttributes.ERROR_CODE, valueOf(e.getResponseCode()));
+        flowFile = session.putAttribute(flowFile, ERROR_MESSAGE, e.getMessage());
+        flowFile = session.putAttribute(flowFile, ERROR_CODE, valueOf(e.getResponseCode()));
         flowFile = session.penalize(flowFile);
         session.transfer(flowFile, REL_FAILURE);
     }

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/ListBoxFileMetadataTemplatesTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/ListBoxFileMetadataTemplatesTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -121,11 +122,11 @@ public class ListBoxFileMetadataTemplatesTest extends AbstractBoxFileTest {
         testRunner.getLogger().info("FlowFile content: {}", content);
 
         // Check that content contains key elements
-        org.junit.jupiter.api.Assertions.assertTrue(content.contains("\"$id\""));
-        org.junit.jupiter.api.Assertions.assertTrue(content.contains("\"$template\""));
-        org.junit.jupiter.api.Assertions.assertTrue(content.contains("\"$scope\""));
-        org.junit.jupiter.api.Assertions.assertTrue(content.contains("["));
-        org.junit.jupiter.api.Assertions.assertTrue(content.contains("]"));
+        assertTrue(content.contains("\"$id\""));
+        assertTrue(content.contains("\"$template\""));
+        assertTrue(content.contains("\"$scope\""));
+        assertTrue(content.contains("["));
+        assertTrue(content.contains("]"));
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
@@ -124,7 +124,6 @@ import static com.github.shyiko.mysql.binlog.event.EventType.WRITE_ROWS;
 import static com.github.shyiko.mysql.binlog.event.EventType.XID;
 import static org.apache.nifi.cdc.event.io.EventWriter.CDC_EVENT_TYPE_ATTRIBUTE;
 import static org.apache.nifi.cdc.event.io.EventWriter.SEQUENCE_ID_KEY;
-import static org.apache.nifi.cdc.event.io.FlowFileEventWriteStrategy.MAX_EVENTS_PER_FLOWFILE;
 
 /**
  * A processor to retrieve Change Data Capture (CDC) events and send them as FlowFiles.
@@ -269,12 +268,12 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
 
     public static final PropertyDescriptor EVENTS_PER_FLOWFILE_STRATEGY = new PropertyDescriptor.Builder()
             .name("Event Processing Strategy")
-            .description("Specifies the strategy to use when writing events to FlowFile(s), such as '" + MAX_EVENTS_PER_FLOWFILE.getDisplayName() + "'")
+            .description("Specifies the strategy to use when writing events to FlowFile(s), such as '" + FlowFileEventWriteStrategy.MAX_EVENTS_PER_FLOWFILE.getDisplayName() + "'")
             .required(true)
             .sensitive(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .allowableValues(FlowFileEventWriteStrategy.class)
-            .defaultValue(MAX_EVENTS_PER_FLOWFILE)
+            .defaultValue(FlowFileEventWriteStrategy.MAX_EVENTS_PER_FLOWFILE)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .build();
 
@@ -287,7 +286,7 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .defaultValue("1")
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
-            .dependsOn(EVENTS_PER_FLOWFILE_STRATEGY, MAX_EVENTS_PER_FLOWFILE)
+            .dependsOn(EVENTS_PER_FLOWFILE_STRATEGY, FlowFileEventWriteStrategy.MAX_EVENTS_PER_FLOWFILE)
             .build();
 
     public static final PropertyDescriptor SERVER_ID = new PropertyDescriptor.Builder()

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
@@ -264,7 +264,7 @@ public class ConfluentSchemaRegistry extends AbstractControllerService implement
     private RecordSchema retrieveSchemaByName(final SchemaIdentifier schemaIdentifier) throws IOException, SchemaNotFoundException {
         final Optional<String> schemaName = schemaIdentifier.getName();
         if (schemaName.isEmpty()) {
-            throw new org.apache.nifi.schema.access.SchemaNotFoundException("Cannot retrieve schema because Schema Name is not present");
+            throw new SchemaNotFoundException("Cannot retrieve schema because Schema Name is not present");
         }
 
         final RecordSchema schema;
@@ -280,7 +280,7 @@ public class ConfluentSchemaRegistry extends AbstractControllerService implement
     private RecordSchema retrieveSchemaById(final SchemaIdentifier schemaIdentifier) throws IOException, SchemaNotFoundException {
         final OptionalLong schemaId = schemaIdentifier.getSchemaVersionId();
         if (schemaId.isEmpty()) {
-            throw new org.apache.nifi.schema.access.SchemaNotFoundException("Cannot retrieve schema because Schema Id is not present");
+            throw new SchemaNotFoundException("Cannot retrieve schema because Schema Id is not present");
         }
 
         final RecordSchema schema = client.getSchema((int) schemaId.getAsLong());

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/IndexOperationRequest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/IndexOperationRequest.java
@@ -177,7 +177,7 @@ public class IndexOperationRequest {
         Update("update"),
         Upsert("upsert");
 
-        private static final List<Operation> VALUES = List.of(Operation.values());
+        private static final List<Operation> VALUES = List.of(values());
 
         private final String value;
 

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -257,10 +257,10 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
                             Incorrect/invalid %s.
                             The HTTP Hosts should be valid URIs including protocol, domain and port for each entry.
                             For example "https://elasticsearch1:9200, https://elasticsearch2:9200".
-                            """.formatted(ElasticSearchClientService.HTTP_HOSTS.getDisplayName()));
+                            """.formatted(HTTP_HOSTS.getDisplayName()));
         } catch (final InitializationException ie) {
             clientSetupResult.outcome(ConfigVerificationResult.Outcome.FAILED)
-                    .explanation("Incorrect/invalid " + ElasticSearchClientService.PROP_SSL_CONTEXT_SERVICE.getDisplayName());
+                    .explanation("Incorrect/invalid " + PROP_SSL_CONTEXT_SERVICE.getDisplayName());
         } catch (final Exception ex) {
             getLogger().warn("Unable to setup Elasticsearch Rest Client", ex);
 

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJson.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJson.java
@@ -425,7 +425,7 @@ public class PutElasticsearchJson extends AbstractPutElasticsearch {
         config.renameProperty("put-es-json-scripted-upsert", SCRIPTED_UPSERT.getName());
         config.renameProperty("put-es-json-dynamic_templates", DYNAMIC_TEMPLATES.getName());
         config.renameProperty("put-es-json-charset", CHARSET.getName());
-        config.renameProperty("put-es-json-not_found-is-error", AbstractPutElasticsearch.NOT_FOUND_IS_SUCCESSFUL.getName());
+        config.renameProperty("put-es-json-not_found-is-error", NOT_FOUND_IS_SUCCESSFUL.getName());
 
         // If INPUT_FORMAT was not explicitly set, this flow was migrated from PutElasticsearchJson — default to Single JSON.
         // Set this before migrating BATCH_SIZE so its dependsOn condition is satisfied when NiFi processes the property.
@@ -451,7 +451,7 @@ public class PutElasticsearchJson extends AbstractPutElasticsearch {
         super.migrateRelationships(config);
 
         // PutElasticsearchJson used "success" before it was renamed to "original"
-        config.renameRelationship("success", AbstractPutElasticsearch.REL_ORIGINAL.getName());
+        config.renameRelationship("success", REL_ORIGINAL.getName());
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
@@ -362,7 +362,7 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
         config.renameProperty("put-es-record-at-timestamp-date-format", DATE_FORMAT.getName());
         config.renameProperty("put-es-record-at-timestamp-time-format", TIME_FORMAT.getName());
         config.renameProperty("put-es-record-at-timestamp-timestamp-format", TIMESTAMP_FORMAT.getName());
-        config.renameProperty("put-es-record-not_found-is-error", AbstractPutElasticsearch.NOT_FOUND_IS_SUCCESSFUL.getName());
+        config.renameProperty("put-es-record-not_found-is-error", NOT_FOUND_IS_SUCCESSFUL.getName());
 
         if (config.getPropertyValue(RESULT_RECORD_WRITER).isEmpty()) {
             final String resultRecordWriterId = config.createControllerService("org.apache.nifi.json.JsonRecordSetWriter", Collections.emptyMap());
@@ -374,8 +374,8 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
     public void migrateRelationships(final RelationshipConfiguration config) {
         super.migrateRelationships(config);
 
-        config.renameRelationship("success", AbstractPutElasticsearch.REL_ORIGINAL.getName());
-        config.renameRelationship("successful_records", AbstractPutElasticsearch.REL_SUCCESSFUL.getName());
+        config.renameRelationship("success", REL_ORIGINAL.getName());
+        config.renameRelationship("successful_records", REL_SUCCESSFUL.getName());
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/AbstractPaginatedJsonQueryElasticsearchTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/AbstractPaginatedJsonQueryElasticsearchTest.java
@@ -98,11 +98,11 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
         final TestRunner runner = createRunner(false);
         runner.setProperty(AbstractJsonQueryElasticsearch.QUERY, matchAllQuery);
         MockFlowFile input = runOnce(runner);
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
+        testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
         final MockFlowFile pageQueryHitsNoSplitting = runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst();
         pageQueryHitsNoSplitting.assertAttributeEquals("hit.count", "10");
         pageQueryHitsNoSplitting.assertAttributeEquals("page.number", "1");
-        AbstractJsonQueryElasticsearchTest.assertOutputContent(pageQueryHitsNoSplitting.getContent(), 10, false);
+        assertOutputContent(pageQueryHitsNoSplitting.getContent(), 10, false);
         assertEquals(1L, runner.getProvenanceEvents().stream().filter(event ->
                 ProvenanceEventType.RECEIVE.equals(event.getEventType()) && event.getAttribute("uuid").equals(pageQueryHitsNoSplitting.getAttribute("uuid"))).count());
 
@@ -112,7 +112,7 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
         // paged query hits splitting
         runner.setProperty(AbstractJsonQueryElasticsearch.SEARCH_RESULTS_SPLIT, ResultOutputStrategy.PER_HIT);
         input = runOnce(runner);
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, isInput() ? 1 : 0, 10, 0, 0);
+        testCounts(runner, isInput() ? 1 : 0, 10, 0, 0);
         runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).forEach(hit -> {
             hit.assertAttributeEquals("hit.count", "1");
             hit.assertAttributeEquals("page.number", "1");
@@ -126,11 +126,11 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
         // paged query hits combined
         runner.setProperty(AbstractJsonQueryElasticsearch.SEARCH_RESULTS_SPLIT, ResultOutputStrategy.PER_QUERY);
         input = runOnce(runner);
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
+        testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
         final MockFlowFile pageQueryHitsCombined = runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst();
         pageQueryHitsCombined.assertAttributeEquals("hit.count", "10");
         pageQueryHitsCombined.assertAttributeEquals("page.number", "1");
-        AbstractJsonQueryElasticsearchTest.assertOutputContent(pageQueryHitsCombined.getContent(), 10, true);
+        assertOutputContent(pageQueryHitsCombined.getContent(), 10, true);
         assertEquals(1L, runner.getProvenanceEvents().stream().filter(event ->
                 ProvenanceEventType.RECEIVE.equals(event.getEventType()) && event.getAttribute("uuid").equals(pageQueryHitsCombined.getAttribute("uuid"))).count());
         assertSendEvent(runner, input);
@@ -176,14 +176,14 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
         }
 
         // Test Relationship counts
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, isInput() ? 1 : 0, flowFileCount, 0, 0);
+        testCounts(runner, isInput() ? 1 : 0, flowFileCount, 0, 0);
 
         // Per response outputs an array of values
         final boolean ndJsonCopy = ndjson;
         final List<MockFlowFile> hits = runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS);
         for (MockFlowFile hit : hits) {
             hit.assertAttributeEquals("hit.count", hitsCount);
-            AbstractJsonQueryElasticsearchTest.assertOutputContent(hit.getContent(), Integer.parseInt(hitsCount), ndJsonCopy);
+            assertOutputContent(hit.getContent(), Integer.parseInt(hitsCount), ndJsonCopy);
             if (ResultOutputStrategy.PER_RESPONSE.equals(resultOutputStrategy)) {
                 JsonUtils.readListOfMaps(hit.getContent()).forEach(h -> assertFormattedResult(searchResultsFormat, h));
             } else {
@@ -221,14 +221,14 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
     @Test
     void testDeleteScrollError() {
         final TestRunner runner = createRunner(false);
-        final TestElasticsearchClientService service = AbstractJsonQueryElasticsearchTest.getService(runner);
+        final TestElasticsearchClientService service = getService(runner);
         service.setThrowErrorInDelete(true);
         runner.setProperty(AbstractPaginatedJsonQueryElasticsearch.PAGINATION_TYPE, PaginationType.SCROLL);
         runner.setProperty(AbstractJsonQueryElasticsearch.QUERY, matchAllWithSortByMsgWithoutSize);
 
         // still expect "success" output for exception during final clean-up
         runMultiple(runner);
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
+        testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
         assertTrue(runner.getLogger().getWarnMessages().stream().anyMatch(logMessage ->
                 logMessage.getMsg().contains("Error while cleaning up Elasticsearch pagination resources") && logMessage.getMsg().contains("Simulated IOException - deleteScroll")));
         // check error was caught and logged
@@ -237,7 +237,7 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
     @Test
     void testScrollError() {
         final TestRunner runner = createRunner(false);
-        final TestElasticsearchClientService service = AbstractJsonQueryElasticsearchTest.getService(runner);
+        final TestElasticsearchClientService service = getService(runner);
         service.setMaxPages(2);
         runner.setProperty(AbstractPaginatedJsonQueryElasticsearch.PAGINATION_TYPE, PaginationType.SCROLL);
         runner.setProperty(AbstractJsonQueryElasticsearch.QUERY, matchAllWithSortByMsgWithSizeQuery);
@@ -246,7 +246,7 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
             // initialize search for SearchElasticsearch, first page successful
             service.setThrowErrorInSearch(false);
             runOnce(runner);
-            AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 1, 0, 0);
+            testCounts(runner, 0, 1, 0, 0);
             runner.clearTransferState();
         }
 
@@ -254,7 +254,7 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
         service.setThrowErrorInSearch(true);
         runOnce(runner);
         // fir PaginatedJsonQueryElasticsearch, the input flowfile will be routed to failure, for SearchElasticsearch, there will be no output
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 0, getStateScope() == null ? 1 : 0, 0);
+        testCounts(runner, 0, 0, getStateScope() == null ? 1 : 0, 0);
         assertTrue(runner.getLogger().getErrorMessages().stream().anyMatch(logMessage ->
                 logMessage.getMsg().contains("Could not query documents") && logMessage.getThrowable().getMessage().contains("Simulated IOException")));
     }
@@ -262,7 +262,7 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
     @Test
     void testDeletePitError() throws JsonProcessingException {
         final TestRunner runner = createRunner(false);
-        final TestElasticsearchClientService service = AbstractJsonQueryElasticsearchTest.getService(runner);
+        final TestElasticsearchClientService service = getService(runner);
         service.setThrowErrorInDelete(true);
         runner.setProperty(AbstractJsonQueryElasticsearch.SEARCH_RESULTS_FORMAT, SearchResultsFormat.FULL);
         runner.setProperty(AbstractJsonQueryElasticsearch.AGGREGATION_RESULTS_FORMAT, AggregationResultsFormat.FULL);
@@ -271,7 +271,7 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
 
         // still expect "success" output for exception during final clean-up
         runMultiple(runner);
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
+        testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
         // check error was caught and logged
         assertTrue(runner.getLogger().getWarnMessages().stream().anyMatch(logMessage ->
                 logMessage.getMsg().contains("Error while cleaning up Elasticsearch pagination resources") && logMessage.getMsg().contains("Simulated IOException - deletePointInTime")));
@@ -280,14 +280,14 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
     @Test
     void testInitialisePitError() throws JsonProcessingException {
         final TestRunner runner = createRunner(false);
-        final TestElasticsearchClientService service = AbstractJsonQueryElasticsearchTest.getService(runner);
+        final TestElasticsearchClientService service = getService(runner);
         service.setThrowErrorInPit(true);
         runner.setProperty(AbstractPaginatedJsonQueryElasticsearch.PAGINATION_TYPE, PaginationType.POINT_IN_TIME);
         setQuery(runner, matchAllWithSortByMsgWithoutSize);
 
         // expect "failure" output for exception during query setup
         runOnce(runner);
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 0, isInput() ? 1 : 0, 0);
+        testCounts(runner, 0, 0, isInput() ? 1 : 0, 0);
         // check error was caught and logged
         assertTrue(runner.getLogger().getErrorMessages().stream().anyMatch(logMessage ->
                 logMessage.getMsg().contains("Could not query documents") && logMessage.getThrowable().getMessage().contains("Simulated IOException - initialisePointInTime")));
@@ -303,16 +303,16 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
         if (PaginationType.SCROLL == paginationType) {
             // test scroll without sort (should succeed)
             runMultiple(runner);
-            AbstractJsonQueryElasticsearchTest.testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
+            testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
         } else {
             // test PiT/search_after without sort
             runOnce(runner);
             if (runner.getProcessor() instanceof ConsumeElasticsearch) {
                 // sort is added based upon the Range Field (which cannot be empty)
-                AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 1, 0, 0);
+                testCounts(runner, 0, 1, 0, 0);
             } else {
                 // expect "failure" output for exception during query setup
-                AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 0, isInput() ? 1 : 0, 0);
+                testCounts(runner, 0, 0, isInput() ? 1 : 0, 0);
 
                 // check error was caught and logged
                 assertTrue(runner.getLogger().getErrorMessages().stream().anyMatch(logMessage ->
@@ -325,7 +325,7 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
     @EnumSource(PaginationType.class)
     void testPagination(final PaginationType paginationType) throws Exception {
         final TestRunner runner = createRunner(false);
-        final TestElasticsearchClientService service = AbstractJsonQueryElasticsearchTest.getService(runner);
+        final TestElasticsearchClientService service = getService(runner);
         service.setMaxPages(2);
         runner.setProperty(AbstractPaginatedJsonQueryElasticsearch.PAGINATION_TYPE, paginationType);
         setQuery(runner, matchAllWithSortByMsgWithSizeQuery);
@@ -378,7 +378,7 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
     @EnumSource(PaginationType.class)
     void testEmptyHitsFlowFileIsProducedForEachResultSplitSetup(final PaginationType paginationType) throws JsonProcessingException {
         final TestRunner runner = createRunner(false);
-        final TestElasticsearchClientService service = AbstractJsonQueryElasticsearchTest.getService(runner);
+        final TestElasticsearchClientService service = getService(runner);
         service.setMaxPages(0);
         runner.setProperty(AbstractPaginatedJsonQueryElasticsearch.PAGINATION_TYPE, paginationType);
         setQuery(runner, matchAllWithSortByMessage);
@@ -388,7 +388,7 @@ public abstract class AbstractPaginatedJsonQueryElasticsearchTest extends Abstra
             // test that an empty flow file is produced for a per query setup
             runner.setProperty(AbstractPaginatedJsonQueryElasticsearch.SEARCH_RESULTS_SPLIT, resultOutputStrategy);
             runOnce(runner);
-            AbstractJsonQueryElasticsearchTest.testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
+            testCounts(runner, isInput() ? 1 : 0, 1, 0, 0);
 
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("hit.count", "0");
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("page.number", "1");

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/GetElasticsearchTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/GetElasticsearchTest.java
@@ -241,7 +241,7 @@ class GetElasticsearchTest {
     }
 
     private static void assertOutputAttribute(final MockFlowFile doc, final boolean attributeOutput) {
-        GetElasticsearchTest.assertOutputAttribute(doc, attributeOutput, "elasticsearch.doc");
+        assertOutputAttribute(doc, attributeOutput, "elasticsearch.doc");
     }
 
     private static void assertCommonAttributes(final MockFlowFile doc, final boolean type) {

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PaginatedJsonQueryElasticsearchTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PaginatedJsonQueryElasticsearchTest.java
@@ -52,7 +52,7 @@ public class PaginatedJsonQueryElasticsearchTest extends AbstractPaginatedJsonQu
         runner.getStateManager().assertStateNotSet();
         switch (resultOutputStrategy) {
             case PER_RESPONSE:
-                AbstractJsonQueryElasticsearchTest.testCounts(runner, 1, 2, 0, 0);
+                testCounts(runner, 1, 2, 0, 0);
                 for (int page = 1; page <= 2; page++) {
                     final MockFlowFile hit = runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).get(page - 1);
                     hit.assertAttributeEquals("hit.count", "10");
@@ -61,13 +61,13 @@ public class PaginatedJsonQueryElasticsearchTest extends AbstractPaginatedJsonQu
                 break;
             case PER_QUERY:
                 final int expectedHits = 20;
-                AbstractJsonQueryElasticsearchTest.testCounts(runner, 1, 1, 0, 0);
+                testCounts(runner, 1, 1, 0, 0);
                 runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("hit.count", Integer.toString(expectedHits));
                 runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("page.number", "2");
                 assertEquals(expectedHits, runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().getContent().split("\n").length);
                 break;
             case PER_HIT:
-                AbstractJsonQueryElasticsearchTest.testCounts(runner, 1, 20, 0, 0);
+                testCounts(runner, 1, 20, 0, 0);
                 long count = 1;
                 final ValueRange firstPage = ValueRange.of(1, 10);
                 for (final MockFlowFile hit : runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS)) {

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/SearchElasticsearchTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/SearchElasticsearchTest.java
@@ -58,7 +58,7 @@ public class SearchElasticsearchTest extends AbstractPaginatedJsonQueryElasticse
     void testPaginationExpiration(final PaginationType paginationType) throws Exception {
         // test flowfile per page
         final TestRunner runner = createRunner(false);
-        final TestElasticsearchClientService service = AbstractJsonQueryElasticsearchTest.getService(runner);
+        final TestElasticsearchClientService service = getService(runner);
         service.setMaxPages(2);
         runner.setProperty(AbstractPaginatedJsonQueryElasticsearch.PAGINATION_TYPE, paginationType);
         runner.setProperty(AbstractPaginatedJsonQueryElasticsearch.PAGINATION_KEEP_ALIVE, "1 sec");
@@ -66,7 +66,7 @@ public class SearchElasticsearchTest extends AbstractPaginatedJsonQueryElasticse
 
         // first page
         runOnce(runner);
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 1, 0, 0);
+        testCounts(runner, 0, 1, 0, 0);
         runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("hit.count", "10");
         runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("page.number", "1");
         assertState(runner, paginationType, 10, 1, false);
@@ -81,7 +81,7 @@ public class SearchElasticsearchTest extends AbstractPaginatedJsonQueryElasticse
 
             // does not expire
             runOnce(runner);
-            AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 1, 0, 0);
+            testCounts(runner, 0, 1, 0, 0);
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("hit.count", "10");
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("page.number", "2");
             assertState(runner, paginationType, 20, 2, false);
@@ -108,7 +108,7 @@ public class SearchElasticsearchTest extends AbstractPaginatedJsonQueryElasticse
 
             // first page again (new query after first query expired)
             runOnce(runner);
-            AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 1, 0, 0);
+            testCounts(runner, 0, 1, 0, 0);
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("hit.count", "10");
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("page.number", "1");
             assertState(runner, paginationType, 10, 1, false);
@@ -120,7 +120,7 @@ public class SearchElasticsearchTest extends AbstractPaginatedJsonQueryElasticse
 
             // second page
             runOnce(runner);
-            AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 1, 0, 0);
+            testCounts(runner, 0, 1, 0, 0);
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("hit.count", "10");
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("page.number", "2");
             assertState(runner, paginationType, 20, 2, false);
@@ -138,25 +138,25 @@ public class SearchElasticsearchTest extends AbstractPaginatedJsonQueryElasticse
         final int expectedHitCount = 10 * iteration;
 
         if (perResponseResultOutputStrategy && (iteration == 1 || iteration == 2)) {
-            AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 1, 0, 0);
+            testCounts(runner, 0, 1, 0, 0);
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("hit.count", "10");
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("page.number", String.valueOf(iteration));
             assertState(runner, paginationType, expectedHitCount, iteration, false);
         } else if (perHitResultOutputStrategy && (iteration == 1 || iteration == 2)) {
-            AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 10, 0, 0);
+            testCounts(runner, 0, 10, 0, 0);
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).forEach(hit -> {
                 hit.assertAttributeEquals("hit.count", "1");
                 hit.assertAttributeEquals("page.number", String.valueOf(iteration));
             });
             assertState(runner, paginationType, expectedHitCount, iteration, false);
         } else if ((perResponseResultOutputStrategy || perHitResultOutputStrategy) && iteration == 3) {
-            AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 0, 0, 0);
+            testCounts(runner, 0, 0, 0, 0);
             if (runner.getProcessor() instanceof ConsumeElasticsearch) {
                 assertEquals("five", runner.getStateManager().getState(getStateScope()).get(ConsumeElasticsearch.STATE_RANGE_VALUE));
             }
             assertState(runner, paginationType, 20, 3, true);
         } else if (ResultOutputStrategy.PER_QUERY.equals(resultOutputStrategy)) {
-            AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 1, 0, 0);
+            testCounts(runner, 0, 1, 0, 0);
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("hit.count", "20");
             // the "last" page.number is used, so 2 here because there were 2 pages of hits
             runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getFirst().assertAttributeEquals("page.number", "2");
@@ -172,7 +172,7 @@ public class SearchElasticsearchTest extends AbstractPaginatedJsonQueryElasticse
     @EnumSource(PaginationType.class)
     void testPaginationWithoutRestartOnFinish(final PaginationType paginationType) throws Exception {
         final TestRunner runner = createRunner(false);
-        final TestElasticsearchClientService service = AbstractJsonQueryElasticsearchTest.getService(runner);
+        final TestElasticsearchClientService service = getService(runner);
         service.setMaxPages(2);
         runner.setProperty(AbstractPaginatedJsonQueryElasticsearch.PAGINATION_TYPE, paginationType);
         runner.setProperty(AbstractPaginatedJsonQueryElasticsearch.SEARCH_RESULTS_SPLIT, ResultOutputStrategy.PER_RESPONSE);
@@ -181,7 +181,7 @@ public class SearchElasticsearchTest extends AbstractPaginatedJsonQueryElasticse
 
         runOnce(runner);
 
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 1, 0, 0);
+        testCounts(runner, 0, 1, 0, 0);
         runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getLast().assertAttributeEquals("hit.count", "10");
         runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getLast().assertAttributeEquals("page.number", "1");
         assertState(runner, paginationType, 10, 1, false);
@@ -189,7 +189,7 @@ public class SearchElasticsearchTest extends AbstractPaginatedJsonQueryElasticse
 
         runOnce(runner);
 
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 2, 0, 0);
+        testCounts(runner, 0, 2, 0, 0);
         runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getLast().assertAttributeEquals("hit.count", "10");
         runner.getFlowFilesForRelationship(AbstractJsonQueryElasticsearch.REL_HITS).getLast().assertAttributeEquals("page.number", "2");
         assertState(runner, paginationType, 20, 2, false);
@@ -197,13 +197,13 @@ public class SearchElasticsearchTest extends AbstractPaginatedJsonQueryElasticse
 
         runOnce(runner);
 
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 2, 0, 0);
+        testCounts(runner, 0, 2, 0, 0);
         assertState(runner, paginationType, 20, 3, true);
         assertFalse(runner.isYieldCalled());
 
         runOnce(runner);
 
-        AbstractJsonQueryElasticsearchTest.testCounts(runner, 0, 2, 0, 0);
+        testCounts(runner, 0, 2, 0, 0);
         assertState(runner, paginationType, 20, 3, true);
         assertTrue(runner.isYieldCalled());
     }

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeIMAP.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeIMAP.java
@@ -64,7 +64,7 @@ public class ConsumeIMAP extends AbstractEmailProcessor<ImapMailReceiver> {
         ImapMailReceiver receiver = new ImapMailReceiver(this.buildUrl(processContext));
         boolean shouldMarkAsRead = processContext.getProperty(SHOULD_MARK_READ).asBoolean();
         receiver.setShouldMarkMessagesAsRead(shouldMarkAsRead);
-        receiver.setShouldDeleteMessages(processContext.getProperty(AbstractEmailProcessor.SHOULD_DELETE_MESSAGES).asBoolean());
+        receiver.setShouldDeleteMessages(processContext.getProperty(SHOULD_DELETE_MESSAGES).asBoolean());
         return receiver;
     }
 

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumePOP3.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumePOP3.java
@@ -40,7 +40,7 @@ public class ConsumePOP3 extends AbstractEmailProcessor<Pop3MailReceiver> {
     @Override
     protected Pop3MailReceiver buildMessageReceiver(ProcessContext context) {
         final Pop3MailReceiver receiver = new Pop3MailReceiver(this.buildUrl(context));
-        receiver.setShouldDeleteMessages(context.getProperty(AbstractEmailProcessor.SHOULD_DELETE_MESSAGES).asBoolean());
+        receiver.setShouldDeleteMessages(context.getProperty(SHOULD_DELETE_MESSAGES).asBoolean());
         return receiver;
     }
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
@@ -60,7 +60,6 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.sql.Types;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -750,7 +749,7 @@ public class JdbcCommon {
             final String sqlArgumentFormat = attributes.containsKey(sqlArgumentFormatAttributeName) ? attributes.get(sqlArgumentFormatAttributeName).getValue() : "";
 
             try {
-                JdbcCommon.setParameter(stmt, sqlArgumentIndex, sqlArgumentValue, sqlType, sqlArgumentFormat);
+                setParameter(stmt, sqlArgumentIndex, sqlArgumentValue, sqlType, sqlArgumentFormat);
             } catch (final NumberFormatException nfe) {
                 throw new SQLDataException("The value of the " + sqlArgumentValueAttributeName + " is '" + sqlArgumentLogValue + "', which cannot be converted into the necessary data type", nfe);
             } catch (ParseException pe) {
@@ -778,36 +777,36 @@ public class JdbcCommon {
             stmt.setNull(parameterIndex, jdbcType);
         } else {
             switch (jdbcType) {
-                case Types.BIT:
+                case BIT:
                     stmt.setBoolean(parameterIndex, "1".equals(parameterValue) || "t".equalsIgnoreCase(parameterValue) || Boolean.parseBoolean(parameterValue));
                     break;
-                case Types.BOOLEAN:
+                case BOOLEAN:
                     stmt.setBoolean(parameterIndex, Boolean.parseBoolean(parameterValue));
                     break;
-                case Types.TINYINT:
+                case TINYINT:
                     stmt.setByte(parameterIndex, Byte.parseByte(parameterValue));
                     break;
-                case Types.SMALLINT:
+                case SMALLINT:
                     stmt.setShort(parameterIndex, Short.parseShort(parameterValue));
                     break;
-                case Types.INTEGER:
+                case INTEGER:
                     stmt.setInt(parameterIndex, Integer.parseInt(parameterValue));
                     break;
-                case Types.BIGINT:
+                case BIGINT:
                     stmt.setLong(parameterIndex, Long.parseLong(parameterValue));
                     break;
-                case Types.REAL:
+                case REAL:
                     stmt.setFloat(parameterIndex, Float.parseFloat(parameterValue));
                     break;
-                case Types.FLOAT:
-                case Types.DOUBLE:
+                case FLOAT:
+                case DOUBLE:
                     stmt.setDouble(parameterIndex, Double.parseDouble(parameterValue));
                     break;
-                case Types.DECIMAL:
-                case Types.NUMERIC:
+                case DECIMAL:
+                case NUMERIC:
                     stmt.setBigDecimal(parameterIndex, new BigDecimal(parameterValue));
                     break;
-                case Types.DATE:
+                case DATE:
                     java.sql.Date date;
 
                     if (valueFormat.equals("")) {
@@ -825,7 +824,7 @@ public class JdbcCommon {
 
                     stmt.setDate(parameterIndex, date);
                     break;
-                case Types.TIME:
+                case TIME:
                     Time time;
 
                     if (valueFormat.equals("")) {
@@ -845,7 +844,7 @@ public class JdbcCommon {
 
                     stmt.setTime(parameterIndex, time);
                     break;
-                case Types.TIMESTAMP:
+                case TIMESTAMP:
                     Timestamp ts;
 
                     // Backwards compatibility note: Format was unsupported for a timestamp field.
@@ -866,9 +865,9 @@ public class JdbcCommon {
 
                     stmt.setTimestamp(parameterIndex, ts);
                     break;
-                case Types.BINARY:
-                case Types.VARBINARY:
-                case Types.LONGVARBINARY:
+                case BINARY:
+                case VARBINARY:
+                case LONGVARBINARY:
                     byte[] bValue;
 
                     switch (valueFormat) {
@@ -897,18 +896,18 @@ public class JdbcCommon {
                     }
 
                     break;
-                case Types.CHAR:
-                case Types.VARCHAR:
-                case Types.LONGNVARCHAR:
-                case Types.LONGVARCHAR:
+                case CHAR:
+                case VARCHAR:
+                case LONGNVARCHAR:
+                case LONGVARCHAR:
                     stmt.setString(parameterIndex, parameterValue);
                     break;
-                case Types.CLOB:
+                case CLOB:
                     try (final StringReader reader = new StringReader(parameterValue)) {
                         stmt.setCharacterStream(parameterIndex, reader);
                     }
                     break;
-                case Types.NCLOB:
+                case NCLOB:
                     try (final StringReader reader = new StringReader(parameterValue)) {
                         stmt.setNCharacterStream(parameterIndex, reader);
                     }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcCommon.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcCommon.java
@@ -29,7 +29,6 @@ import org.apache.avro.util.Utf8;
 import org.apache.commons.io.input.ReaderInputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +50,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -81,6 +81,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -433,7 +434,7 @@ public class TestJdbcCommon extends AbstractConnectionTest {
 
         final ResultSet rs = JdbcCommonTestUtils.resultSetReturningMetadata(metadata);
 
-        when(rs.getObject(Mockito.anyInt())).thenReturn(bigDecimal);
+        when(rs.getObject(anyInt())).thenReturn(bigDecimal);
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -604,7 +605,7 @@ public class TestJdbcCommon extends AbstractConnectionTest {
         when(clob.getCharacterStream()).thenReturn(reader);
         when(clob.length()).thenReturn((long) byteBuffer.length);
         doThrow(SQLFeatureNotSupportedException.class).when(clob).free();
-        when(rs.getClob(Mockito.anyInt())).thenReturn(clob);
+        when(rs.getClob(anyInt())).thenReturn(clob);
 
         final InputStream instream = JdbcCommonTestUtils.convertResultSetToAvroInputStream(rs);
 
@@ -631,14 +632,14 @@ public class TestJdbcCommon extends AbstractConnectionTest {
         final ResultSet rs = JdbcCommonTestUtils.resultSetReturningMetadata(metadata);
 
         final byte[] byteBuffer = "test blob".getBytes(StandardCharsets.UTF_8);
-        when(rs.getObject(Mockito.anyInt())).thenReturn(byteBuffer);
+        when(rs.getObject(anyInt())).thenReturn(byteBuffer);
 
         ByteArrayInputStream bais = new ByteArrayInputStream(byteBuffer);
         Blob blob = mock(Blob.class);
         when(blob.getBinaryStream()).thenReturn(bais);
         when(blob.length()).thenReturn((long) byteBuffer.length);
         doThrow(SQLFeatureNotSupportedException.class).when(blob).free();
-        when(rs.getBlob(Mockito.anyInt())).thenReturn(blob);
+        when(rs.getBlob(anyInt())).thenReturn(blob);
 
         final InputStream instream = JdbcCommonTestUtils.convertResultSetToAvroInputStream(rs);
 
@@ -666,7 +667,7 @@ public class TestJdbcCommon extends AbstractConnectionTest {
         final ResultSet rs = JdbcCommonTestUtils.resultSetReturningMetadata(metadata);
 
         final short s = 25;
-        when(rs.getObject(Mockito.anyInt())).thenReturn(s);
+        when(rs.getObject(anyInt())).thenReturn(s);
 
         final InputStream instream = JdbcCommonTestUtils.convertResultSetToAvroInputStream(rs);
 
@@ -694,7 +695,7 @@ public class TestJdbcCommon extends AbstractConnectionTest {
         final ResultSet rs = JdbcCommonTestUtils.resultSetReturningMetadata(metadata);
 
         final long ret = 0L;
-        when(rs.getObject(Mockito.anyInt())).thenReturn(ret);
+        when(rs.getObject(anyInt())).thenReturn(ret);
 
         final InputStream instream = JdbcCommonTestUtils.convertResultSetToAvroInputStream(rs);
 
@@ -722,7 +723,7 @@ public class TestJdbcCommon extends AbstractConnectionTest {
         final ResultSet rs = JdbcCommonTestUtils.resultSetReturningMetadata(metadata);
 
         final long ret = 0L;
-        when(rs.getObject(Mockito.anyInt())).thenReturn(ret);
+        when(rs.getObject(anyInt())).thenReturn(ret);
 
         final InputStream instream = JdbcCommonTestUtils.convertResultSetToAvroInputStream(rs);
 
@@ -776,7 +777,7 @@ public class TestJdbcCommon extends AbstractConnectionTest {
     }
 
     private void testConvertToAvroStreamForDateTime(
-            JdbcCommon.AvroConversionOptions options, BiConsumer<GenericRecord, java.sql.Date> assertDate,
+            JdbcCommon.AvroConversionOptions options, BiConsumer<GenericRecord, Date> assertDate,
             BiConsumer<GenericRecord, Time> assertTime, BiConsumer<GenericRecord, Timestamp> assertTimeStamp)
             throws SQLException, IOException {
 
@@ -790,7 +791,7 @@ public class TestJdbcCommon extends AbstractConnectionTest {
 
         when(metadata.getColumnType(1)).thenReturn(Types.DATE);
         when(metadata.getColumnName(1)).thenReturn("date");
-        final java.sql.Date date = java.sql.Date.valueOf("2017-05-10");
+        final Date date = Date.valueOf("2017-05-10");
         when(rs.getObject(1)).thenReturn(date);
 
         when(metadata.getColumnType(2)).thenReturn(Types.TIME);
@@ -804,7 +805,7 @@ public class TestJdbcCommon extends AbstractConnectionTest {
         when(rs.getObject(3)).thenReturn(timestamp);
 
         final AtomicInteger counter = new AtomicInteger(1);
-        Mockito.doAnswer((Answer<Boolean>) invocation -> counter.getAndDecrement() > 0).when(rs).next();
+        doAnswer((Answer<Boolean>) invocation -> counter.getAndDecrement() > 0).when(rs).next();
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-dbcp-utils/src/main/java/org/apache/nifi/dbcp/utils/DriverUtils.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-dbcp-utils/src/main/java/org/apache/nifi/dbcp/utils/DriverUtils.java
@@ -34,6 +34,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Pattern;
 
+import static java.lang.reflect.Modifier.isAbstract;
+
 public class DriverUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DriverUtils.class);
@@ -136,7 +138,7 @@ public class DriverUtils {
 
         for (final ResourceReference resource : driverResources.flattenRecursively().asList()) {
             try {
-                final List<File> jarFiles = DriverUtils.getJarFilesFromResource(resource);
+                final List<File> jarFiles = getJarFilesFromResource(resource);
                 for (final File jarFile : jarFiles) {
                     driverClasses.addAll(scanJarForDriverClasses(jarFile));
                 }
@@ -199,7 +201,7 @@ public class DriverUtils {
             // Check if it implements Driver interface and is not abstract/interface
             return Driver.class.isAssignableFrom(clazz)
                     && !clazz.isInterface()
-                    && !java.lang.reflect.Modifier.isAbstract(clazz.getModifiers());
+                    && !isAbstract(clazz.getModifiers());
         } catch (final Throwable e) {
             // Class couldn't be loaded or has issues - not a valid driver
             return false;

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/event/StandardEventFactory.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/event/StandardEventFactory.java
@@ -30,9 +30,9 @@ public class StandardEventFactory<T extends Event<?>> implements EventFactory<St
     public StandardEvent create(final byte[] data, final Map<String, String> metadata, final ChannelResponder responder) {
         String sender = null;
         String senderPort = null;
-        if (metadata != null && metadata.containsKey(EventFactory.SENDER_KEY)) {
-            sender = metadata.get(EventFactory.SENDER_KEY);
-            senderPort = metadata.get(EventFactory.SENDER_PORT_KEY);
+        if (metadata != null && metadata.containsKey(SENDER_KEY)) {
+            sender = metadata.get(SENDER_KEY);
+            senderPort = metadata.get(SENDER_PORT_KEY);
         }
         return new StandardEvent(sender, senderPort, data, responder);
     }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/test/java/org/apache/nifi/processor/util/listen/EventBatcherTest.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/test/java/org/apache/nifi/processor/util/listen/EventBatcherTest.java
@@ -29,7 +29,6 @@ import org.apache.nifi.util.MockProcessSession;
 import org.apache.nifi.util.SharedSessionState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
@@ -65,7 +64,7 @@ public class EventBatcherTest {
                 return event.getSender();
             }
         };
-        session = new MockProcessSession(new SharedSessionState(processor, idGenerator), Mockito.mock(Processor.class));
+        session = new MockProcessSession(new SharedSessionState(processor, idGenerator), mock(Processor.class));
         eventFactory = new StandardNetworkEventFactory();
     }
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
@@ -40,7 +40,6 @@ import org.apache.nifi.registry.flow.FlowAlreadyExistsException;
 import org.apache.nifi.registry.flow.FlowLocation;
 import org.apache.nifi.registry.flow.FlowRegistryBranch;
 import org.apache.nifi.registry.flow.FlowRegistryBucket;
-import org.apache.nifi.registry.flow.FlowRegistryClient;
 import org.apache.nifi.registry.flow.FlowRegistryClientConfigurationContext;
 import org.apache.nifi.registry.flow.FlowRegistryClientInitializationContext;
 import org.apache.nifi.registry.flow.FlowRegistryException;
@@ -830,7 +829,7 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
                 try {
                     String branch = context.getProperty(REPOSITORY_BRANCH).getValue();
                     if (StringUtils.isBlank(branch)) {
-                        branch = FlowRegistryClient.DEFAULT_BRANCH_NAME;
+                        branch = DEFAULT_BRANCH_NAME;
                     }
 
                     final String exclusionPatternValue = context.getProperty(DIRECTORY_FILTER_EXCLUDE).getValue();

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -451,8 +452,8 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
      *            the Hadoop Configuration
      * @return CompressionCodec or null
      */
-    protected org.apache.hadoop.io.compress.CompressionCodec getCompressionCodec(ProcessContext context, Configuration configuration) {
-        org.apache.hadoop.io.compress.CompressionCodec codec = null;
+    protected CompressionCodec getCompressionCodec(ProcessContext context, Configuration configuration) {
+        CompressionCodec codec = null;
         if (context.getProperty(COMPRESSION_CODEC).isSet()) {
             String compressionClassname = CompressionType.valueOf(context.getProperty(COMPRESSION_CODEC).getValue()).toString();
             CompressionCodecFactory ccf = new CompressionCodecFactory(configuration);

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/CompressionType.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/CompressionType.java
@@ -66,7 +66,7 @@ public enum CompressionType {
 
     public static AllowableValue[] allowableValues() {
         List<AllowableValue> values = new ArrayList<>();
-        for (CompressionType type : CompressionType.values()) {
+        for (CompressionType type : values()) {
             values.add(new AllowableValue(type.name(), type.name(), type.getDescription()));
         }
         return values.toArray(new AllowableValue[values.size()]);

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/WriteJsonResult.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/WriteJsonResult.java
@@ -46,6 +46,7 @@ import org.apache.nifi.serialization.record.util.DataTypeUtils;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
+import java.sql.Time;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -336,7 +337,7 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
             return;
         }
 
-        if (value instanceof java.sql.Time) {
+        if (value instanceof Time) {
             final Object formatted = STRING_FIELD_CONVERTER.convertField(value, Optional.ofNullable(timeFormat), fieldName);
             generator.writeObject(formatted);
             return;

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/validation/StandardSchemaValidator.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/validation/StandardSchemaValidator.java
@@ -34,6 +34,9 @@ import org.apache.nifi.serialization.record.validation.ValidationError;
 import org.apache.nifi.serialization.record.validation.ValidationErrorType;
 
 import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
 
@@ -250,13 +253,13 @@ public class StandardSchemaValidator implements RecordSchemaValidator {
             case CHAR:
                 return value instanceof Character;
             case DATE:
-                return value instanceof java.sql.Date;
+                return value instanceof Date;
             case STRING:
                 return value instanceof String;
             case TIME:
-                return value instanceof java.sql.Time;
+                return value instanceof Time;
             case TIMESTAMP:
-                return value instanceof java.sql.Timestamp;
+                return value instanceof Timestamp;
 
             // Numeric data types
             case BIGINT:

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
@@ -401,14 +401,14 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
     }
 
     private void handleUnexpectedError(final ProcessSession session, FlowFile flowFile, final Exception e) {
-        flowFile = session.putAttribute(flowFile, GoogleDriveAttributes.ERROR_MESSAGE, e.getMessage());
+        flowFile = session.putAttribute(flowFile, ERROR_MESSAGE, e.getMessage());
         flowFile = session.penalize(flowFile);
         session.transfer(flowFile, REL_FAILURE);
     }
 
     private void handleExpectedError(final ProcessSession session, FlowFile flowFile, final GoogleJsonResponseException e) {
-        flowFile = session.putAttribute(flowFile, GoogleDriveAttributes.ERROR_MESSAGE, e.getMessage());
-        flowFile = session.putAttribute(flowFile, GoogleDriveAttributes.ERROR_CODE, valueOf(e.getStatusCode()));
+        flowFile = session.putAttribute(flowFile, ERROR_MESSAGE, e.getMessage());
+        flowFile = session.putAttribute(flowFile, ERROR_CODE, valueOf(e.getStatusCode()));
         flowFile = session.penalize(flowFile);
         session.transfer(flowFile, REL_FAILURE);
     }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractStartGcpVisionOperation.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractStartGcpVisionOperation.java
@@ -18,6 +18,7 @@
 package org.apache.nifi.processors.gcp.vision;
 
 import com.google.api.gax.longrunning.OperationFuture;
+import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -38,7 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class AbstractStartGcpVisionOperation<B extends com.google.protobuf.Message.Builder> extends AbstractGcpVisionProcessor  {
+public abstract class AbstractStartGcpVisionOperation<B extends Message.Builder> extends AbstractGcpVisionProcessor  {
     public static final PropertyDescriptor FEATURE_TYPE = new PropertyDescriptor.Builder()
             .name("Vision Feature Type")
             .description("Type of GCP Vision Feature. The value of this property applies when the JSON Payload property is configured. " +

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/credentials/service/GCPCredentialsControllerServiceMigrationTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/credentials/service/GCPCredentialsControllerServiceMigrationTest.java
@@ -18,7 +18,6 @@ package org.apache.nifi.processors.gcp.credentials.service;
 
 import org.apache.nifi.migration.ProxyServiceMigration;
 import org.apache.nifi.processors.gcp.credentials.factory.AuthenticationStrategy;
-import org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors;
 import org.apache.nifi.util.MockPropertyConfiguration;
 import org.apache.nifi.util.PropertyMigrationResult;
 import org.junit.jupiter.api.Test;
@@ -26,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors.AUTHENTICATION_STRATEGY;
 import static org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors.LEGACY_USE_APPLICATION_DEFAULT_CREDENTIALS;
 import static org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors.LEGACY_USE_COMPUTE_ENGINE_CREDENTIALS;
 import static org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors.SERVICE_ACCOUNT_JSON;
@@ -41,64 +41,64 @@ class GCPCredentialsControllerServiceMigrationTest {
     @Test
     void testMigratesApplicationDefaultFlag() {
         final Map<String, String> properties = new HashMap<>();
-        properties.put(CredentialPropertyDescriptors.LEGACY_USE_APPLICATION_DEFAULT_CREDENTIALS.getName(), "true");
+        properties.put(LEGACY_USE_APPLICATION_DEFAULT_CREDENTIALS.getName(), "true");
 
         final MockPropertyConfiguration configuration = new MockPropertyConfiguration(properties);
         service.migrateProperties(configuration);
 
         assertEquals(AuthenticationStrategy.APPLICATION_DEFAULT.getValue(),
-                configuration.getRawProperties().get(CredentialPropertyDescriptors.AUTHENTICATION_STRATEGY.getName()));
-        assertFalse(configuration.getRawProperties().containsKey(CredentialPropertyDescriptors.LEGACY_USE_APPLICATION_DEFAULT_CREDENTIALS.getName()));
+                configuration.getRawProperties().get(AUTHENTICATION_STRATEGY.getName()));
+        assertFalse(configuration.getRawProperties().containsKey(LEGACY_USE_APPLICATION_DEFAULT_CREDENTIALS.getName()));
     }
 
     @Test
     void testMigratesServiceAccountFile() {
         final Map<String, String> properties = new HashMap<>();
-        properties.put(CredentialPropertyDescriptors.SERVICE_ACCOUNT_JSON_FILE.getName(), "/tmp/account.json");
+        properties.put(SERVICE_ACCOUNT_JSON_FILE.getName(), "/tmp/account.json");
 
         final MockPropertyConfiguration configuration = new MockPropertyConfiguration(properties);
         service.migrateProperties(configuration);
 
         assertEquals(AuthenticationStrategy.SERVICE_ACCOUNT_JSON_FILE.getValue(),
-                configuration.getRawProperties().get(CredentialPropertyDescriptors.AUTHENTICATION_STRATEGY.getName()));
+                configuration.getRawProperties().get(AUTHENTICATION_STRATEGY.getName()));
     }
 
     @Test
     void testMigratesServiceAccountJson() {
         final Map<String, String> properties = new HashMap<>();
-        properties.put(CredentialPropertyDescriptors.SERVICE_ACCOUNT_JSON.getName(), SERVICE_ACCOUNT_JSON_PLACEHOLDER);
+        properties.put(SERVICE_ACCOUNT_JSON.getName(), SERVICE_ACCOUNT_JSON_PLACEHOLDER);
 
         final MockPropertyConfiguration configuration = new MockPropertyConfiguration(properties);
         service.migrateProperties(configuration);
 
         assertEquals(AuthenticationStrategy.SERVICE_ACCOUNT_JSON.getValue(),
-                configuration.getRawProperties().get(CredentialPropertyDescriptors.AUTHENTICATION_STRATEGY.getName()));
+                configuration.getRawProperties().get(AUTHENTICATION_STRATEGY.getName()));
     }
 
     @Test
     void testMigratesComputeEngineFlag() {
         final Map<String, String> properties = new HashMap<>();
-        properties.put(CredentialPropertyDescriptors.LEGACY_USE_COMPUTE_ENGINE_CREDENTIALS.getName(), "true");
+        properties.put(LEGACY_USE_COMPUTE_ENGINE_CREDENTIALS.getName(), "true");
 
         final MockPropertyConfiguration configuration = new MockPropertyConfiguration(properties);
         service.migrateProperties(configuration);
 
         assertEquals(AuthenticationStrategy.COMPUTE_ENGINE.getValue(),
-                configuration.getRawProperties().get(CredentialPropertyDescriptors.AUTHENTICATION_STRATEGY.getName()));
-        assertFalse(configuration.getRawProperties().containsKey(CredentialPropertyDescriptors.LEGACY_USE_COMPUTE_ENGINE_CREDENTIALS.getName()));
+                configuration.getRawProperties().get(AUTHENTICATION_STRATEGY.getName()));
+        assertFalse(configuration.getRawProperties().containsKey(LEGACY_USE_COMPUTE_ENGINE_CREDENTIALS.getName()));
     }
 
     @Test
     void testDoesNotOverrideExistingAuthenticationStrategy() {
         final Map<String, String> properties = new HashMap<>();
-        properties.put(CredentialPropertyDescriptors.AUTHENTICATION_STRATEGY.getName(), AuthenticationStrategy.SERVICE_ACCOUNT_JSON.getValue());
-        properties.put(CredentialPropertyDescriptors.SERVICE_ACCOUNT_JSON_FILE.getName(), "/tmp/account.json");
+        properties.put(AUTHENTICATION_STRATEGY.getName(), AuthenticationStrategy.SERVICE_ACCOUNT_JSON.getValue());
+        properties.put(SERVICE_ACCOUNT_JSON_FILE.getName(), "/tmp/account.json");
 
         final MockPropertyConfiguration configuration = new MockPropertyConfiguration(properties);
         service.migrateProperties(configuration);
 
         assertEquals(AuthenticationStrategy.SERVICE_ACCOUNT_JSON.getValue(),
-                configuration.getRawProperties().get(CredentialPropertyDescriptors.AUTHENTICATION_STRATEGY.getName()));
+                configuration.getRawProperties().get(AUTHENTICATION_STRATEGY.getName()));
     }
 
     @Test
@@ -109,32 +109,32 @@ class GCPCredentialsControllerServiceMigrationTest {
         service.migrateProperties(configuration);
 
         assertEquals(AuthenticationStrategy.APPLICATION_DEFAULT.getValue(),
-                configuration.getRawProperties().get(CredentialPropertyDescriptors.AUTHENTICATION_STRATEGY.getName()));
+                configuration.getRawProperties().get(AUTHENTICATION_STRATEGY.getName()));
     }
 
     @Test
     void testLegacyPropertiesDeriveAuthenticationStrategyWhenMissing() {
         final Map<String, String> properties = new HashMap<>();
-        properties.put(CredentialPropertyDescriptors.SERVICE_ACCOUNT_JSON_FILE.getName(), "/tmp/account.json");
+        properties.put(SERVICE_ACCOUNT_JSON_FILE.getName(), "/tmp/account.json");
 
         final MockPropertyConfiguration configuration = new MockPropertyConfiguration(properties);
         service.migrateProperties(configuration);
 
         assertEquals(AuthenticationStrategy.SERVICE_ACCOUNT_JSON_FILE.getValue(),
-                configuration.getRawProperties().get(CredentialPropertyDescriptors.AUTHENTICATION_STRATEGY.getName()));
+                configuration.getRawProperties().get(AUTHENTICATION_STRATEGY.getName()));
     }
 
     @Test
     void testDoesNotOverrideExplicitStrategyWhenServiceAccountPropertiesSet() {
         final Map<String, String> properties = new HashMap<>();
-        properties.put(CredentialPropertyDescriptors.AUTHENTICATION_STRATEGY.getName(), AuthenticationStrategy.APPLICATION_DEFAULT.getValue());
-        properties.put(CredentialPropertyDescriptors.SERVICE_ACCOUNT_JSON_FILE.getName(), "/tmp/account.json");
+        properties.put(AUTHENTICATION_STRATEGY.getName(), AuthenticationStrategy.APPLICATION_DEFAULT.getValue());
+        properties.put(SERVICE_ACCOUNT_JSON_FILE.getName(), "/tmp/account.json");
 
         final MockPropertyConfiguration configuration = new MockPropertyConfiguration(properties);
         service.migrateProperties(configuration);
 
         assertEquals(AuthenticationStrategy.APPLICATION_DEFAULT.getValue(),
-                configuration.getRawProperties().get(CredentialPropertyDescriptors.AUTHENTICATION_STRATEGY.getName()));
+                configuration.getRawProperties().get(AUTHENTICATION_STRATEGY.getName()));
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveIT.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveIT.java
@@ -52,11 +52,11 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
         File file = createFileWithDefaultContent("test_file.txt", mainFolderId);
 
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
-        inputFlowFileAttributes.put(GoogleDriveAttributes.ID, file.getId());
-        inputFlowFileAttributes.put(GoogleDriveAttributes.FILENAME, file.getName());
-        inputFlowFileAttributes.put(GoogleDriveAttributes.SIZE, valueOf(DEFAULT_FILE_CONTENT.length()));
-        inputFlowFileAttributes.put(GoogleDriveAttributes.SIZE_AVAILABLE, "true");
-        inputFlowFileAttributes.put(GoogleDriveAttributes.MIME_TYPE, "text/plain");
+        inputFlowFileAttributes.put(ID, file.getId());
+        inputFlowFileAttributes.put(FILENAME, file.getName());
+        inputFlowFileAttributes.put(SIZE, valueOf(DEFAULT_FILE_CONTENT.length()));
+        inputFlowFileAttributes.put(SIZE_AVAILABLE, "true");
+        inputFlowFileAttributes.put(MIME_TYPE, "text/plain");
 
         Set<Map<String, String>> expectedAttributes = new HashSet<>(singletonList(inputFlowFileAttributes));
         List<String> expectedContent = singletonList(DEFAULT_FILE_CONTENT);
@@ -73,13 +73,13 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
     @Test
     void testInputFlowFileReferencesMissingFile() {
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
-        inputFlowFileAttributes.put(GoogleDriveAttributes.ID, "missing");
-        inputFlowFileAttributes.put(GoogleDriveAttributes.FILENAME, "missing_filename");
+        inputFlowFileAttributes.put(ID, "missing");
+        inputFlowFileAttributes.put(FILENAME, "missing_filename");
 
         Set<Map<String, String>> expectedFailureAttributes = new HashSet<>(singletonList(
-                Map.of(GoogleDriveAttributes.ID, "missing",
-                    GoogleDriveAttributes.FILENAME, "missing_filename",
-                    GoogleDriveAttributes.ERROR_CODE, "404")
+                Map.of(ID, "missing",
+                    FILENAME, "missing_filename",
+                    ERROR_CODE, "404")
         ));
 
         testRunner.enqueue("unimportant_data", inputFlowFileAttributes);
@@ -94,8 +94,8 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
         File file = createFileWithDefaultContent("test_file.txt", mainFolderId);
 
         Map<String, String> inputFlowFileAttributes = new HashMap<>();
-        inputFlowFileAttributes.put(GoogleDriveAttributes.ID, file.getId());
-        inputFlowFileAttributes.put(GoogleDriveAttributes.FILENAME, file.getName());
+        inputFlowFileAttributes.put(ID, file.getId());
+        inputFlowFileAttributes.put(FILENAME, file.getName());
         MockFlowFile input = new MockFlowFile(1) {
             final AtomicBoolean throwException = new AtomicBoolean(true);
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrivePathTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrivePathTest.java
@@ -26,7 +26,6 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -51,7 +50,7 @@ public class ListGoogleDrivePathTest implements OutputChecker {
 
     @BeforeEach
     void setUp() throws Exception {
-        mockDriverService = mock(Drive.class, Mockito.RETURNS_DEEP_STUBS);
+        mockDriverService = mock(Drive.class, RETURNS_DEEP_STUBS);
 
         testSubject = new ListGoogleDrive() {
             @Override
@@ -151,9 +150,9 @@ public class ListGoogleDrivePathTest implements OutputChecker {
 
     private Map<String, String> createAttributeMap(String fileId, String fileName, String path) {
         return Map.of(
-                GoogleDriveAttributes.ID, fileId,
-                GoogleDriveAttributes.FILENAME, fileName,
-                GoogleDriveAttributes.PATH, path
+                ID, fileId,
+                FILENAME, fileName,
+                PATH, path
         );
     }
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
@@ -33,7 +33,6 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -83,7 +82,7 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
 
     @BeforeEach
     void setUp() throws Exception {
-        mockDriverService = mock(Drive.class, Mockito.RETURNS_DEEP_STUBS);
+        mockDriverService = mock(Drive.class, RETURNS_DEEP_STUBS);
 
         when(mockDriverService.files()
                 .get(folderId)
@@ -300,25 +299,25 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
                 return super.put(key, value);
             }
         };
-        inputFlowFileAttributes.put(GoogleDriveAttributes.ID, id);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.FILENAME, filename);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.SIZE, valueOf(size != null ? size : 0L));
-        inputFlowFileAttributes.put(GoogleDriveAttributes.SIZE_AVAILABLE, valueOf(size != null));
-        inputFlowFileAttributes.put(GoogleDriveAttributes.TIMESTAMP, valueOf(expectedTimestamp));
-        inputFlowFileAttributes.put(GoogleDriveAttributes.CREATED_TIME, Instant.ofEpochMilli(createdTime != null ? createdTime : 0L).toString());
-        inputFlowFileAttributes.put(GoogleDriveAttributes.MODIFIED_TIME, Instant.ofEpochMilli(modifiedTime != null ? modifiedTime : 0L).toString());
-        inputFlowFileAttributes.put(GoogleDriveAttributes.MIME_TYPE, mimeType);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.PATH, folderName);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.OWNER, owner);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.LAST_MODIFYING_USER, lastModifyingUser);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.WEB_VIEW_LINK, webViewLink);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.WEB_CONTENT_LINK, webContentLink);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.PARENT_FOLDER_ID, folderId);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.PARENT_FOLDER_NAME, folderName);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.LISTED_FOLDER_ID, folderId);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.LISTED_FOLDER_NAME, folderName);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.SHARED_DRIVE_ID, driveId);
-        inputFlowFileAttributes.put(GoogleDriveAttributes.SHARED_DRIVE_NAME, driveName);
+        inputFlowFileAttributes.put(ID, id);
+        inputFlowFileAttributes.put(FILENAME, filename);
+        inputFlowFileAttributes.put(SIZE, valueOf(size != null ? size : 0L));
+        inputFlowFileAttributes.put(SIZE_AVAILABLE, valueOf(size != null));
+        inputFlowFileAttributes.put(TIMESTAMP, valueOf(expectedTimestamp));
+        inputFlowFileAttributes.put(CREATED_TIME, Instant.ofEpochMilli(createdTime != null ? createdTime : 0L).toString());
+        inputFlowFileAttributes.put(MODIFIED_TIME, Instant.ofEpochMilli(modifiedTime != null ? modifiedTime : 0L).toString());
+        inputFlowFileAttributes.put(MIME_TYPE, mimeType);
+        inputFlowFileAttributes.put(PATH, folderName);
+        inputFlowFileAttributes.put(OWNER, owner);
+        inputFlowFileAttributes.put(LAST_MODIFYING_USER, lastModifyingUser);
+        inputFlowFileAttributes.put(WEB_VIEW_LINK, webViewLink);
+        inputFlowFileAttributes.put(WEB_CONTENT_LINK, webContentLink);
+        inputFlowFileAttributes.put(PARENT_FOLDER_ID, folderId);
+        inputFlowFileAttributes.put(PARENT_FOLDER_NAME, folderName);
+        inputFlowFileAttributes.put(LISTED_FOLDER_ID, folderId);
+        inputFlowFileAttributes.put(LISTED_FOLDER_NAME, folderName);
+        inputFlowFileAttributes.put(SHARED_DRIVE_ID, driveId);
+        inputFlowFileAttributes.put(SHARED_DRIVE_NAME, driveName);
         Set<Map<String, String>> expectedAttributes = new HashSet<>(singletonList(inputFlowFileAttributes));
 
         testRunner.run();

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/PutGCSObjectTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/PutGCSObjectTest.java
@@ -49,7 +49,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.cloud.storage.Storage.PredefinedAcl.BUCKET_OWNER_READ;
-import static org.apache.nifi.processors.gcp.storage.PutGCSObject.GZIPCONTENT;
 import static org.apache.nifi.processors.gcp.storage.StorageAttributes.BUCKET_ATTR;
 import static org.apache.nifi.processors.gcp.storage.StorageAttributes.CACHE_CONTROL_ATTR;
 import static org.apache.nifi.processors.gcp.storage.StorageAttributes.COMPONENT_COUNT_ATTR;
@@ -236,7 +235,7 @@ public class PutGCSObjectTest extends AbstractGCSTest {
         runner.setProperty(PutGCSObject.ENCRYPTION_KEY, ENCRYPTION_KEY);
         runner.setProperty(PutGCSObject.OVERWRITE, String.valueOf(OVERWRITE));
         runner.setProperty(PutGCSObject.CONTENT_DISPOSITION_TYPE, CONTENT_DISPOSITION_TYPE);
-        runner.setProperty(GZIPCONTENT, Boolean.FALSE.toString());
+        runner.setProperty(PutGCSObject.GZIPCONTENT, Boolean.FALSE.toString());
         runner.assertValid();
 
         when(storage.createFrom(blobInfoArgumentCaptor.capture(),

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
@@ -55,6 +55,7 @@ import org.codehaus.groovy.runtime.ResourceGroovyMethods;
 import org.codehaus.groovy.runtime.StackTraceUtils;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
@@ -172,7 +173,7 @@ public class ExecuteGroovyScript extends AbstractProcessor {
         return new File(f);
     }
 
-    private void callScriptStatic(String method, final ProcessContext context) throws IllegalAccessException, java.lang.reflect.InvocationTargetException {
+    private void callScriptStatic(String method, final ProcessContext context) throws IllegalAccessException, InvocationTargetException {
         if (compiled != null) {
             Method m = null;
             try {
@@ -244,7 +245,7 @@ public class ExecuteGroovyScript extends AbstractProcessor {
     @Override
     public void onPropertyModified(final PropertyDescriptor descriptor, final String oldValue, final String newValue) {
         // Only re-create the shell if necessary, this helps if loading native libraries
-        if (ExecuteGroovyScript.ADD_CLASSPATH.equals(descriptor)) {
+        if (ADD_CLASSPATH.equals(descriptor)) {
             this.shell = null;
         }
         this.compiled = null;

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/flow/GroovyProcessSessionWrap.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/flow/GroovyProcessSessionWrap.java
@@ -20,6 +20,7 @@ import groovy.lang.Closure;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.FlowFileFilter;
 import org.apache.nifi.processor.ProcessSession;
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 
 import java.util.List;
 
@@ -63,7 +64,7 @@ public class GroovyProcessSessionWrap extends ProcessSessionWrap {
             if (res instanceof final FlowFileFilter.FlowFileFilterResult flowFileFilterResult) {
                 return flowFileFilterResult;
             }
-            return (org.codehaus.groovy.runtime.DefaultGroovyMethods.asBoolean(res)
+            return (DefaultGroovyMethods.asBoolean(res)
                     ? FlowFileFilter.FlowFileFilterResult.ACCEPT_AND_CONTINUE : FlowFileFilter.FlowFileFilterResult.REJECT_AND_CONTINUE);
         });
     }

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/sql/OSql.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/sql/OSql.java
@@ -25,6 +25,7 @@ import java.io.Reader;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.sql.Types;
 
 /***
@@ -53,8 +54,8 @@ public class OSql extends Sql {
                     statement.setDate(i, new java.sql.Date(date.getTime()));
                     return;
                 }
-                if (p.getType() == Types.TIMESTAMP && p.getValue() instanceof final java.util.Date date && !(p.getValue() instanceof java.sql.Timestamp)) {
-                    statement.setTimestamp(i, new java.sql.Timestamp(date.getTime()));
+                if (p.getType() == Types.TIMESTAMP && p.getValue() instanceof final java.util.Date date && !(p.getValue() instanceof Timestamp)) {
+                    statement.setTimestamp(i, new Timestamp(date.getTime()));
                     return;
                 }
             }

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFS.java
@@ -410,7 +410,7 @@ public class GetHDFS extends AbstractHadoopProcessor {
      *
      * @param context context
      * @return null if POLLING_INTERVAL has not lapsed. Will return an empty set if no files were found on HDFS that matched the configured filters
-     * @throws java.io.IOException ex
+     * @throws IOException ex
      */
     protected Set<Path> performListing(final ProcessContext context) throws IOException, InterruptedException {
 
@@ -448,7 +448,7 @@ public class GetHDFS extends AbstractHadoopProcessor {
      * @param dir dir
      * @param filesVisited filesVisited
      * @return files to process
-     * @throws java.io.IOException ex
+     * @throws IOException ex
      */
     protected Set<Path> selectFiles(final FileSystem hdfs, final Path dir, Set<Path> filesVisited) throws IOException, InterruptedException {
         if (null == filesVisited) {

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestListHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestListHDFS.java
@@ -52,8 +52,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.apache.nifi.processors.hadoop.ListHDFS.LATEST_TIMESTAMP_KEY;
-import static org.apache.nifi.processors.hadoop.ListHDFS.REL_SUCCESS;
 import static org.apache.nifi.processors.hadoop.util.FilterMode.FILTER_DIRECTORIES_AND_FILES;
 import static org.apache.nifi.processors.hadoop.util.FilterMode.FILTER_MODE_FILES_ONLY;
 import static org.apache.nifi.processors.hadoop.util.FilterMode.FILTER_MODE_FULL_PATH;
@@ -369,7 +367,7 @@ class TestListHDFS {
 
         runner.assertAllFlowFilesTransferred(ListHDFS.REL_SUCCESS, 1);
         Map<String, String> newState = runner.getStateManager().getState(Scope.CLUSTER).toMap();
-        assertEquals("2000", newState.get(LATEST_TIMESTAMP_KEY));
+        assertEquals("2000", newState.get(ListHDFS.LATEST_TIMESTAMP_KEY));
     }
 
     @Test
@@ -545,8 +543,8 @@ class TestListHDFS {
 
         runner.run();
 
-        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
-        final List<MockFlowFile> flowFilesForRelationship = runner.getFlowFilesForRelationship(REL_SUCCESS);
+        runner.assertAllFlowFilesTransferred(ListHDFS.REL_SUCCESS, 1);
+        final List<MockFlowFile> flowFilesForRelationship = runner.getFlowFilesForRelationship(ListHDFS.REL_SUCCESS);
         final MockFlowFile flowFile = flowFilesForRelationship.getFirst();
         flowFile.assertAttributeEquals("record.count", "8");
     }

--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/main/java/org/apache/nifi/processors/iceberg/PutIcebergRecord.java
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/main/java/org/apache/nifi/processors/iceberg/PutIcebergRecord.java
@@ -40,6 +40,7 @@ import org.apache.nifi.processors.iceberg.record.DelegatedRecord;
 import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
+import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.services.iceberg.IcebergCatalog;
 import org.apache.nifi.services.iceberg.IcebergRowWriter;
 import org.apache.nifi.services.iceberg.IcebergWriter;
@@ -233,7 +234,7 @@ public class PutIcebergRecord extends AbstractProcessor {
             final Types.StructType struct,
             final AtomicLong recordsProcessed
     ) throws IOException, MalformedRecordException {
-        org.apache.nifi.serialization.record.Record inputRecord = recordReader.nextRecord();
+        Record inputRecord = recordReader.nextRecord();
         while (inputRecord != null) {
             final DelegatedRecord delegatedRecord = new DelegatedRecord(inputRecord, struct);
             // Write Records to storage based on Iceberg Table configuration

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProperties.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProperties.java
@@ -72,10 +72,10 @@ public class JMSConnectionFactoryProperties {
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            JMSConnectionFactoryProperties.JMS_CONNECTION_FACTORY_IMPL,
-            JMSConnectionFactoryProperties.JMS_CLIENT_LIBRARIES,
-            JMSConnectionFactoryProperties.JMS_BROKER_URI,
-            JMSConnectionFactoryProperties.JMS_SSL_CONTEXT_SERVICE
+            JMS_CONNECTION_FACTORY_IMPL,
+            JMS_CLIENT_LIBRARIES,
+            JMS_BROKER_URI,
+            JMS_SSL_CONTEXT_SERVICE
     );
 
     public static List<PropertyDescriptor> getPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProperties.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProperties.java
@@ -24,7 +24,6 @@ import org.apache.nifi.components.Validator;
 import org.apache.nifi.components.resource.ResourceCardinality;
 import org.apache.nifi.components.resource.ResourceType;
 import org.apache.nifi.expression.ExpressionLanguageScope;
-import org.apache.nifi.processor.util.StandardValidators;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -86,7 +85,7 @@ public class JndiJmsConnectionFactoryProperties {
             .name("JNDI Principal")
             .description("The Principal to use when authenticating with JNDI (java.naming.security.principal).")
             .required(false)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
@@ -100,12 +99,12 @@ public class JndiJmsConnectionFactoryProperties {
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            JndiJmsConnectionFactoryProperties.JNDI_INITIAL_CONTEXT_FACTORY,
-            JndiJmsConnectionFactoryProperties.JNDI_PROVIDER_URL,
-            JndiJmsConnectionFactoryProperties.JNDI_CONNECTION_FACTORY_NAME,
-            JndiJmsConnectionFactoryProperties.JNDI_CLIENT_LIBRARIES,
-            JndiJmsConnectionFactoryProperties.JNDI_PRINCIPAL,
-            JndiJmsConnectionFactoryProperties.JNDI_CREDENTIALS
+            JNDI_INITIAL_CONTEXT_FACTORY,
+            JNDI_PROVIDER_URL,
+            JNDI_CONNECTION_FACTORY_NAME,
+            JNDI_CLIENT_LIBRARIES,
+            JNDI_PRINCIPAL,
+            JNDI_CREDENTIALS
     );
 
     public static List<PropertyDescriptor> getPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSPublisher.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSPublisher.java
@@ -145,7 +145,7 @@ class JMSPublisher extends JMSWorker {
     }
 
     /**
-     * Implementations of this interface use {@link jakarta.jms.Message} methods to set strongly typed properties.
+     * Implementations of this interface use {@link Message} methods to set strongly typed properties.
      */
     public interface JmsPropertySetter {
         void setProperty(final Message message, final String name, final String value) throws JMSException, NumberFormatException;

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/MessageBodyToBytesConverter.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/MessageBodyToBytesConverter.java
@@ -47,7 +47,7 @@ abstract class MessageBodyToBytesConverter {
      * @return  byte array representing the {@link TextMessage}
      */
     public static byte[] toBytes(TextMessage message) {
-        return MessageBodyToBytesConverter.toBytes(message, null);
+        return toBytes(message, null);
     }
 
     /**

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
@@ -295,7 +295,7 @@ public class ConsumeKafka extends AbstractProcessor implements VerifiableProcess
             .name("Key Record Reader")
             .description("The Record Reader to use for parsing the Kafka Record Key into a Record")
             .identifiesControllerService(RecordReaderFactory.class)
-            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .expressionLanguageSupported(NONE)
             .required(true)
             .dependsOn(KEY_FORMAT, KeyFormat.RECORD)
             .build();
@@ -853,7 +853,7 @@ public class ConsumeKafka extends AbstractProcessor implements VerifiableProcess
     }
 
     private Iterator<ByteRecord> transformDemarcator(final ProcessContext context, final Iterator<ByteRecord> consumerRecords) {
-        final String demarcatorValue = context.getProperty(ConsumeKafka.MESSAGE_DEMARCATOR).getValue();
+        final String demarcatorValue = context.getProperty(MESSAGE_DEMARCATOR).getValue();
         if (demarcatorValue == null) {
             return consumerRecords;
         }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/convert/WrapperRecordStreamKafkaMessageConverter.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/convert/WrapperRecordStreamKafkaMessageConverter.java
@@ -38,6 +38,7 @@ import org.apache.nifi.util.Tuple;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class WrapperRecordStreamKafkaMessageConverter extends AbstractRecordStreamKafkaMessageConverter {
 
@@ -50,7 +51,7 @@ public class WrapperRecordStreamKafkaMessageConverter extends AbstractRecordStre
             final RecordSetWriterFactory writerFactory,
             final RecordReaderFactory keyReaderFactory,
             final HeaderValueConverter headerValueConverter,
-            final java.util.regex.Pattern headerNamePattern,
+            final Pattern headerNamePattern,
             final KeyFormat keyFormat,
             final KeyEncoding keyEncoding,
             final boolean commitOffsets,

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/producer/convert/RecordStreamKafkaRecordConverter.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/producer/convert/RecordStreamKafkaRecordConverter.java
@@ -45,7 +45,7 @@ import java.util.Map;
 
 /**
  * {@link KafkaRecordConverter} implementation for transforming NiFi
- * {@link org.apache.nifi.serialization.record.Record} objects to {@link KafkaRecord} for publish to
+ * {@link Record} objects to {@link KafkaRecord} for publish to
  * Kafka.
  */
 public class RecordStreamKafkaRecordConverter implements KafkaRecordConverter {

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/producer/convert/RecordWrapperStreamKafkaRecordConverter.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/producer/convert/RecordWrapperStreamKafkaRecordConverter.java
@@ -45,7 +45,7 @@ import java.util.Map;
 
 /**
  * {@link KafkaRecordConverter} implementation for transforming NiFi
- * {@link org.apache.nifi.serialization.record.Record} objects to {@link KafkaRecord} for publish to
+ * {@link Record} objects to {@link KafkaRecord} for publish to
  * Kafka.
  */
 public class RecordWrapperStreamKafkaRecordConverter implements KafkaRecordConverter {

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/producer/wrapper/InjectMetadataRecord.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/producer/wrapper/InjectMetadataRecord.java
@@ -111,26 +111,26 @@ public class InjectMetadataRecord extends MapRecord {
 
     public static MapRecord toWrapperRecord(final HeaderValueConverter headerValueConverter, final ByteRecord consumerRecord, final Record record, final Tuple<RecordField, Object> tupleKey) {
         final RecordSchema schema = record.getSchema();
-        RecordSchema finalSchema = InjectMetadataRecord.toWrapperSchema(tupleKey.getKey(), schema);
+        RecordSchema finalSchema = toWrapperSchema(tupleKey.getKey(), schema);
 
         final Map<String, Object> valuesMetadata = new HashMap<>();
-        valuesMetadata.put(InjectMetadataRecord.TOPIC, consumerRecord.getTopic());
-        valuesMetadata.put(InjectMetadataRecord.PARTITION, consumerRecord.getPartition());
-        valuesMetadata.put(InjectMetadataRecord.OFFSET, consumerRecord.getOffset());
-        valuesMetadata.put(InjectMetadataRecord.TIMESTAMP, consumerRecord.getTimestamp());
+        valuesMetadata.put(TOPIC, consumerRecord.getTopic());
+        valuesMetadata.put(PARTITION, consumerRecord.getPartition());
+        valuesMetadata.put(OFFSET, consumerRecord.getOffset());
+        valuesMetadata.put(TIMESTAMP, consumerRecord.getTimestamp());
         if (tupleKey.getKey() != null) {
-            valuesMetadata.put(InjectMetadataRecord.KEY, tupleKey.getValue());
+            valuesMetadata.put(KEY, tupleKey.getValue());
         }
 
         final Map<String, Object> valuesHeaders = new HashMap<>();
         for (RecordHeader header : consumerRecord.getHeaders()) {
             valuesHeaders.put(header.key(), headerValueConverter.convert(header.value()));
         }
-        valuesMetadata.put(InjectMetadataRecord.HEADERS, valuesHeaders);
+        valuesMetadata.put(HEADERS, valuesHeaders);
 
         final Map<String, Object> valueMap = record.toMap();
         final Map<String, Object> valueMapWithInjectedMetadata = new HashMap<>(valueMap);
-        valueMapWithInjectedMetadata.put(InjectMetadataRecord.METADATA, valuesMetadata);
+        valueMapWithInjectedMetadata.put(METADATA, valuesMetadata);
 
         return new MapRecord(finalSchema, valueMapWithInjectedMetadata);
     }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/convert/RecordStreamKafkaMessageConverterTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/convert/RecordStreamKafkaMessageConverterTest.java
@@ -30,7 +30,6 @@ import org.apache.nifi.util.MockFlowFile;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -47,12 +46,13 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 class RecordStreamKafkaMessageConverterTest {
 
-    private final RecordSetWriterFactory writerFactory = Mockito.mock(RecordSetWriterFactory.class, Mockito.withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS));
+    private final RecordSetWriterFactory writerFactory = mock(RecordSetWriterFactory.class, withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS));
     private final ComponentLog logger = mock(ComponentLog.class);
-    private final ProcessSession session = Mockito.mock(ProcessSession.class, Mockito.withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS));
+    private final ProcessSession session = mock(ProcessSession.class, withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS));
 
     private final OffsetTracker offsetTracker = new OffsetTracker();
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/convert/WrapperRecordStreamKafkaMessageConverterTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/convert/WrapperRecordStreamKafkaMessageConverterTest.java
@@ -33,7 +33,6 @@ import org.apache.nifi.util.MockFlowFile;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -48,13 +47,14 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 class WrapperRecordStreamKafkaMessageConverterTest {
 
-    private final RecordSetWriterFactory writerFactory = Mockito.mock(RecordSetWriterFactory.class, Mockito.withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS));
-    private final RecordReaderFactory keyReaderFactory = Mockito.mock(RecordReaderFactory.class, Mockito.withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS));
+    private final RecordSetWriterFactory writerFactory = mock(RecordSetWriterFactory.class, withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS));
+    private final RecordReaderFactory keyReaderFactory = mock(RecordReaderFactory.class, withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS));
     private final ComponentLog logger = mock(ComponentLog.class);
-    private final ProcessSession session = Mockito.mock(ProcessSession.class, Mockito.withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS));
+    private final ProcessSession session = mock(ProcessSession.class, withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS));
 
     private final OffsetTracker offsetTracker = new OffsetTracker();
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionService.java
@@ -80,7 +80,7 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
             .name("AWS Web Identity Session Time")
             .description("Session time for AWS STS AssumeRoleWithWebIdentity (between 900 seconds and 3600 seconds).")
             .dependsOn(
-                    KafkaClientComponent.AWS_ROLE_SOURCE,
+                    AWS_ROLE_SOURCE,
                     AwsRoleSource.WEB_IDENTITY_TOKEN
             )
             .required(true)
@@ -93,7 +93,7 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
             .name("AWS Web Identity STS Region")
             .description("Region identifier used for the AWS Security Token Service when exchanging Web Identity tokens.")
             .dependsOn(
-                    KafkaClientComponent.AWS_ROLE_SOURCE,
+                    AWS_ROLE_SOURCE,
                     AwsRoleSource.WEB_IDENTITY_TOKEN
             )
             .required(false)
@@ -104,7 +104,7 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
             .name("AWS Web Identity STS Endpoint")
             .description("Optional endpoint override for the AWS Security Token Service.")
             .dependsOn(
-                    KafkaClientComponent.AWS_ROLE_SOURCE,
+                    AWS_ROLE_SOURCE,
                     AwsRoleSource.WEB_IDENTITY_TOKEN
             )
             .required(false)
@@ -116,7 +116,7 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
             .description("SSL Context Service used when communicating with AWS STS for Web Identity federation.")
             .identifiesControllerService(SSLContextProvider.class)
             .dependsOn(
-                    KafkaClientComponent.AWS_ROLE_SOURCE,
+                    AWS_ROLE_SOURCE,
                     AwsRoleSource.WEB_IDENTITY_TOKEN
             )
             .required(false)
@@ -134,10 +134,10 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
                 descriptors.remove();
                 // Add AWS MSK properties
                 descriptors.add(AWS_SASL_MECHANISM);
-                descriptors.add(KafkaClientComponent.AWS_ROLE_SOURCE);
-                descriptors.add(KafkaClientComponent.AWS_PROFILE_NAME);
-                descriptors.add(KafkaClientComponent.AWS_ASSUME_ROLE_ARN);
-                descriptors.add(KafkaClientComponent.AWS_ASSUME_ROLE_SESSION_NAME);
+                descriptors.add(AWS_ROLE_SOURCE);
+                descriptors.add(AWS_PROFILE_NAME);
+                descriptors.add(AWS_ASSUME_ROLE_ARN);
+                descriptors.add(AWS_ASSUME_ROLE_SESSION_NAME);
                 descriptors.add(AWS_WEB_IDENTITY_TOKEN_PROVIDER);
                 descriptors.add(AWS_WEB_IDENTITY_SESSION_TIME);
                 descriptors.add(AWS_WEB_IDENTITY_STS_REGION);
@@ -158,7 +158,7 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
     protected Collection<ValidationResult> customValidate(final ValidationContext validationContext) {
         final Collection<ValidationResult> results = new ArrayList<>(super.customValidate(validationContext));
 
-        final AwsRoleSource roleSource = validationContext.getProperty(KafkaClientComponent.AWS_ROLE_SOURCE).asAllowableValue(AwsRoleSource.class);
+        final AwsRoleSource roleSource = validationContext.getProperty(AWS_ROLE_SOURCE).asAllowableValue(AwsRoleSource.class);
         if (roleSource == AwsRoleSource.WEB_IDENTITY_TOKEN) {
             if (!validationContext.getProperty(AWS_WEB_IDENTITY_TOKEN_PROVIDER).isSet()) {
                 results.add(new ValidationResult.Builder()
@@ -194,7 +194,7 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
     }
 
     private void setAuthenticationProperties(final Properties properties, final PropertyContext propertyContext) {
-        final AwsRoleSource roleSource = propertyContext.getProperty(KafkaClientComponent.AWS_ROLE_SOURCE).asAllowableValue(AwsRoleSource.class);
+        final AwsRoleSource roleSource = propertyContext.getProperty(AWS_ROLE_SOURCE).asAllowableValue(AwsRoleSource.class);
         if (roleSource == AwsRoleSource.WEB_IDENTITY_TOKEN) {
             final AwsCredentialsProvider credentialsProvider = createWebIdentityCredentialsProvider(propertyContext);
             properties.put(AmazonMSKProperty.NIFI_AWS_MSK_CREDENTIALS_PROVIDER.getProperty(), credentialsProvider);
@@ -207,8 +207,8 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
             throw new IllegalStateException("AWS Web Identity Token Provider is required when AWS Role Source is set to Web Identity Provider");
         }
 
-        final String roleArn = propertyContext.getProperty(KafkaClientComponent.AWS_ASSUME_ROLE_ARN).getValue();
-        final String roleSessionName = propertyContext.getProperty(KafkaClientComponent.AWS_ASSUME_ROLE_SESSION_NAME).getValue();
+        final String roleArn = propertyContext.getProperty(AWS_ASSUME_ROLE_ARN).getValue();
+        final String roleSessionName = propertyContext.getProperty(AWS_ASSUME_ROLE_SESSION_NAME).getValue();
         final Long sessionTimeSeconds = propertyContext.getProperty(AWS_WEB_IDENTITY_SESSION_TIME).asTimePeriod(TimeUnit.SECONDS);
         final Integer sessionSeconds = sessionTimeSeconds == null ? null : sessionTimeSeconds.intValue();
         final String stsRegionId = propertyContext.getProperty(AWS_WEB_IDENTITY_STS_REGION).getValue();
@@ -351,8 +351,8 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
     public void migrateProperties(final PropertyConfiguration config) {
         // For backward compatibility: if an AWS Profile Name was configured previously,
         // set AWS Role Source to SPECIFIED_PROFILE
-        if (config.isPropertySet(KafkaClientComponent.AWS_PROFILE_NAME)) {
-            config.setProperty(KafkaClientComponent.AWS_ROLE_SOURCE, AwsRoleSource.SPECIFIED_PROFILE.name());
+        if (config.isPropertySet(AWS_PROFILE_NAME)) {
+            config.setProperty(AWS_ROLE_SOURCE, AwsRoleSource.SPECIFIED_PROFILE.name());
         }
     }
 }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/security/OAuthBearerLoginCallbackHandler.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/security/OAuthBearerLoginCallbackHandler.java
@@ -42,8 +42,8 @@ import static org.apache.nifi.kafka.shared.util.SaslExtensionUtil.isSaslExtensio
 import static org.apache.nifi.kafka.shared.util.SaslExtensionUtil.removeSaslExtensionPropertyPrefix;
 
 /**
- * {@link org.apache.kafka.common.security.auth.AuthenticateCallbackHandler} implementation to support OAuth 2 in NiFi Kafka components.
- * It uses {@link org.apache.nifi.oauth2.OAuth2AccessTokenProvider} controller service to acquire Access Tokens. The service reference is injected via the Kafka configuration.
+ * {@link AuthenticateCallbackHandler} implementation to support OAuth 2 in NiFi Kafka components.
+ * It uses {@link OAuth2AccessTokenProvider} controller service to acquire Access Tokens. The service reference is injected via the Kafka configuration.
  * The service identifier will be validated against the serviceId provided in the JAAS configuration to ensure consistency.
  * For Access Token validation and parsing, the handler relies on the Kafka OAuth support classes. Only the token retrieval is NiFi specific.
  */

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
@@ -126,7 +126,7 @@ public interface KafkaClientComponent {
             .displayName("AWS Profile Name")
             .description("The Amazon Web Services Profile to select when multiple profiles are available.")
             .dependsOn(
-                    KafkaClientComponent.AWS_ROLE_SOURCE,
+                    AWS_ROLE_SOURCE,
                     AwsRoleSource.SPECIFIED_PROFILE
             )
             .required(true)
@@ -139,7 +139,7 @@ public interface KafkaClientComponent {
             .description("The AWS Role ARN for cross-account access when using AWS MSK IAM. Used with Assume Role Session Name.")
             .required(true)
             .dependsOn(
-                    KafkaClientComponent.AWS_ROLE_SOURCE,
+                    AWS_ROLE_SOURCE,
                     AwsRoleSource.SPECIFIED_ROLE,
                     AwsRoleSource.WEB_IDENTITY_TOKEN
             )
@@ -152,7 +152,7 @@ public interface KafkaClientComponent {
             .description("The AWS Role Session Name for cross-account access. Used in conjunction with Assume Role ARN.")
             .required(true)
             .dependsOn(
-                    KafkaClientComponent.AWS_ROLE_SOURCE,
+                    AWS_ROLE_SOURCE,
                     AwsRoleSource.SPECIFIED_ROLE,
                     AwsRoleSource.WEB_IDENTITY_TOKEN
             )
@@ -166,7 +166,7 @@ public interface KafkaClientComponent {
             .identifiesControllerService(OAuth2AccessTokenProvider.class)
             .required(true)
             .dependsOn(
-                    KafkaClientComponent.AWS_ROLE_SOURCE,
+                    AWS_ROLE_SOURCE,
                     AwsRoleSource.WEB_IDENTITY_TOKEN
             )
             .build();

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
@@ -47,7 +47,7 @@ public enum SaslMechanism implements DescribedValue {
         if (StandardKafkaPropertyProvider.isAwsMskIamCallbackHandlerFound()) {
             return EnumSet.allOf(SaslMechanism.class);
         } else {
-            return EnumSet.complementOf(EnumSet.of(SaslMechanism.AWS_MSK_IAM));
+            return EnumSet.complementOf(EnumSet.of(AWS_MSK_IAM));
         }
     }
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProviderTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProviderTest.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.kafka.shared.login;
 
 import org.apache.nifi.context.PropertyContext;
+import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
 import org.apache.nifi.kafka.shared.property.AwsRoleSource;
 import org.apache.nifi.kafka.shared.property.SaslMechanism;
@@ -98,7 +99,7 @@ class AwsMskIamLoginConfigProviderTest {
                 "awsRoleSessionName JAAS option not present");
     }
 
-    private static class MockOAuth2AccessTokenProvider extends org.apache.nifi.controller.AbstractControllerService implements OAuth2AccessTokenProvider {
+    private static class MockOAuth2AccessTokenProvider extends AbstractControllerService implements OAuth2AccessTokenProvider {
         @Override
         public AccessToken getAccessDetails() {
             final AccessToken accessToken = new AccessToken();

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestPublishMQTT.java
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestPublishMQTT.java
@@ -526,7 +526,7 @@ public class TestPublishMQTT {
     }
 
     private static List<String> createMultipleInput() {
-        return Arrays.asList("message1", "message2", "message3");
+        return asList("message1", "message2", "message3");
     }
 
     private TestRunner initializeTestRunner(MqttTestClient mqttTestClient) {

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-content-viewer/src/main/java/org/apache/nifi/parquet/web/controller/ParquetContentViewerController.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-content-viewer/src/main/java/org/apache/nifi/parquet/web/controller/ParquetContentViewerController.java
@@ -25,6 +25,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.nifi.authorization.AccessDeniedException;
@@ -159,7 +160,7 @@ public class ParquetContentViewerController extends HttpServlet {
             case GenericData.EnumSymbol enumSymbol -> {
                 return enumSymbol.toString();
             }
-            case org.apache.avro.util.Utf8 utf8 -> {
+            case Utf8 utf8 -> {
                 return utf8.toString();
             }
             case null, default -> {

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/utils/ParquetUtils.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/utils/ParquetUtils.java
@@ -101,7 +101,7 @@ public class ParquetUtils {
     public static final PropertyDescriptor WRITER_VERSION = new PropertyDescriptor.Builder()
             .name("Writer Version")
             .description("Specifies the version used by Parquet writer")
-            .allowableValues(org.apache.parquet.column.ParquetProperties.WriterVersion.values())
+            .allowableValues(ParquetProperties.WriterVersion.values())
             .build();
 
     public static final PropertyDescriptor AVRO_READ_COMPATIBILITY = new PropertyDescriptor.Builder()
@@ -167,8 +167,8 @@ public class ParquetUtils {
         final ParquetFileWriter.Mode mode = overwrite ? ParquetFileWriter.Mode.OVERWRITE : ParquetFileWriter.Mode.CREATE;
         parquetConfig.setWriterMode(mode);
 
-        if (context.getProperty(ParquetUtils.COMPRESSION_TYPE).isSet()) {
-            final String compressionTypeValue = context.getProperty(ParquetUtils.COMPRESSION_TYPE).getValue();
+        if (context.getProperty(COMPRESSION_TYPE).isSet()) {
+            final String compressionTypeValue = context.getProperty(COMPRESSION_TYPE).getValue();
             final CompressionCodecName codecName = CompressionCodecName.valueOf(compressionTypeValue);
             parquetConfig.setCompressionCodec(codecName);
         }

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/main/java/org/apache/nifi/services/protobuf/FieldType.java
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/main/java/org/apache/nifi/services/protobuf/FieldType.java
@@ -49,7 +49,7 @@ public enum FieldType {
     }
 
     public static FieldType findValue(final String value) {
-        return Arrays.stream(FieldType.values())
+        return Arrays.stream(values())
                 .filter((type -> type.getType().equalsIgnoreCase(value)))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException(String.format("ProtoType [%s] not found", value)));

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-utils/src/main/java/org/apache/nifi/redis/util/RedisUtils.java
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-utils/src/main/java/org/apache/nifi/redis/util/RedisUtils.java
@@ -277,56 +277,56 @@ public class RedisUtils {
             .build();
 
     public static final List<PropertyDescriptor> REDIS_CONNECTION_PROPERTY_DESCRIPTORS = List.of(
-        RedisUtils.REDIS_MODE,
-        RedisUtils.CONNECTION_STRING,
-        RedisUtils.DATABASE,
-        RedisUtils.COMMUNICATION_TIMEOUT,
-        RedisUtils.CLUSTER_MAX_REDIRECTS,
-        RedisUtils.SENTINEL_MASTER,
-        RedisUtils.USERNAME,
-        RedisUtils.PASSWORD,
-        RedisUtils.SENTINEL_USERNAME,
-        RedisUtils.SENTINEL_PASSWORD,
-        RedisUtils.SSL_CONTEXT_SERVICE,
-        RedisUtils.POOL_MAX_TOTAL,
-        RedisUtils.POOL_MAX_IDLE,
-        RedisUtils.POOL_MIN_IDLE,
-        RedisUtils.POOL_BLOCK_WHEN_EXHAUSTED,
-        RedisUtils.POOL_MAX_WAIT_TIME,
-        RedisUtils.POOL_MIN_EVICTABLE_IDLE_TIME,
-        RedisUtils.POOL_TIME_BETWEEN_EVICTION_RUNS,
-        RedisUtils.POOL_NUM_TESTS_PER_EVICTION_RUN,
-        RedisUtils.POOL_TEST_ON_CREATE,
-        RedisUtils.POOL_TEST_ON_BORROW,
-        RedisUtils.POOL_TEST_ON_RETURN,
-        RedisUtils.POOL_TEST_WHILE_IDLE
+        REDIS_MODE,
+        CONNECTION_STRING,
+        DATABASE,
+        COMMUNICATION_TIMEOUT,
+        CLUSTER_MAX_REDIRECTS,
+        SENTINEL_MASTER,
+        USERNAME,
+        PASSWORD,
+        SENTINEL_USERNAME,
+        SENTINEL_PASSWORD,
+        SSL_CONTEXT_SERVICE,
+        POOL_MAX_TOTAL,
+        POOL_MAX_IDLE,
+        POOL_MIN_IDLE,
+        POOL_BLOCK_WHEN_EXHAUSTED,
+        POOL_MAX_WAIT_TIME,
+        POOL_MIN_EVICTABLE_IDLE_TIME,
+        POOL_TIME_BETWEEN_EVICTION_RUNS,
+        POOL_NUM_TESTS_PER_EVICTION_RUN,
+        POOL_TEST_ON_CREATE,
+        POOL_TEST_ON_BORROW,
+        POOL_TEST_ON_RETURN,
+        POOL_TEST_WHILE_IDLE
     );
 
     public static RedisConfig createRedisConfig(final PropertyContext context) {
-        final RedisType redisType = RedisType.fromDisplayName(context.getProperty(RedisUtils.REDIS_MODE).getValue());
-        final String connectString =   context.getProperty(RedisUtils.CONNECTION_STRING).evaluateAttributeExpressions().getValue();
+        final RedisType redisType = RedisType.fromDisplayName(context.getProperty(REDIS_MODE).getValue());
+        final String connectString =   context.getProperty(CONNECTION_STRING).evaluateAttributeExpressions().getValue();
 
         final RedisConfig redisConfig = new RedisConfig(redisType, connectString);
-        redisConfig.setSentinelMaster(context.getProperty(RedisUtils.SENTINEL_MASTER).evaluateAttributeExpressions().getValue());
-        redisConfig.setDbIndex(context.getProperty(RedisUtils.DATABASE).evaluateAttributeExpressions().asInteger());
-        redisConfig.setUsername(context.getProperty(RedisUtils.USERNAME).evaluateAttributeExpressions().getValue());
-        redisConfig.setPassword(context.getProperty(RedisUtils.PASSWORD).evaluateAttributeExpressions().getValue());
-        redisConfig.setSentinelUsername(context.getProperty(RedisUtils.SENTINEL_USERNAME).evaluateAttributeExpressions().getValue());
-        redisConfig.setSentinelPassword(context.getProperty(RedisUtils.SENTINEL_PASSWORD).evaluateAttributeExpressions().getValue());
-        redisConfig.setTimeout(context.getProperty(RedisUtils.COMMUNICATION_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue());
-        redisConfig.setClusterMaxRedirects(context.getProperty(RedisUtils.CLUSTER_MAX_REDIRECTS).asInteger());
-        redisConfig.setPoolMaxTotal(context.getProperty(RedisUtils.POOL_MAX_TOTAL).asInteger());
-        redisConfig.setPoolMaxIdle(context.getProperty(RedisUtils.POOL_MAX_IDLE).asInteger());
-        redisConfig.setPoolMinIdle(context.getProperty(RedisUtils.POOL_MIN_IDLE).asInteger());
-        redisConfig.setBlockWhenExhausted(context.getProperty(RedisUtils.POOL_BLOCK_WHEN_EXHAUSTED).asBoolean());
-        redisConfig.setMaxWaitTime(Duration.ofMillis(context.getProperty(RedisUtils.POOL_MAX_WAIT_TIME).asTimePeriod(TimeUnit.MILLISECONDS)));
-        redisConfig.setMinEvictableIdleDuration(Duration.ofMillis(context.getProperty(RedisUtils.POOL_MIN_EVICTABLE_IDLE_TIME).asTimePeriod(TimeUnit.MILLISECONDS)));
-        redisConfig.setTimeBetweenEvictionRuns(Duration.ofMillis(context.getProperty(RedisUtils.POOL_TIME_BETWEEN_EVICTION_RUNS).asTimePeriod(TimeUnit.MILLISECONDS)));
-        redisConfig.setNumTestsPerEvictionRun(context.getProperty(RedisUtils.POOL_NUM_TESTS_PER_EVICTION_RUN).asInteger());
-        redisConfig.setTestOnCreate(context.getProperty(RedisUtils.POOL_TEST_ON_CREATE).asBoolean());
-        redisConfig.setTestOnBorrow(context.getProperty(RedisUtils.POOL_TEST_ON_BORROW).asBoolean());
-        redisConfig.setTestOnReturn(context.getProperty(RedisUtils.POOL_TEST_ON_RETURN).asBoolean());
-        redisConfig.setTestWhenIdle(context.getProperty(RedisUtils.POOL_TEST_WHILE_IDLE).asBoolean());
+        redisConfig.setSentinelMaster(context.getProperty(SENTINEL_MASTER).evaluateAttributeExpressions().getValue());
+        redisConfig.setDbIndex(context.getProperty(DATABASE).evaluateAttributeExpressions().asInteger());
+        redisConfig.setUsername(context.getProperty(USERNAME).evaluateAttributeExpressions().getValue());
+        redisConfig.setPassword(context.getProperty(PASSWORD).evaluateAttributeExpressions().getValue());
+        redisConfig.setSentinelUsername(context.getProperty(SENTINEL_USERNAME).evaluateAttributeExpressions().getValue());
+        redisConfig.setSentinelPassword(context.getProperty(SENTINEL_PASSWORD).evaluateAttributeExpressions().getValue());
+        redisConfig.setTimeout(context.getProperty(COMMUNICATION_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue());
+        redisConfig.setClusterMaxRedirects(context.getProperty(CLUSTER_MAX_REDIRECTS).asInteger());
+        redisConfig.setPoolMaxTotal(context.getProperty(POOL_MAX_TOTAL).asInteger());
+        redisConfig.setPoolMaxIdle(context.getProperty(POOL_MAX_IDLE).asInteger());
+        redisConfig.setPoolMinIdle(context.getProperty(POOL_MIN_IDLE).asInteger());
+        redisConfig.setBlockWhenExhausted(context.getProperty(POOL_BLOCK_WHEN_EXHAUSTED).asBoolean());
+        redisConfig.setMaxWaitTime(Duration.ofMillis(context.getProperty(POOL_MAX_WAIT_TIME).asTimePeriod(TimeUnit.MILLISECONDS)));
+        redisConfig.setMinEvictableIdleDuration(Duration.ofMillis(context.getProperty(POOL_MIN_EVICTABLE_IDLE_TIME).asTimePeriod(TimeUnit.MILLISECONDS)));
+        redisConfig.setTimeBetweenEvictionRuns(Duration.ofMillis(context.getProperty(POOL_TIME_BETWEEN_EVICTION_RUNS).asTimePeriod(TimeUnit.MILLISECONDS)));
+        redisConfig.setNumTestsPerEvictionRun(context.getProperty(POOL_NUM_TESTS_PER_EVICTION_RUN).asInteger());
+        redisConfig.setTestOnCreate(context.getProperty(POOL_TEST_ON_CREATE).asBoolean());
+        redisConfig.setTestOnBorrow(context.getProperty(POOL_TEST_ON_BORROW).asBoolean());
+        redisConfig.setTestOnReturn(context.getProperty(POOL_TEST_ON_RETURN).asBoolean());
+        redisConfig.setTestWhenIdle(context.getProperty(POOL_TEST_WHILE_IDLE).asBoolean());
         return redisConfig;
     }
 
@@ -460,21 +460,21 @@ public class RedisUtils {
     public static List<ValidationResult> validate(ValidationContext validationContext) {
         final List<ValidationResult> results = new ArrayList<>();
 
-        final String redisMode = validationContext.getProperty(RedisUtils.REDIS_MODE).getValue();
-        final String connectionString = validationContext.getProperty(RedisUtils.CONNECTION_STRING).evaluateAttributeExpressions().getValue();
-        final Integer dbIndex = validationContext.getProperty(RedisUtils.DATABASE).evaluateAttributeExpressions().asInteger();
+        final String redisMode = validationContext.getProperty(REDIS_MODE).getValue();
+        final String connectionString = validationContext.getProperty(CONNECTION_STRING).evaluateAttributeExpressions().getValue();
+        final Integer dbIndex = validationContext.getProperty(DATABASE).evaluateAttributeExpressions().asInteger();
 
         if (StringUtils.isBlank(connectionString)) {
             results.add(new ValidationResult.Builder()
-                    .subject(RedisUtils.CONNECTION_STRING.getDisplayName())
+                    .subject(CONNECTION_STRING.getDisplayName())
                     .valid(false)
                     .explanation("Connection String cannot be blank")
                     .build());
-        } else if (RedisUtils.REDIS_MODE_STANDALONE.getValue().equals(redisMode)) {
+        } else if (REDIS_MODE_STANDALONE.getValue().equals(redisMode)) {
             final String[] hostAndPort = connectionString.split("[:]");
             if (hostAndPort == null || hostAndPort.length != 2 || StringUtils.isBlank(hostAndPort[0]) || StringUtils.isBlank(hostAndPort[1]) || !isInteger(hostAndPort[1])) {
                 results.add(new ValidationResult.Builder()
-                        .subject(RedisUtils.CONNECTION_STRING.getDisplayName())
+                        .subject(CONNECTION_STRING.getDisplayName())
                         .input(connectionString)
                         .valid(false)
                         .explanation("Standalone Connection String must be in the form host:port")
@@ -485,7 +485,7 @@ public class RedisUtils {
                 final String[] hostAndPort = connection.split("[:]");
                 if (hostAndPort == null || hostAndPort.length != 2 || StringUtils.isBlank(hostAndPort[0]) || StringUtils.isBlank(hostAndPort[1]) || !isInteger(hostAndPort[1])) {
                     results.add(new ValidationResult.Builder()
-                            .subject(RedisUtils.CONNECTION_STRING.getDisplayName())
+                            .subject(CONNECTION_STRING.getDisplayName())
                             .input(connection)
                             .valid(false)
                             .explanation("Connection String must be in the form host:port,host:port,host:port,etc.")
@@ -494,19 +494,19 @@ public class RedisUtils {
             }
         }
 
-        if (RedisUtils.REDIS_MODE_CLUSTER.getValue().equals(redisMode) && dbIndex > 0) {
+        if (REDIS_MODE_CLUSTER.getValue().equals(redisMode) && dbIndex > 0) {
             results.add(new ValidationResult.Builder()
-                    .subject(RedisUtils.DATABASE.getDisplayName())
+                    .subject(DATABASE.getDisplayName())
                     .valid(false)
                     .explanation("Database Index must be 0 when using clustered Redis")
                     .build());
         }
 
-        if (RedisUtils.REDIS_MODE_SENTINEL.getValue().equals(redisMode)) {
-            final String sentinelMaster = validationContext.getProperty(RedisUtils.SENTINEL_MASTER).evaluateAttributeExpressions().getValue();
+        if (REDIS_MODE_SENTINEL.getValue().equals(redisMode)) {
+            final String sentinelMaster = validationContext.getProperty(SENTINEL_MASTER).evaluateAttributeExpressions().getValue();
             if (StringUtils.isEmpty(sentinelMaster)) {
                 results.add(new ValidationResult.Builder()
-                        .subject(RedisUtils.SENTINEL_MASTER.getDisplayName())
+                        .subject(SENTINEL_MASTER.getDisplayName())
                         .valid(false)
                         .explanation("Sentinel Master must be provided when Mode is Sentinel")
                         .build());

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/main/java/org/apache/nifi/schemaregistry/services/StandardJsonSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/main/java/org/apache/nifi/schemaregistry/services/StandardJsonSchemaRegistry.java
@@ -109,7 +109,7 @@ public class StandardJsonSchemaRegistry extends AbstractControllerService implem
                     .build());
         } else {
             // Iterate over dynamic properties, validating only newly added schemas, and adding results
-            schemaVersion = SchemaVersion.valueOf(validationContext.getProperty(JsonSchemaRegistryComponent.SCHEMA_VERSION).getValue());
+            schemaVersion = SchemaVersion.valueOf(validationContext.getProperty(SCHEMA_VERSION).getValue());
             validationContext.getProperties().entrySet().stream()
                     .filter(entry -> entry.getKey().isDynamic() && !jsonSchemas.containsKey(entry.getKey().getName()))
                     .forEach(entry -> {

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentHelper.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentHelper.java
@@ -247,7 +247,7 @@ public class ScriptingComponentHelper {
      * called, and the configurator is saved for future calls.
      *
      * @param numberOfScriptEngines number of engines to setup
-     * @see org.apache.nifi.processors.script.ScriptRunner
+     * @see ScriptRunner
      */
     public void setupScriptRunners(final boolean newQ, final int numberOfScriptEngines, final String scriptToRun, final ComponentLog log) {
         if (newQ) {

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentUtils.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/ScriptingComponentUtils.java
@@ -89,8 +89,8 @@ public class ScriptingComponentUtils {
 
         final String term = context.getSearchTerm();
 
-        final ResourceReference scriptFile = context.getProperty(ScriptingComponentUtils.SCRIPT_FILE).evaluateAttributeExpressions().asResource();
-        String script = context.getProperty(ScriptingComponentUtils.SCRIPT_BODY).getValue();
+        final ResourceReference scriptFile = context.getProperty(SCRIPT_FILE).evaluateAttributeExpressions().asResource();
+        String script = context.getProperty(SCRIPT_BODY).getValue();
 
         if (StringUtils.isBlank(script) && scriptFile == null) {
             return results;

--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/s2s/SiteToSiteUtils.java
+++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/s2s/SiteToSiteUtils.java
@@ -121,7 +121,7 @@ public class SiteToSiteUtils {
             .build();
 
     public static SiteToSiteClient getClient(PropertyContext reportContext, ComponentLog logger, StateManager stateManager) {
-        final SSLContextProvider sslContextProvider = reportContext.getProperty(SiteToSiteUtils.SSL_CONTEXT).asControllerService(SSLContextProvider.class);
+        final SSLContextProvider sslContextProvider = reportContext.getProperty(SSL_CONTEXT).asControllerService(SSLContextProvider.class);
         final SSLContext sslContext = sslContextProvider == null ? null : sslContextProvider.createContext();
         final SiteToSiteEventReporter eventReporter = (severity, category, message) -> {
             switch (severity) {
@@ -135,13 +135,13 @@ public class SiteToSiteUtils {
                     break;
             }
         };
-        final String destinationUrl = reportContext.getProperty(SiteToSiteUtils.DESTINATION_URL).evaluateAttributeExpressions().getValue();
+        final String destinationUrl = reportContext.getProperty(DESTINATION_URL).evaluateAttributeExpressions().getValue();
 
-        final SiteToSiteTransportProtocol mode = SiteToSiteTransportProtocol.valueOf(reportContext.getProperty(SiteToSiteUtils.TRANSPORT_PROTOCOL).getValue());
+        final SiteToSiteTransportProtocol mode = SiteToSiteTransportProtocol.valueOf(reportContext.getProperty(TRANSPORT_PROTOCOL).getValue());
 
         HttpProxy httpProxy = null;
         if (mode == SiteToSiteTransportProtocol.HTTP) {
-            final ProxyConfigurationService proxyConfigurationService = reportContext.getProperty(SiteToSiteUtils.PROXY_CONFIGURATION_SERVICE).asControllerService(ProxyConfigurationService.class);
+            final ProxyConfigurationService proxyConfigurationService = reportContext.getProperty(PROXY_CONFIGURATION_SERVICE).asControllerService(ProxyConfigurationService.class);
             if (proxyConfigurationService != null) {
                 final ProxyConfiguration proxyConfiguration = proxyConfigurationService.getConfiguration();
                 if (proxyConfiguration.getProxyType() == Proxy.Type.HTTP) {
@@ -157,11 +157,11 @@ public class SiteToSiteUtils {
         }
         return new SiteToSiteClient.Builder()
                 .urls(ClusterUrlParser.parseClusterUrls(destinationUrl))
-                .portName(reportContext.getProperty(SiteToSiteUtils.PORT_NAME).getValue())
-                .useCompression(reportContext.getProperty(SiteToSiteUtils.COMPRESS).asBoolean())
+                .portName(reportContext.getProperty(PORT_NAME).getValue())
+                .useCompression(reportContext.getProperty(COMPRESS).asBoolean())
                 .eventReporter(eventReporter)
                 .sslContext(sslContext)
-                .timeout(reportContext.getProperty(SiteToSiteUtils.TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
+                .timeout(reportContext.getProperty(TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
                 .transportProtocol(mode)
                 .httpProxy(httpProxy)
                 .stateManager(stateManager)

--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteBulletinReportingTask.java
+++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteBulletinReportingTask.java
@@ -34,7 +34,6 @@ import org.apache.nifi.reporting.s2s.SiteToSiteUtils;
 import org.apache.nifi.reporting.s2s.SiteToSiteUtils.NiFiUrlValidator;
 import org.apache.nifi.util.MockPropertyValue;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayInputStream;
@@ -50,14 +49,18 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestSiteToSiteBulletinReportingTask {
 
     @Test
     public void testUrls() {
-        final ValidationContext context = Mockito.mock(ValidationContext.class);
-        Mockito.when(context.newPropertyValue(Mockito.anyString())).then((Answer<PropertyValue>) invocation -> {
+        final ValidationContext context = mock(ValidationContext.class);
+        when(context.newPropertyValue(anyString())).then((Answer<PropertyValue>) invocation -> {
             String value = (String) invocation.getArguments()[0];
             return new StandardPropertyValue(value, null, null);
         });
@@ -80,10 +83,10 @@ public class TestSiteToSiteBulletinReportingTask {
         bulletins.add(BulletinFactory.createBulletin("group-id", "group-name", "source-id", ComponentType.PROCESSOR, "source-name", "category", "severity", "message", "group-path", "flowFileUuid"));
 
         // mock the access to the list of bulletins
-        final ReportingContext context = Mockito.mock(ReportingContext.class);
-        final BulletinRepository repository = Mockito.mock(BulletinRepository.class);
-        Mockito.when(context.getBulletinRepository()).thenReturn(repository);
-        Mockito.when(repository.findBulletins(Mockito.any(BulletinQuery.class))).thenReturn(bulletins);
+        final ReportingContext context = mock(ReportingContext.class);
+        final BulletinRepository repository = mock(BulletinRepository.class);
+        when(context.getBulletinRepository()).thenReturn(repository);
+        when(repository.findBulletins(any(BulletinQuery.class))).thenReturn(bulletins);
 
         // creating reporting task
         final MockSiteToSiteBulletinReportingTask task = new MockSiteToSiteBulletinReportingTask();
@@ -96,16 +99,16 @@ public class TestSiteToSiteBulletinReportingTask {
         properties.put(SiteToSiteUtils.BATCH_SIZE, "1000");
         properties.put(SiteToSiteUtils.PLATFORM, "nifi");
 
-        Mockito.doAnswer((Answer<PropertyValue>) invocation -> {
+        doAnswer((Answer<PropertyValue>) invocation -> {
             final PropertyDescriptor descriptor = invocation.getArgument(0, PropertyDescriptor.class);
             return new MockPropertyValue(properties.get(descriptor));
-        }).when(context).getProperty(Mockito.any(PropertyDescriptor.class));
+        }).when(context).getProperty(any(PropertyDescriptor.class));
 
         // setup the mock initialization context
-        final ComponentLog logger = Mockito.mock(ComponentLog.class);
-        final ReportingInitializationContext initContext = Mockito.mock(ReportingInitializationContext.class);
-        Mockito.when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString());
-        Mockito.when(initContext.getLogger()).thenReturn(logger);
+        final ComponentLog logger = mock(ComponentLog.class);
+        final ReportingInitializationContext initContext = mock(ReportingInitializationContext.class);
+        when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString());
+        when(initContext.getLogger()).thenReturn(logger);
 
         task.initialize(initContext);
         task.onTrigger(context);
@@ -129,10 +132,10 @@ public class TestSiteToSiteBulletinReportingTask {
         bulletins.add(BulletinFactory.createBulletin("group-id", "group-name", "source-id", "source-name", "category", "severity", "message"));
 
         // mock the access to the list of bulletins
-        final ReportingContext context = Mockito.mock(ReportingContext.class);
-        final BulletinRepository repository = Mockito.mock(BulletinRepository.class);
-        Mockito.when(context.getBulletinRepository()).thenReturn(repository);
-        Mockito.when(repository.findBulletins(Mockito.any(BulletinQuery.class))).thenReturn(bulletins);
+        final ReportingContext context = mock(ReportingContext.class);
+        final BulletinRepository repository = mock(BulletinRepository.class);
+        when(context.getBulletinRepository()).thenReturn(repository);
+        when(repository.findBulletins(any(BulletinQuery.class))).thenReturn(bulletins);
 
         // creating reporting task
         final MockSiteToSiteBulletinReportingTask task = new MockSiteToSiteBulletinReportingTask();
@@ -146,16 +149,16 @@ public class TestSiteToSiteBulletinReportingTask {
         properties.put(SiteToSiteUtils.PLATFORM, "nifi");
         properties.put(SiteToSiteStatusReportingTask.ALLOW_NULL_VALUES, "true");
 
-        Mockito.doAnswer((Answer<PropertyValue>) invocation -> {
+        doAnswer((Answer<PropertyValue>) invocation -> {
             final PropertyDescriptor descriptor = invocation.getArgument(0, PropertyDescriptor.class);
             return new MockPropertyValue(properties.get(descriptor));
-        }).when(context).getProperty(Mockito.any(PropertyDescriptor.class));
+        }).when(context).getProperty(any(PropertyDescriptor.class));
 
         // setup the mock initialization context
-        final ComponentLog logger = Mockito.mock(ComponentLog.class);
-        final ReportingInitializationContext initContext = Mockito.mock(ReportingInitializationContext.class);
-        Mockito.when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString());
-        Mockito.when(initContext.getLogger()).thenReturn(logger);
+        final ComponentLog logger = mock(ComponentLog.class);
+        final ReportingInitializationContext initContext = mock(ReportingInitializationContext.class);
+        when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString());
+        when(initContext.getLogger()).thenReturn(logger);
 
         task.initialize(initContext);
         task.onTrigger(context);
@@ -176,17 +179,17 @@ public class TestSiteToSiteBulletinReportingTask {
         @Override
         public void setup(PropertyContext reportContext) {
             if (siteToSiteClient == null) {
-                final SiteToSiteClient client = Mockito.mock(SiteToSiteClient.class);
-                final Transaction transaction = Mockito.mock(Transaction.class);
+                final SiteToSiteClient client = mock(SiteToSiteClient.class);
+                final Transaction transaction = mock(Transaction.class);
 
                 assertDoesNotThrow(() -> {
-                    Mockito.doAnswer((Answer<Object>) invocation -> {
+                    doAnswer((Answer<Object>) invocation -> {
                         final byte[] data = invocation.getArgument(0, byte[].class);
                         dataSent.add(data);
                         return null;
-                    }).when(transaction).send(Mockito.any(byte[].class), Mockito.any(Map.class));
+                    }).when(transaction).send(any(byte[].class), any(Map.class));
 
-                    when(client.createTransaction(Mockito.any(TransferDirection.class))).thenReturn(transaction);
+                    when(client.createTransaction(any(TransferDirection.class))).thenReturn(transaction);
                 });
                 siteToSiteClient = client;
             }

--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteMetricsReportingTask.java
+++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteMetricsReportingTask.java
@@ -41,7 +41,6 @@ import org.apache.nifi.state.MockStateManager;
 import org.apache.nifi.util.MockPropertyValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayInputStream;
@@ -58,6 +57,9 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestSiteToSiteMetricsReportingTask {
@@ -105,26 +107,26 @@ public class TestSiteToSiteMetricsReportingTask {
         }
         properties.putAll(customProperties);
 
-        context = Mockito.mock(ReportingContext.class);
-        Mockito.when(context.getStateManager()).thenReturn(new MockStateManager(task));
-        Mockito.doAnswer((Answer<PropertyValue>) invocation -> {
+        context = mock(ReportingContext.class);
+        when(context.getStateManager()).thenReturn(new MockStateManager(task));
+        doAnswer((Answer<PropertyValue>) invocation -> {
             final PropertyDescriptor descriptor = invocation.getArgument(0, PropertyDescriptor.class);
             return new MockPropertyValue(properties.get(descriptor));
-        }).when(context).getProperty(Mockito.any(PropertyDescriptor.class));
+        }).when(context).getProperty(any(PropertyDescriptor.class));
 
-        final EventAccess eventAccess = Mockito.mock(EventAccess.class);
-        Mockito.when(context.getEventAccess()).thenReturn(eventAccess);
-        Mockito.when(eventAccess.getControllerStatus()).thenReturn(status);
+        final EventAccess eventAccess = mock(EventAccess.class);
+        when(context.getEventAccess()).thenReturn(eventAccess);
+        when(eventAccess.getControllerStatus()).thenReturn(status);
 
-        final PropertyValue pValue = Mockito.mock(StandardPropertyValue.class);
+        final PropertyValue pValue = mock(StandardPropertyValue.class);
         MockRecordWriter writer = new MockRecordWriter();
-        Mockito.when(context.getProperty(MockSiteToSiteMetricsReportingTask.RECORD_WRITER)).thenReturn(pValue);
-        Mockito.when(pValue.asControllerService(RecordSetWriterFactory.class)).thenReturn(writer);
+        when(context.getProperty(MockSiteToSiteMetricsReportingTask.RECORD_WRITER)).thenReturn(pValue);
+        when(pValue.asControllerService(RecordSetWriterFactory.class)).thenReturn(writer);
 
-        final ComponentLog logger = Mockito.mock(ComponentLog.class);
-        final ReportingInitializationContext initContext = Mockito.mock(ReportingInitializationContext.class);
-        Mockito.when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString());
-        Mockito.when(initContext.getLogger()).thenReturn(logger);
+        final ComponentLog logger = mock(ComponentLog.class);
+        final ReportingInitializationContext initContext = mock(ReportingInitializationContext.class);
+        when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString());
+        when(initContext.getLogger()).thenReturn(logger);
         task.initialize(initContext);
 
         return task;
@@ -132,7 +134,7 @@ public class TestSiteToSiteMetricsReportingTask {
 
     @Test
     public void testValidationBothAmbariFormatRecordWriter() throws IOException {
-        ValidationContext validationContext = Mockito.mock(ValidationContext.class);
+        ValidationContext validationContext = mock(ValidationContext.class);
         final String urlEL = "http://${hostname(true)}:8080/nifi";
         final String url = "http://localhost:8080/nifi";
 
@@ -147,20 +149,20 @@ public class TestSiteToSiteMetricsReportingTask {
         properties.put(SiteToSiteUtils.INSTANCE_URL, url);
         properties.put(SiteToSiteUtils.PORT_NAME, "port");
 
-        final PropertyValue pValueUrl = Mockito.mock(StandardPropertyValue.class);
-        Mockito.when(validationContext.newPropertyValue(url)).thenReturn(pValueUrl);
-        Mockito.when(validationContext.newPropertyValue(urlEL)).thenReturn(pValueUrl);
-        Mockito.when(pValueUrl.evaluateAttributeExpressions()).thenReturn(pValueUrl);
-        Mockito.when(pValueUrl.getValue()).thenReturn(url);
+        final PropertyValue pValueUrl = mock(StandardPropertyValue.class);
+        when(validationContext.newPropertyValue(url)).thenReturn(pValueUrl);
+        when(validationContext.newPropertyValue(urlEL)).thenReturn(pValueUrl);
+        when(pValueUrl.evaluateAttributeExpressions()).thenReturn(pValueUrl);
+        when(pValueUrl.getValue()).thenReturn(url);
 
-        Mockito.doAnswer((Answer<PropertyValue>) invocation -> {
+        doAnswer((Answer<PropertyValue>) invocation -> {
             final PropertyDescriptor descriptor = invocation.getArgument(0, PropertyDescriptor.class);
             return new MockPropertyValue(properties.get(descriptor));
-        }).when(validationContext).getProperty(Mockito.any(PropertyDescriptor.class));
+        }).when(validationContext).getProperty(any(PropertyDescriptor.class));
 
-        final PropertyValue pValue = Mockito.mock(StandardPropertyValue.class);
-        Mockito.when(validationContext.getProperty(MockSiteToSiteMetricsReportingTask.RECORD_WRITER)).thenReturn(pValue);
-        Mockito.when(pValue.isSet()).thenReturn(true);
+        final PropertyValue pValue = mock(StandardPropertyValue.class);
+        when(validationContext.getProperty(MockSiteToSiteMetricsReportingTask.RECORD_WRITER)).thenReturn(pValue);
+        when(pValue.isSet()).thenReturn(true);
 
         // should be invalid because both ambari format and record writer are set
         Collection<ValidationResult> list = task.validate(validationContext);
@@ -170,7 +172,7 @@ public class TestSiteToSiteMetricsReportingTask {
 
     @Test
     public void testValidationRecordFormatNoRecordWriter() throws IOException {
-        ValidationContext validationContext = Mockito.mock(ValidationContext.class);
+        ValidationContext validationContext = mock(ValidationContext.class);
         final String urlEL = "http://${hostname(true)}:8080/nifi";
         final String url = "http://localhost:8080/nifi";
 
@@ -185,20 +187,20 @@ public class TestSiteToSiteMetricsReportingTask {
         properties.put(SiteToSiteUtils.INSTANCE_URL, url);
         properties.put(SiteToSiteUtils.PORT_NAME, "port");
 
-        final PropertyValue pValueUrl = Mockito.mock(StandardPropertyValue.class);
-        Mockito.when(validationContext.newPropertyValue(url)).thenReturn(pValueUrl);
-        Mockito.when(validationContext.newPropertyValue(urlEL)).thenReturn(pValueUrl);
-        Mockito.when(pValueUrl.evaluateAttributeExpressions()).thenReturn(pValueUrl);
-        Mockito.when(pValueUrl.getValue()).thenReturn(url);
+        final PropertyValue pValueUrl = mock(StandardPropertyValue.class);
+        when(validationContext.newPropertyValue(url)).thenReturn(pValueUrl);
+        when(validationContext.newPropertyValue(urlEL)).thenReturn(pValueUrl);
+        when(pValueUrl.evaluateAttributeExpressions()).thenReturn(pValueUrl);
+        when(pValueUrl.getValue()).thenReturn(url);
 
-        Mockito.doAnswer((Answer<PropertyValue>) invocation -> {
+        doAnswer((Answer<PropertyValue>) invocation -> {
             final PropertyDescriptor descriptor = invocation.getArgument(0, PropertyDescriptor.class);
             return new MockPropertyValue(properties.get(descriptor));
-        }).when(validationContext).getProperty(Mockito.any(PropertyDescriptor.class));
+        }).when(validationContext).getProperty(any(PropertyDescriptor.class));
 
-        final PropertyValue pValue = Mockito.mock(StandardPropertyValue.class);
-        Mockito.when(validationContext.getProperty(MockSiteToSiteMetricsReportingTask.RECORD_WRITER)).thenReturn(pValue);
-        Mockito.when(pValue.isSet()).thenReturn(false);
+        final PropertyValue pValue = mock(StandardPropertyValue.class);
+        when(validationContext.getProperty(MockSiteToSiteMetricsReportingTask.RECORD_WRITER)).thenReturn(pValue);
+        when(pValue.isSet()).thenReturn(false);
 
         // should be invalid because both ambari format and record writer are set
         Collection<ValidationResult> list = task.validate(validationContext);
@@ -287,17 +289,17 @@ public class TestSiteToSiteMetricsReportingTask {
         @Override
         public void setup(PropertyContext reportContext) {
             if (siteToSiteClient == null) {
-                final SiteToSiteClient client = Mockito.mock(SiteToSiteClient.class);
-                final Transaction transaction = Mockito.mock(Transaction.class);
+                final SiteToSiteClient client = mock(SiteToSiteClient.class);
+                final Transaction transaction = mock(Transaction.class);
 
                 assertDoesNotThrow(() -> {
-                    Mockito.doAnswer((Answer<Object>) invocation -> {
+                    doAnswer((Answer<Object>) invocation -> {
                         final byte[] data = invocation.getArgument(0, byte[].class);
                         dataSent.add(data);
                         return null;
-                    }).when(transaction).send(Mockito.any(byte[].class), Mockito.any(Map.class));
+                    }).when(transaction).send(any(byte[].class), any(Map.class));
 
-                    when(client.createTransaction(Mockito.any(TransferDirection.class))).thenReturn(transaction);
+                    when(client.createTransaction(any(TransferDirection.class))).thenReturn(transaction);
                 });
                 siteToSiteClient = client;
             }

--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
+++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
@@ -44,7 +44,6 @@ import org.apache.nifi.state.MockStateManager;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.MockPropertyValue;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayInputStream;
@@ -63,6 +62,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestSiteToSiteStatusReportingTask {
@@ -77,23 +79,23 @@ public class TestSiteToSiteStatusReportingTask {
         }
         properties.putAll(customProperties);
 
-        context = Mockito.mock(ReportingContext.class);
-        Mockito.when(context.getStateManager())
+        context = mock(ReportingContext.class);
+        when(context.getStateManager())
                 .thenReturn(new MockStateManager(task));
-        Mockito.doAnswer((Answer<PropertyValue>) invocation -> {
+        doAnswer((Answer<PropertyValue>) invocation -> {
             final PropertyDescriptor descriptor = invocation.getArgument(0, PropertyDescriptor.class);
             return new MockPropertyValue(properties.get(descriptor));
-        }).when(context).getProperty(Mockito.any(PropertyDescriptor.class));
+        }).when(context).getProperty(any(PropertyDescriptor.class));
 
-        final EventAccess eventAccess = Mockito.mock(EventAccess.class);
+        final EventAccess eventAccess = mock(EventAccess.class);
 
-        Mockito.when(context.getEventAccess()).thenReturn(eventAccess);
-        Mockito.when(eventAccess.getControllerStatus()).thenReturn(pgStatus);
+        when(context.getEventAccess()).thenReturn(eventAccess);
+        when(eventAccess.getControllerStatus()).thenReturn(pgStatus);
 
-        final ComponentLog logger = Mockito.mock(ComponentLog.class);
-        final ReportingInitializationContext initContext = Mockito.mock(ReportingInitializationContext.class);
-        Mockito.when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString());
-        Mockito.when(initContext.getLogger()).thenReturn(logger);
+        final ComponentLog logger = mock(ComponentLog.class);
+        final ReportingInitializationContext initContext = mock(ReportingInitializationContext.class);
+        when(initContext.getIdentifier()).thenReturn(UUID.randomUUID().toString());
+        when(initContext.getLogger()).thenReturn(logger);
         task.initialize(initContext);
 
         return task;
@@ -531,17 +533,17 @@ public class TestSiteToSiteStatusReportingTask {
         @Override
         public void setup(PropertyContext reportContext) {
             if (siteToSiteClient == null) {
-                final SiteToSiteClient client = Mockito.mock(SiteToSiteClient.class);
-                final Transaction transaction = Mockito.mock(Transaction.class);
+                final SiteToSiteClient client = mock(SiteToSiteClient.class);
+                final Transaction transaction = mock(Transaction.class);
 
                 assertDoesNotThrow(() -> {
-                    Mockito.doAnswer((Answer<Object>) invocation -> {
+                    doAnswer((Answer<Object>) invocation -> {
                         final byte[] data = invocation.getArgument(0, byte[].class);
                         dataSent.add(data);
                         return null;
-                    }).when(transaction).send(Mockito.any(byte[].class), Mockito.any(Map.class));
+                    }).when(transaction).send(any(byte[].class), any(Map.class));
 
-                    when(client.createTransaction(Mockito.any(TransferDirection.class))).thenReturn(transaction);
+                    when(client.createTransaction(any(TransferDirection.class))).thenReturn(transaction);
                 });
                 siteToSiteClient = client;
             }

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/ListSmb.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/ListSmb.java
@@ -121,7 +121,7 @@ import static org.apache.nifi.services.smb.SmbListableEntity.SIZE;
         @WritesAttribute(attribute = SIZE, description = "The size of the file in bytes."),
         @WritesAttribute(attribute = ALLOCATION_SIZE, description = "The number of bytes allocated for the file on the server."),
 })
-@Stateful(scopes = {Scope.CLUSTER}, description =
+@Stateful(scopes = {CLUSTER}, description =
         "After performing a listing of files, the state of the previous listing can be stored in order to list files "
                 + "continuously without duplication."
 )
@@ -250,12 +250,12 @@ public class ListSmb extends AbstractListProcessor<SmbListableEntity> {
             FILE_FILTER,
             PATH_FILTER,
             IGNORE_FILES_WITH_SUFFIX,
-            AbstractListProcessor.RECORD_WRITER,
+            RECORD_WRITER,
             MINIMUM_AGE,
             MAXIMUM_AGE,
             MINIMUM_SIZE,
             MAXIMUM_SIZE,
-            AbstractListProcessor.TARGET_SYSTEM_TIMESTAMP_PRECISION,
+            TARGET_SYSTEM_TIMESTAMP_PRECISION,
             TRACKING_STATE_CACHE,
             TRACKING_TIME_WINDOW,
             INITIAL_LISTING_TARGET

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/ListSmbIT.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/ListSmbIT.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -167,7 +166,7 @@ public class ListSmbIT extends SambaTestContainers {
                 .map(attributes -> attributes.get("filename"))
                 .collect(toSet());
 
-        assertEquals(new HashSet<>(Arrays.asList("file_name")), fileNames);
+        assertEquals(Set.of("file_name"), fileNames);
 
         testRunner.assertValid();
         testRunner.disableControllerService(smbjClientProviderService);

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/SmbDfsIT.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/SmbDfsIT.java
@@ -24,7 +24,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.services.smb.SmbjClientProviderService;
-import org.apache.nifi.smb.common.SmbProperties;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.AfterEach;
@@ -167,7 +166,7 @@ class SmbDfsIT {
         testRunner.setProperty(PutSmbFile.DIRECTORY, "dfs-link");
         testRunner.setProperty(PutSmbFile.USERNAME, "myuser");
         testRunner.setProperty(PutSmbFile.PASSWORD, "mypass");
-        testRunner.setProperty(SmbProperties.ENABLE_DFS, "true");
+        testRunner.setProperty(ENABLE_DFS, "true");
 
         testRunner.enqueue("put_content", Map.of(CoreAttributes.FILENAME.key(), "put_file"));
         testRunner.run();
@@ -188,7 +187,7 @@ class SmbDfsIT {
         testRunner.setProperty(GetSmbFile.DIRECTORY, "dfs-link");
         testRunner.setProperty(GetSmbFile.USERNAME, "myuser");
         testRunner.setProperty(GetSmbFile.PASSWORD, "mypass");
-        testRunner.setProperty(SmbProperties.ENABLE_DFS, "true");
+        testRunner.setProperty(ENABLE_DFS, "true");
 
         testRunner.run();
 

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-smbj-common/src/main/java/org/apache/nifi/smb/common/SmbClient.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-smbj-common/src/main/java/org/apache/nifi/smb/common/SmbClient.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Extends {@link com.hierynomus.smbj.SMBClient} with connection health check.
+ * Extends {@link SMBClient} with connection health check.
  * <br/>
  * Workaround to https://github.com/hierynomus/smbj/issues/796.
  * <br/><br/>

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/utils/SNMPUtils.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/utils/SNMPUtils.java
@@ -120,17 +120,17 @@ public final class SNMPUtils {
         boolean result = false;
         try {
             for (Map.Entry<String, String> attributeEntry : attributes.entrySet()) {
-                if (attributeEntry.getKey().startsWith(SNMPUtils.SNMP_PROP_PREFIX)) {
-                    final String[] splits = attributeEntry.getKey().split("\\" + SNMPUtils.SNMP_PROP_DELIMITER);
+                if (attributeEntry.getKey().startsWith(SNMP_PROP_PREFIX)) {
+                    final String[] splits = attributeEntry.getKey().split("\\" + SNMP_PROP_DELIMITER);
                     final String snmpPropName = splits[1];
                     final String snmpPropValue = attributeEntry.getValue();
-                    if (SNMPUtils.OID_PATTERN.matcher(snmpPropName).matches()) {
+                    if (OID_PATTERN.matcher(snmpPropName).matches()) {
                         final Optional<Variable> snmpVar;
                         if (splits.length == 2) { // no SMI syntax defined
                             snmpVar = Optional.of(new OctetString(snmpPropValue));
                         } else {
                             final int smiSyntax = Integer.parseInt(splits[2]);
-                            snmpVar = SNMPUtils.stringToVariable(snmpPropValue, smiSyntax);
+                            snmpVar = stringToVariable(snmpPropValue, smiSyntax);
                         }
                         if (snmpVar.isPresent()) {
                             final VariableBinding varBind = new VariableBinding(new OID(snmpPropName), snmpVar.get());
@@ -150,10 +150,10 @@ public final class SNMPUtils {
         Set<VariableBinding> variableBindings = new HashSet<>();
         try {
             for (Map.Entry<String, String> attributeEntry : attributes.entrySet()) {
-                if (attributeEntry.getKey().startsWith(SNMPUtils.SNMP_PROP_PREFIX)) {
-                    final String[] splits = attributeEntry.getKey().split("\\" + SNMPUtils.SNMP_PROP_DELIMITER);
+                if (attributeEntry.getKey().startsWith(SNMP_PROP_PREFIX)) {
+                    final String[] splits = attributeEntry.getKey().split("\\" + SNMP_PROP_DELIMITER);
                     final String snmpPropName = splits[1];
-                    if (SNMPUtils.OID_PATTERN.matcher(snmpPropName).matches()) {
+                    if (OID_PATTERN.matcher(snmpPropName).matches()) {
                         variableBindings.add(new VariableBinding(new OID(snmpPropName)));
                     }
                 }
@@ -168,10 +168,10 @@ public final class SNMPUtils {
         List<OID> oids = new ArrayList<>();
         try {
             for (Map.Entry<String, String> attributeEntry : attributes.entrySet()) {
-                if (attributeEntry.getKey().startsWith(SNMPUtils.SNMP_PROP_PREFIX)) {
-                    final String[] splits = attributeEntry.getKey().split("\\" + SNMPUtils.SNMP_PROP_DELIMITER);
+                if (attributeEntry.getKey().startsWith(SNMP_PROP_PREFIX)) {
+                    final String[] splits = attributeEntry.getKey().split("\\" + SNMP_PROP_DELIMITER);
                     final String snmpPropName = splits[1];
-                    if (SNMPUtils.OID_PATTERN.matcher(snmpPropName).matches()) {
+                    if (OID_PATTERN.matcher(snmpPropName).matches()) {
                         oids.add(new OID(snmpPropName));
                     }
                 }

--- a/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/main/java/org/apache/nifi/snowflake/service/SnowflakeComputingConnectionPool.java
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/main/java/org/apache/nifi/snowflake/service/SnowflakeComputingConnectionPool.java
@@ -132,13 +132,13 @@ public class SnowflakeComputingConnectionPool extends AbstractDBCPConnectionPool
             .build();
 
     public static final PropertyDescriptor SNOWFLAKE_USER = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(DBCPProperties.DB_USER)
+            .fromPropertyDescriptor(DB_USER)
             .displayName("Username")
             .description("The Snowflake user name.")
             .build();
 
     public static final PropertyDescriptor SNOWFLAKE_PASSWORD = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(DBCPProperties.DB_PASSWORD)
+            .fromPropertyDescriptor(DB_PASSWORD)
             .description("The password for the Snowflake user.")
             .build();
 

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/GetSplunk.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/GetSplunk.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processors.splunk;
 
+import com.splunk.HttpException;
 import com.splunk.JobExportArgs;
 import com.splunk.SSLSecurityProtocol;
 import com.splunk.Service;
@@ -495,7 +496,7 @@ public class GetSplunk extends AbstractProcessor implements ClassloaderIsolation
         try {
             export = splunkService.export(query, exportArgs);
         //Catch Stale connection exception, reinitialize, and retry
-        } catch (com.splunk.HttpException e) {
+        } catch (HttpException e) {
             getLogger().error("Splunk request status code:{} Retrying the request.", e.getStatus());
             splunkService.logout();
             splunkService = createSplunkService(context);

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunkHTTP.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunkHTTP.java
@@ -240,8 +240,8 @@ public class PutSplunkHTTP extends SplunkAPICall {
 
     private FlowFile enrichFlowFile(final ProcessSession session, final FlowFile flowFile, final long ackId) {
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put(SplunkAPICall.ACKNOWLEDGEMENT_ID_ATTRIBUTE, String.valueOf(ackId));
-        attributes.put(SplunkAPICall.RESPONDED_AT_ATTRIBUTE, String.valueOf(System.currentTimeMillis()));
+        attributes.put(ACKNOWLEDGEMENT_ID_ATTRIBUTE, String.valueOf(ackId));
+        attributes.put(RESPONDED_AT_ATTRIBUTE, String.valueOf(System.currentTimeMillis()));
         return session.putAllAttributes(flowFile, attributes);
     }
 

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/QuerySplunkIndexingStatus.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/QuerySplunkIndexingStatus.java
@@ -165,12 +165,12 @@ public class QuerySplunkIndexingStatus extends SplunkAPICall {
         final Map<Long, FlowFile> undetermined = new HashMap<>();
 
         for (final FlowFile flowFile : flowFiles)  {
-            final Optional<Long> sentAt = extractLong(flowFile.getAttribute(SplunkAPICall.RESPONDED_AT_ATTRIBUTE));
-            final Optional<Long> ackId = extractLong(flowFile.getAttribute(SplunkAPICall.ACKNOWLEDGEMENT_ID_ATTRIBUTE));
+            final Optional<Long> sentAt = extractLong(flowFile.getAttribute(RESPONDED_AT_ATTRIBUTE));
+            final Optional<Long> ackId = extractLong(flowFile.getAttribute(ACKNOWLEDGEMENT_ID_ATTRIBUTE));
 
             if (!sentAt.isPresent() || !ackId.isPresent()) {
                 getLogger().error("Flow file ({}) attributes {} and {} are expected to be set using 64-bit integer values!",
-                        flowFile.getId(), SplunkAPICall.RESPONDED_AT_ATTRIBUTE, SplunkAPICall.ACKNOWLEDGEMENT_ID_ATTRIBUTE);
+                        flowFile.getId(), RESPONDED_AT_ATTRIBUTE, ACKNOWLEDGEMENT_ID_ATTRIBUTE);
                 session.transfer(flowFile, RELATIONSHIP_FAILURE);
             } else {
                 undetermined.put(ackId.get(), flowFile);
@@ -201,7 +201,7 @@ public class QuerySplunkIndexingStatus extends SplunkAPICall {
                     if (isAcknowledged) {
                         session.transfer(toTransfer, RELATIONSHIP_ACKNOWLEDGED);
                     } else {
-                        final Long sentAt = extractLong(toTransfer.getAttribute(SplunkAPICall.RESPONDED_AT_ATTRIBUTE)).get();
+                        final Long sentAt = extractLong(toTransfer.getAttribute(RESPONDED_AT_ATTRIBUTE)).get();
                         if (sentAt + ttl < currentTime) {
                             session.transfer(toTransfer, RELATIONSHIP_UNACKNOWLEDGED);
                         } else {

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/SplunkAPICall.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/SplunkAPICall.java
@@ -160,7 +160,7 @@ abstract class SplunkAPICall extends AbstractProcessor {
     public void onScheduled(final ProcessContext context) {
         splunkServiceArguments = getSplunkServiceArgs(context);
         splunkService = getSplunkService(splunkServiceArguments);
-        requestChannel = context.getProperty(SplunkAPICall.REQUEST_CHANNEL).evaluateAttributeExpressions().getValue();
+        requestChannel = context.getProperty(REQUEST_CHANNEL).evaluateAttributeExpressions().getValue();
         final String scheme = context.getProperty(SCHEME).getValue();
         final String hostname = context.getProperty(HOSTNAME).evaluateAttributeExpressions().getValue();
         final int port = context.getProperty(PORT).evaluateAttributeExpressions().asInteger();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/main/java/org/apache/nifi/parameter/EnvironmentVariableParameterProvider.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/main/java/org/apache/nifi/parameter/EnvironmentVariableParameterProvider.java
@@ -55,8 +55,8 @@ public class EnvironmentVariableParameterProvider extends AbstractParameterProvi
             "Include Environment Variable names that match a Regular Expression");
 
     private enum InclusionStrategyValue {
-        INCLUDE_ALL(EnvironmentVariableParameterProvider.INCLUDE_ALL_STRATEGY.getValue(), IncludeAllEnvironmentVariableInclusionStrategy::new),
-        COMMA_SEPARATED(EnvironmentVariableParameterProvider.COMMA_SEPARATED_STRATEGY.getValue(), CommaSeparatedEnvironmentVariableInclusionStrategy::new),
+        INCLUDE_ALL(INCLUDE_ALL_STRATEGY.getValue(), IncludeAllEnvironmentVariableInclusionStrategy::new),
+        COMMA_SEPARATED(COMMA_SEPARATED_STRATEGY.getValue(), CommaSeparatedEnvironmentVariableInclusionStrategy::new),
         REGEX_STRATEGY(EnvironmentVariableParameterProvider.REGEX_STRATEGY.getValue(), RegexEnvironmentVariableInclusionStrategy::new);
 
         private String name;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/test/java/org/apache/nifi/parameter/TestDatabaseParameterProvider.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/test/java/org/apache/nifi/parameter/TestDatabaseParameterProvider.java
@@ -255,10 +255,10 @@ public class TestDatabaseParameterProvider {
 
     private class ResultSetAnswer implements Answer<Boolean> {
 
-        private final Iterator<java.util.Map<String, String>> rowIterator;
-        private java.util.Map<String, String> currentRow;
+        private final Iterator<Map<String, String>> rowIterator;
+        private Map<String, String> currentRow;
 
-        private ResultSetAnswer(final List<java.util.Map<String, String>> rows) {
+        private ResultSetAnswer(final List<Map<String, String>> rows) {
             this.rowIterator = rows.iterator();
         }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractDatabaseFetchProcessor.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractDatabaseFetchProcessor.java
@@ -441,15 +441,15 @@ public abstract class AbstractDatabaseFetchProcessor extends AbstractSessionFact
 
             case TIMESTAMP:
                 Timestamp colTimestampValue = resultSet.getTimestamp(columnIndex);
-                java.sql.Timestamp maxTimestampValue = null;
+                Timestamp maxTimestampValue = null;
                 if (maxValueString != null) {
                     // For backwards compatibility, the type might be TIMESTAMP but the state value is in DATE format. This should be a one-time occurrence as the next maximum value
                     // should be stored as a full timestamp. Even so, check to see if the value is missing time-of-day information, and use the "date" coercion rather than the
                     // "timestamp" coercion in that case
                     try {
-                        maxTimestampValue = java.sql.Timestamp.valueOf(maxValueString);
+                        maxTimestampValue = Timestamp.valueOf(maxValueString);
                     } catch (IllegalArgumentException iae) {
-                        maxTimestampValue = new java.sql.Timestamp(java.sql.Date.valueOf(maxValueString).getTime());
+                        maxTimestampValue = new Timestamp(java.sql.Date.valueOf(maxValueString).getTime());
                     }
                 }
                 if (maxTimestampValue == null || colTimestampValue.after(maxTimestampValue)) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractJsonPathProcessor.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractJsonPathProcessor.java
@@ -107,7 +107,7 @@ public abstract class AbstractJsonPathProcessor extends AbstractProcessor {
     }
 
     /**
-     * Determines the context by which JsonSmartJsonProvider would treat the value. {@link java.util.Map} and {@link java.util.List} objects can be rendered as JSON elements, everything else is
+     * Determines the context by which JsonSmartJsonProvider would treat the value. {@link Map} and {@link List} objects can be rendered as JSON elements, everything else is
      * treated as a scalar.
      *
      * @param obj item to be inspected if it is a scalar or a JSON element

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeduplicateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeduplicateRecord.java
@@ -115,7 +115,7 @@ public class DeduplicateRecord extends AbstractProcessor {
 
     static final AllowableValue NONE_ALGORITHM_VALUE = new AllowableValue("none", "None",
             "Do not use a hashing algorithm. The value of resolved RecordPaths will be combined with a delimiter " +
-                    "(" + DeduplicateRecord.JOIN_CHAR + ") to form the unique cache key. " +
+                    "(" + JOIN_CHAR + ") to form the unique cache key. " +
                     "This may use significantly more storage depending on the size and shape or your data.");
     static final AllowableValue SHA256_ALGORITHM_VALUE = new AllowableValue(MessageDigestAlgorithms.SHA_256, "SHA-256",
             "SHA-256 cryptographic hashing algorithm.");

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteProcess.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteProcess.java
@@ -293,8 +293,8 @@ public class ExecuteProcess extends AbstractProcessor {
             if (arguments != null) {
                 attributes.put(ATTRIBUTE_COMMAND_ARGS, arguments);
             }
-            if (batchNanos == null && context.getProperty(ExecuteProcess.MIME_TYPE).isSet()) {
-                attributes.put(CoreAttributes.MIME_TYPE.key(), context.getProperty(ExecuteProcess.MIME_TYPE).getValue());
+            if (batchNanos == null && context.getProperty(MIME_TYPE).isSet()) {
+                attributes.put(CoreAttributes.MIME_TYPE.key(), context.getProperty(MIME_TYPE).getValue());
             }
             flowFile = session.putAllAttributes(flowFile, attributes);
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchDistributedMapCache.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchDistributedMapCache.java
@@ -177,7 +177,7 @@ public class FetchDistributedMapCache extends AbstractProcessor {
             // or a single EL statement with commas inside it but that evaluates to a single item.
             results.add(new ValidationResult.Builder().valid(true).explanation("Contains Expression Language").build());
         } else {
-            if (!validationContext.getProperty(FetchDistributedMapCache.PUT_CACHE_VALUE_IN_ATTRIBUTE).isSet()) {
+            if (!validationContext.getProperty(PUT_CACHE_VALUE_IN_ATTRIBUTE).isSet()) {
                 String identifierString = cacheEntryIdentifier.getValue();
                 if (identifierString.contains(",")) {
                     results.add(new ValidationResult.Builder().valid(false)

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -688,7 +688,7 @@ public class InvokeHTTP extends AbstractProcessor {
                 if (newValue == null || newValue.isEmpty()) {
                     requestHeaderAttributesPattern = null;
                 } else {
-                    final String trimmedValue = StringUtils.trimToEmpty(newValue);
+                    final String trimmedValue = trimToEmpty(newValue);
                     requestHeaderAttributesPattern = Pattern.compile(trimmedValue);
                 }
             }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -34,7 +34,6 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyDescriptor.Builder;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.context.PropertyContext;
-import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.migration.PropertyConfiguration;
@@ -239,7 +238,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
             "this property will result in less heap utilization, while a larger value may provide more accurate insights into how the disk access operations are performing")
         .required(true)
         .addValidator(POSITIVE_INTEGER_VALIDATOR)
-        .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+        .expressionLanguageSupported(ENVIRONMENT)
         .defaultValue("100000")
         .build();
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -325,8 +325,8 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
         final Map<String, StatementFlowFileEnclosure> sqlToEnclosure = new HashMap<>();
 
         for (final FlowFile flowFile : flowFiles) {
-            final String sql = context.getProperty(PutSQL.SQL_STATEMENT).isSet()
-                    ? context.getProperty(PutSQL.SQL_STATEMENT).evaluateAttributeExpressions(flowFile).getValue()
+            final String sql = context.getProperty(SQL_STATEMENT).isSet()
+                    ? context.getProperty(SQL_STATEMENT).evaluateAttributeExpressions(flowFile).getValue()
                     : getSQL(session, flowFile);
 
             final StatementFlowFileEnclosure enclosure = sqlToEnclosure
@@ -338,8 +338,8 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
 
     private final GroupingFunction groupFlowFilesBySQLBatch = (context, session, fc, conn, flowFiles, groups, result) -> {
         for (final FlowFile flowFile : flowFiles) {
-            final String sql = context.getProperty(PutSQL.SQL_STATEMENT).isSet()
-                    ? context.getProperty(PutSQL.SQL_STATEMENT).evaluateAttributeExpressions(flowFile).getValue()
+            final String sql = context.getProperty(SQL_STATEMENT).isSet()
+                    ? context.getProperty(SQL_STATEMENT).evaluateAttributeExpressions(flowFile).getValue()
                     : getSQL(session, flowFile);
 
             // Create a new PreparedStatement or reuse the one from the last group if that is the same.
@@ -367,8 +367,8 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
 
     private final GroupingFunction groupFlowFilesBySQL = (context, session, fc, conn, flowFiles, groups, result) -> {
         for (final FlowFile flowFile : flowFiles) {
-            final String sql = context.getProperty(PutSQL.SQL_STATEMENT).isSet()
-                    ? context.getProperty(PutSQL.SQL_STATEMENT).evaluateAttributeExpressions(flowFile).getValue()
+            final String sql = context.getProperty(SQL_STATEMENT).isSet()
+                    ? context.getProperty(SQL_STATEMENT).evaluateAttributeExpressions(flowFile).getValue()
                     : getSQL(session, flowFile);
 
             // Create a new PreparedStatement or reuse the one from the last group if that is the same.

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitXml.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitXml.java
@@ -45,6 +45,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 
+import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -153,7 +154,7 @@ public class SplitXml extends AbstractProcessor {
 
         final AtomicBoolean failed = new AtomicBoolean(false);
         session.read(original, rawIn -> {
-            try (final InputStream in = new java.io.BufferedInputStream(rawIn)) {
+            try (final InputStream in = new BufferedInputStream(rawIn)) {
                 try {
                     final StandardInputSourceParser inputSourceParser = new StandardInputSourceParser();
                     inputSourceParser.setNamespaceAware(true);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
@@ -986,7 +986,7 @@ public class TailFile extends AbstractProcessor {
      * will be also written to the OutputStream
      *
      * @return The new position after the lines have been read
-     * @throws java.io.IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     private long readLines(final FileChannel reader, final ByteBuffer buffer, final OutputStream out, final Checksum checksum,
                            Boolean reReadOnNul, final boolean readFully) throws IOException {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UpdateDatabaseTable.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UpdateDatabaseTable.java
@@ -35,7 +35,6 @@ import org.apache.nifi.database.dialect.service.api.StatementResponse;
 import org.apache.nifi.database.dialect.service.api.StatementType;
 import org.apache.nifi.database.dialect.service.api.TableDefinition;
 import org.apache.nifi.dbcp.DBCPService;
-import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.logging.ComponentLog;
@@ -147,7 +146,7 @@ public class UpdateDatabaseTable extends AbstractProcessor {
             .description("The name of the database table to update. If the table does not exist, then it will either be created or an error thrown, depending "
                     + "on the value of the Create Table property.")
             .required(true)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .expressionLanguageSupported(FLOWFILE_ATTRIBUTES)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
@@ -248,7 +247,7 @@ public class UpdateDatabaseTable extends AbstractProcessor {
             .defaultValue("0")
             .required(true)
             .addValidator(StandardValidators.INTEGER_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .expressionLanguageSupported(FLOWFILE_ATTRIBUTES)
             .build();
 
     static final PropertyDescriptor DB_TYPE = DatabaseAdapterDescriptor.getDatabaseTypeDescriptor();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/hash/HashAlgorithm.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/hash/HashAlgorithm.java
@@ -135,7 +135,7 @@ public enum HashAlgorithm {
     }
 
     public static HashAlgorithm fromName(String algorithmName) {
-        HashAlgorithm match = Arrays.stream(HashAlgorithm.values())
+        HashAlgorithm match = Arrays.stream(values())
                 .filter(algo -> algorithmName.equalsIgnoreCase(algo.name))
                 .findAny()
                 .orElse(null);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/hash/HashService.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/hash/HashService.java
@@ -93,7 +93,7 @@ public class HashService {
     }
 
     /**
-     * Returns the hash of the specified value. This method uses an {@link java.io.InputStream} to perform the operation in a streaming manner for large inputs.
+     * Returns the hash of the specified value. This method uses an {@link InputStream} to perform the operation in a streaming manner for large inputs.
      *
      * @param algorithm the hash algorithm to use
      * @param value     the value to hash (cannot be {@code null} but can be an empty stream)

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
@@ -173,9 +173,9 @@ public class FTPTransfer implements FileTransfer {
 
     @Override
     public List<FileInfo> getListing(final boolean applyFilters) throws IOException {
-        final String path = ctx.getProperty(FileTransfer.REMOTE_PATH).evaluateAttributeExpressions().getValue();
+        final String path = ctx.getProperty(REMOTE_PATH).evaluateAttributeExpressions().getValue();
         final int depth = 0;
-        final int maxResults = ctx.getProperty(FileTransfer.REMOTE_POLL_BATCH_SIZE).asInteger();
+        final int maxResults = ctx.getProperty(REMOTE_POLL_BATCH_SIZE).asInteger();
         return getListing(path, depth, maxResults, applyFilters);
     }
 
@@ -190,14 +190,14 @@ public class FTPTransfer implements FileTransfer {
             return listing;
         }
 
-        final boolean ignoreDottedFiles = ctx.getProperty(FileTransfer.IGNORE_DOTTED_FILES).asBoolean();
-        final boolean recurse = ctx.getProperty(FileTransfer.RECURSIVE_SEARCH).asBoolean();
-        final boolean symlink = ctx.getProperty(FileTransfer.FOLLOW_SYMLINK).asBoolean();
-        final String fileFilterRegex = ctx.getProperty(FileTransfer.FILE_FILTER_REGEX).getValue();
+        final boolean ignoreDottedFiles = ctx.getProperty(IGNORE_DOTTED_FILES).asBoolean();
+        final boolean recurse = ctx.getProperty(RECURSIVE_SEARCH).asBoolean();
+        final boolean symlink = ctx.getProperty(FOLLOW_SYMLINK).asBoolean();
+        final String fileFilterRegex = ctx.getProperty(FILE_FILTER_REGEX).getValue();
         final Pattern pattern = (fileFilterRegex == null) ? null : Pattern.compile(fileFilterRegex);
-        final String pathFilterRegex = ctx.getProperty(FileTransfer.PATH_FILTER_REGEX).getValue();
+        final String pathFilterRegex = ctx.getProperty(PATH_FILTER_REGEX).getValue();
         final Pattern pathPattern = (!recurse || pathFilterRegex == null) ? null : Pattern.compile(pathFilterRegex);
-        final String remotePath = ctx.getProperty(FileTransfer.REMOTE_PATH).evaluateAttributeExpressions().getValue();
+        final String remotePath = ctx.getProperty(REMOTE_PATH).evaluateAttributeExpressions().getValue();
 
         // check if this directory path matches the PATH_FILTER_REGEX
         boolean pathFilterMatches = true;
@@ -536,8 +536,8 @@ public class FTPTransfer implements FileTransfer {
     private FTPClient getClient(final FlowFile flowFile) throws IOException {
         final String hostname = ctx.getProperty(HOSTNAME).evaluateAttributeExpressions(flowFile).getValue();
         final String port = ctx.getProperty(PORT).evaluateAttributeExpressions(flowFile).getValue();
-        final String username = ctx.getProperty(FileTransfer.USERNAME).evaluateAttributeExpressions(flowFile).getValue();
-        final String password = ctx.getProperty(FileTransfer.PASSWORD).evaluateAttributeExpressions(flowFile).getValue();
+        final String username = ctx.getProperty(USERNAME).evaluateAttributeExpressions(flowFile).getValue();
+        final String password = ctx.getProperty(PASSWORD).evaluateAttributeExpressions(flowFile).getValue();
 
         if (client != null) {
             if (Objects.equals(remoteHostName, hostname)

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
@@ -312,11 +312,11 @@ public class SFTPTransfer implements FileTransfer {
 
     @Override
     public List<FileInfo> getListing(final boolean applyFilters) throws IOException {
-        final String path = ctx.getProperty(FileTransfer.REMOTE_PATH).evaluateAttributeExpressions().getValue();
+        final String path = ctx.getProperty(REMOTE_PATH).evaluateAttributeExpressions().getValue();
         final int depth = 0;
 
         final int maxResults;
-        final PropertyValue batchSizeValue = ctx.getProperty(FileTransfer.REMOTE_POLL_BATCH_SIZE);
+        final PropertyValue batchSizeValue = ctx.getProperty(REMOTE_POLL_BATCH_SIZE);
         if (batchSizeValue == null) {
             maxResults = Integer.MAX_VALUE;
         } else {
@@ -346,14 +346,14 @@ public class SFTPTransfer implements FileTransfer {
             return;
         }
 
-        final boolean ignoreDottedFiles = ctx.getProperty(FileTransfer.IGNORE_DOTTED_FILES).asBoolean();
-        final boolean recurse = ctx.getProperty(FileTransfer.RECURSIVE_SEARCH).asBoolean();
-        final boolean symlink  = ctx.getProperty(FileTransfer.FOLLOW_SYMLINK).asBoolean();
-        final String fileFilterRegex = ctx.getProperty(FileTransfer.FILE_FILTER_REGEX).getValue();
+        final boolean ignoreDottedFiles = ctx.getProperty(IGNORE_DOTTED_FILES).asBoolean();
+        final boolean recurse = ctx.getProperty(RECURSIVE_SEARCH).asBoolean();
+        final boolean symlink  = ctx.getProperty(FOLLOW_SYMLINK).asBoolean();
+        final String fileFilterRegex = ctx.getProperty(FILE_FILTER_REGEX).getValue();
         final Pattern fileFilterPattern = (fileFilterRegex == null) ? null : Pattern.compile(fileFilterRegex);
-        final String pathFilterRegex = ctx.getProperty(FileTransfer.PATH_FILTER_REGEX).getValue();
+        final String pathFilterRegex = ctx.getProperty(PATH_FILTER_REGEX).getValue();
         final Pattern pathPattern = (!recurse || pathFilterRegex == null) ? null : Pattern.compile(pathFilterRegex);
-        final String remotePath = ctx.getProperty(FileTransfer.REMOTE_PATH).evaluateAttributeExpressions().getValue();
+        final String remotePath = ctx.getProperty(REMOTE_PATH).evaluateAttributeExpressions().getValue();
 
         // check if this directory path matches the PATH_FILTER_REGEX
         boolean pathFilterMatches = true;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordTest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentMatchers;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
@@ -2352,7 +2351,7 @@ class PutDatabaseRecordTest extends AbstractDatabaseConnectionServiceTest {
                 return spyStmt[0];
             }
         };
-        doAnswer(answer).when(dbcp).getConnection(ArgumentMatchers.anyMap());
+        doAnswer(answer).when(dbcp).getConnection(anyMap());
         return () -> spyStmt[0];
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDetectDuplicate.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDetectDuplicate.java
@@ -178,7 +178,7 @@ public class TestDetectDuplicate {
         }
 
         @Override
-        protected java.util.List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
             final List<PropertyDescriptor> props = new ArrayList<>();
             props.add(MapCacheClientService.HOSTNAME);
             props.add(MapCacheClientService.COMMUNICATIONS_TIMEOUT);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateRecord.java
@@ -257,16 +257,16 @@ public class TestGenerateRecord {
             assertEquals(RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType()), guidField.get().getDataType());
 
             // Check object type, class etc.
-            final org.apache.nifi.serialization.record.Record record = recordReader.nextRecord();
+            final Record record = recordReader.nextRecord();
             assertNotNull(record);
             final Object systemObject = record.getValue("System");
             assertNotNull(systemObject);
             assertInstanceOf(Record.class, systemObject);
-            final org.apache.nifi.serialization.record.Record systemRecord = (org.apache.nifi.serialization.record.Record) systemObject;
+            final Record systemRecord = (Record) systemObject;
             final Object providerObject = systemRecord.getValue("Provider");
             assertNotNull(providerObject);
             assertInstanceOf(Record.class, providerObject);
-            final org.apache.nifi.serialization.record.Record providerRecord = (org.apache.nifi.serialization.record.Record) providerObject;
+            final Record providerRecord = (Record) providerObject;
             final Object guidObject = providerRecord.getValue("Guid");
             assertNotNull(guidObject);
             assertInstanceOf(Object[].class, guidObject);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
@@ -37,10 +37,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor.DB_TYPE;
 import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor.FRAGMENT_COUNT;
 import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor.FRAGMENT_ID;
 import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor.FRAGMENT_INDEX;
 import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor.REL_SUCCESS;
+import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor.SQL_QUERY;
+import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor.WHERE_CLAUSE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -381,8 +384,8 @@ class TestGenerateTableFetch extends AbstractDatabaseConnectionServiceTest {
         runner.setProperty(GenerateTableFetch.PARTITION_SIZE, "0");
 
         runner.run();
-        runner.assertAllFlowFilesTransferred(GenerateTableFetch.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(GenerateTableFetch.REL_SUCCESS).getFirst();
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(REL_SUCCESS).getFirst();
         flowFile.assertContentEquals("SELECT * FROM TEST_QUERY_DB_TABLE WHERE ID <= 2");
         flowFile.assertAttributeExists("generatetablefetch.limit");
         flowFile.assertAttributeEquals("generatetablefetch.limit", null);
@@ -402,13 +405,13 @@ class TestGenerateTableFetch extends AbstractDatabaseConnectionServiceTest {
         runner.setProperty(GenerateTableFetch.OUTPUT_EMPTY_FLOWFILE_ON_ZERO_RESULTS, "false");
 
         runner.run();
-        runner.assertAllFlowFilesTransferred(GenerateTableFetch.REL_SUCCESS, 0);
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 0);
         runner.clearTransferState();
 
         runner.setProperty(GenerateTableFetch.OUTPUT_EMPTY_FLOWFILE_ON_ZERO_RESULTS, "true");
         runner.run();
-        runner.assertAllFlowFilesTransferred(GenerateTableFetch.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(GenerateTableFetch.REL_SUCCESS).getFirst();
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(REL_SUCCESS).getFirst();
         assertEquals("TEST_QUERY_DB_TABLE", flowFile.getAttribute("generatetablefetch.tableName"));
         assertEquals("ID,BUCKET", flowFile.getAttribute("generatetablefetch.columnNames"));
         assertEquals("1=1", flowFile.getAttribute("generatetablefetch.whereClause"));
@@ -432,30 +435,30 @@ class TestGenerateTableFetch extends AbstractDatabaseConnectionServiceTest {
         runner.setProperty(GenerateTableFetch.PARTITION_SIZE, "1");
 
         runner.run();
-        runner.assertAllFlowFilesTransferred(GenerateTableFetch.REL_SUCCESS, 2);
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 2);
         runner.clearTransferState();
 
         // Add a new row in the same bucket
         executeSql("insert into TEST_QUERY_DB_TABLE (id, bucket) VALUES (2, 0)");
         runner.run();
-        runner.assertAllFlowFilesTransferred(GenerateTableFetch.REL_SUCCESS, 1);
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
         runner.clearTransferState();
 
         // Add a new row in a new bucket
         executeSql("insert into TEST_QUERY_DB_TABLE (id, bucket) VALUES (3, 1)");
         runner.run();
-        runner.assertAllFlowFilesTransferred(GenerateTableFetch.REL_SUCCESS, 1);
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
         runner.clearTransferState();
 
         // Add a new row in an old bucket, it should not be transferred
         executeSql("insert into TEST_QUERY_DB_TABLE (id, bucket) VALUES (4, 0)");
         runner.run();
-        runner.assertTransferCount(GenerateTableFetch.REL_SUCCESS, 0);
+        runner.assertTransferCount(REL_SUCCESS, 0);
 
         // Add a new row in the second bucket, only the new row should be transferred
         executeSql("insert into TEST_QUERY_DB_TABLE (id, bucket) VALUES (5, 1)");
         runner.run();
-        runner.assertAllFlowFilesTransferred(GenerateTableFetch.REL_SUCCESS, 1);
+        runner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
         runner.clearTransferState();
     }
 
@@ -480,16 +483,16 @@ class TestGenerateTableFetch extends AbstractDatabaseConnectionServiceTest {
         runner.enqueue("".getBytes(), Map.of("tableName", "TEST_QUERY_DB_TABLE3", "partSize", "1"));
 
         runner.run(3);
-        runner.assertTransferCount(AbstractDatabaseFetchProcessor.REL_SUCCESS, 3);
+        runner.assertTransferCount(REL_SUCCESS, 3);
 
         // Two records from table 1
         assertEquals(2,
-                runner.getFlowFilesForRelationship(AbstractDatabaseFetchProcessor.REL_SUCCESS).stream().filter(
+                runner.getFlowFilesForRelationship(REL_SUCCESS).stream().filter(
                         (ff) -> "TEST_QUERY_DB_TABLE1".equals(ff.getAttribute("tableName"))).count());
 
         // One record from table 2
         assertEquals(1,
-                runner.getFlowFilesForRelationship(AbstractDatabaseFetchProcessor.REL_SUCCESS).stream().filter(
+                runner.getFlowFilesForRelationship(REL_SUCCESS).stream().filter(
                         (ff) -> "TEST_QUERY_DB_TABLE2".equals(ff.getAttribute("tableName"))).count());
 
         // Table 3 doesn't exist, should be routed to failure
@@ -826,7 +829,7 @@ class TestGenerateTableFetch extends AbstractDatabaseConnectionServiceTest {
         executeSql("insert into TEST_QUERY_DB_TABLE (id, type, name, scale, created_on) VALUES (2, NULL, NULL, 2.0, '2010-01-01 00:00:00')");
 
         runner.setProperty(GenerateTableFetch.TABLE_NAME, "TEST_QUERY_DB_TABLE");
-        runner.setProperty(GenerateTableFetch.WHERE_CLAUSE, "type = 'male' OR type IS NULL");
+        runner.setProperty(WHERE_CLAUSE, "type = 'male' OR type IS NULL");
         runner.setIncomingConnection(false);
         runner.setProperty(GenerateTableFetch.MAX_VALUE_COLUMN_NAMES, "ID");
 
@@ -1102,9 +1105,9 @@ class TestGenerateTableFetch extends AbstractDatabaseConnectionServiceTest {
     @Test
     void testMigrateProperties() {
         final Map<String, String> expectedRenamed = Map.ofEntries(
-                Map.entry("db-fetch-db-type", AbstractDatabaseFetchProcessor.DB_TYPE.getName()),
-                Map.entry("db-fetch-where-clause", AbstractDatabaseFetchProcessor.WHERE_CLAUSE.getName()),
-                Map.entry("db-fetch-sql-query", AbstractDatabaseFetchProcessor.SQL_QUERY.getName()),
+                Map.entry("db-fetch-db-type", DB_TYPE.getName()),
+                Map.entry("db-fetch-where-clause", WHERE_CLAUSE.getName()),
+                Map.entry("db-fetch-sql-query", SQL_QUERY.getName()),
                 Map.entry("gen-table-fetch-partition-size", GenerateTableFetch.PARTITION_SIZE.getName()),
                 Map.entry("gen-table-column-for-val-partitioning", GenerateTableFetch.COLUMN_FOR_VALUE_PARTITIONING.getName()),
                 Map.entry("gen-table-output-flowfile-on-zero-results", GenerateTableFetch.OUTPUT_EMPTY_FLOWFILE_ON_ZERO_RESULTS.getName()),

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
@@ -723,8 +723,8 @@ public class TestListenHTTP {
             assertTrue(response.isSuccessful(), String.format("Unexpected code: %s, body: %s", response.code(), response.body()));
         }
 
-        runner.assertAllFlowFilesTransferred(ListenHTTP.RELATIONSHIP_SUCCESS, 5);
-        List<MockFlowFile> flowFilesForRelationship = runner.getFlowFilesForRelationship(ListenHTTP.RELATIONSHIP_SUCCESS);
+        runner.assertAllFlowFilesTransferred(RELATIONSHIP_SUCCESS, 5);
+        List<MockFlowFile> flowFilesForRelationship = runner.getFlowFilesForRelationship(RELATIONSHIP_SUCCESS);
         // Part fragments are not processed in the order we submitted them.
         // We cannot rely on the order we sent them in.
         MockFlowFile mff = findFlowFile(flowFilesForRelationship, "p1");

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPackageFlowFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPackageFlowFile.java
@@ -24,7 +24,6 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.PropertyMigrationResult;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -33,7 +32,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestPackageFlowFile {
 
@@ -60,7 +61,7 @@ public class TestPackageFlowFile {
         final MockFlowFile outputFlowFile = runner.getFlowFilesForRelationship(PackageFlowFile.REL_SUCCESS).getFirst();
 
         // mime.type has changed
-        Assertions.assertEquals(StandardFlowFileMediaType.VERSION_3.getMediaType(),
+        assertEquals(StandardFlowFileMediaType.VERSION_3.getMediaType(),
                 outputFlowFile.getAttribute(CoreAttributes.MIME_TYPE.key()));
 
         // content can be unpacked with FlowFileUnpackagerV3
@@ -69,14 +70,14 @@ public class TestPackageFlowFile {
              ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             Map<String, String> unpackedAttributes = unpackager.unpackageFlowFile(bais, baos);
             // verify attributes in package
-            Assertions.assertEquals(5, unpackedAttributes.size());
-            Assertions.assertNotNull(unpackedAttributes.get(CoreAttributes.UUID.key()));
-            Assertions.assertNotNull(unpackedAttributes.get(CoreAttributes.PATH.key()));
-            Assertions.assertEquals(SAMPLE_ATTR_FILENAME, unpackedAttributes.get(CoreAttributes.FILENAME.key()));
-            Assertions.assertEquals(SAMPLE_ATTR_MIME_TYPE, unpackedAttributes.get(CoreAttributes.MIME_TYPE.key()));
-            Assertions.assertEquals(EXTRA_ATTR_VALUE, unpackedAttributes.get(EXTRA_ATTR_KEY));
+            assertEquals(5, unpackedAttributes.size());
+            assertNotNull(unpackedAttributes.get(CoreAttributes.UUID.key()));
+            assertNotNull(unpackedAttributes.get(CoreAttributes.PATH.key()));
+            assertEquals(SAMPLE_ATTR_FILENAME, unpackedAttributes.get(CoreAttributes.FILENAME.key()));
+            assertEquals(SAMPLE_ATTR_MIME_TYPE, unpackedAttributes.get(CoreAttributes.MIME_TYPE.key()));
+            assertEquals(EXTRA_ATTR_VALUE, unpackedAttributes.get(EXTRA_ATTR_KEY));
             // verify content in package
-            Assertions.assertArrayEquals(SAMPLE_CONTENT.getBytes(), baos.toByteArray());
+            assertArrayEquals(SAMPLE_CONTENT.getBytes(), baos.toByteArray());
         }
     }
 
@@ -98,7 +99,7 @@ public class TestPackageFlowFile {
         final MockFlowFile outputFlowFile = runner.getFlowFilesForRelationship(PackageFlowFile.REL_SUCCESS).getFirst();
 
         // mime.type has changed
-        Assertions.assertEquals(StandardFlowFileMediaType.VERSION_3.getMediaType(),
+        assertEquals(StandardFlowFileMediaType.VERSION_3.getMediaType(),
                 outputFlowFile.getAttribute(CoreAttributes.MIME_TYPE.key()));
 
         // content can be unpacked with FlowFileUnpackagerV3
@@ -108,13 +109,13 @@ public class TestPackageFlowFile {
             for (int i = 0; i < fileCount; i++) {
                 Map<String, String> unpackedAttributes = unpackager.unpackageFlowFile(bais, baos);
                 // verify attributes in package
-                Assertions.assertEquals(4, unpackedAttributes.size());
-                Assertions.assertNotNull(unpackedAttributes.get(CoreAttributes.UUID.key()));
-                Assertions.assertNotNull(unpackedAttributes.get(CoreAttributes.PATH.key()));
-                Assertions.assertEquals(i + SAMPLE_ATTR_FILENAME, unpackedAttributes.get(CoreAttributes.FILENAME.key()));
-                Assertions.assertEquals(SAMPLE_ATTR_MIME_TYPE, unpackedAttributes.get(CoreAttributes.MIME_TYPE.key()));
+                assertEquals(4, unpackedAttributes.size());
+                assertNotNull(unpackedAttributes.get(CoreAttributes.UUID.key()));
+                assertNotNull(unpackedAttributes.get(CoreAttributes.PATH.key()));
+                assertEquals(i + SAMPLE_ATTR_FILENAME, unpackedAttributes.get(CoreAttributes.FILENAME.key()));
+                assertEquals(SAMPLE_ATTR_MIME_TYPE, unpackedAttributes.get(CoreAttributes.MIME_TYPE.key()));
                 // verify content in package
-                Assertions.assertArrayEquals(SAMPLE_CONTENT.getBytes(), baos.toByteArray());
+                assertArrayEquals(SAMPLE_CONTENT.getBytes(), baos.toByteArray());
                 baos.reset();
             }
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
@@ -527,7 +527,7 @@ public class TestPutSQL {
         final String arg2TS = "2001-01-01 00:01:01.001";
         final String art3TS = "2002-02-02 12:02:02.002";
         final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
-        java.util.Date parsedDate = Date.from(LocalDateTime.parse(arg2TS, dateTimeFormatter).atZone(ZoneId.systemDefault()).toInstant());
+        Date parsedDate = Date.from(LocalDateTime.parse(arg2TS, dateTimeFormatter).atZone(ZoneId.systemDefault()).toInstant());
 
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("sql.args.1.type", String.valueOf(Types.TIMESTAMP));
@@ -631,9 +631,9 @@ public class TestPutSQL {
         // Since Derby database which is used for unit test does not have timezone in DATE and TIME type,
         // and PutSQL converts date string into long representation using local timezone,
         // we need to use local timezone.
-        java.util.Date parsedLocalTime = java.sql.Time.valueOf(timeStr);
+        Date parsedLocalTime = Time.valueOf(timeStr);
 
-        java.util.Date parsedLocalDate = java.sql.Date.valueOf(dateStr);
+        Date parsedLocalDate = java.sql.Date.valueOf(dateStr);
 
         // test Long pattern without format attribute
         attributes = new HashMap<>();
@@ -806,7 +806,7 @@ public class TestPutSQL {
         final String art3TS = "12:03:04";
         final String timeFormatString = "HH:mm:ss";
         final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(timeFormatString);
-        java.util.Date parsedDate = Date.from(LocalTime.parse(arg2TS, dateTimeFormatter).atDate(LocalDate.now()).atZone(ZoneId.systemDefault()).toInstant());
+        Date parsedDate = Date.from(LocalTime.parse(arg2TS, dateTimeFormatter).atDate(LocalDate.now()).atZone(ZoneId.systemDefault()).toInstant());
 
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("sql.args.1.type", String.valueOf(Types.TIME));
@@ -843,7 +843,7 @@ public class TestPutSQL {
 
         final String arg2TS = "2001-01-01";
         final String art3TS = "2002-02-02";
-        java.util.Date parsedDate = java.sql.Date.valueOf(arg2TS);
+        Date parsedDate = java.sql.Date.valueOf(arg2TS);
 
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("sql.args.1.type", String.valueOf(Types.DATE));

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutTCP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutTCP.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 
@@ -79,6 +78,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Timeout(30)
@@ -147,9 +147,9 @@ public class TestPutTCP {
     public void testRunSuccessSslContextService() throws Exception {
         final SSLContext sslContext = getSslContext();
         final String identifier = SSLContextProvider.class.getName();
-        final SSLContextProvider sslContextProvider = Mockito.mock(SSLContextProvider.class);
-        Mockito.when(sslContextProvider.getIdentifier()).thenReturn(identifier);
-        Mockito.when(sslContextProvider.createContext()).thenReturn(sslContext);
+        final SSLContextProvider sslContextProvider = mock(SSLContextProvider.class);
+        when(sslContextProvider.getIdentifier()).thenReturn(identifier);
+        when(sslContextProvider.createContext()).thenReturn(sslContext);
         runner.addControllerService(identifier, sslContextProvider);
         runner.enableControllerService(sslContextProvider);
         runner.setProperty(PutTCP.SSL_CONTEXT_SERVICE, identifier);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestQueryRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestQueryRecord.java
@@ -60,6 +60,7 @@ import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -151,7 +152,7 @@ public class TestQueryRecord {
         assertArrayEquals(new String[] {"red", "green"}, (Object[]) output.getValue("colors"));
         assertArrayEquals(new String[] {"John Doe", "Jane Doe"}, (Object[]) output.getValue("names"));
 
-        assertEquals(java.time.LocalDate.parse(ISO_DATE), output.getAsLocalDate("joinTime", ISO_DATE_FORMAT));
+        assertEquals(LocalDate.parse(ISO_DATE), output.getAsLocalDate("joinTime", ISO_DATE_FORMAT));
         assertEquals(Double.valueOf(180.8D), output.getAsDouble("weight"));
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestRetryFlowFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestRetryFlowFile.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.nifi.processors.standard.RetryFlowFile.FAIL_ON_OVERWRITE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -141,7 +140,7 @@ public class TestRetryFlowFile {
 
     @Test
     public void testFailOnOverwrite() {
-        runner.setProperty(FAIL_ON_OVERWRITE, "true");
+        runner.setProperty(RetryFlowFile.FAIL_ON_OVERWRITE, "true");
         runner.enqueue("", Collections.singletonMap("flowfile.retries", "ZZAaa"));
         runner.run();
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUpdateCounter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUpdateCounter.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -57,7 +58,7 @@ public class TestUpdateCounter {
         runner.enqueue(new byte[0], attributes);
         runner.run();
         Long counter = runner.getCounterValue("test");
-        assertEquals(java.util.Optional.ofNullable(counter), java.util.Optional.of(40L));
+        assertEquals(Optional.ofNullable(counter), Optional.of(40L));
         runner.assertAllFlowFilesTransferred(UpdateCounter.SUCCESS, 1);
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/calcite/TestRecordResultSetOutputStreamCallback.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/calcite/TestRecordResultSetOutputStreamCallback.java
@@ -18,6 +18,7 @@ package org.apache.nifi.processors.standard.calcite;
 
 import org.apache.calcite.adapter.java.ReflectiveSchema;
 import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.jdbc.Driver;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.nifi.csv.CSVRecordSetWriter;
 import org.apache.nifi.flowfile.FlowFile;
@@ -81,7 +82,7 @@ public class TestRecordResultSetOutputStreamCallback {
     }
 
     private ResultSet getResultSet() throws SQLException {
-        DriverManager.registerDriver(new org.apache.calcite.jdbc.Driver());
+        DriverManager.registerDriver(new Driver());
         final Connection connection = DriverManager.getConnection("jdbc:calcite:");
         final CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class);
         calciteConnection.getRootSchema().add("TEST", new ReflectiveSchema(new CalciteTestSchema()));

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-rules/src/main/java/org/apache/nifi/flowanalysis/rules/util/FlowAnalysisRuleUtils.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-rules/src/main/java/org/apache/nifi/flowanalysis/rules/util/FlowAnalysisRuleUtils.java
@@ -54,7 +54,7 @@ public class FlowAnalysisRuleUtils {
      */
     public static Collection<GroupAnalysisResult> convertToGroupAnalysisResults(VersionedProcessGroup pg, Collection<ConnectionViolation> violations) {
         if (!violations.isEmpty()) {
-            final Map<String, VersionedComponent> components = FlowAnalysisRuleUtils.gatherComponents(pg);
+            final Map<String, VersionedComponent> components = gatherComponents(pg);
             final Collection<GroupAnalysisResult> results = new HashSet<>();
             violations.forEach(violation -> results.add(violation.convertToGroupAnalysisResult(components)));
             return results;

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/java/org/apache/nifi/dbcp/DBCPServiceTest.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/java/org/apache/nifi/dbcp/DBCPServiceTest.java
@@ -50,15 +50,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.nifi.dbcp.utils.DBCPProperties.DB_DRIVER_LOCATION;
-import static org.apache.nifi.dbcp.utils.DBCPProperties.EVICTION_RUN_PERIOD;
-import static org.apache.nifi.dbcp.utils.DBCPProperties.KERBEROS_USER_SERVICE;
-import static org.apache.nifi.dbcp.utils.DBCPProperties.MAX_CONN_LIFETIME;
-import static org.apache.nifi.dbcp.utils.DBCPProperties.MAX_IDLE;
-import static org.apache.nifi.dbcp.utils.DBCPProperties.MIN_EVICTABLE_IDLE_TIME;
-import static org.apache.nifi.dbcp.utils.DBCPProperties.MIN_IDLE;
-import static org.apache.nifi.dbcp.utils.DBCPProperties.SOFT_MIN_EVICTABLE_IDLE_TIME;
-import static org.apache.nifi.dbcp.utils.DBCPProperties.VALIDATION_QUERY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -282,16 +273,16 @@ public class DBCPServiceTest {
     @Test
     void testMigrateProperties() {
         final Map<String, String> expectedRenamed = Map.ofEntries(
-                Map.entry("database-driver-locations", DB_DRIVER_LOCATION.getName()),
-                Map.entry("Database Driver Location(s)", DB_DRIVER_LOCATION.getName()),
-                Map.entry(DBCPProperties.OLD_VALIDATION_QUERY_PROPERTY_NAME, VALIDATION_QUERY.getName()),
-                Map.entry(DBCPProperties.OLD_MIN_IDLE_PROPERTY_NAME, MIN_IDLE.getName()),
-                Map.entry(DBCPProperties.OLD_MAX_IDLE_PROPERTY_NAME, MAX_IDLE.getName()),
-                Map.entry(DBCPProperties.OLD_MAX_CONN_LIFETIME_PROPERTY_NAME, MAX_CONN_LIFETIME.getName()),
-                Map.entry(DBCPProperties.OLD_EVICTION_RUN_PERIOD_PROPERTY_NAME, EVICTION_RUN_PERIOD.getName()),
-                Map.entry(DBCPProperties.OLD_MIN_EVICTABLE_IDLE_TIME_PROPERTY_NAME, MIN_EVICTABLE_IDLE_TIME.getName()),
-                Map.entry(DBCPProperties.OLD_SOFT_MIN_EVICTABLE_IDLE_TIME_PROPERTY_NAME, SOFT_MIN_EVICTABLE_IDLE_TIME.getName()),
-                Map.entry(DBCPProperties.OLD_KERBEROS_USER_SERVICE_PROPERTY_NAME, KERBEROS_USER_SERVICE.getName())
+                Map.entry("database-driver-locations", DBCPProperties.DB_DRIVER_LOCATION.getName()),
+                Map.entry("Database Driver Location(s)", DBCPProperties.DB_DRIVER_LOCATION.getName()),
+                Map.entry(DBCPProperties.OLD_VALIDATION_QUERY_PROPERTY_NAME, DBCPProperties.VALIDATION_QUERY.getName()),
+                Map.entry(DBCPProperties.OLD_MIN_IDLE_PROPERTY_NAME, DBCPProperties.MIN_IDLE.getName()),
+                Map.entry(DBCPProperties.OLD_MAX_IDLE_PROPERTY_NAME, DBCPProperties.MAX_IDLE.getName()),
+                Map.entry(DBCPProperties.OLD_MAX_CONN_LIFETIME_PROPERTY_NAME, DBCPProperties.MAX_CONN_LIFETIME.getName()),
+                Map.entry(DBCPProperties.OLD_EVICTION_RUN_PERIOD_PROPERTY_NAME, DBCPProperties.EVICTION_RUN_PERIOD.getName()),
+                Map.entry(DBCPProperties.OLD_MIN_EVICTABLE_IDLE_TIME_PROPERTY_NAME, DBCPProperties.MIN_EVICTABLE_IDLE_TIME.getName()),
+                Map.entry(DBCPProperties.OLD_SOFT_MIN_EVICTABLE_IDLE_TIME_PROPERTY_NAME, DBCPProperties.SOFT_MIN_EVICTABLE_IDLE_TIME.getName()),
+                Map.entry(DBCPProperties.OLD_KERBEROS_USER_SERVICE_PROPERTY_NAME, DBCPProperties.KERBEROS_USER_SERVICE.getName())
         );
 
         final Map<String, String> propertyValues = Map.of();

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/java/org/apache/nifi/record/sink/db/DatabaseRecordSinkTest.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/java/org/apache/nifi/record/sink/db/DatabaseRecordSinkTest.java
@@ -23,7 +23,6 @@ import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.dbcp.DBCPConnectionPool;
 import org.apache.nifi.dbcp.DBCPService;
-import org.apache.nifi.dbcp.utils.DBCPProperties;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.record.sink.RecordSinkService;
 import org.apache.nifi.reporting.InitializationException;
@@ -103,10 +102,10 @@ public class DatabaseRecordSinkTest {
         runner.addControllerService(SERVICE_ID, dbcpService);
 
         connectionUrl = CONNECTION_URL_FORMAT.formatted(tempDir);
-        runner.setProperty(dbcpService, DBCPProperties.DATABASE_URL, connectionUrl);
-        runner.setProperty(dbcpService, DBCPProperties.DB_USER, String.class.getSimpleName());
-        runner.setProperty(dbcpService, DBCPProperties.DB_PASSWORD, String.class.getName());
-        runner.setProperty(dbcpService, DBCPProperties.DB_DRIVERNAME, DRIVER_CLASS);
+        runner.setProperty(dbcpService, DATABASE_URL, connectionUrl);
+        runner.setProperty(dbcpService, DB_USER, String.class.getSimpleName());
+        runner.setProperty(dbcpService, DB_PASSWORD, String.class.getName());
+        runner.setProperty(dbcpService, DB_DRIVERNAME, DRIVER_CLASS);
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/main/java/org/apache/nifi/dbcp/HikariCPConnectionPool.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/main/java/org/apache/nifi/dbcp/HikariCPConnectionPool.java
@@ -257,7 +257,7 @@ public class HikariCPConnectionPool extends AbstractControllerService implements
      * Shutdown pool, close all open connections.
      * If a principal is authenticated with a KDC, that principal is logged out.
      * <p>
-     * If a @{@link LoginException} occurs while attempting to log out the @{@link org.apache.nifi.security.krb.KerberosUser},
+     * If a @{@link LoginException} occurs while attempting to log out the @{@link KerberosUser},
      * an attempt will still be made to shut down the pool and close open connections.
      *
      */

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/test/java/org/apache/nifi/dbcp/HikariCPConnectionPoolTest.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/test/java/org/apache/nifi/dbcp/HikariCPConnectionPoolTest.java
@@ -26,7 +26,6 @@ import org.apache.nifi.util.NoOpProcessor;
 import org.apache.nifi.util.PropertyMigrationResult;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -139,8 +138,8 @@ public class HikariCPConnectionPoolTest {
 
         runner.enableControllerService(service);
 
-        Assertions.assertEquals(4, service.getDataSource().getMinimumIdle());
-        Assertions.assertEquals(1000, service.getDataSource().getMaxLifetime());
+        assertEquals(4, service.getDataSource().getMinimumIdle());
+        assertEquals(1000, service.getDataSource().getMaxLifetime());
 
         service.getDataSource().close();
     }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/Deserializer.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/Deserializer.java
@@ -34,7 +34,7 @@ public interface Deserializer<T> {
      * @return returns deserialized value
      * @throws DeserializationException if a valid object cannot be deserialized
      * from the given byte array
-     * @throws java.io.IOException ex
+     * @throws IOException ex
      */
     T deserialize(byte[] input) throws DeserializationException, IOException;
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/DistributedMapCacheClient.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/DistributedMapCacheClient.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 /**
  * This interface defines an API that can be used for interacting with a
- * Distributed Cache that functions similarly to a {@link java.util.Map Map}.
+ * Distributed Cache that functions similarly to a {@link Map Map}.
  *
  */
 @Tags({"distributed", "client", "cluster", "map", "cache"})
@@ -168,7 +168,7 @@ public interface DistributedMapCacheClient extends ControllerService {
      * Attempts to notify the server that we are finished communicating with it
      * and cleans up resources
      *
-     * @throws java.io.IOException ex
+     * @throws IOException ex
      */
     void close() throws IOException;
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/DistributedSetCacheClient.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/DistributedSetCacheClient.java
@@ -72,7 +72,7 @@ public interface DistributedSetCacheClient extends ControllerService {
      * Attempts to notify the server that we are finished communicating with it
      * and cleans up resources
      *
-     * @throws java.io.IOException ex
+     * @throws IOException ex
      */
     void close() throws IOException;
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/Serializer.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-client-service-api/src/main/java/org/apache/nifi/distributed/cache/client/Serializer.java
@@ -34,7 +34,7 @@ public interface Serializer<T> {
      * @param value value
      * @param output stream
      * @throws SerializationException If unable to serialize the given value
-     * @throws java.io.IOException ex
+     * @throws IOException ex
      */
     void serialize(T value, OutputStream output) throws SerializationException, IOException;
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/CacheClientChannelInitializer.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/CacheClientChannelInitializer.java
@@ -43,7 +43,7 @@ public class CacheClientChannelInitializer extends ChannelInitializer<Channel> {
     private final SSLContext sslContext;
 
     /**
-     * The factory used to create the {@link org.apache.nifi.remote.VersionNegotiator}
+     * The factory used to create the {@link VersionNegotiator}
      * upon initialization of the channel.
      */
     private final VersionNegotiatorFactory versionNegotiatorFactory;

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/PersistentMapCache.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/PersistentMapCache.java
@@ -25,6 +25,7 @@ import org.wali.UpdateType;
 import org.wali.WriteAheadRepository;
 
 import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
@@ -191,7 +192,7 @@ public class PersistentMapCache implements MapCache {
     private static class Serde implements SerDe<MapWaliRecord> {
 
         @Override
-        public void serializeEdit(final MapWaliRecord previousRecordState, final MapWaliRecord newRecordState, final java.io.DataOutputStream out) throws IOException {
+        public void serializeEdit(final MapWaliRecord previousRecordState, final MapWaliRecord newRecordState, final DataOutputStream out) throws IOException {
             final UpdateType updateType = newRecordState.getUpdateType();
             if (updateType == UpdateType.DELETE) {
                 out.write(0);
@@ -209,7 +210,7 @@ public class PersistentMapCache implements MapCache {
         }
 
         @Override
-        public void serializeRecord(final MapWaliRecord record, final java.io.DataOutputStream out) throws IOException {
+        public void serializeRecord(final MapWaliRecord record, final DataOutputStream out) throws IOException {
             serializeEdit(null, record, out);
         }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestDistributedMapCacheLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestDistributedMapCacheLookupService.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -106,7 +107,7 @@ public class TestDistributedMapCacheLookupService {
         }
 
         @Override
-        protected java.util.List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
             return new ArrayList<>();
         }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/XMLReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/XMLReader.java
@@ -54,10 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static org.apache.nifi.schema.inference.SchemaInferenceUtil.INFER_SCHEMA;
-import static org.apache.nifi.schema.inference.SchemaInferenceUtil.OBSOLETE_SCHEMA_CACHE;
-import static org.apache.nifi.schema.inference.SchemaInferenceUtil.SCHEMA_CACHE;
-
 @Tags({"xml", "record", "reader", "parser"})
 @CapabilityDescription("Reads XML content and creates Record objects. Records are expected in the second level of " +
         "XML data, embedded in an enclosing root tag.")
@@ -116,7 +112,7 @@ public class XMLReader extends SchemaRegistryService implements RecordReaderFact
             .allowableValues("true", "false")
             .defaultValue("true")
             .required(false)
-            .dependsOn(SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, INFER_SCHEMA)
+            .dependsOn(SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaInferenceUtil.INFER_SCHEMA)
             .build();
 
     private volatile boolean parseXmlAttributes;
@@ -139,7 +135,7 @@ public class XMLReader extends SchemaRegistryService implements RecordReaderFact
         config.renameProperty("attribute_prefix", ATTRIBUTE_PREFIX.getName());
         config.renameProperty("content_field_name", CONTENT_FIELD_NAME.getName());
         config.renameProperty("parse_xml_attributes", PARSE_XML_ATTRIBUTES.getName());
-        config.renameProperty(OBSOLETE_SCHEMA_CACHE, SCHEMA_CACHE.getName());
+        config.renameProperty(SchemaInferenceUtil.OBSOLETE_SCHEMA_CACHE, SchemaInferenceUtil.SCHEMA_CACHE.getName());
     }
 
     @Override
@@ -159,7 +155,7 @@ public class XMLReader extends SchemaRegistryService implements RecordReaderFact
     @Override
     protected List<AllowableValue> getSchemaAccessStrategyValues() {
         final List<AllowableValue> allowableValues = new ArrayList<>(super.getSchemaAccessStrategyValues());
-        allowableValues.add(INFER_SCHEMA);
+        allowableValues.add(SchemaInferenceUtil.INFER_SCHEMA);
         return allowableValues;
     }
 
@@ -191,7 +187,7 @@ public class XMLReader extends SchemaRegistryService implements RecordReaderFact
 
     @Override
     protected AllowableValue getDefaultSchemaAccessStrategy() {
-        return INFER_SCHEMA;
+        return SchemaInferenceUtil.INFER_SCHEMA;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestAvroReaderWithEmbeddedSchema.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestAvroReaderWithEmbeddedSchema.java
@@ -42,6 +42,8 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -109,10 +111,10 @@ public class TestAvroReaderWithEmbeddedSchema {
             assertEquals(RecordFieldType.DECIMAL, recordSchema.getDataType("decimal").get().getFieldType());
 
             final Record record = reader.nextRecord();
-            assertEquals(new java.sql.Time(millisSinceMidnight), record.getValue("timeMillis"));
-            assertEquals(new java.sql.Time(millisSinceMidnight), record.getValue("timeMicros"));
-            assertEquals(new java.sql.Timestamp(timeLong), record.getValue("timestampMillis"));
-            assertEquals(new java.sql.Timestamp(timeLong), record.getValue("timestampMicros"));
+            assertEquals(new Time(millisSinceMidnight), record.getValue("timeMillis"));
+            assertEquals(new Time(millisSinceMidnight), record.getValue("timeMicros"));
+            assertEquals(new Timestamp(timeLong), record.getValue("timestampMillis"));
+            assertEquals(new Timestamp(timeLong), record.getValue("timestampMicros"));
 
             final Object date = record.getValue("date");
             assertEquals(LocalDate.ofEpochDay(epochDay).toString(), date.toString());

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/cef/TestCEFReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/cef/TestCEFReader.java
@@ -51,13 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_BRANCH_NAME;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_NAME;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REFERENCE_READER;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REGISTRY;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_TEXT;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_VERSION;
 import static org.apache.nifi.schema.inference.SchemaInferenceUtil.OBSOLETE_SCHEMA_CACHE;
 import static org.apache.nifi.schema.inference.SchemaInferenceUtil.SCHEMA_CACHE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -239,13 +232,13 @@ public class TestCEFReader {
                 Map.entry("datetime-representation", CEFReader.DATETIME_REPRESENTATION.getName()),
                 Map.entry("accept-empty-extensions", CEFReader.ACCEPT_EMPTY_EXTENSIONS.getName()),
                 Map.entry(OBSOLETE_SCHEMA_CACHE, SCHEMA_CACHE.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_ACCESS_STRATEGY_PROPERTY_NAME, SCHEMA_ACCESS_STRATEGY.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REGISTRY_PROPERTY_NAME, SCHEMA_REGISTRY.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_NAME_PROPERTY_NAME, SCHEMA_NAME.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_BRANCH_NAME_PROPERTY_NAME, SCHEMA_BRANCH_NAME.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_VERSION_PROPERTY_NAME, SCHEMA_VERSION.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_TEXT_PROPERTY_NAME, SCHEMA_TEXT.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REFERENCE_READER_PROPERTY_NAME, SCHEMA_REFERENCE_READER.getName())
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_ACCESS_STRATEGY_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REGISTRY_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_REGISTRY.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_NAME_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_NAME.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_BRANCH_NAME_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_BRANCH_NAME.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_VERSION_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_VERSION.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_TEXT_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_TEXT.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REFERENCE_READER_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_REFERENCE_READER.getName())
         );
 
         final Map<String, String> propertyValues = Map.of();

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/cef/TestCEFUtil.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/cef/TestCEFUtil.java
@@ -53,9 +53,9 @@ public class TestCEFUtil {
     static final Map<String, Object> EXPECTED_EXTENSION_VALUES = new HashMap<>();
 
     static final String CUSTOM_EXTENSION_FIELD_NAME = "loginsequence";
-    static final RecordField CUSTOM_EXTENSION_FIELD = new RecordField(TestCEFUtil.CUSTOM_EXTENSION_FIELD_NAME, RecordFieldType.INT.getDataType());
-    static final RecordField CUSTOM_EXTENSION_FIELD_AS_STRING = new RecordField(TestCEFUtil.CUSTOM_EXTENSION_FIELD_NAME, RecordFieldType.STRING.getDataType());
-    static final RecordField CUSTOM_EXTENSION_FIELD_AS_CHOICE = new RecordField(TestCEFUtil.CUSTOM_EXTENSION_FIELD_NAME, RecordFieldType.CHOICE.getChoiceDataType(
+    static final RecordField CUSTOM_EXTENSION_FIELD = new RecordField(CUSTOM_EXTENSION_FIELD_NAME, RecordFieldType.INT.getDataType());
+    static final RecordField CUSTOM_EXTENSION_FIELD_AS_STRING = new RecordField(CUSTOM_EXTENSION_FIELD_NAME, RecordFieldType.STRING.getDataType());
+    static final RecordField CUSTOM_EXTENSION_FIELD_AS_CHOICE = new RecordField(CUSTOM_EXTENSION_FIELD_NAME, RecordFieldType.CHOICE.getChoiceDataType(
             RecordFieldType.FLOAT.getDataType(), RecordFieldType.STRING.getDataType()
     ));
 
@@ -102,7 +102,7 @@ public class TestCEFUtil {
     }
 
     static List<RecordField> getFieldsWithCustomExtensions(RecordField... customExtensions) {
-        final List<RecordField> result = TestCEFUtil.getFieldWithExtensions();
+        final List<RecordField> result = getFieldWithExtensions();
 
         Collections.addAll(result, customExtensions);
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestCSVRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestCSVRecordReader.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.sql.Date;
 import java.sql.Time;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -108,7 +109,7 @@ public class TestCSVRecordReader {
 
                 final Record record = reader.nextRecord(coerceTypes, false);
                 final Object date = record.getValue("date");
-                assertEquals(java.sql.Date.valueOf(dateValue), date);
+                assertEquals(Date.valueOf(dateValue), date);
             }
         }
     }
@@ -148,7 +149,7 @@ public class TestCSVRecordReader {
 
             final Record record = reader.nextRecord(false, false);
             final Object date = record.getValue("date");
-            assertEquals(java.sql.Date.valueOf(dateValue), date);
+            assertEquals(Date.valueOf(dateValue), date);
         }
     }
 
@@ -220,7 +221,7 @@ public class TestCSVRecordReader {
                      RecordFieldType.DATE.getDefaultFormat(), timeFormat, RecordFieldType.TIMESTAMP.getDefaultFormat(), "UTF-8")) {
 
             final Record record = reader.nextRecord(false, false);
-            final java.sql.Time time = (Time) record.getValue("time");
+            final Time time = (Time) record.getValue("time");
 
             final LocalTime localTime = LocalTime.parse(timeVal, dateTimeFormatter);
             assertEquals(Time.valueOf(localTime), time);

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestFastCSVRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestFastCSVRecordReader.java
@@ -36,6 +36,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -132,7 +133,7 @@ public class TestFastCSVRecordReader {
 
             final Record record = reader.nextRecord();
             final Object date = record.getValue("date");
-            assertEquals(java.sql.Date.valueOf(dateValue), date);
+            assertEquals(Date.valueOf(dateValue), date);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestJacksonCSVRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/TestJacksonCSVRecordReader.java
@@ -36,6 +36,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -148,7 +149,7 @@ public class TestJacksonCSVRecordReader {
 
             final Record record = reader.nextRecord();
             final Object date = record.getValue("date");
-            assertEquals(java.sql.Date.valueOf(dateValue), date);
+            assertEquals(Date.valueOf(dateValue), date);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/grok/TestGrokReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/grok/TestGrokReader.java
@@ -42,13 +42,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_BRANCH_NAME;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_NAME;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REFERENCE_READER;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REGISTRY;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_TEXT;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_VERSION;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -219,13 +212,13 @@ public class TestGrokReader {
                 Map.entry("Grok Pattern File", GrokReader.GROK_PATTERNS.getName()),
                 Map.entry("Grok Expression", GrokReader.GROK_EXPRESSION.getName()),
                 Map.entry("no-match-behavior", GrokReader.NO_MATCH_BEHAVIOR.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_ACCESS_STRATEGY_PROPERTY_NAME, SCHEMA_ACCESS_STRATEGY.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REGISTRY_PROPERTY_NAME, SCHEMA_REGISTRY.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_NAME_PROPERTY_NAME, SCHEMA_NAME.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_BRANCH_NAME_PROPERTY_NAME, SCHEMA_BRANCH_NAME.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_VERSION_PROPERTY_NAME, SCHEMA_VERSION.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_TEXT_PROPERTY_NAME, SCHEMA_TEXT.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REFERENCE_READER_PROPERTY_NAME, SCHEMA_REFERENCE_READER.getName())
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_ACCESS_STRATEGY_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REGISTRY_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_REGISTRY.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_NAME_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_NAME.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_BRANCH_NAME_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_BRANCH_NAME.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_VERSION_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_VERSION.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_TEXT_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_TEXT.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REFERENCE_READER_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_REFERENCE_READER.getName())
         );
 
         final Map<String, String> propertyValues = Map.of();

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
@@ -244,9 +244,9 @@ class TestWriteJsonResult {
     @Test
     void testTimestampWithNullFormat() throws IOException {
         final Map<String, Object> values = new HashMap<>();
-        values.put("timestamp", new java.sql.Timestamp(37293723L));
-        values.put("time", new java.sql.Time(37293723L));
-        final java.sql.Date date = java.sql.Date.valueOf("1970-01-01");
+        values.put("timestamp", new Timestamp(37293723L));
+        values.put("time", new Time(37293723L));
+        final Date date = Date.valueOf("1970-01-01");
         values.put("date", date);
 
         final List<RecordField> fields = new ArrayList<>();
@@ -507,10 +507,10 @@ class TestWriteJsonResult {
     @Test
     void testOnelineOutput() throws IOException {
         final Map<String, Object> values1 = new HashMap<>();
-        values1.put("timestamp", new java.sql.Timestamp(37293723L));
-        values1.put("time", new java.sql.Time(37293723L));
+        values1.put("timestamp", new Timestamp(37293723L));
+        values1.put("time", new Time(37293723L));
 
-        final java.sql.Date date = java.sql.Date.valueOf("1970-01-01");
+        final Date date = Date.valueOf("1970-01-01");
         values1.put("date", date);
 
         final List<RecordField> fields1 = new ArrayList<>();
@@ -523,8 +523,8 @@ class TestWriteJsonResult {
         final Record record1 = new MapRecord(schema, values1);
 
         final Map<String, Object> values2 = new HashMap<>();
-        values2.put("timestamp", new java.sql.Timestamp(37293999L));
-        values2.put("time", new java.sql.Time(37293999L));
+        values2.put("timestamp", new Timestamp(37293999L));
+        values2.put("time", new Time(37293999L));
         values2.put("date", date);
 
         final Record record2 = new MapRecord(schema, values2);

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLReader.java
@@ -48,13 +48,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_BRANCH_NAME;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_NAME;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REFERENCE_READER;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REGISTRY;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_TEXT;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_VERSION;
 import static org.apache.nifi.schema.inference.SchemaInferenceUtil.OBSOLETE_SCHEMA_CACHE;
 import static org.apache.nifi.schema.inference.SchemaInferenceUtil.SCHEMA_CACHE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -350,13 +343,13 @@ class TestXMLReader {
                 Map.entry("content_field_name", XMLReader.CONTENT_FIELD_NAME.getName()),
                 Map.entry("parse_xml_attributes", XMLReader.PARSE_XML_ATTRIBUTES.getName()),
                 Map.entry(OBSOLETE_SCHEMA_CACHE, SCHEMA_CACHE.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_ACCESS_STRATEGY_PROPERTY_NAME, SCHEMA_ACCESS_STRATEGY.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REGISTRY_PROPERTY_NAME, SCHEMA_REGISTRY.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_NAME_PROPERTY_NAME, SCHEMA_NAME.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_BRANCH_NAME_PROPERTY_NAME, SCHEMA_BRANCH_NAME.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_VERSION_PROPERTY_NAME, SCHEMA_VERSION.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_TEXT_PROPERTY_NAME, SCHEMA_TEXT.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REFERENCE_READER_PROPERTY_NAME, SCHEMA_REFERENCE_READER.getName())
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_ACCESS_STRATEGY_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REGISTRY_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_REGISTRY.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_NAME_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_NAME.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_BRANCH_NAME_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_BRANCH_NAME.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_VERSION_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_VERSION.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_TEXT_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_TEXT.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REFERENCE_READER_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_REFERENCE_READER.getName())
         );
 
         final Map<String, String> propertyValues = Map.of();

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLRecordSetWriter.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLRecordSetWriter.java
@@ -44,13 +44,6 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_BRANCH_NAME;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_NAME;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REFERENCE_READER;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_REGISTRY;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_TEXT;
-import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_VERSION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -252,13 +245,13 @@ public class TestXMLRecordSetWriter {
                 Map.entry("array_wrapping", XMLRecordSetWriter.ARRAY_WRAPPING.getName()),
                 Map.entry("array_tag_name", XMLRecordSetWriter.ARRAY_TAG_NAME.getName()),
                 Map.entry("schema-cache", SchemaRegistryRecordSetWriter.SCHEMA_CACHE.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_ACCESS_STRATEGY_PROPERTY_NAME, SCHEMA_ACCESS_STRATEGY.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REGISTRY_PROPERTY_NAME, SCHEMA_REGISTRY.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_NAME_PROPERTY_NAME, SCHEMA_NAME.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_BRANCH_NAME_PROPERTY_NAME, SCHEMA_BRANCH_NAME.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_VERSION_PROPERTY_NAME, SCHEMA_VERSION.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_TEXT_PROPERTY_NAME, SCHEMA_TEXT.getName()),
-                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REFERENCE_READER_PROPERTY_NAME, SCHEMA_REFERENCE_READER.getName())
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_ACCESS_STRATEGY_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REGISTRY_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_REGISTRY.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_NAME_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_NAME.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_BRANCH_NAME_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_BRANCH_NAME.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_VERSION_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_VERSION.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_TEXT_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_TEXT.getName()),
+                Map.entry(SchemaAccessUtils.OLD_SCHEMA_REFERENCE_READER_PROPERTY_NAME, SchemaAccessUtils.SCHEMA_REFERENCE_READER.getName())
         );
 
         final Map<String, String> propertyValues = Map.of();

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/EmailRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/EmailRecordSink.java
@@ -176,7 +176,7 @@ public class EmailRecordSink extends AbstractControllerService implements Record
             SMTP_STARTTLS,
             SMTP_SSL,
             HEADER_XMAILER,
-            RecordSinkService.RECORD_WRITER_FACTORY
+            RECORD_WRITER_FACTORY
     );
 
     private volatile RecordSetWriterFactory writerFactory;

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/LoggingRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/LoggingRecordSink.java
@@ -51,7 +51,7 @@ public class LoggingRecordSink extends AbstractControllerService implements Reco
             .build();
 
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            RecordSinkService.RECORD_WRITER_FACTORY,
+            RECORD_WRITER_FACTORY,
             LOG_LEVEL
     );
 
@@ -65,7 +65,7 @@ public class LoggingRecordSink extends AbstractControllerService implements Reco
 
     @OnEnabled
     public void onEnabled(final ConfigurationContext context) throws InitializationException {
-        writerFactory = context.getProperty(RecordSinkService.RECORD_WRITER_FACTORY).asControllerService(RecordSetWriterFactory.class);
+        writerFactory = context.getProperty(RECORD_WRITER_FACTORY).asControllerService(RecordSetWriterFactory.class);
         logLevel = LogLevel.valueOf(context.getProperty(LOG_LEVEL).getValue());
     }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardTlsConfiguration.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardTlsConfiguration.java
@@ -310,7 +310,7 @@ class StandardTlsConfiguration implements TlsConfiguration {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        org.apache.nifi.security.util.TlsConfiguration that = (org.apache.nifi.security.util.TlsConfiguration) o;
+        TlsConfiguration that = (TlsConfiguration) o;
         return Objects.equals(keystorePath, that.getKeystorePath())
                 && Objects.equals(keystorePassword, that.getKeystorePassword())
                 && Objects.equals(keyPassword, that.getKeyPassword())

--- a/nifi-extension-bundles/nifi-standard-services/nifi-web-client-provider-bundle/nifi-web-client-provider-service/src/main/java/org/apache/nifi/web/client/provider/service/StandardWebClientServiceProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-web-client-provider-bundle/nifi-web-client-provider-service/src/main/java/org/apache/nifi/web/client/provider/service/StandardWebClientServiceProvider.java
@@ -50,8 +50,6 @@ import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
-import static org.apache.nifi.proxy.ProxyConfigurationService.PROXY_CONFIGURATION_SERVICE;
-
 @CapabilityDescription("Web Client Service Provider with support for configuring standard HTTP connection properties")
 @Tags({ "HTTP", "Web", "Client" })
 public class StandardWebClientServiceProvider extends AbstractControllerService implements WebClientServiceProvider {
@@ -110,7 +108,7 @@ public class StandardWebClientServiceProvider extends AbstractControllerService 
             REDIRECT_HANDLING_STRATEGY,
             HTTP_PROTOCOL_VERSION,
             SSL_CONTEXT_SERVICE,
-            PROXY_CONFIGURATION_SERVICE
+            ProxyConfigurationService.PROXY_CONFIGURATION_SERVICE
     );
 
     private StandardWebClientService webClientService;
@@ -152,9 +150,9 @@ public class StandardWebClientServiceProvider extends AbstractControllerService 
             standardWebClientService.setTlsContext(tlsContext);
         }
 
-        final PropertyValue proxyConfigurationServiceProperty = context.getProperty(PROXY_CONFIGURATION_SERVICE);
+        final PropertyValue proxyConfigurationServiceProperty = context.getProperty(ProxyConfigurationService.PROXY_CONFIGURATION_SERVICE);
         if (proxyConfigurationServiceProperty.isSet()) {
-            final ProxyConfigurationService proxyConfigurationService = context.getProperty(PROXY_CONFIGURATION_SERVICE).asControllerService(ProxyConfigurationService.class);
+            final ProxyConfigurationService proxyConfigurationService = context.getProperty(ProxyConfigurationService.PROXY_CONFIGURATION_SERVICE).asControllerService(ProxyConfigurationService.class);
             final ProxyConfiguration proxyConfiguration = proxyConfigurationService.getConfiguration();
             final ProxyContext proxyContext = getProxyContext(proxyConfiguration);
             standardWebClientService.setProxyContext(proxyContext);

--- a/nifi-extension-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-processors/src/test/java/org/apache/nifi/processors/stateful/analysis/AttributeRollingWindowIT.java
+++ b/nifi-extension-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-processors/src/test/java/org/apache/nifi/processors/stateful/analysis/AttributeRollingWindowIT.java
@@ -92,7 +92,7 @@ public class AttributeRollingWindowIT {
 
         runner.assertQueueEmpty();
 
-        runner.assertAllFlowFilesTransferred(AttributeRollingWindow.REL_FAILED_SET_STATE, 1);
+        runner.assertAllFlowFilesTransferred(REL_FAILED_SET_STATE, 1);
         MockFlowFile mockFlowFile = runner.getFlowFilesForRelationship(REL_FAILED_SET_STATE).getFirst();
         mockFlowFile.assertAttributeNotExists(ROLLING_WINDOW_VALUE_KEY);
         mockFlowFile.assertAttributeNotExists(ROLLING_WINDOW_COUNT_KEY);

--- a/nifi-extension-bundles/nifi-workday-bundle/nifi-workday-processors/src/test/java/org/apache/nifi/processors/workday/GetWorkdayReportTest.java
+++ b/nifi-extension-bundles/nifi-workday-bundle/nifi-workday-processors/src/test/java/org/apache/nifi/processors/workday/GetWorkdayReportTest.java
@@ -212,7 +212,7 @@ class GetWorkdayReportTest {
         runner.assertAllFlowFilesTransferred(FAILURE);
         runner.assertPenalizeCount(1);
 
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(GetWorkdayReport.FAILURE).getFirst();
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(FAILURE).getFirst();
         flowFile.assertAttributeEquals(GET_WORKDAY_REPORT_JAVA_EXCEPTION_CLASS, URISyntaxException.class.getSimpleName());
         flowFile.assertAttributeExists(GET_WORKDAY_REPORT_JAVA_EXCEPTION_MESSAGE);
     }

--- a/nifi-framework-api/src/main/java/org/apache/nifi/components/connector/ConnectorConfigurationProvider.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/components/connector/ConnectorConfigurationProvider.java
@@ -19,6 +19,7 @@ package org.apache.nifi.components.connector;
 
 import org.apache.nifi.flow.VersionedConnectorState;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
@@ -208,9 +209,9 @@ public interface ConnectorConfigurationProvider {
      * @param nifiUuid the NiFi-assigned UUID for this asset
      * @param assetName the filename of the asset (e.g., "postgresql-42.6.0.jar")
      * @param content the binary content of the asset
-     * @throws java.io.IOException if the asset cannot be stored
+     * @throws IOException if the asset cannot be stored
      */
-    void storeAsset(String connectorId, String nifiUuid, String assetName, InputStream content) throws java.io.IOException;
+    void storeAsset(String connectorId, String nifiUuid, String assetName, InputStream content) throws IOException;
 
     /**
      * Deletes an asset from the local {@link org.apache.nifi.asset.AssetManager} and from the

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/ContentRepository.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/ContentRepository.java
@@ -38,7 +38,7 @@ public interface ContentRepository {
      * ContentRepositoryContext.
      *
      * @param context to initialize repository
-     * @throws java.io.IOException if unable to init
+     * @throws IOException if unable to init
      */
     void initialize(ContentRepositoryContext context) throws IOException;
 
@@ -58,7 +58,7 @@ public interface ContentRepository {
      * @param containerName name of container to check capacity on
      * @return the maximum number of bytes that can be stored in the storage
      * mechanism that backs the container with the given name
-     * @throws java.io.IOException if unable to check capacity
+     * @throws IOException if unable to check capacity
      * @throws IllegalArgumentException if no container exists with the given
      * name
      */
@@ -68,7 +68,7 @@ public interface ContentRepository {
      * @param containerName to check space on
      * @return the number of bytes available to be used used by the storage
      * mechanism that backs the container with the given name
-     * @throws java.io.IOException if unable to check space
+     * @throws IOException if unable to check space
      * @throws IllegalArgumentException if no container exists with the given
      * name
      */
@@ -90,7 +90,7 @@ public interface ContentRepository {
      * loss tolerant. If true the repository might choose more volatile storage
      * options which could increase performance for a tradeoff with reliability
      * @return newly created claim
-     * @throws java.io.IOException if unable to create claim
+     * @throws IOException if unable to create claim
      */
     ContentClaim create(boolean lossTolerant) throws IOException;
 

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/FlowFileRecord.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/FlowFileRecord.java
@@ -42,7 +42,7 @@ public interface FlowFileRecord extends FlowFile {
      * FlowFile's content occurs. This mechanism allows multiple FlowFiles to
      * have the same ContentClaim, which can be significantly more efficient for
      * some implementations of
-     * {@link org.apache.nifi.controller.repository.ContentRepository ContentRepository}
+     * {@link ContentRepository ContentRepository}
      */
     long getContentClaimOffset();
 }

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/FlowFileRepository.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/repository/FlowFileRepository.java
@@ -40,7 +40,7 @@ public interface FlowFileRepository extends Closeable {
      * Claims
      *
      * @param claimManager for handling claims
-     * @throws java.io.IOException if unable to initialize repository
+     * @throws IOException if unable to initialize repository
      */
     void initialize(ResourceClaimManager claimManager) throws IOException;
 
@@ -72,7 +72,7 @@ public interface FlowFileRepository extends Closeable {
      * Updates the repository with the given RepositoryRecords.
      *
      * @param records the records to update the repository with
-     * @throws java.io.IOException if update fails
+     * @throws IOException if update fails
      */
     void updateRepository(Collection<RepositoryRecord> records) throws IOException;
 

--- a/nifi-framework-api/src/main/java/org/apache/nifi/provenance/ProvenanceRepository.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/provenance/ProvenanceRepository.java
@@ -38,7 +38,7 @@ public interface ProvenanceRepository extends ProvenanceEventRepository {
      * @param authorizer the authorizer to use for authorizing individual events
      * @param resourceFactory the resource factory to use for generating Provenance Resource objects for authorization purposes
      * @param identifierLookup a mechanism for looking up identifiers in the flow
-     * @throws java.io.IOException if unable to initialize
+     * @throws IOException if unable to initialize
      */
     void initialize(EventReporter eventReporter, Authorizer authorizer, ProvenanceAuthorizableFactory resourceFactory, IdentifierLookup identifierLookup) throws IOException;
 
@@ -70,7 +70,7 @@ public interface ProvenanceRepository extends ProvenanceEventRepository {
      *                      It can be {@code null} if called by NiFi components internally
      *                      where authorization is not required.
      * @return records
-     * @throws java.io.IOException if error reading from repository
+     * @throws IOException if error reading from repository
      */
     List<ProvenanceEventRecord> getEvents(long firstRecordId, final int maxRecords, NiFiUser user) throws IOException;
 
@@ -224,7 +224,7 @@ public interface ProvenanceRepository extends ProvenanceEventRepository {
      * @param containerName name of container to check capacity on
      * @return the maximum number of bytes that can be stored in the storage
      * mechanism that backs the container with the given name
-     * @throws java.io.IOException if unable to check capacity
+     * @throws IOException if unable to check capacity
      * @throws IllegalArgumentException if no container exists with the given
      * name
      */
@@ -243,7 +243,7 @@ public interface ProvenanceRepository extends ProvenanceEventRepository {
      * @param containerName to check space on
      * @return the number of bytes available to be used used by the storage
      * mechanism that backs the container with the given name
-     * @throws java.io.IOException if unable to check space
+     * @throws IOException if unable to check space
      * @throws IllegalArgumentException if no container exists with the given
      * name
      */

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-cluster-zookeeper/src/main/java/org/apache/nifi/framework/cluster/zookeeper/SecureClientZooKeeperFactory.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-cluster-zookeeper/src/main/java/org/apache/nifi/framework/cluster/zookeeper/SecureClientZooKeeperFactory.java
@@ -18,6 +18,7 @@
 package org.apache.nifi.framework.cluster.zookeeper;
 
 import org.apache.curator.utils.ZookeeperFactory;
+import org.apache.zookeeper.ClientCnxnSocketNetty;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.admin.ZooKeeperAdmin;
@@ -27,7 +28,7 @@ import org.apache.zookeeper.common.X509Util;
 
 public class SecureClientZooKeeperFactory implements ZookeeperFactory {
 
-    public static final String NETTY_CLIENT_CNXN_SOCKET = org.apache.zookeeper.ClientCnxnSocketNetty.class.getName();
+    public static final String NETTY_CLIENT_CNXN_SOCKET = ClientCnxnSocketNetty.class.getName();
 
     private ZKClientConfig zkSecureClientConfig;
 

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-cluster-zookeeper/src/main/java/org/apache/nifi/framework/cluster/zookeeper/ZooKeeperClientConfig.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-cluster-zookeeper/src/main/java/org/apache/nifi/framework/cluster/zookeeper/ZooKeeperClientConfig.java
@@ -19,6 +19,8 @@ package org.apache.nifi.framework.cluster.zookeeper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.util.NiFiProperties;
+import org.apache.zookeeper.ClientCnxnSocketNIO;
+import org.apache.zookeeper.ClientCnxnSocketNetty;
 import org.apache.zookeeper.common.PathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,11 +32,9 @@ import java.util.regex.Pattern;
 
 public class ZooKeeperClientConfig {
 
-    public static final String NETTY_CLIENT_CNXN_SOCKET =
-        org.apache.zookeeper.ClientCnxnSocketNetty.class.getName();
+    public static final String NETTY_CLIENT_CNXN_SOCKET = ClientCnxnSocketNetty.class.getName();
 
-    public static final String NIO_CLIENT_CNXN_SOCKET =
-        org.apache.zookeeper.ClientCnxnSocketNIO.class.getName();
+    public static final String NIO_CLIENT_CNXN_SOCKET = ClientCnxnSocketNIO.class.getName();
 
     private static final Logger logger = LoggerFactory.getLogger(ZooKeeperClientConfig.class);
     private static final Pattern PORT_PATTERN = Pattern.compile("[0-9]{1,5}");

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-zookeeper-leader-election/src/main/java/org/apache/nifi/framework/cluster/leader/zookeeper/CuratorLeaderElectionManager.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-zookeeper-leader-election/src/main/java/org/apache/nifi/framework/cluster/leader/zookeeper/CuratorLeaderElectionManager.java
@@ -32,6 +32,7 @@ import org.apache.nifi.controller.leader.election.TrackedLeaderElectionManager;
 import org.apache.nifi.engine.FlowEngine;
 import org.apache.nifi.framework.cluster.zookeeper.ZooKeeperClientConfig;
 import org.apache.nifi.util.NiFiProperties;
+import org.apache.zookeeper.ClientCnxnSocketNetty;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
@@ -581,8 +582,7 @@ public class CuratorLeaderElectionManager extends TrackedLeaderElectionManager {
 
     public static class SecureClientZooKeeperFactory implements ZookeeperFactory {
 
-        public static final String NETTY_CLIENT_CNXN_SOCKET =
-            org.apache.zookeeper.ClientCnxnSocketNetty.class.getName();
+        public static final String NETTY_CLIENT_CNXN_SOCKET = ClientCnxnSocketNetty.class.getName();
 
         private final ZKClientConfig zkSecureClientConfig;
 

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/test/java/org/apache/nifi/ldap/tenants/LdapUserGroupProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/src/test/java/org/apache/nifi/ldap/tenants/LdapUserGroupProviderTest.java
@@ -29,7 +29,6 @@ import org.apache.nifi.util.NiFiProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.security.ldap.server.UnboundIdContainer;
 
@@ -825,7 +824,7 @@ public class LdapUserGroupProviderTest {
     }
 
     private NiFiProperties getNiFiProperties(final Properties properties) {
-        final NiFiProperties nifiProperties = Mockito.mock(NiFiProperties.class);
+        final NiFiProperties nifiProperties = mock(NiFiProperties.class);
         when(nifiProperties.getPropertyKeys()).thenReturn(properties.stringPropertyNames());
         when(nifiProperties.getProperty(anyString())).then(invocationOnMock -> properties.getProperty((String) invocationOnMock.getArguments()[0]));
         return nifiProperties;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/Permissible.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/Permissible.java
@@ -19,7 +19,7 @@ package org.apache.nifi.web.api.entity;
 import org.apache.nifi.web.api.dto.PermissionsDTO;
 
 /**
- * Provides access to a component given an {@link org.apache.nifi.web.api.dto.PermissionsDTO}.  This is intended to be used by classes that extend {@link Entity}.
+ * Provides access to a component given an {@link PermissionsDTO}.  This is intended to be used by classes that extend {@link Entity}.
  * @param <DtoType> type of component
  */
 public interface Permissible<DtoType> {

--- a/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/test/java/org/apache/nifi/authorization/FileAccessPolicyProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-file-authorizer/src/test/java/org/apache/nifi/authorization/FileAccessPolicyProviderTest.java
@@ -26,7 +26,6 @@ import org.apache.nifi.util.file.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.io.File;
@@ -649,11 +648,11 @@ public class FileAccessPolicyProviderTest {
         final String nodeIdentity1 = "node1";
         final String nodeIdentity2 = "node2";
 
-        when(configurationContext.getProperty(Mockito.eq(FileAccessPolicyProvider.PROP_INITIAL_ADMIN_IDENTITY)))
+        when(configurationContext.getProperty(eq(FileAccessPolicyProvider.PROP_INITIAL_ADMIN_IDENTITY)))
                 .thenReturn(new StandardPropertyValue(adminIdentity, null, ParameterLookup.EMPTY));
-        when(configurationContext.getProperty(Mockito.eq(FileAccessPolicyProvider.PROP_NODE_IDENTITY_PREFIX + "1")))
+        when(configurationContext.getProperty(eq(FileAccessPolicyProvider.PROP_NODE_IDENTITY_PREFIX + "1")))
                 .thenReturn(new StandardPropertyValue(nodeIdentity1, null, ParameterLookup.EMPTY));
-        when(configurationContext.getProperty(Mockito.eq(FileAccessPolicyProvider.PROP_NODE_IDENTITY_PREFIX + "2")))
+        when(configurationContext.getProperty(eq(FileAccessPolicyProvider.PROP_NODE_IDENTITY_PREFIX + "2")))
                 .thenReturn(new StandardPropertyValue(nodeIdentity2, null, ParameterLookup.EMPTY));
 
         when(configurationContext.getProperty(eq(FileUserGroupProvider.PROP_INITIAL_USER_IDENTITY_PREFIX + "1")))
@@ -1083,7 +1082,7 @@ public class FileAccessPolicyProviderTest {
     }
 
     private NiFiProperties getNiFiProperties(final Properties properties) {
-        final NiFiProperties nifiProperties = Mockito.mock(NiFiProperties.class);
+        final NiFiProperties nifiProperties = mock(NiFiProperties.class);
         when(nifiProperties.getPropertyKeys()).thenReturn(properties.stringPropertyNames());
 
         when(nifiProperties.getProperty(anyString())).then((Answer<String>) invocationOnMock -> properties.getProperty((String) invocationOnMock.getArguments()[0]));

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/ProtocolListener.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/ProtocolListener.java
@@ -31,7 +31,7 @@ public interface ProtocolListener {
      * Starts the instance for listening for messages. Start may only be called
      * if the instance is not running.
      *
-     * @throws java.io.IOException ex
+     * @throws IOException ex
      */
     void start() throws IOException;
 
@@ -39,7 +39,7 @@ public interface ProtocolListener {
      * Stops the instance from listening for messages. Stop may only be called
      * if the instance is running.
      *
-     * @throws java.io.IOException ex
+     * @throws IOException ex
      */
     void stop() throws IOException;
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ClearBulletinsEndpointMergerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ClearBulletinsEndpointMergerTest.java
@@ -17,12 +17,14 @@
 package org.apache.nifi.cluster.coordination.http.endpoints;
 
 import org.apache.nifi.cluster.protocol.NodeIdentifier;
+import org.apache.nifi.web.api.dto.BulletinDTO;
 import org.apache.nifi.web.api.entity.BulletinEntity;
 import org.apache.nifi.web.api.entity.ClearBulletinsResultEntity;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,16 +97,16 @@ public class ClearBulletinsEndpointMergerTest {
             final BulletinEntity bulletin = new BulletinEntity();
             bulletin.setId((long) i);
             bulletin.setCanRead(true);
-            bulletin.setTimestamp(new java.util.Date());
+            bulletin.setTimestamp(new Date());
             bulletin.setSourceId("test-source");
             bulletin.setGroupId("test-group");
 
             // Create the nested BulletinDTO
-            final org.apache.nifi.web.api.dto.BulletinDTO bulletinDto = new org.apache.nifi.web.api.dto.BulletinDTO();
+            final BulletinDTO bulletinDto = new BulletinDTO();
             bulletinDto.setMessage("Test bulletin " + i);
             bulletinDto.setLevel("INFO");
             bulletinDto.setSourceId("test-source");
-            bulletinDto.setTimestamp(new java.util.Date());
+            bulletinDto.setTimestamp(new Date());
             bulletin.setBulletin(bulletinDto);
 
             bulletins.add(bulletin);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -87,6 +87,7 @@ import org.apache.nifi.parameter.ParameterUpdate;
 import org.apache.nifi.parameter.StandardParameterUpdate;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.StandardProcessContext;
 import org.apache.nifi.registry.flow.FlowLocation;
 import org.apache.nifi.registry.flow.FlowRegistryClientContextFactory;
@@ -4031,7 +4032,7 @@ public final class StandardProcessGroup implements ProcessGroup {
     }
 
     private ProcessContext createProcessContext(final ProcessorNode processorNode) {
-        final org.apache.nifi.processor.Processor processor = processorNode.getProcessor();
+        final Processor processor = processorNode.getProcessor();
         final Class<?> componentClass = processor == null ? null : processor.getClass();
         return new StandardProcessContext(processorNode, controllerServiceProvider,
             stateManagerProvider.getStateManager(processorNode.getIdentifier(), componentClass), () -> false, nodeTypeProvider);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizerTest.java
@@ -85,7 +85,6 @@ import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.time.Duration;
@@ -209,18 +208,18 @@ public class StandardVersionedComponentSynchronizerTest {
 
     @BeforeEach
     public void setup() {
-        final ExtensionManager extensionManager = Mockito.mock(ExtensionManager.class);
-        flowManager = Mockito.mock(FlowManager.class);
-        controllerServiceProvider = Mockito.mock(ControllerServiceProvider.class);
-        final Function<ProcessorNode, ProcessContext> processContextFactory = proc -> Mockito.mock(ProcessContext.class);
-        final ReloadComponent reloadComponent = Mockito.mock(ReloadComponent.class);
+        final ExtensionManager extensionManager = mock(ExtensionManager.class);
+        flowManager = mock(FlowManager.class);
+        controllerServiceProvider = mock(ControllerServiceProvider.class);
+        final Function<ProcessorNode, ProcessContext> processContextFactory = proc -> mock(ProcessContext.class);
+        final ReloadComponent reloadComponent = mock(ReloadComponent.class);
         componentIdGenerator = (proposed, instance, group) -> proposed == null ? instance : proposed;
-        componentScheduler = Mockito.mock(ComponentScheduler.class);
+        componentScheduler = mock(ComponentScheduler.class);
         parameterContextManager = new StandardParameterContextManager();
-        parameterReferenceManager = Mockito.mock(ParameterReferenceManager.class);
+        parameterReferenceManager = mock(ParameterReferenceManager.class);
 
         bundleCoordinate = new BundleCoordinate("org.apache.nifi", "nifi-standard-nar", "1.18.0");
-        controllerServiceNode = Mockito.mock(ControllerServiceNode.class);
+        controllerServiceNode = mock(ControllerServiceNode.class);
         when(controllerServiceNode.getBundleCoordinate()).thenReturn(bundleCoordinate);
         when(flowManager.createControllerService(anyString(), anyString(), any(BundleCoordinate.class), anySet(), anyBoolean(), anyBoolean(), nullable(String.class)))
             .thenReturn(controllerServiceNode);
@@ -267,7 +266,7 @@ public class StandardVersionedComponentSynchronizerTest {
             .reloadComponent(reloadComponent)
             .build();
 
-        group = Mockito.mock(ProcessGroup.class);
+        group = mock(ProcessGroup.class);
 
         processorA = createMockProcessor();
         processorB = createMockProcessor();
@@ -307,7 +306,7 @@ public class StandardVersionedComponentSynchronizerTest {
     private ProcessorNode createMockProcessor() {
         final String uuid = UUID.randomUUID().toString();
 
-        final ProcessorNode processor = Mockito.mock(ProcessorNode.class);
+        final ProcessorNode processor = mock(ProcessorNode.class);
         instrumentComponentNodeMethods(uuid, processor);
         when(processor.isRunning()).thenReturn(false);
         when(processor.getProcessGroup()).thenReturn(group);
@@ -320,7 +319,7 @@ public class StandardVersionedComponentSynchronizerTest {
     private ControllerServiceNode createMockControllerService() {
         final String uuid = UUID.randomUUID().toString();
 
-        final ControllerServiceNode service = Mockito.mock(ControllerServiceNode.class);
+        final ControllerServiceNode service = mock(ControllerServiceNode.class);
         instrumentComponentNodeMethods(uuid, service);
 
         when(service.isActive()).thenReturn(false);
@@ -344,7 +343,7 @@ public class StandardVersionedComponentSynchronizerTest {
     private Port createMockPort(final ConnectableType connectableType) {
         final String uuid = UUID.randomUUID().toString();
 
-        final Port port = Mockito.mock(Port.class);
+        final Port port = mock(Port.class);
         when(port.getIdentifier()).thenReturn(uuid);
         when(port.isRunning()).thenReturn(false);
         when(port.getProcessGroup()).thenReturn(group);
@@ -367,11 +366,11 @@ public class StandardVersionedComponentSynchronizerTest {
     private Connection createMockConnection(final Connectable source, final Connectable destination, final ProcessGroup group) {
         final String uuid = UUID.randomUUID().toString();
 
-        final FlowFileQueue flowFileQueue = Mockito.mock(FlowFileQueue.class);
+        final FlowFileQueue flowFileQueue = mock(FlowFileQueue.class);
         when(flowFileQueue.getIdentifier()).thenReturn(uuid);
         when(flowFileQueue.isEmpty()).thenAnswer(invocation -> !queuesWithData.contains(uuid));
 
-        final Connection connection = Mockito.mock(Connection.class);
+        final Connection connection = mock(Connection.class);
         when(connection.getIdentifier()).thenReturn(uuid);
         when(connection.getSource()).thenReturn(source);
         when(connection.getDestination()).thenReturn(destination);
@@ -1077,7 +1076,7 @@ public class StandardVersionedComponentSynchronizerTest {
         final ControllerServiceNode service = createMockControllerService();
         when(service.isActive()).thenReturn(true);
         when(service.getState()).thenReturn(ControllerServiceState.ENABLED);
-        when(service.getReferences()).thenReturn(Mockito.mock(ControllerServiceReference.class));
+        when(service.getReferences()).thenReturn(mock(ControllerServiceReference.class));
 
         when(controllerServiceProvider.unscheduleReferencingComponents(service)).thenReturn(Collections.emptyMap());
         when(controllerServiceProvider.disableControllerServicesAsync(anyCollection())).thenReturn(CompletableFuture.completedFuture(null));
@@ -1137,13 +1136,13 @@ public class StandardVersionedComponentSynchronizerTest {
         verify(controllerServiceProvider).unscheduleReferencingComponents(service);
         verify(controllerServiceProvider).disableControllerServicesAsync(Collections.singleton(service));
 
-        Mockito.doAnswer((Answer<Void>) invocationOnMock -> {
+        doAnswer((Answer<Void>) invocationOnMock -> {
             final Set<?> services = invocationOnMock.getArgument(0);
             assertTrue(services.isEmpty());
             return null;
-        }).when(controllerServiceProvider).enableControllerServicesAsync(Mockito.anySet());
+        }).when(controllerServiceProvider).enableControllerServicesAsync(anySet());
 
-        verify(controllerServiceProvider, times(0)).scheduleReferencingComponents(Mockito.any(ControllerServiceNode.class), Mockito.anySet(), Mockito.any(ComponentScheduler.class));
+        verify(controllerServiceProvider, times(0)).scheduleReferencingComponents(any(ControllerServiceNode.class), anySet(), any(ComponentScheduler.class));
     }
 
     @Test
@@ -1611,7 +1610,7 @@ public class StandardVersionedComponentSynchronizerTest {
     }
 
     private void setReferences(final ControllerServiceNode service, final ComponentNode... reference) {
-        final ControllerServiceReference csReference = Mockito.mock(ControllerServiceReference.class);
+        final ControllerServiceReference csReference = mock(ControllerServiceReference.class);
         when(csReference.getReferencingComponents()).thenReturn(new HashSet<>(Arrays.asList(reference)));
         when(service.getReferences()).thenReturn(csReference);
     }
@@ -1737,7 +1736,7 @@ public class StandardVersionedComponentSynchronizerTest {
 
     private PublicPort createMappablePublicInputPort(final ProcessGroup processGroup, final String versionedId, final String localName, final String comments) {
         final String groupId = processGroup.getIdentifier();
-        final PublicPort port = Mockito.mock(PublicPort.class);
+        final PublicPort port = mock(PublicPort.class);
         when(port.getIdentifier()).thenReturn(UUID.randomUUID().toString());
         when(port.getProcessGroupIdentifier()).thenReturn(groupId);
         when(port.getVersionedComponentId()).thenReturn(Optional.of(versionedId));

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/groups/RetainExistingStateComponentSchedulerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/groups/RetainExistingStateComponentSchedulerTest.java
@@ -25,8 +25,8 @@ import org.apache.nifi.controller.service.ControllerServiceState;
 import org.apache.nifi.flow.ExecutionEngine;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -313,9 +313,9 @@ class RetainExistingStateComponentSchedulerTest {
     }
 
     private ProcessGroup createProcessGroup(final Set<ProcessorNode> processors, final Set<Port> inputPorts, final Set<ControllerServiceNode> services) {
-        final ProcessGroup group = Mockito.mock(ProcessGroup.class);
+        final ProcessGroup group = mock(ProcessGroup.class);
         when(group.getProcessors()).thenReturn(processors);
-        when(group.findAllProcessors()).thenReturn(new java.util.ArrayList<>(processors));
+        when(group.findAllProcessors()).thenReturn(new ArrayList<>(processors));
         when(group.getInputPorts()).thenReturn(inputPorts);
         when(group.getOutputPorts()).thenReturn(Collections.emptySet());
         when(group.getFunnels()).thenReturn(Collections.emptySet());

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
@@ -1060,7 +1060,7 @@ public class TestFlowDifferenceFilters {
         final VersionedProcessor processorA = new VersionedProcessor();
         final VersionedProcessor processorB = new VersionedProcessor();
         processorA.setScheduledState(null);
-        processorB.setScheduledState(org.apache.nifi.flow.ScheduledState.RUNNING);
+        processorB.setScheduledState(ScheduledState.RUNNING);
 
         final StandardFlowDifference scheduledStateDiff = new StandardFlowDifference(
                 DifferenceType.SCHEDULED_STATE_CHANGED, processorA, processorB,

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
@@ -627,7 +627,7 @@ public abstract class AbstractComponentNode implements ComponentNode {
      * @param name the property to remove
      * @param allowRemovalOfRequiredProperties whether or not the property should be removed if it's required
      * @return true if removed; false otherwise
-     * @throws java.lang.IllegalArgumentException if the name is null
+     * @throws IllegalArgumentException if the name is null
      */
     private boolean removeProperty(final String name, final boolean allowRemovalOfRequiredProperties) {
         if (null == name) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/StandardFunnel.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/StandardFunnel.java
@@ -432,7 +432,7 @@ public class StandardFunnel implements Funnel {
     /**
      * Updates the amount of time that this processor should avoid being
      * scheduled when the processor calls
-     * {@link org.apache.nifi.processor.ProcessContext#yield() ProcessContext.yield()}
+     * {@link ProcessContext#yield() ProcessContext.yield()}
      *
      * @param yieldPeriod new period
      */

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/repository/FlowFileEventRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/repository/FlowFileEventRepository.java
@@ -27,7 +27,7 @@ public interface FlowFileEventRepository extends Closeable {
      * Updates the repository to include a new process session event
      *
      * @param event new event, including the identifier of the component that the event belongs to
-     * @throws java.io.IOException ioe
+     * @throws IOException ioe
      */
     void updateRepository(ProcessSessionEvent event) throws IOException;
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/ProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/ProcessGroup.java
@@ -918,7 +918,7 @@ public interface ProcessGroup extends ComponentAuthorizable, Positionable, Versi
     RemoteGroupPort findRemoteGroupPort(String identifier);
 
     /**
-     * @return a Set of all {@link org.apache.nifi.connectable.Positionable}s contained within this
+     * @return a Set of all {@link Positionable}s contained within this
      * {@link ProcessGroup} and any child {@link ProcessGroup}s
      */
     Set<Positionable> findAllPositionables();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/RemoteProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/RemoteProcessGroup.java
@@ -148,7 +148,7 @@ public interface RemoteProcessGroup extends ComponentAuthorizable, Positionable,
     /**
      * @return Indicates whether or not communications with this RemoteProcessGroup will
      * be secure (2-way authentication)
-     * @throws org.apache.nifi.controller.exception.CommunicationsException ce
+     * @throws CommunicationsException ce
      */
     boolean isSecure() throws CommunicationsException;
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/test/java/org/apache/nifi/controller/TestAbstractComponentNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/test/java/org/apache/nifi/controller/TestAbstractComponentNode.java
@@ -443,7 +443,7 @@ public class TestAbstractComponentNode {
         when(context.getProperties()).thenReturn(properties);
         final PropertyValue propertyValue = mock(PropertyValue.class);
         when(propertyValue.getValue()).thenReturn(serviceIdentifier);
-        when(context.getProperty(Mockito.eq(property))).thenReturn(propertyValue);
+        when(context.getProperty(eq(property))).thenReturn(propertyValue);
         when(context.isDependencySatisfied(any(PropertyDescriptor.class), any(Function.class))).thenReturn(true);
         return context;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardFrameworkConnectorMigrationContext.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardFrameworkConnectorMigrationContext.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -63,7 +64,7 @@ public class StandardFrameworkConnectorMigrationContext implements FrameworkConn
     private final ConnectorRepository connectorRepository;
     private final StateManagerProvider stateManagerProvider;
     private final ClusterTopologyProvider clusterTopologyProvider;
-    private final Set<String> copiedAssetIds = Collections.synchronizedSet(new java.util.LinkedHashSet<>());
+    private final Set<String> copiedAssetIds = Collections.synchronizedSet(new LinkedHashSet<>());
 
     private final Object stagingLock = new Object();
     private final Map<String, VersionedComponentState> stagedComponentStates = new LinkedHashMap<>();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/server/ConnectionLoadBalanceServer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/server/ConnectionLoadBalanceServer.java
@@ -212,8 +212,8 @@ public class ConnectionLoadBalanceServer {
 
         /**
          * Determines how to record the TLS-related error
-         * ({@link org.apache.nifi.security.util.TlsException}, {@link SSLPeerUnverifiedException},
-         * {@link java.security.cert.CertificateException}, etc.) to the log, based on how recently it was last seen.
+         * ({@link TlsException}, {@link SSLPeerUnverifiedException},
+         * {@link CertificateException}, etc.) to the log, based on how recently it was last seen.
          *
          * @param channelDescription the channel's String representation for the log message
          * @param e               the exception

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/flowanalysis/StandardFlowAnalyzer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/flowanalysis/StandardFlowAnalyzer.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * {@link FlowAnalyzer} that uses {@link org.apache.nifi.flowanalysis.FlowAnalysisRule FlowAnalysisRules}.
+ * {@link FlowAnalyzer} that uses {@link FlowAnalysisRule FlowAnalysisRules}.
  */
 public class StandardFlowAnalyzer implements FlowAnalyzer {
     private Logger logger = LoggerFactory.getLogger(this.getClass());

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/manifest/StandardRuntimeManifestService.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/manifest/StandardRuntimeManifestService.java
@@ -33,6 +33,7 @@ import org.apache.nifi.extension.manifest.InputRequirement;
 import org.apache.nifi.extension.manifest.MultiProcessorUseCase;
 import org.apache.nifi.extension.manifest.ProcessorConfiguration;
 import org.apache.nifi.extension.manifest.Property;
+import org.apache.nifi.extension.manifest.Relationship;
 import org.apache.nifi.extension.manifest.UseCase;
 import org.apache.nifi.extension.manifest.parser.ExtensionManifestParser;
 import org.apache.nifi.nar.ExtensionDefinition;
@@ -199,10 +200,10 @@ public class StandardRuntimeManifestService implements RuntimeManifestService {
         extension.setTriggerSerially(false);
         extension.setTriggerWhenAnyDestinationAvailable(false);
 
-        final List<org.apache.nifi.extension.manifest.Relationship> relationships = new ArrayList<>();
+        final List<Relationship> relationships = new ArrayList<>();
         extension.setRelationships(relationships);
         for (final String relationshipName : List.of("success", "failure", "original")) {
-            final org.apache.nifi.extension.manifest.Relationship relationship = new org.apache.nifi.extension.manifest.Relationship();
+            final Relationship relationship = new Relationship();
             relationship.setAutoTerminated(false);
             relationship.setName(relationshipName);
             relationships.add(relationship);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/persistence/FlowConfigurationDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/persistence/FlowConfigurationDAO.java
@@ -48,7 +48,7 @@ public interface FlowConfigurationDAO {
      * @param dataFlow the flow to load
      * @param flowService the flow service
      * @param bundleUpdateStrategy specifies how to handle bundle updates
-     * @throws java.io.IOException for unspecified read/write failure
+     * @throws IOException for unspecified read/write failure
      *
      * @throws FlowSerializationException if proposed flow is not a valid flow configuration file
      * @throws UninheritableFlowException if the proposed flow cannot be loaded by the controller because in doing so would risk orphaning FlowFiles

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorNode.java
@@ -1216,7 +1216,7 @@ public class TestStandardConnectorNode {
     }
 
     private StepConfiguration createStepConfiguration(final Map<String, String> properties) {
-        final Map<String, ConnectorValueReference> valueReferences = new java.util.HashMap<>();
+        final Map<String, ConnectorValueReference> valueReferences = new HashMap<>();
         for (final Map.Entry<String, String> entry : properties.entrySet()) {
             valueReferences.put(entry.getKey(), new StringLiteralValue(entry.getValue()));
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorRepository.java
@@ -70,6 +70,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -1076,7 +1077,7 @@ public class TestStandardConnectorRepository {
         // Step 1: provider.syncAssets() called
         verify(provider).syncAssets("connector-1");
         // Step 2: provider.load() called to reload updated config (may also have been called during addConnector)
-        verify(provider, org.mockito.Mockito.atLeastOnce()).load("connector-1");
+        verify(provider, atLeastOnce()).load("connector-1");
     }
 
     @Test

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/LoadBalancedQueueIT.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/LoadBalancedQueueIT.java
@@ -59,7 +59,6 @@ import org.apache.nifi.security.ssl.StandardSslContextBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -98,9 +97,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.nullable;
 import static org.mockito.Mockito.when;
 
 public class LoadBalancedQueueIT {
@@ -167,8 +169,8 @@ public class LoadBalancedQueueIT {
         doAnswer(invocation -> compressionReference.get()).when(serverQueue).getLoadBalanceCompression();
 
         flowController = mock(FlowController.class);
-        final FlowManager flowManager = Mockito.mock(FlowManager.class);
-        when(flowManager.getConnection(Mockito.anyString())).thenReturn(connection);
+        final FlowManager flowManager = mock(FlowManager.class);
+        when(flowManager.getConnection(anyString())).thenReturn(connection);
         when(flowController.getFlowManager()).thenReturn(flowManager);
 
         // Create repos for the server
@@ -1303,9 +1305,9 @@ public class LoadBalancedQueueIT {
     private ContentRepository createContentRepository(final ConcurrentMap<ContentClaim, byte[]> claimContents) throws IOException {
         final ContentRepository contentRepo = mock(ContentRepository.class);
 
-        Mockito.doAnswer((Answer<ContentClaim>) invocation -> createContentClaim(null)).when(contentRepo).create(Mockito.anyBoolean());
+        doAnswer((Answer<ContentClaim>) invocation -> createContentClaim(null)).when(contentRepo).create(anyBoolean());
 
-        Mockito.doAnswer(new Answer<OutputStream>() {
+        doAnswer(new Answer<OutputStream>() {
             @Override
             public OutputStream answer(final InvocationOnMock invocation) {
                 final ContentClaim contentClaim = invocation.getArgument(0);
@@ -1322,7 +1324,7 @@ public class LoadBalancedQueueIT {
             }
         }).when(contentRepo).write(any(ContentClaim.class));
 
-        Mockito.doAnswer((Answer<InputStream>) invocation -> {
+        doAnswer((Answer<InputStream>) invocation -> {
             final ContentClaim contentClaim = invocation.getArgument(0);
             if (contentClaim == null) {
                 return new ByteArrayInputStream(new byte[0]);
@@ -1334,7 +1336,7 @@ public class LoadBalancedQueueIT {
             }
 
             return new ByteArrayInputStream(bytes);
-        }).when(contentRepo).read(Mockito.nullable(ContentClaim.class));
+        }).when(contentRepo).read(nullable(ContentClaim.class));
 
         return contentRepo;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/TestSocketLoadBalancedFlowFileQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/TestSocketLoadBalancedFlowFileQueue.java
@@ -48,7 +48,6 @@ import org.apache.nifi.provenance.StandardProvenanceEventRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
@@ -73,6 +72,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -118,14 +118,14 @@ public class TestSocketLoadBalancedFlowFileQueue {
         nodeIds.add(createNodeIdentifier("11111111-1111-1111-1111-111111111111"));
         nodeIds.add(createNodeIdentifier("22222222-2222-2222-2222-222222222222"));
 
-        Mockito.doAnswer((Answer<Set<NodeIdentifier>>) invocation -> new HashSet<>(nodeIds)).when(clusterCoordinator).getNodeIdentifiers();
+        doAnswer((Answer<Set<NodeIdentifier>>) invocation -> new HashSet<>(nodeIds)).when(clusterCoordinator).getNodeIdentifiers();
 
         when(clusterCoordinator.getLocalNodeIdentifier()).thenReturn(localNodeIdentifier);
 
         doAnswer(invocation -> {
             clusterTopologyEventListener = invocation.getArgument(0);
             return null;
-        }).when(clusterCoordinator).registerEventListener(Mockito.any(ClusterTopologyEventListener.class));
+        }).when(clusterCoordinator).registerEventListener(any(ClusterTopologyEventListener.class));
 
         when(provRepo.eventBuilder()).thenReturn(new StandardProvenanceEventRecord.Builder());
         doAnswer((Answer<Object>) invocation -> {
@@ -134,13 +134,13 @@ public class TestSocketLoadBalancedFlowFileQueue {
                 provRecords.add(record);
             }
             return null;
-        }).when(provRepo).registerEvents(Mockito.any(Iterable.class));
+        }).when(provRepo).registerEvents(any(Iterable.class));
 
         doAnswer((Answer<Object>) invocation -> {
             final Collection<RepositoryRecord> records = (Collection<RepositoryRecord>) invocation.getArguments()[0];
             repoRecords.addAll(records);
             return null;
-        }).when(flowFileRepo).updateRepository(Mockito.any(Collection.class));
+        }).when(flowFileRepo).updateRepository(any(Collection.class));
 
         final ProcessScheduler scheduler = mock(ProcessScheduler.class);
 
@@ -700,7 +700,7 @@ public class TestSocketLoadBalancedFlowFileQueue {
         queue.put(secondLocal);
         queue.put(remote);
 
-        final org.apache.nifi.controller.queue.FlowFileQueueSnapshot snapshot = queue.getQueueSnapshot();
+        final FlowFileQueueSnapshot snapshot = queue.getQueueSnapshot();
 
         assertEquals(3, snapshot.queueSize().getObjectCount());
         assertEquals(70L, snapshot.queueSize().getByteCount());
@@ -726,7 +726,7 @@ public class TestSocketLoadBalancedFlowFileQueue {
             queue.put(new MockFlowFileRecord(1L));
         }
 
-        final org.apache.nifi.controller.queue.FlowFileQueueSnapshot initialSnapshot = queue.getQueueSnapshot();
+        final FlowFileQueueSnapshot initialSnapshot = queue.getQueueSnapshot();
         assertEquals(5, initialSnapshot.queueSize().getObjectCount());
         assertEquals(5, initialSnapshot.activeFlowFiles().size());
         assertEquals(initialSnapshot.queueSize().getObjectCount(), initialSnapshot.activeFlowFiles().size(),
@@ -758,7 +758,7 @@ public class TestSocketLoadBalancedFlowFileQueue {
         putThread.join(5_000L);
         assertTrue(putReturned.get(), "Put did not complete after the snapshot lock was released");
 
-        final org.apache.nifi.controller.queue.FlowFileQueueSnapshot afterPutSnapshot = queue.getQueueSnapshot();
+        final FlowFileQueueSnapshot afterPutSnapshot = queue.getQueueSnapshot();
         assertEquals(6, afterPutSnapshot.queueSize().getObjectCount());
         assertEquals(6, afterPutSnapshot.activeFlowFiles().size());
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/TestSwappablePriorityQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/TestSwappablePriorityQueue.java
@@ -36,7 +36,6 @@ import org.apache.nifi.util.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +65,7 @@ public class TestSwappablePriorityQueue {
     private final List<String> events = new ArrayList<>();
     private EventReporter eventReporter;
 
-    private final FlowFileQueue flowFileQueue = Mockito.mock(FlowFileQueue.class);
+    private final FlowFileQueue flowFileQueue = mock(FlowFileQueue.class);
     private final DropFlowFileAction dropAction = (flowFiles, requestor) -> {
         return new QueueSize(flowFiles.size(), flowFiles.stream().mapToLong(FlowFileRecord::getSize).sum());
     };

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/StandardProcessSessionIT.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/StandardProcessSessionIT.java
@@ -67,7 +67,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -118,8 +117,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -189,11 +190,11 @@ public class StandardProcessSessionIT {
         final List<Connection> connList = new ArrayList<>();
         connList.add(connection);
 
-        final ProcessGroup procGroup = Mockito.mock(ProcessGroup.class);
+        final ProcessGroup procGroup = mock(ProcessGroup.class);
         when(procGroup.getIdentifier()).thenReturn("proc-group-identifier-1");
         when(procGroup.getLoggingAttributes()).thenReturn(Map.of());
 
-        connectable = Mockito.mock(Connectable.class);
+        connectable = mock(Connectable.class);
         when(connectable.hasIncomingConnection()).thenReturn(true);
         when(connectable.getIncomingConnections()).thenReturn(connList);
         when(connectable.getProcessGroup()).thenReturn(procGroup);
@@ -204,7 +205,7 @@ public class StandardProcessSessionIT {
         when(connectable.getMaxBackoffPeriod()).thenReturn("1 sec");
         when(connectable.getFlowFileActivity()).thenReturn(new ConnectableFlowFileActivity());
 
-        Mockito.doAnswer((Answer<Set<Connection>>) invocation -> {
+        doAnswer((Answer<Set<Connection>>) invocation -> {
             final Object[] arguments = invocation.getArguments();
             final Relationship relationship = (Relationship) arguments[0];
             if (relationship == Relationship.SELF) {
@@ -214,7 +215,7 @@ public class StandardProcessSessionIT {
             } else {
                 return new HashSet<>(connList);
             }
-        }).when(connectable).getConnections(Mockito.any(Relationship.class));
+        }).when(connectable).getConnections(any(Relationship.class));
 
         when(connectable.getConnections()).thenReturn(new HashSet<>(connList));
         when(connectable.getFlowFileActivity()).thenReturn(new ConnectableFlowFileActivity());
@@ -239,17 +240,17 @@ public class StandardProcessSessionIT {
     }
 
     private FlowFileQueue createFlowFileQueueSpy(Connection connection) {
-        final FlowFileSwapManager swapManager = Mockito.mock(FlowFileSwapManager.class);
-        final ProcessScheduler processScheduler = Mockito.mock(ProcessScheduler.class);
+        final FlowFileSwapManager swapManager = mock(FlowFileSwapManager.class);
+        final ProcessScheduler processScheduler = mock(ProcessScheduler.class);
 
         final StandardFlowFileQueue actualQueue = new StandardFlowFileQueue("1", flowFileRepo, provenanceRepo,
                 processScheduler, swapManager, null, 10000, "0 sec", 0L, "0 B");
-        return Mockito.spy(actualQueue);
+        return spy(actualQueue);
     }
 
     @SuppressWarnings("unchecked")
     private Connection createConnection(AtomicReference<FlowFileQueue> flowFileQueueReference) {
-        final Connection connection = Mockito.mock(Connection.class);
+        final Connection connection = mock(Connection.class);
 
         FlowFileQueue flowFileQueueFromReference = flowFileQueueReference.get();
 
@@ -264,26 +265,26 @@ public class StandardProcessSessionIT {
 
         when(connection.getFlowFileQueue()).thenReturn(localFlowFileQueue);
 
-        Mockito.doAnswer((Answer<Object>) invocation -> {
+        doAnswer((Answer<Object>) invocation -> {
             localFlowFileQueue.put((FlowFileRecord) invocation.getArguments()[0]);
             return null;
-        }).when(connection).enqueue(Mockito.any(FlowFileRecord.class));
+        }).when(connection).enqueue(any(FlowFileRecord.class));
 
-        Mockito.doAnswer((Answer<Object>) invocation -> {
+        doAnswer((Answer<Object>) invocation -> {
             localFlowFileQueue.putAll((Collection<FlowFileRecord>) invocation.getArguments()[0]);
             return null;
-        }).when(connection).enqueue(Mockito.any(Collection.class));
+        }).when(connection).enqueue(any(Collection.class));
 
-        final Connectable dest = Mockito.mock(Connectable.class);
+        final Connectable dest = mock(Connectable.class);
         when(connection.getDestination()).thenReturn(dest);
         when(connection.getSource()).thenReturn(dest);
 
-        Mockito.doAnswer((Answer<FlowFile>) invocation -> localFlowFileQueue.poll(invocation.getArgument(0))).when(connection).poll(any(Set.class));
+        doAnswer((Answer<FlowFile>) invocation -> localFlowFileQueue.poll(invocation.getArgument(0))).when(connection).poll(any(Set.class));
 
-        Mockito.doAnswer((Answer<List<FlowFileRecord>>) invocation ->
+        doAnswer((Answer<List<FlowFileRecord>>) invocation ->
                 localFlowFileQueue.poll((FlowFileFilter) invocation.getArgument(0), invocation.getArgument(1))).when(connection).poll(any(FlowFileFilter.class), any(Set.class));
 
-        Mockito.when(connection.getIdentifier()).thenReturn("conn-uuid");
+        when(connection.getIdentifier()).thenReturn("conn-uuid");
         return connection;
     }
 
@@ -1258,7 +1259,7 @@ public class StandardProcessSessionIT {
         os.close();
 
         // should throw ProcessException because of IOException (from processor code)
-        FileOutputStream mock = Mockito.mock(FileOutputStream.class);
+        FileOutputStream mock = mock(FileOutputStream.class);
         doThrow(new IOException()).when(mock).write(notNull(), any(Integer.class), any(Integer.class));
 
         final FlowFile finalFlowfile = flowFile;
@@ -1702,7 +1703,7 @@ public class StandardProcessSessionIT {
                 .contentClaim(contentClaim)
                 .build();
 
-        Mockito.doAnswer(new Answer<List<FlowFileRecord>>() {
+        doAnswer(new Answer<List<FlowFileRecord>>() {
             int iterations = 0;
 
             @Override
@@ -1714,7 +1715,7 @@ public class StandardProcessSessionIT {
 
                 return null;
             }
-        }).when(flowFileQueue).poll(Mockito.any(FlowFileFilter.class), Mockito.any(Set.class), Mockito.any(PollStrategy.class));
+        }).when(flowFileQueue).poll(any(FlowFileFilter.class), any(Set.class), any(PollStrategy.class));
 
         session.expireFlowFiles();
         session.commit(); // if the content claim count is decremented to less than 0, an exception will be thrown.
@@ -3073,7 +3074,7 @@ public class StandardProcessSessionIT {
         when(connectable.getComponentType()).thenReturn("Unit Test Component");
         when(connectable.getFlowFileActivity()).thenReturn(new ConnectableFlowFileActivity());
 
-        Mockito.doAnswer((Answer<Set<Connection>>) invocation -> {
+        doAnswer((Answer<Set<Connection>>) invocation -> {
             final Object[] arguments = invocation.getArguments();
             final Relationship relationship = (Relationship) arguments[0];
             if (relationship == Relationship.SELF) {
@@ -3085,7 +3086,7 @@ public class StandardProcessSessionIT {
             } else {
                 return new HashSet<>(connList);
             }
-        }).when(connectable).getConnections(Mockito.any(Relationship.class));
+        }).when(connectable).getConnections(any(Relationship.class));
 
         when(connectable.getConnections()).thenReturn(new HashSet<>(connList));
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
@@ -83,7 +83,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.AdditionalMatchers;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.io.File;
@@ -120,6 +119,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class TestStandardProcessScheduler {
@@ -127,7 +128,7 @@ public class TestStandardProcessScheduler {
     private StandardProcessScheduler scheduler = null;
     private ReportingTaskNode taskNode = null;
     private TestReportingTask reportingTask = null;
-    private final StateManagerProvider stateMgrProvider = Mockito.mock(StateManagerProvider.class);
+    private final StateManagerProvider stateMgrProvider = mock(StateManagerProvider.class);
     private FlowController controller;
     private FlowManager flowManager;
     private ProcessGroup rootGroup;
@@ -150,36 +151,36 @@ public class TestStandardProcessScheduler {
         extensionManager = new StandardExtensionDiscoveringManager();
         extensionManager.discoverExtensions(systemBundle, Collections.emptySet());
 
-        scheduler = new StandardProcessScheduler(new FlowEngine(1, "Unit Test", true), Mockito.mock(FlowController.class),
+        scheduler = new StandardProcessScheduler(new FlowEngine(1, "Unit Test", true), mock(FlowController.class),
             stateMgrProvider, nifiProperties, new StandardLifecycleStateManager());
-        scheduler.setSchedulingAgent(SchedulingStrategy.TIMER_DRIVEN, Mockito.mock(SchedulingAgent.class));
+        scheduler.setSchedulingAgent(SchedulingStrategy.TIMER_DRIVEN, mock(SchedulingAgent.class));
 
         reportingTask = new TestReportingTask();
         final ReportingInitializationContext config = new StandardReportingInitializationContext(UUID.randomUUID().toString(), "Test", SchedulingStrategy.TIMER_DRIVEN, "5 secs",
-                Mockito.mock(ComponentLog.class), null, KerberosConfig.NOT_CONFIGURED, null);
+                mock(ComponentLog.class), null, KerberosConfig.NOT_CONFIGURED, null);
         reportingTask.initialize(config);
 
         final ValidationContextFactory validationContextFactory = new StandardValidationContextFactory(null);
-        final TerminationAwareLogger logger = Mockito.mock(TerminationAwareLogger.class);
-        final ReloadComponent reloadComponent = Mockito.mock(ReloadComponent.class);
+        final TerminationAwareLogger logger = mock(TerminationAwareLogger.class);
+        final ReloadComponent reloadComponent = mock(ReloadComponent.class);
         final LoggableComponent<ReportingTask> loggableComponent = new LoggableComponent<>(reportingTask, systemBundle.getBundleDetails().getCoordinate(), logger);
-        taskNode = new StandardReportingTaskNode(loggableComponent, UUID.randomUUID().toString(), Mockito.mock(FlowController.class), scheduler, validationContextFactory,
+        taskNode = new StandardReportingTaskNode(loggableComponent, UUID.randomUUID().toString(), mock(FlowController.class), scheduler, validationContextFactory,
             reloadComponent, extensionManager, new SynchronousValidationTrigger());
 
-        flowManager = Mockito.mock(FlowManager.class);
-        controller = Mockito.mock(FlowController.class);
+        flowManager = mock(FlowManager.class);
+        controller = mock(FlowController.class);
         when(controller.getFlowManager()).thenReturn(flowManager);
-        Mockito.when(controller.getExtensionManager()).thenReturn(extensionManager);
+        when(controller.getExtensionManager()).thenReturn(extensionManager);
 
         serviceProvider = new StandardControllerServiceProvider(scheduler, null, flowManager, extensionManager);
 
         final ConcurrentMap<String, ProcessorNode> processorMap = new ConcurrentHashMap<>();
-        Mockito.doAnswer((Answer<ProcessorNode>) invocation -> {
+        doAnswer((Answer<ProcessorNode>) invocation -> {
             final String id = invocation.getArgument(0);
             return processorMap.get(id);
-        }).when(flowManager).getProcessorNode(Mockito.anyString());
+        }).when(flowManager).getProcessorNode(anyString());
 
-        Mockito.doAnswer((Answer<Object>) invocation -> {
+        doAnswer((Answer<Object>) invocation -> {
             final ProcessorNode procNode = invocation.getArgument(0);
             processorMap.putIfAbsent(procNode.getIdentifier(), procNode);
             return null;
@@ -188,9 +189,9 @@ public class TestStandardProcessScheduler {
         when(controller.getControllerServiceProvider()).thenReturn(serviceProvider);
 
         rootGroup = new MockProcessGroup(flowManager);
-        when(flowManager.getGroup(Mockito.anyString())).thenReturn(rootGroup);
+        when(flowManager.getGroup(anyString())).thenReturn(rootGroup);
 
-        when(controller.getReloadComponent()).thenReturn(Mockito.mock(ReloadComponent.class));
+        when(controller.getReloadComponent()).thenReturn(mock(ReloadComponent.class));
 
         doAnswer((Answer<ControllerServiceNode>) invocation -> {
             final String type = invocation.getArgument(0);
@@ -202,12 +203,12 @@ public class TestStandardProcessScheduler {
                 .type(type)
                 .bundleCoordinate(bundleCoordinate)
                 .controllerServiceProvider(serviceProvider)
-                .processScheduler(Mockito.mock(ProcessScheduler.class))
-                .nodeTypeProvider(Mockito.mock(NodeTypeProvider.class))
-                .validationTrigger(Mockito.mock(ValidationTrigger.class))
-                .reloadComponent(Mockito.mock(ReloadComponent.class))
-                .verifiableComponentFactory(Mockito.mock(VerifiableComponentFactory.class))
-                .stateManagerProvider(Mockito.mock(StateManagerProvider.class))
+                .processScheduler(mock(ProcessScheduler.class))
+                .nodeTypeProvider(mock(NodeTypeProvider.class))
+                .validationTrigger(mock(ValidationTrigger.class))
+                .reloadComponent(mock(ReloadComponent.class))
+                .verifiableComponentFactory(mock(VerifiableComponentFactory.class))
+                .stateManagerProvider(mock(StateManagerProvider.class))
                 .extensionManager(extensionManager)
                 .buildControllerService();
 
@@ -257,8 +258,8 @@ public class TestStandardProcessScheduler {
         final Processor proc = new ServiceReferencingProcessor();
         proc.initialize(new StandardProcessorInitializationContext(uuid, null, null, null, KerberosConfig.NOT_CONFIGURED));
 
-        final ReloadComponent reloadComponent = Mockito.mock(ReloadComponent.class);
-        final VerifiableComponentFactory verifiableComponentFactory = Mockito.mock(VerifiableComponentFactory.class);
+        final ReloadComponent reloadComponent = mock(ReloadComponent.class);
+        final VerifiableComponentFactory verifiableComponentFactory = mock(VerifiableComponentFactory.class);
 
         final ControllerServiceNode service = flowManager.createControllerService(NoStartServiceImpl.class.getName(), "service",
                 systemBundle.getBundleDetails().getCoordinate(), null, true, true, null);
@@ -555,8 +556,8 @@ public class TestStandardProcessScheduler {
         proc.setDesiredFailureCount(3);
 
         proc.initialize(new StandardProcessorInitializationContext(UUID.randomUUID().toString(), null, null, null, KerberosConfig.NOT_CONFIGURED));
-        final ReloadComponent reloadComponent = Mockito.mock(ReloadComponent.class);
-        final VerifiableComponentFactory verifiableComponentFactory = Mockito.mock(VerifiableComponentFactory.class);
+        final ReloadComponent reloadComponent = mock(ReloadComponent.class);
+        final VerifiableComponentFactory verifiableComponentFactory = mock(VerifiableComponentFactory.class);
         final LoggableComponent<Processor> loggableComponent = new LoggableComponent<>(proc, systemBundle.getBundleDetails().getCoordinate(), null);
 
         final ProcessorNode procNode = new StandardProcessorNode(loggableComponent, UUID.randomUUID().toString(),
@@ -583,8 +584,8 @@ public class TestStandardProcessScheduler {
         proc.setOnScheduledSleepDuration(20, TimeUnit.MINUTES, true, 1);
 
         proc.initialize(new StandardProcessorInitializationContext(UUID.randomUUID().toString(), null, null, null, KerberosConfig.NOT_CONFIGURED));
-        final ReloadComponent reloadComponent = Mockito.mock(ReloadComponent.class);
-        final VerifiableComponentFactory verifiableComponentFactory = Mockito.mock(VerifiableComponentFactory.class);
+        final ReloadComponent reloadComponent = mock(ReloadComponent.class);
+        final VerifiableComponentFactory verifiableComponentFactory = mock(VerifiableComponentFactory.class);
         final LoggableComponent<Processor> loggableComponent = new LoggableComponent<>(proc, systemBundle.getBundleDetails().getCoordinate(), null);
 
         final ProcessorNode procNode = new StandardProcessorNode(loggableComponent, UUID.randomUUID().toString(),
@@ -614,8 +615,8 @@ public class TestStandardProcessScheduler {
         proc.setOnScheduledSleepDuration(20, TimeUnit.MINUTES, false, 1);
 
         proc.initialize(new StandardProcessorInitializationContext(UUID.randomUUID().toString(), null, null, null, KerberosConfig.NOT_CONFIGURED));
-        final ReloadComponent reloadComponent = Mockito.mock(ReloadComponent.class);
-        final VerifiableComponentFactory verifiableComponentFactory = Mockito.mock(VerifiableComponentFactory.class);
+        final ReloadComponent reloadComponent = mock(ReloadComponent.class);
+        final VerifiableComponentFactory verifiableComponentFactory = mock(VerifiableComponentFactory.class);
         final LoggableComponent<Processor> loggableComponent = new LoggableComponent<>(proc, systemBundle.getBundleDetails().getCoordinate(), null);
 
         final ProcessorNode procNode = new StandardProcessorNode(loggableComponent, UUID.randomUUID().toString(),
@@ -715,7 +716,7 @@ public class TestStandardProcessScheduler {
     }
 
     private StandardProcessScheduler createScheduler() {
-        return new StandardProcessScheduler(new FlowEngine(1, "Unit Test", true), Mockito.mock(FlowController.class),
+        return new StandardProcessScheduler(new FlowEngine(1, "Unit Test", true), mock(FlowController.class),
             stateMgrProvider, nifiProperties, new StandardLifecycleStateManager());
     }
 
@@ -737,8 +738,8 @@ public class TestStandardProcessScheduler {
 
         final LifecycleState lifecycleState = harness.lifecycleStateManager().getOrRegisterLifecycleState(procNode.getIdentifier(), false, false);
 
-        final ProcessSession retainedSession = Mockito.mock(ProcessSession.class);
-        final ProcessSessionFactory delegateFactory = Mockito.mock(ProcessSessionFactory.class);
+        final ProcessSession retainedSession = mock(ProcessSession.class);
+        final ProcessSessionFactory delegateFactory = mock(ProcessSessionFactory.class);
         when(delegateFactory.createSession()).thenReturn(retainedSession);
 
         final WeakHashMapProcessSessionFactory retainedFactory = new WeakHashMapProcessSessionFactory(delegateFactory);
@@ -751,7 +752,7 @@ public class TestStandardProcessScheduler {
 
         harness.scheduler().terminateProcessor(procNode);
 
-        Mockito.verify(retainedSession).rollback();
+        verify(retainedSession).rollback();
         // Keep the Session wrapper reachable through verification so that the factory's WeakHashMap
         // entry tracking it cannot be cleared by the GC before terminateActiveSessions() iterates it.
         Reference.reachabilityFence(sessionWrapper);
@@ -807,9 +808,9 @@ public class TestStandardProcessScheduler {
     }
 
     private TerminationTestHarness createTerminationTestHarness() {
-        final FlowController flowController = Mockito.mock(FlowController.class);
+        final FlowController flowController = mock(FlowController.class);
         when(flowController.getExtensionManager()).thenReturn(extensionManager);
-        when(flowController.getReloadComponent()).thenReturn(Mockito.mock(ReloadComponent.class));
+        when(flowController.getReloadComponent()).thenReturn(mock(ReloadComponent.class));
         when(flowController.getControllerServiceProvider()).thenReturn(serviceProvider);
 
         final LifecycleStateManager lifecycleStateManager = new StandardLifecycleStateManager();
@@ -817,7 +818,7 @@ public class TestStandardProcessScheduler {
 
         final StandardProcessScheduler localScheduler = new StandardProcessScheduler(componentLifeCyclePool, flowController,
             stateMgrProvider, nifiProperties, lifecycleStateManager);
-        localScheduler.setSchedulingAgent(SchedulingStrategy.TIMER_DRIVEN, Mockito.mock(SchedulingAgent.class));
+        localScheduler.setSchedulingAgent(SchedulingStrategy.TIMER_DRIVEN, mock(SchedulingAgent.class));
 
         return new TerminationTestHarness(localScheduler, lifecycleStateManager, componentLifeCyclePool);
     }
@@ -827,11 +828,11 @@ public class TestStandardProcessScheduler {
         final Processor processor = new NoOpProcessor();
         processor.initialize(new StandardProcessorInitializationContext(uuid, null, null, null, KerberosConfig.NOT_CONFIGURED));
 
-        final TerminationAwareLogger logger = Mockito.mock(TerminationAwareLogger.class);
+        final TerminationAwareLogger logger = mock(TerminationAwareLogger.class);
         final LoggableComponent<Processor> loggableComponent = new LoggableComponent<>(processor, systemBundle.getBundleDetails().getCoordinate(), logger);
         final ProcessorNode procNode = new StandardProcessorNode(loggableComponent, uuid,
-            new StandardValidationContextFactory(serviceProvider), harness.scheduler(), serviceProvider, Mockito.mock(ReloadComponent.class),
-            Mockito.mock(VerifiableComponentFactory.class), extensionManager, new SynchronousValidationTrigger());
+            new StandardValidationContextFactory(serviceProvider), harness.scheduler(), serviceProvider, mock(ReloadComponent.class),
+            mock(VerifiableComponentFactory.class), extensionManager, new SynchronousValidationTrigger());
         rootGroup.addProcessor(procNode);
         return procNode;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/processors/FailOnScheduledProcessor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/processors/FailOnScheduledProcessor.java
@@ -19,6 +19,8 @@ package org.apache.nifi.controller.scheduling.processors;
 
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 
 import java.util.concurrent.TimeUnit;
@@ -84,6 +86,6 @@ public class FailOnScheduledProcessor extends AbstractProcessor {
     }
 
     @Override
-    public void onTrigger(org.apache.nifi.processor.ProcessContext context, org.apache.nifi.processor.ProcessSession session) throws ProcessException {
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizerTest.java
@@ -78,6 +78,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -465,13 +466,13 @@ class VersionedFlowSynchronizerTest {
         final ConnectorNode orphanConnector = mock(ConnectorNode.class);
         when(orphanConnector.getIdentifier()).thenReturn("orphan-connector-id");
         when(connectorRepository.stopConnector(orphanConnector))
-                .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(null));
+                .thenReturn(CompletableFuture.completedFuture(null));
 
         final ConnectorNode syncedNode = mock(ConnectorNode.class);
         when(connectorRepository.syncConnector(proposedConnector))
                 .thenReturn(ConnectorSyncResult.syncedConfigUnchanged(syncedNode, VersionedConnectorState.ENABLED));
         when(connectorRepository.stopConnector(syncedNode))
-                .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(null));
+                .thenReturn(CompletableFuture.completedFuture(null));
 
         setFlowController(connectorRepository);
         when(connectorRepository.getConnectors(ConnectorSyncMode.LOCAL_ONLY)).thenReturn(List.of(orphanConnector));
@@ -505,7 +506,7 @@ class VersionedFlowSynchronizerTest {
         when(connectorRepository.syncConnector(versionedConnector))
                 .thenReturn(ConnectorSyncResult.syncedConfigUnchanged(syncedNode, VersionedConnectorState.ENABLED));
         when(connectorRepository.stopConnector(syncedNode))
-                .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(null));
+                .thenReturn(CompletableFuture.completedFuture(null));
 
         setFlowController(connectorRepository);
         when(connectorRepository.getConnectors(ConnectorSyncMode.LOCAL_ONLY)).thenReturn(List.of(existingConnector));
@@ -534,7 +535,7 @@ class VersionedFlowSynchronizerTest {
         final ConnectorNode orphanConnector = mock(ConnectorNode.class);
         when(orphanConnector.getIdentifier()).thenReturn("orphan-connector-id");
 
-        final java.util.concurrent.CompletableFuture<Void> failedFuture = new java.util.concurrent.CompletableFuture<>();
+        final CompletableFuture<Void> failedFuture = new CompletableFuture<>();
         failedFuture.completeExceptionally(new RuntimeException("Stop failed"));
         when(connectorRepository.stopConnector(orphanConnector)).thenReturn(failedFuture);
 
@@ -542,7 +543,7 @@ class VersionedFlowSynchronizerTest {
         when(connectorRepository.syncConnector(proposedConnector))
                 .thenReturn(ConnectorSyncResult.syncedConfigUnchanged(syncedNode, VersionedConnectorState.ENABLED));
         when(connectorRepository.stopConnector(syncedNode))
-                .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(null));
+                .thenReturn(CompletableFuture.completedFuture(null));
 
         setFlowController(connectorRepository);
         when(connectorRepository.getConnectors(ConnectorSyncMode.LOCAL_ONLY)).thenReturn(List.of(orphanConnector));

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/TestStandardControllerServiceProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/TestStandardControllerServiceProvider.java
@@ -59,7 +59,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.net.URL;
@@ -82,6 +81,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -109,15 +109,15 @@ public class TestStandardControllerServiceProvider {
 
     @BeforeEach
     public void setup() {
-        flowManager = Mockito.mock(FlowManager.class);
+        flowManager = mock(FlowManager.class);
 
         final ConcurrentMap<String, ProcessorNode> processorMap = new ConcurrentHashMap<>();
-        Mockito.doAnswer((Answer<ProcessorNode>) invocation -> {
+        doAnswer((Answer<ProcessorNode>) invocation -> {
             final String id = invocation.getArgument(0);
             return processorMap.get(id);
-        }).when(flowManager).getProcessorNode(Mockito.anyString());
+        }).when(flowManager).getProcessorNode(anyString());
 
-        Mockito.doAnswer((Answer<Object>) invocation -> {
+        doAnswer((Answer<Object>) invocation -> {
             final ProcessorNode procNode = invocation.getArgument(0);
             processorMap.putIfAbsent(procNode.getIdentifier(), procNode);
             return null;
@@ -125,7 +125,7 @@ public class TestStandardControllerServiceProvider {
     }
 
     private StandardProcessScheduler createScheduler() {
-        return new StandardProcessScheduler(new FlowEngine(1, "Unit Test", true), Mockito.mock(FlowController.class),
+        return new StandardProcessScheduler(new FlowEngine(1, "Unit Test", true), mock(FlowController.class),
                 stateManagerProvider, niFiProperties, new StandardLifecycleStateManager());
     }
 
@@ -141,12 +141,12 @@ public class TestStandardControllerServiceProvider {
             .type(type)
             .bundleCoordinate(bundleCoordinate)
             .controllerServiceProvider(serviceProvider)
-            .processScheduler(Mockito.mock(ProcessScheduler.class))
-            .nodeTypeProvider(Mockito.mock(NodeTypeProvider.class))
-            .validationTrigger(Mockito.mock(ValidationTrigger.class))
-            .reloadComponent(Mockito.mock(ReloadComponent.class))
-            .verifiableComponentFactory(Mockito.mock(VerifiableComponentFactory.class))
-            .stateManagerProvider(Mockito.mock(StateManagerProvider.class))
+            .processScheduler(mock(ProcessScheduler.class))
+            .nodeTypeProvider(mock(NodeTypeProvider.class))
+            .validationTrigger(mock(ValidationTrigger.class))
+            .reloadComponent(mock(ReloadComponent.class))
+            .verifiableComponentFactory(mock(VerifiableComponentFactory.class))
+            .stateManagerProvider(mock(StateManagerProvider.class))
             .extensionManager(extensionManager)
             .buildControllerService();
 
@@ -158,9 +158,9 @@ public class TestStandardControllerServiceProvider {
     @Test
     public void testDisableControllerService() {
         final ProcessGroup procGroup = new MockProcessGroup(flowManager);
-        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final FlowManager flowManager = mock(FlowManager.class);
 
-        Mockito.when(flowManager.getGroup(Mockito.anyString())).thenReturn(procGroup);
+        when(flowManager.getGroup(anyString())).thenReturn(procGroup);
 
         final StandardProcessScheduler scheduler = createScheduler();
         final StandardControllerServiceProvider provider = new StandardControllerServiceProvider(scheduler, null, flowManager, extensionManager);
@@ -176,9 +176,9 @@ public class TestStandardControllerServiceProvider {
     @Timeout(10)
     public void testEnableDisableWithReference() {
         final ProcessGroup group = new MockProcessGroup(flowManager);
-        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final FlowManager flowManager = mock(FlowManager.class);
 
-        Mockito.when(flowManager.getGroup(Mockito.anyString())).thenReturn(group);
+        when(flowManager.getGroup(anyString())).thenReturn(group);
 
         final StandardProcessScheduler scheduler = createScheduler();
         final StandardControllerServiceProvider provider = new StandardControllerServiceProvider(scheduler, null, flowManager, extensionManager);
@@ -212,8 +212,8 @@ public class TestStandardControllerServiceProvider {
     public void testOrderingOfServices() {
         final ProcessGroup procGroup = new MockProcessGroup(flowManager);
 
-        final FlowManager flowManager = Mockito.mock(FlowManager.class);
-        Mockito.when(flowManager.getGroup(Mockito.anyString())).thenReturn(procGroup);
+        final FlowManager flowManager = mock(FlowManager.class);
+        when(flowManager.getGroup(anyString())).thenReturn(procGroup);
 
         final StandardControllerServiceProvider provider = new StandardControllerServiceProvider(null, null, flowManager, extensionManager);
         final ControllerServiceNode serviceNode1 = createControllerService(ServiceA.class.getName(), "1", systemBundle.getBundleDetails().getCoordinate(), provider);
@@ -358,11 +358,11 @@ public class TestStandardControllerServiceProvider {
     }
 
     private ProcessorNode createProcessor(final StandardProcessScheduler scheduler, final ControllerServiceProvider serviceProvider) {
-        final ReloadComponent reloadComponent = Mockito.mock(ReloadComponent.class);
-        final VerifiableComponentFactory verifiableComponentFactory = Mockito.mock(VerifiableComponentFactory.class);
+        final ReloadComponent reloadComponent = mock(ReloadComponent.class);
+        final VerifiableComponentFactory verifiableComponentFactory = mock(VerifiableComponentFactory.class);
 
         final Processor processor = new DummyProcessor();
-        final MockProcessContext context = new MockProcessContext(processor, Mockito.mock(StateManager.class));
+        final MockProcessContext context = new MockProcessContext(processor, mock(StateManager.class));
         final MockProcessorInitializationContext mockInitContext = new MockProcessorInitializationContext(processor, context);
         processor.initialize(mockInitContext);
 
@@ -371,10 +371,10 @@ public class TestStandardControllerServiceProvider {
                 new StandardValidationContextFactory(serviceProvider), scheduler, serviceProvider,
                 reloadComponent, verifiableComponentFactory, extensionManager, new SynchronousValidationTrigger());
 
-        final FlowManager flowManager = Mockito.mock(FlowManager.class);
-        final FlowController flowController = Mockito.mock(FlowController.class);
-        Mockito.when(flowController.getFlowManager()).thenReturn(flowManager);
-        Mockito.when(flowController.getStateManagerProvider()).thenReturn(stateManagerProvider);
+        final FlowManager flowManager = mock(FlowManager.class);
+        final FlowController flowController = mock(FlowController.class);
+        when(flowController.getFlowManager()).thenReturn(flowManager);
+        when(flowController.getStateManagerProvider()).thenReturn(stateManagerProvider);
 
         final ProcessGroup group = new MockProcessGroup(null);
         group.addProcessor(procNode);
@@ -387,8 +387,8 @@ public class TestStandardControllerServiceProvider {
     public void testEnableReferencingComponents() {
         final ProcessGroup procGroup = new MockProcessGroup(flowManager);
 
-        final FlowManager flowManager = Mockito.mock(FlowManager.class);
-        Mockito.when(flowManager.getGroup(Mockito.anyString())).thenReturn(procGroup);
+        final FlowManager flowManager = mock(FlowManager.class);
+        when(flowManager.getGroup(anyString())).thenReturn(procGroup);
 
         final StandardProcessScheduler scheduler = createScheduler();
         final StandardControllerServiceProvider provider = new StandardControllerServiceProvider(scheduler, null, flowManager, extensionManager);
@@ -509,14 +509,14 @@ public class TestStandardControllerServiceProvider {
 
     @Test
     public void validateEnableServices() {
-        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final FlowManager flowManager = mock(FlowManager.class);
 
         StandardProcessScheduler scheduler = createScheduler();
 
         final StandardControllerServiceProvider provider = new StandardControllerServiceProvider(scheduler, null, flowManager, extensionManager);
         ProcessGroup procGroup = new MockProcessGroup(flowManager);
 
-        Mockito.when(flowManager.getGroup(Mockito.anyString())).thenReturn(procGroup);
+        when(flowManager.getGroup(anyString())).thenReturn(procGroup);
 
         ControllerServiceNode serviceA = createControllerService(ServiceA.class.getName(), "A", systemBundle.getBundleDetails().getCoordinate(), provider);
         ControllerServiceNode serviceB = createControllerService(ServiceA.class.getName(), "B", systemBundle.getBundleDetails().getCoordinate(), provider);
@@ -558,14 +558,14 @@ public class TestStandardControllerServiceProvider {
      */
     @Test
     public void validateEnableServices2() {
-        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final FlowManager flowManager = mock(FlowManager.class);
 
         StandardProcessScheduler scheduler = createScheduler();
 
         final StandardControllerServiceProvider provider = new StandardControllerServiceProvider(scheduler, null, flowManager, extensionManager);
         ProcessGroup procGroup = new MockProcessGroup(flowManager);
 
-        Mockito.when(flowManager.getGroup(Mockito.anyString())).thenReturn(procGroup);
+        when(flowManager.getGroup(anyString())).thenReturn(procGroup);
 
         ControllerServiceNode serviceA = createControllerService(ServiceC.class.getName(), "A", systemBundle.getBundleDetails().getCoordinate(), provider);
         ControllerServiceNode serviceB = createControllerService(ServiceA.class.getName(), "B", systemBundle.getBundleDetails().getCoordinate(), provider);
@@ -600,14 +600,14 @@ public class TestStandardControllerServiceProvider {
 
     @Test
     public void validateEnableServicesWithDisabledMissingService() {
-        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final FlowManager flowManager = mock(FlowManager.class);
 
         StandardProcessScheduler scheduler = createScheduler();
 
         final StandardControllerServiceProvider provider = new StandardControllerServiceProvider(scheduler, null, flowManager, extensionManager);
         ProcessGroup procGroup = new MockProcessGroup(flowManager);
 
-        Mockito.when(flowManager.getGroup(Mockito.anyString())).thenReturn(procGroup);
+        when(flowManager.getGroup(anyString())).thenReturn(procGroup);
 
         ControllerServiceNode serviceNode1 = createControllerService(ServiceA.class.getName(), "1", systemBundle.getBundleDetails().getCoordinate(), provider);
         ControllerServiceNode serviceNode2 = createControllerService(ServiceA.class.getName(), "2", systemBundle.getBundleDetails().getCoordinate(), provider);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/tasks/TestConnectableTask.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/tasks/TestConnectableTask.java
@@ -35,7 +35,6 @@ import org.apache.nifi.controller.scheduling.SchedulingAgent;
 import org.apache.nifi.controller.status.FlowFileAvailability;
 import org.apache.nifi.processor.Processor;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,44 +44,45 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestConnectableTask {
 
     private ConnectableTask createTask(final Connectable connectable) {
-        final FlowController flowController = Mockito.mock(FlowController.class);
-        Mockito.when(flowController.getStateManagerProvider()).thenReturn(Mockito.mock(StateManagerProvider.class));
+        final FlowController flowController = mock(FlowController.class);
+        when(flowController.getStateManagerProvider()).thenReturn(mock(StateManagerProvider.class));
 
-        final RepositoryContext repoContext = Mockito.mock(StandardRepositoryContext.class);
-        Mockito.when(repoContext.getFlowFileEventRepository()).thenReturn(Mockito.mock(FlowFileEventRepository.class));
+        final RepositoryContext repoContext = mock(StandardRepositoryContext.class);
+        when(repoContext.getFlowFileEventRepository()).thenReturn(mock(FlowFileEventRepository.class));
 
         when(flowController.getGarbageCollectionLog()).thenReturn(mock(GarbageCollectionLog.class));
 
-        final RepositoryContextFactory contextFactory = Mockito.mock(RepositoryContextFactory.class);
-        Mockito.when(contextFactory.newProcessContext(Mockito.any(Connectable.class), Mockito.any(AtomicLong.class))).thenReturn(repoContext);
+        final RepositoryContextFactory contextFactory = mock(RepositoryContextFactory.class);
+        when(contextFactory.newProcessContext(any(Connectable.class), any(AtomicLong.class))).thenReturn(repoContext);
 
         final LifecycleState scheduleState = new LifecycleState(connectable.getIdentifier());
 
-        return new ConnectableTask(Mockito.mock(SchedulingAgent.class), connectable,
+        return new ConnectableTask(mock(SchedulingAgent.class), connectable,
                 flowController, contextFactory, scheduleState);
     }
 
     @Test
     public void testIsWorkToDo() {
-        final ProcessorNode procNode = Mockito.mock(ProcessorNode.class);
-        Mockito.when(procNode.hasIncomingConnection()).thenReturn(false);
+        final ProcessorNode procNode = mock(ProcessorNode.class);
+        when(procNode.hasIncomingConnection()).thenReturn(false);
 
-        final Processor processor = Mockito.mock(Processor.class);
-        Mockito.when(procNode.getIdentifier()).thenReturn("123");
-        Mockito.when(procNode.getRunnableComponent()).thenReturn(processor);
+        final Processor processor = mock(Processor.class);
+        when(procNode.getIdentifier()).thenReturn("123");
+        when(procNode.getRunnableComponent()).thenReturn(processor);
 
         // There is work to do because there are no incoming connections.
         final ConnectableTask task = createTask(procNode);
         assertFalse(task.invoke().isYield());
 
         // Test with only a single connection that is self-looping and empty
-        final Connection selfLoopingConnection = Mockito.mock(Connection.class);
+        final Connection selfLoopingConnection = mock(Connection.class);
         when(selfLoopingConnection.getSource()).thenReturn(procNode);
         when(selfLoopingConnection.getDestination()).thenReturn(procNode);
 
@@ -91,18 +91,18 @@ public class TestConnectableTask {
         assertFalse(task.invoke().isYield());
 
         // Test with only a single connection that is self-looping and empty
-        final FlowFileQueue flowFileQueue = Mockito.mock(FlowFileQueue.class);
+        final FlowFileQueue flowFileQueue = mock(FlowFileQueue.class);
         when(flowFileQueue.getFlowFileAvailability()).thenReturn(FlowFileAvailability.ACTIVE_QUEUE_EMPTY);
 
-        final FlowFileQueue nonEmptyQueue = Mockito.mock(FlowFileQueue.class);
+        final FlowFileQueue nonEmptyQueue = mock(FlowFileQueue.class);
         when(nonEmptyQueue.getFlowFileAvailability()).thenReturn(FlowFileAvailability.FLOWFILE_AVAILABLE);
 
         when(selfLoopingConnection.getFlowFileQueue()).thenReturn(nonEmptyQueue);
         assertFalse(task.invoke().isYield());
 
         // Test with only a non-looping Connection that has no FlowFiles
-        final Connection emptyConnection = Mockito.mock(Connection.class);
-        when(emptyConnection.getSource()).thenReturn(Mockito.mock(ProcessorNode.class));
+        final Connection emptyConnection = mock(Connection.class);
+        when(emptyConnection.getSource()).thenReturn(mock(ProcessorNode.class));
         when(emptyConnection.getDestination()).thenReturn(procNode);
 
         when(emptyConnection.getFlowFileQueue()).thenReturn(flowFileQueue);
@@ -111,8 +111,8 @@ public class TestConnectableTask {
         assertTrue(task.invoke().isYield());
 
         // test when the queue has data
-        final Connection nonEmptyConnection = Mockito.mock(Connection.class);
-        when(nonEmptyConnection.getSource()).thenReturn(Mockito.mock(ProcessorNode.class));
+        final Connection nonEmptyConnection = mock(Connection.class);
+        when(nonEmptyConnection.getSource()).thenReturn(mock(ProcessorNode.class));
         when(nonEmptyConnection.getDestination()).thenReturn(procNode);
         when(nonEmptyConnection.getFlowFileQueue()).thenReturn(nonEmptyQueue);
         when(procNode.getIncomingConnections()).thenReturn(Collections.singletonList(nonEmptyConnection));
@@ -121,11 +121,11 @@ public class TestConnectableTask {
 
     @Test
     public void testIsWorkToDoFunnels() {
-        final Funnel funnel = Mockito.mock(Funnel.class);
-        Mockito.when(funnel.hasIncomingConnection()).thenReturn(false);
-        Mockito.when(funnel.getRunnableComponent()).thenReturn(funnel);
-        Mockito.when(funnel.getConnectableType()).thenReturn(ConnectableType.FUNNEL);
-        Mockito.when(funnel.getIdentifier()).thenReturn("funnel-1");
+        final Funnel funnel = mock(Funnel.class);
+        when(funnel.hasIncomingConnection()).thenReturn(false);
+        when(funnel.getRunnableComponent()).thenReturn(funnel);
+        when(funnel.getConnectableType()).thenReturn(ConnectableType.FUNNEL);
+        when(funnel.getIdentifier()).thenReturn("funnel-1");
 
         final ConnectableTask task = createTask(funnel);
         assertTrue(task.invoke().isYield(),
@@ -134,14 +134,14 @@ public class TestConnectableTask {
         // Test with only a single connection that is self-looping and empty.
         // Actually, this self-loop input can not be created for Funnels using NiFi API because an outer layer check condition does not allow it.
         // But test it anyways.
-        final Connection selfLoopingConnection = Mockito.mock(Connection.class);
+        final Connection selfLoopingConnection = mock(Connection.class);
         when(selfLoopingConnection.getSource()).thenReturn(funnel);
         when(selfLoopingConnection.getDestination()).thenReturn(funnel);
 
         when(funnel.hasIncomingConnection()).thenReturn(true);
         when(funnel.getIncomingConnections()).thenReturn(Collections.singletonList(selfLoopingConnection));
 
-        final FlowFileQueue emptyQueue = Mockito.mock(FlowFileQueue.class);
+        final FlowFileQueue emptyQueue = mock(FlowFileQueue.class);
         when(emptyQueue.getFlowFileAvailability()).thenReturn(FlowFileAvailability.ACTIVE_QUEUE_EMPTY);
         when(selfLoopingConnection.getFlowFileQueue()).thenReturn(emptyQueue);
 
@@ -153,8 +153,8 @@ public class TestConnectableTask {
                 "If there is no incoming connection from other components, it should be yielded.");
 
         // Add an incoming connection from another component.
-        final ProcessorNode inputProcessor = Mockito.mock(ProcessorNode.class);
-        final Connection incomingFromAnotherComponent = Mockito.mock(Connection.class);
+        final ProcessorNode inputProcessor = mock(ProcessorNode.class);
+        final Connection incomingFromAnotherComponent = mock(Connection.class);
         when(incomingFromAnotherComponent.getSource()).thenReturn(inputProcessor);
         when(incomingFromAnotherComponent.getDestination()).thenReturn(funnel);
         when(incomingFromAnotherComponent.getFlowFileQueue()).thenReturn(emptyQueue);
@@ -166,8 +166,8 @@ public class TestConnectableTask {
                 " it should be yielded because there's no outgoing connections.");
 
         // Add an outgoing connection to another component.
-        final ProcessorNode outputProcessor = Mockito.mock(ProcessorNode.class);
-        final Connection outgoingToAnotherComponent = Mockito.mock(Connection.class);
+        final ProcessorNode outputProcessor = mock(ProcessorNode.class);
+        final Connection outgoingToAnotherComponent = mock(Connection.class);
         when(outgoingToAnotherComponent.getSource()).thenReturn(funnel);
         when(outgoingToAnotherComponent.getDestination()).thenReturn(outputProcessor);
         outgoingConnections.add(outgoingToAnotherComponent);
@@ -176,7 +176,7 @@ public class TestConnectableTask {
                 " it should be yielded because there's no incoming FlowFiles to process.");
 
         // Adding input FlowFiles.
-        final FlowFileQueue nonEmptyQueue = Mockito.mock(FlowFileQueue.class);
+        final FlowFileQueue nonEmptyQueue = mock(FlowFileQueue.class);
         when(nonEmptyQueue.getFlowFileAvailability()).thenReturn(FlowFileAvailability.FLOWFILE_AVAILABLE);
         when(incomingFromAnotherComponent.getFlowFileQueue()).thenReturn(nonEmptyQueue);
         assertFalse(task.invoke().isYield(),

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/registry/flow/mapping/VersionedComponentFlowMapperTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/registry/flow/mapping/VersionedComponentFlowMapperTest.java
@@ -89,7 +89,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -142,10 +141,10 @@ public class VersionedComponentFlowMapperTest {
     @BeforeEach
     public void setup() {
         final FlowRegistryClientNode flowRegistry = mock(FlowRegistryClientNode.class);
-        Mockito.when(flowRegistry.getComponentType()).thenReturn(TestNifiRegistryFlowRegistryClient.class.getName());
-        Mockito.when(flowRegistry.getRawPropertyValue(Mockito.any())).thenReturn("");
-        Mockito.when(flowRegistry.getPropertyDescriptor(TestNifiRegistryFlowRegistryClient.PROPERTY_URL.getName())).thenReturn(TestNifiRegistryFlowRegistryClient.PROPERTY_URL);
-        Mockito.when(flowRegistry.getRawPropertyValue(TestNifiRegistryFlowRegistryClient.PROPERTY_URL)).thenReturn("http://127.0.0.1:18080");
+        when(flowRegistry.getComponentType()).thenReturn(TestNifiRegistryFlowRegistryClient.class.getName());
+        when(flowRegistry.getRawPropertyValue(any())).thenReturn("");
+        when(flowRegistry.getPropertyDescriptor(TestNifiRegistryFlowRegistryClient.PROPERTY_URL.getName())).thenReturn(TestNifiRegistryFlowRegistryClient.PROPERTY_URL);
+        when(flowRegistry.getRawPropertyValue(TestNifiRegistryFlowRegistryClient.PROPERTY_URL)).thenReturn("http://127.0.0.1:18080");
 
         when(flowManager.getFlowRegistryClient(anyString())).thenReturn(flowRegistry);
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-status-history-shared/src/main/java/org/apache/nifi/controller/status/history/ProcessorStatusDescriptor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-status-history-shared/src/main/java/org/apache/nifi/controller/status/history/ProcessorStatusDescriptor.java
@@ -314,7 +314,7 @@ public enum ProcessorStatusDescriptor {
                     final long millis = snapshot.getStatusMetric(metricDescriptor);
                     metricMillis += millis;
 
-                    final long taskNanos = snapshot.getStatusMetric(ProcessorStatusDescriptor.TASK_NANOS.getDescriptor());
+                    final long taskNanos = snapshot.getStatusMetric(TASK_NANOS.getDescriptor());
                     procNanos += taskNanos;
                 }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarClassLoader.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarClassLoader.java
@@ -39,7 +39,7 @@ import java.util.List;
  *
  * <p>
  * <tt>NarClassLoader</tt> follows the delegation model described in
- * {@link ClassLoader#findClass(java.lang.String) ClassLoader.findClass(...)};
+ * {@link ClassLoader#findClass(String) ClassLoader.findClass(...)};
  * classes are first loaded from the parent <tt>ClassLoader</tt>, and only if
  * they cannot be found there does the <tt>NarClassLoader</tt> provide a
  * definition. Specifically, this means that resources are loaded from NiFi's

--- a/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarClassLoaders.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarClassLoaders.java
@@ -92,8 +92,8 @@ public final class NarClassLoaders {
      *
      * @param frameworkWorkingDir where to find framework artifacts
      * @param extensionsWorkingDir where to find extension artifacts
-     * @throws java.io.IOException if any issue occurs while exploding nar working directories.
-     * @throws java.lang.ClassNotFoundException if unable to load class definition
+     * @throws IOException if any issue occurs while exploding nar working directories.
+     * @throws ClassNotFoundException if unable to load class definition
      * @throws IllegalStateException already initialized with a given pair of
      * directories cannot reinitialize or use a different pair of directories.
      */
@@ -120,8 +120,8 @@ public final class NarClassLoaders {
      * @param rootClassloader the root classloader to use for booting Jetty
      * @param frameworkWorkingDir where to find framework artifacts
      * @param extensionsWorkingDir where to find extension artifacts
-     * @throws java.io.IOException if any issue occurs while exploding nar working directories.
-     * @throws java.lang.ClassNotFoundException if unable to load class definition
+     * @throws IOException if any issue occurs while exploding nar working directories.
+     * @throws ClassNotFoundException if unable to load class definition
      * @throws IllegalStateException already initialized with a given pair of
      * directories cannot reinitialize or use a different pair of directories.
      */

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ComponentStateAuditor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ComponentStateAuditor.java
@@ -45,7 +45,7 @@ public class ComponentStateAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint join point
      * @param processor the processor
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.ComponentStateDAO+) && "
         + "execution(void clearState(org.apache.nifi.controller.ProcessorNode)) && "
@@ -78,7 +78,7 @@ public class ComponentStateAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint join point
      * @param controllerService the controller service
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.ComponentStateDAO+) && "
         + "execution(void clearState(org.apache.nifi.controller.service.ControllerServiceNode)) && "
@@ -112,7 +112,7 @@ public class ComponentStateAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint join point
      * @param reportingTask the reporting task
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.ComponentStateDAO+) && "
         + "execution(void clearState(org.apache.nifi.controller.ReportingTaskNode)) && "
@@ -145,7 +145,7 @@ public class ComponentStateAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint join point
      * @param flowAnalysisRule the flow analysis rule
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.ComponentStateDAO+) && "
         + "execution(void clearState(org.apache.nifi.controller.FlowAnalysisRuleNode)) && "
@@ -178,7 +178,7 @@ public class ComponentStateAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint join point
      * @param parameterProvider the parameter provider
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.ComponentStateDAO+) && "
         + "execution(void clearState(org.apache.nifi.controller.ParameterProviderNode)) && "
@@ -211,7 +211,7 @@ public class ComponentStateAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint join point
      * @param flowRegistryClient the flow registry client
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.ComponentStateDAO+) && "
             + "execution(void clearState(org.apache.nifi.registry.flow.FlowRegistryClientNode)) && "

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ControllerAuditor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ControllerAuditor.java
@@ -43,7 +43,7 @@ public class ControllerAuditor extends NiFiAuditor {
      * @param proceedingJoinPoint joint point
      * @param maxTimerDrivenThreadCount thread count
      * @param controllerFacade facade
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.controller.ControllerFacade) && "
             + "execution(void setMaxTimerDrivenThreadCount(int)) && "

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ControllerServiceAuditor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ControllerServiceAuditor.java
@@ -72,7 +72,7 @@ public class ControllerServiceAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint join point
      * @return node
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.ControllerServiceDAO+) && "
             + "execution(org.apache.nifi.controller.service.ControllerServiceNode createControllerService(org.apache.nifi.web.api.dto.ControllerServiceDTO))")

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ProcessGroupAuditor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ProcessGroupAuditor.java
@@ -68,7 +68,7 @@ public class ProcessGroupAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint join point
      * @return group
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.ProcessGroupDAO+) && "
             + "execution(org.apache.nifi.groups.ProcessGroup createProcessGroup(String, org.apache.nifi.web.api.dto.ProcessGroupDTO))")

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ProcessorAuditor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ProcessorAuditor.java
@@ -93,7 +93,7 @@ public class ProcessorAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint join point
      * @return node
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.ProcessorDAO+) && "
             + "execution(org.apache.nifi.controller.ProcessorNode createProcessor(java.lang.String, org.apache.nifi.web.api.dto.ProcessorDTO))")

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/RelationshipAuditor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/RelationshipAuditor.java
@@ -75,7 +75,7 @@ public class RelationshipAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint join point
      * @return connection
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.ConnectionDAO+) && "
             + "execution(org.apache.nifi.connectable.Connection createConnection(java.lang.String, org.apache.nifi.web.api.dto.ConnectionDTO))")

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/RemoteProcessGroupAuditor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/RemoteProcessGroupAuditor.java
@@ -113,7 +113,7 @@ public class RemoteProcessGroupAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint join point
      * @return group
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.RemoteProcessGroupDAO+) && "
             + "execution(org.apache.nifi.groups.RemoteProcessGroup createRemoteProcessGroup(java.lang.String, org.apache.nifi.web.api.dto.RemoteProcessGroupDTO))")

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ReportingTaskAuditor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/audit/ReportingTaskAuditor.java
@@ -65,7 +65,7 @@ public class ReportingTaskAuditor extends NiFiAuditor {
      *
      * @param proceedingJoinPoint joinpoint
      * @return node
-     * @throws java.lang.Throwable ex
+     * @throws Throwable ex
      */
     @Around("within(org.apache.nifi.web.dao.ReportingTaskDAO+) && "
             + "execution(org.apache.nifi.controller.ReportingTaskNode createReportingTask(org.apache.nifi.web.api.dto.ReportingTaskDTO))")

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizableLookup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizableLookup.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.authorization;
 
 import org.apache.nifi.authorization.resource.Authorizable;
+import org.apache.nifi.authorization.resource.VersionedComponentAuthorizable;
 import org.apache.nifi.components.ConfigurableComponent;
 import org.apache.nifi.parameter.ParameterContext;
 import org.apache.nifi.web.api.dto.BundleDTO;
@@ -182,7 +183,7 @@ public interface AuthorizableLookup {
      * @param filter the filter
      * @return all encapsulated controller services
      */
-    Set<ComponentAuthorizable> getControllerServices(String groupId, Predicate<org.apache.nifi.authorization.resource.VersionedComponentAuthorizable> filter);
+    Set<ComponentAuthorizable> getControllerServices(String groupId, Predicate<VersionedComponentAuthorizable> filter);
 
     /**
      * Get the authorizable ControllerService.

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -4947,14 +4947,14 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
      * component hierarchy via the {@code findX} APIs first. This is required for
      * bulletins generated inside a connector's managed flow: the standard
      * {@link AuthorizableLookup} is backed by {@link org.apache.nifi.web.dao.impl.StandardProcessorDAO}
-     * (and its peers) which only walks the {@link org.apache.nifi.controller.flow.FlowManager}'s
+     * (and its peers) which only walks the {@link FlowManager}'s
      * root group, so any source that lives inside a connector's managed flow context
      * would otherwise resolve to {@link ResourceNotFoundException} and report
      * {@code canRead = false} for every bulletin -- preventing the canvas from
      * rendering bulletin icons for the connector's components and child groups.
      * Resolving via the live group preserves the source's authorizable parent chain
      * (which terminates at the connector node via
-     * {@link org.apache.nifi.groups.ProcessGroup#setExplicitParentAuthorizable(Authorizable)}),
+     * {@link ProcessGroup#setExplicitParentAuthorizable(Authorizable)}),
      * so READ on the connector correctly grants READ on its inner bulletins.</p>
      *
      * <p>The fallback to {@code authorizableLookup} handles source types that are

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/StandardNiFiServiceFacadeTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/StandardNiFiServiceFacadeTest.java
@@ -39,7 +39,10 @@ import org.apache.nifi.authorization.user.StandardNiFiUser.Builder;
 import org.apache.nifi.components.Backlog;
 import org.apache.nifi.components.BacklogReportingException;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.connector.BacklogReportingConnector;
+import org.apache.nifi.components.connector.Connector;
 import org.apache.nifi.components.connector.ConnectorNode;
+import org.apache.nifi.components.connector.ConnectorState;
 import org.apache.nifi.components.connector.ConnectorSyncMode;
 import org.apache.nifi.components.connector.FrameworkFlowContext;
 import org.apache.nifi.components.connector.Secret;
@@ -47,6 +50,7 @@ import org.apache.nifi.components.connector.secrets.AuthorizableSecret;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateManagerProvider;
 import org.apache.nifi.components.state.StateMap;
+import org.apache.nifi.components.validation.ValidationStatus;
 import org.apache.nifi.controller.ClusterTopologyProvider;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.Counter;
@@ -94,6 +98,7 @@ import org.apache.nifi.registry.flow.diff.ComparableDataFlow;
 import org.apache.nifi.registry.flow.diff.DifferenceType;
 import org.apache.nifi.registry.flow.diff.FlowComparator;
 import org.apache.nifi.registry.flow.diff.FlowComparatorVersionedStrategy;
+import org.apache.nifi.registry.flow.diff.FlowComparison;
 import org.apache.nifi.registry.flow.diff.StandardComparableDataFlow;
 import org.apache.nifi.registry.flow.diff.StandardFlowComparator;
 import org.apache.nifi.registry.flow.diff.StaticDifferenceDescriptor;
@@ -165,7 +170,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -218,7 +222,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 public class StandardNiFiServiceFacadeTest {
 
@@ -308,7 +314,7 @@ public class StandardNiFiServiceFacadeTest {
 
             return componentAuthorizable;
         };
-        when(authorizableLookup.getProcessor(Mockito.anyString())).then(processorLookupAnswer);
+        when(authorizableLookup.getProcessor(anyString())).then(processorLookupAnswer);
 
         // authorizer
         authorizer = mock(Authorizer.class);
@@ -412,7 +418,7 @@ public class StandardNiFiServiceFacadeTest {
                 VersionedComponent::getIdentifier,
                 FlowComparatorVersionedStrategy.DEEP);
 
-        final org.apache.nifi.registry.flow.diff.FlowComparison comparison = flowComparator.compare();
+        final FlowComparison comparison = flowComparator.compare();
         final boolean hasExecEngineChange = comparison.getDifferences().stream()
                 .anyMatch(d -> d.getDifferenceType() == DifferenceType.EXECUTION_ENGINE_CHANGED
                         && d.getComponentA() == null
@@ -477,14 +483,14 @@ public class StandardNiFiServiceFacadeTest {
         final StatusHistoryDTO dto = new StatusHistoryDTO();
         dto.setGenerated(generated);
         final ControllerFacade controllerFacade = mock(ControllerFacade.class);
-        Mockito.when(controllerFacade.getNodeStatusHistory()).thenReturn(dto);
+        when(controllerFacade.getNodeStatusHistory()).thenReturn(dto);
         serviceFacade.setControllerFacade(controllerFacade);
 
         // when
         final StatusHistoryEntity result = serviceFacade.getNodeStatusHistory();
 
         // then
-        Mockito.verify(controllerFacade).getNodeStatusHistory();
+        verify(controllerFacade).getNodeStatusHistory();
         assertNotNull(result);
         assertEquals(generated, result.getStatusHistory().getGenerated());
     }
@@ -797,8 +803,8 @@ public class StandardNiFiServiceFacadeTest {
         final VersionedControllerService versionedControllerService1 = mock(VersionedControllerService.class);
         final VersionedControllerService versionedControllerService2 = mock(VersionedControllerService.class);
 
-        Mockito.when(versionedControllerService1.getIdentifier()).thenReturn("test");
-        Mockito.when(versionedControllerService2.getIdentifier()).thenReturn("test2");
+        when(versionedControllerService1.getIdentifier()).thenReturn("test");
+        when(versionedControllerService2.getIdentifier()).thenReturn("test2");
 
         when(flowMapper.mapControllerService(same(parentControllerService1), same(controllerServiceProvider), anySet(), anyMap())).thenReturn(versionedControllerService1);
         when(flowMapper.mapControllerService(same(parentControllerService2), same(controllerServiceProvider), anySet(), anyMap())).thenReturn(versionedControllerService2);
@@ -2387,7 +2393,7 @@ public class StandardNiFiServiceFacadeTest {
         final ParameterContextEntity entity = serviceFacade.getConnectorParameterContext(connectorId, processGroupId);
 
         assertNull(entity);
-        Mockito.verifyNoInteractions(dtoFactory);
+        verifyNoInteractions(dtoFactory);
     }
 
     @Test
@@ -2725,7 +2731,7 @@ public class StandardNiFiServiceFacadeTest {
         serviceFacade.setConnectorDAO(connectorDAO);
 
         final ConnectorNode connectorNode = mock(ConnectorNode.class);
-        final org.apache.nifi.components.connector.Connector connector = mock(org.apache.nifi.components.connector.Connector.class);
+        final Connector connector = mock(Connector.class);
         when(connectorDAO.getConnector(connectorId, ConnectorSyncMode.LOCAL_ONLY)).thenReturn(connectorNode);
         when(connectorNode.getConnector()).thenReturn(connector);
 
@@ -2743,12 +2749,11 @@ public class StandardNiFiServiceFacadeTest {
         // The capability is declared by implementing BacklogReportingConnector, not by a flag, so
         // the mock must satisfy both Connector and BacklogReportingConnector for the instanceof
         // check to succeed.
-        final org.apache.nifi.components.connector.Connector connector = mock(org.apache.nifi.components.connector.Connector.class,
-                org.mockito.Mockito.withSettings().extraInterfaces(org.apache.nifi.components.connector.BacklogReportingConnector.class));
+        final Connector connector = mock(Connector.class, withSettings().extraInterfaces(BacklogReportingConnector.class));
         when(connectorDAO.getConnector(connectorId, ConnectorSyncMode.LOCAL_ONLY)).thenReturn(connectorNode);
         when(connectorNode.getConnector()).thenReturn(connector);
-        when(connectorNode.getValidationStatus()).thenReturn(org.apache.nifi.components.validation.ValidationStatus.VALID);
-        when(connectorNode.getCurrentState()).thenReturn(org.apache.nifi.components.connector.ConnectorState.STOPPED);
+        when(connectorNode.getValidationStatus()).thenReturn(ValidationStatus.VALID);
+        when(connectorNode.getCurrentState()).thenReturn(ConnectorState.STOPPED);
 
         serviceFacade.verifyCanReportConnectorBacklog(connectorId);
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/TestConnectorResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/TestConnectorResource.java
@@ -71,11 +71,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -296,9 +299,9 @@ public class TestConnectorResource {
         final ConnectorResource spyResource = spy(connectorResource);
         doReturn(true).when(spyResource).isRequestFromClusterNode();
 
-        final java.io.File tempFile = java.io.File.createTempFile("test-asset", ".txt");
+        final File tempFile = File.createTempFile("test-asset", ".txt");
         tempFile.deleteOnExit();
-        java.nio.file.Files.writeString(tempFile.toPath(), "asset-content");
+        Files.writeString(tempFile.toPath(), "asset-content");
 
         final Asset mockAsset = mock(Asset.class);
         when(mockAsset.getOwnerIdentifier()).thenReturn(CONNECTOR_ID);
@@ -306,7 +309,7 @@ public class TestConnectorResource {
         when(mockAsset.getName()).thenReturn("test-asset.txt");
 
         final String assetId = "test-asset-id";
-        when(serviceFacade.getConnectorAsset(assetId)).thenReturn(java.util.Optional.of(mockAsset));
+        when(serviceFacade.getConnectorAsset(assetId)).thenReturn(Optional.of(mockAsset));
 
         try (Response response = spyResource.getAssetContent(CONNECTOR_ID, assetId)) {
             assertEquals(200, response.getStatus());

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/dto/DtoFactoryTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/dto/DtoFactoryTest.java
@@ -62,6 +62,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -286,7 +287,7 @@ public class DtoFactoryTest {
         when(serviceNode.isSupportsSensitiveDynamicProperties()).thenReturn(false);
         when(serviceNode.isDeprecated()).thenReturn(false);
         when(serviceNode.isExtensionMissing()).thenReturn(true); // ghost component
-        when(serviceNode.getVersionedComponentId()).thenReturn(java.util.Optional.empty());
+        when(serviceNode.getVersionedComponentId()).thenReturn(Optional.empty());
         when(serviceNode.getRawPropertyValues()).thenReturn(Collections.emptyMap());
         final ControllerService controllerService = mock(ControllerService.class);
         when(controllerService.getPropertyDescriptors()).thenReturn(Collections.emptyList());
@@ -325,7 +326,7 @@ public class DtoFactoryTest {
         when(serviceNode.isSupportsSensitiveDynamicProperties()).thenReturn(false);
         when(serviceNode.isDeprecated()).thenReturn(false);
         when(serviceNode.isExtensionMissing()).thenReturn(false); // not ghost
-        when(serviceNode.getVersionedComponentId()).thenReturn(java.util.Optional.empty());
+        when(serviceNode.getVersionedComponentId()).thenReturn(Optional.empty());
         when(serviceNode.getRawPropertyValues()).thenReturn(Collections.emptyMap());
         final ControllerService controllerService = mock(ControllerService.class);
         when(controllerService.getPropertyDescriptors()).thenReturn(Collections.emptyList());
@@ -365,7 +366,7 @@ public class DtoFactoryTest {
         when(serviceNode.isSupportsSensitiveDynamicProperties()).thenReturn(false);
         when(serviceNode.isDeprecated()).thenReturn(false);
         when(serviceNode.isExtensionMissing()).thenReturn(false); // not ghost
-        when(serviceNode.getVersionedComponentId()).thenReturn(java.util.Optional.empty());
+        when(serviceNode.getVersionedComponentId()).thenReturn(Optional.empty());
         when(serviceNode.getRawPropertyValues()).thenReturn(Collections.emptyMap());
         final ControllerService controllerService = mock(ControllerService.class);
         when(controllerService.getPropertyDescriptors()).thenReturn(Collections.emptyList());
@@ -469,7 +470,7 @@ public class DtoFactoryTest {
         when(connection.getBendPoints()).thenReturn(Collections.emptyList());
         when(connection.getLabelIndex()).thenReturn(0);
         when(connection.getZIndex()).thenReturn(0L);
-        when(connection.getVersionedComponentId()).thenReturn(java.util.Optional.empty());
+        when(connection.getVersionedComponentId()).thenReturn(Optional.empty());
 
         // Create the DTO factory
         final DtoFactory dtoFactory = new DtoFactory();
@@ -544,7 +545,7 @@ public class DtoFactoryTest {
         when(connection.getBendPoints()).thenReturn(Collections.emptyList());
         when(connection.getLabelIndex()).thenReturn(0);
         when(connection.getZIndex()).thenReturn(0L);
-        when(connection.getVersionedComponentId()).thenReturn(java.util.Optional.empty());
+        when(connection.getVersionedComponentId()).thenReturn(Optional.empty());
 
         // Create the DTO factory
         final DtoFactory dtoFactory = new DtoFactory();
@@ -619,7 +620,7 @@ public class DtoFactoryTest {
         when(connection.getBendPoints()).thenReturn(Collections.emptyList());
         when(connection.getLabelIndex()).thenReturn(0);
         when(connection.getZIndex()).thenReturn(0L);
-        when(connection.getVersionedComponentId()).thenReturn(java.util.Optional.empty());
+        when(connection.getVersionedComponentId()).thenReturn(Optional.empty());
 
         // Create the DTO factory
         final DtoFactory dtoFactory = new DtoFactory();

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/StandardConnectionDAOTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/StandardConnectionDAOTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -184,10 +185,10 @@ class StandardConnectionDAOTest {
     @Test
     void testGetConnectionWithMultipleConnectors() {
         // Setup a second connector
-        final ConnectorNode connectorNode2 = org.mockito.Mockito.mock(ConnectorNode.class);
-        final FrameworkFlowContext flowContext2 = org.mockito.Mockito.mock(FrameworkFlowContext.class);
-        final ProcessGroup managedGroup2 = org.mockito.Mockito.mock(ProcessGroup.class);
-        final Connection connectionInSecondConnector = org.mockito.Mockito.mock(Connection.class);
+        final ConnectorNode connectorNode2 = mock(ConnectorNode.class);
+        final FrameworkFlowContext flowContext2 = mock(FrameworkFlowContext.class);
+        final ProcessGroup managedGroup2 = mock(ProcessGroup.class);
+        final Connection connectionInSecondConnector = mock(Connection.class);
         final String secondConnectorConnectionId = "second-connector-connection-id";
 
         when(connectorRepository.getConnectors(ConnectorSyncMode.LOCAL_ONLY)).thenReturn(List.of(connectorNode, connectorNode2));

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/anonymous/NiFiAnonymousAuthenticationProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/anonymous/NiFiAnonymousAuthenticationProviderTest.java
@@ -24,7 +24,6 @@ import org.apache.nifi.web.security.InvalidAuthenticationException;
 import org.apache.nifi.web.security.NiFiWebAuthenticationDetails;
 import org.apache.nifi.web.security.token.NiFiAuthenticationToken;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -36,7 +35,7 @@ public class NiFiAnonymousAuthenticationProviderTest {
 
     @Test
     public void testAnonymousDisabledNotSecure() {
-        final NiFiProperties nifiProperties = Mockito.mock(NiFiProperties.class);
+        final NiFiProperties nifiProperties = mock(NiFiProperties.class);
         when(nifiProperties.isAnonymousAuthenticationAllowed()).thenReturn(false);
 
         final NiFiAnonymousAuthenticationProvider anonymousAuthenticationProvider = new NiFiAnonymousAuthenticationProvider(nifiProperties, mock(Authorizer.class));
@@ -53,7 +52,7 @@ public class NiFiAnonymousAuthenticationProviderTest {
 
     @Test
     public void testAnonymousEnabledNotSecure() {
-        final NiFiProperties nifiProperties = Mockito.mock(NiFiProperties.class);
+        final NiFiProperties nifiProperties = mock(NiFiProperties.class);
         when(nifiProperties.isAnonymousAuthenticationAllowed()).thenReturn(true);
 
         final NiFiAnonymousAuthenticationProvider anonymousAuthenticationProvider = new NiFiAnonymousAuthenticationProvider(nifiProperties, mock(Authorizer.class));
@@ -70,7 +69,7 @@ public class NiFiAnonymousAuthenticationProviderTest {
 
     @Test
     public void testAnonymousDisabledSecure() {
-        final NiFiProperties nifiProperties = Mockito.mock(NiFiProperties.class);
+        final NiFiProperties nifiProperties = mock(NiFiProperties.class);
         when(nifiProperties.isAnonymousAuthenticationAllowed()).thenReturn(false);
 
         final NiFiAnonymousAuthenticationProvider anonymousAuthenticationProvider = new NiFiAnonymousAuthenticationProvider(nifiProperties, mock(Authorizer.class));
@@ -85,7 +84,7 @@ public class NiFiAnonymousAuthenticationProviderTest {
 
     @Test
     public void testAnonymousEnabledSecure() {
-        final NiFiProperties nifiProperties = Mockito.mock(NiFiProperties.class);
+        final NiFiProperties nifiProperties = mock(NiFiProperties.class);
         when(nifiProperties.isAnonymousAuthenticationAllowed()).thenReturn(true);
 
         final NiFiAnonymousAuthenticationProvider anonymousAuthenticationProvider = new NiFiAnonymousAuthenticationProvider(nifiProperties, mock(Authorizer.class));

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
@@ -379,7 +379,7 @@ public class MockProcessSession implements ProcessSession {
 
     /**
      * Clear the 'committed' flag so that we can test that the next iteration of
-     * {@link org.apache.nifi.processor.Processor#onTrigger} commits or rolls back the
+     * {@link Processor#onTrigger} commits or rolls back the
      * session
      */
     public void clearCommitted() {
@@ -388,7 +388,7 @@ public class MockProcessSession implements ProcessSession {
 
     /**
      * Clear the 'rolledBack' flag so that we can test that the next iteration
-     * of {@link org.apache.nifi.processor.Processor#onTrigger} commits or rolls back the
+     * of {@link Processor#onTrigger} commits or rolls back the
      * session
      */
     public void clearRollback() {

--- a/nifi-registry/nifi-registry-core/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/ShutdownHook.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/ShutdownHook.java
@@ -79,7 +79,7 @@ public class ShutdownHook extends Thread {
                 break;
             } else {
                 try {
-                    Thread.sleep(1000L);
+                    sleep(1000L);
                 } catch (final InterruptedException ignored) {
                 }
             }

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
@@ -19,6 +19,7 @@ package org.apache.nifi.registry.flow.diff;
 
 import org.apache.nifi.components.PortFunction;
 import org.apache.nifi.flow.ExecutionEngine;
+import org.apache.nifi.flow.ScheduledState;
 import org.apache.nifi.flow.VersionedAsset;
 import org.apache.nifi.flow.VersionedComponent;
 import org.apache.nifi.flow.VersionedConnection;
@@ -578,7 +579,7 @@ public class StandardFlowComparator implements FlowComparator {
         addIfDifferent(differences, DifferenceType.PARAMETER_CONTEXT_CHANGED, groupA, groupB, VersionedProcessGroup::getParameterContextName, true, null);
         addIfDifferent(differences, DifferenceType.LOG_FILE_SUFFIX_CHANGED, groupA, groupB, VersionedProcessGroup::getLogFileSuffix, true, null);
         addIfDifferent(differences, DifferenceType.EXECUTION_ENGINE_CHANGED, groupA, groupB, VersionedProcessGroup::getExecutionEngine, true, ExecutionEngine.INHERITED);
-        addIfDifferent(differences, DifferenceType.SCHEDULED_STATE_CHANGED, groupA, groupB, VersionedProcessGroup::getScheduledState, true, org.apache.nifi.flow.ScheduledState.ENABLED);
+        addIfDifferent(differences, DifferenceType.SCHEDULED_STATE_CHANGED, groupA, groupB, VersionedProcessGroup::getScheduledState, true, ScheduledState.ENABLED);
         addIfDifferent(differences, DifferenceType.CONCURRENT_TASKS_CHANGED, groupA, groupB, VersionedProcessGroup::getMaxConcurrentTasks, true, 1);
         addIfDifferent(differences, DifferenceType.TIMEOUT_CHANGED, groupA, groupB, VersionedProcessGroup::getStatelessFlowTimeout, false, "1 min");
     }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
@@ -445,7 +445,7 @@ class GitFlowMetaData {
     void saveBucket(final Bucket bucket, final File bucketDir) throws IOException {
         final Yaml yaml = new Yaml();
         final Map<String, Object> serializedBucket = bucket.serialize();
-        final File bucketFile = new File(bucketDir, GitFlowMetaData.BUCKET_FILENAME);
+        final File bucketFile = new File(bucketDir, BUCKET_FILENAME);
 
         try (final Writer writer = new OutputStreamWriter(
                 new FileOutputStream(bucketFile), StandardCharsets.UTF_8)) {

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/AuthorizerFactory.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/AuthorizerFactory.java
@@ -231,7 +231,7 @@ public class AuthorizerFactory implements UserGroupProviderLookup, AccessPolicyP
                             final ClassLoader authorizerClassLoader = authorizer.getClass().getClassLoader();
 
                             // install integrity checks
-                            authorizer = AuthorizerFactory.installIntegrityChecks(authorizer);
+                            authorizer = installIntegrityChecks(authorizer);
 
                             // load the configuration context for the selected authorizer
                             AuthorizerConfigurationContext authorizerConfigurationContext = null;

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseUserGroupProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseUserGroupProvider.java
@@ -51,7 +51,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.sql.DataSource;
 
 /**
- * Implementation of {@link org.apache.nifi.registry.security.authorization.ConfigurableUserGroupProvider} backed by a relational database.
+ * Implementation of {@link ConfigurableUserGroupProvider} backed by a relational database.
  */
 public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider {
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/AuthorizationsHolder.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/AuthorizationsHolder.java
@@ -20,6 +20,7 @@ import org.apache.nifi.registry.security.authorization.AccessPolicy;
 import org.apache.nifi.registry.security.authorization.RequestAction;
 import org.apache.nifi.registry.security.authorization.file.generated.Authorizations;
 import org.apache.nifi.registry.security.authorization.file.generated.Policies;
+import org.apache.nifi.registry.security.authorization.file.generated.Policy;
 import org.apache.nifi.registry.security.authorization.util.AccessPolicyProviderUtils;
 
 import java.util.Collections;
@@ -68,14 +69,14 @@ public class AuthorizationsHolder {
      * @param policies the JAXB Policies element
      * @return a set of AccessPolicies corresponding to the provided Resources
      */
-    private Set<AccessPolicy> createAccessPolicies(org.apache.nifi.registry.security.authorization.file.generated.Policies policies) {
+    private Set<AccessPolicy> createAccessPolicies(Policies policies) {
         Set<AccessPolicy> allPolicies = new HashSet<>();
         if (policies == null || policies.getPolicy() == null) {
             return allPolicies;
         }
 
         // load the new authorizations
-        for (final org.apache.nifi.registry.security.authorization.file.generated.Policy policy : policies.getPolicy()) {
+        for (final Policy policy : policies.getPolicy()) {
             final String policyIdentifier = policy.getIdentifier();
             final String resourceIdentifier = policy.getResource();
 
@@ -85,12 +86,12 @@ public class AuthorizationsHolder {
                     .resource(resourceIdentifier);
 
             // add each user identifier
-            for (org.apache.nifi.registry.security.authorization.file.generated.Policy.User user : policy.getUser()) {
+            for (Policy.User user : policy.getUser()) {
                 builder.addUser(user.getIdentifier());
             }
 
             // add each group identifier
-            for (org.apache.nifi.registry.security.authorization.file.generated.Policy.Group group : policy.getGroup()) {
+            for (Policy.Group group : policy.getGroup()) {
                 builder.addGroup(group.getIdentifier());
             }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileAuthorizer.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileAuthorizer.java
@@ -103,8 +103,8 @@ public class FileAuthorizer extends AbstractPolicyBasedAuthorizer {
         if (configurationProperties.containsKey(FileUserGroupProvider.PROP_TENANTS_FILE)) {
             userGroupProperties.put(FileUserGroupProvider.PROP_TENANTS_FILE, configurationProperties.get(FileUserGroupProvider.PROP_TENANTS_FILE));
         }
-        if (configurationProperties.containsKey(FileAuthorizer.PROP_LEGACY_AUTHORIZED_USERS_FILE)) {
-            userGroupProperties.put(FileAuthorizer.PROP_LEGACY_AUTHORIZED_USERS_FILE, configurationProperties.get(FileAuthorizer.PROP_LEGACY_AUTHORIZED_USERS_FILE));
+        if (configurationProperties.containsKey(PROP_LEGACY_AUTHORIZED_USERS_FILE)) {
+            userGroupProperties.put(PROP_LEGACY_AUTHORIZED_USERS_FILE, configurationProperties.get(PROP_LEGACY_AUTHORIZED_USERS_FILE));
         }
 
         // relay the relevant config
@@ -116,8 +116,8 @@ public class FileAuthorizer extends AbstractPolicyBasedAuthorizer {
         if (configurationProperties.containsKey(AccessPolicyProviderUtils.PROP_INITIAL_ADMIN_IDENTITY)) {
             accessPolicyProperties.put(AccessPolicyProviderUtils.PROP_INITIAL_ADMIN_IDENTITY, configurationProperties.get(AccessPolicyProviderUtils.PROP_INITIAL_ADMIN_IDENTITY));
         }
-        if (configurationProperties.containsKey(FileAuthorizer.PROP_LEGACY_AUTHORIZED_USERS_FILE)) {
-            accessPolicyProperties.put(FileAuthorizer.PROP_LEGACY_AUTHORIZED_USERS_FILE, configurationProperties.get(FileAuthorizer.PROP_LEGACY_AUTHORIZED_USERS_FILE));
+        if (configurationProperties.containsKey(PROP_LEGACY_AUTHORIZED_USERS_FILE)) {
+            accessPolicyProperties.put(PROP_LEGACY_AUTHORIZED_USERS_FILE, configurationProperties.get(PROP_LEGACY_AUTHORIZED_USERS_FILE));
         }
 
         // ensure all nifi identities are seeded into the user provider

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/user/NiFiUserUtils.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/user/NiFiUserUtils.java
@@ -53,7 +53,7 @@ public final class NiFiUserUtils {
 
     public static String getNiFiUserIdentity() {
         // get the nifi user to extract the username
-        NiFiUser user = NiFiUserUtils.getNiFiUser();
+        NiFiUser user = getNiFiUser();
         if (user == null) {
             return "unknown";
         } else {

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/util/UserGroupProviderUtils.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/util/UserGroupProviderUtils.java
@@ -40,7 +40,7 @@ public final class UserGroupProviderUtils {
     public static Set<String> getInitialUserIdentities(final AuthorizerConfigurationContext configurationContext, final IdentityMapper identityMapper) {
         final Set<String> initialUserIdentities = new HashSet<>();
         for (Map.Entry<String, String> entry : configurationContext.getProperties().entrySet()) {
-            Matcher matcher = UserGroupProviderUtils.INITIAL_USER_IDENTITY_PATTERN.matcher(entry.getKey());
+            Matcher matcher = INITIAL_USER_IDENTITY_PATTERN.matcher(entry.getKey());
             if (matcher.matches() && !StringUtils.isBlank(entry.getValue())) {
                 initialUserIdentities.add(identityMapper.mapUser(entry.getValue()));
             }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/serialization/ExtensionSerializer.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/serialization/ExtensionSerializer.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * Current data model version is 1.
  * Data Model Version Histories:
  * <ul>
- *     <li>version 1: Serialized by {@link org.apache.nifi.registry.serialization.jackson.JacksonExtensionSerializer}</li>
+ *     <li>version 1: Serialized by {@link JacksonExtensionSerializer}</li>
  * </ul>
  * </p>
  */

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/AuthorizationService.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/AuthorizationService.java
@@ -123,20 +123,20 @@ public class AuthorizationService {
 
     public void verifyAuthorizerIsManaged() {
         if (!isManagedAuthorizer()) {
-            throw new IllegalStateException(AuthorizationService.MSG_NON_MANAGED_AUTHORIZER);
+            throw new IllegalStateException(MSG_NON_MANAGED_AUTHORIZER);
         }
     }
 
     public void verifyAuthorizerSupportsConfigurablePolicies() {
         if (!isConfigurableAccessPolicyProvider()) {
             verifyAuthorizerIsManaged();
-            throw new IllegalStateException(AuthorizationService.MSG_NON_CONFIGURABLE_POLICIES);
+            throw new IllegalStateException(MSG_NON_CONFIGURABLE_POLICIES);
         }
     }
 
     public void verifyAuthorizerSupportsConfigurableUserGroups() {
         if (!isConfigurableUserGroupProvider()) {
-            throw new IllegalStateException(AuthorizationService.MSG_NON_CONFIGURABLE_USERS);
+            throw new IllegalStateException(MSG_NON_CONFIGURABLE_USERS);
         }
     }
 
@@ -284,8 +284,7 @@ public class AuthorizationService {
             throw new IllegalArgumentException("User group identity must be specified when creating a new group.");
         }
 
-        final org.apache.nifi.registry.security.authorization.Group createdGroup =
-                configurableUserGroupProvider().addGroup(userGroupFromDTO(userGroup));
+        final Group createdGroup = configurableUserGroupProvider().addGroup(userGroupFromDTO(userGroup));
         return userGroupToDTO(createdGroup);
     }
 
@@ -294,7 +293,7 @@ public class AuthorizationService {
     }
 
     public UserGroup getUserGroup(final String identifier) {
-        final org.apache.nifi.registry.security.authorization.Group group = userGroupProvider.getGroup(identifier);
+        final Group group = userGroupProvider.getGroup(identifier);
 
         if (group == null) {
             LOGGER.warn("The specified user group id [{}] does not exist.", identifier);
@@ -305,7 +304,7 @@ public class AuthorizationService {
     }
 
     public void verifyUserGroupExists(final String identifier) {
-        final org.apache.nifi.registry.security.authorization.Group group = userGroupProvider.getGroup(identifier);
+        final Group group = userGroupProvider.getGroup(identifier);
         if (group == null) {
             LOGGER.warn("The specified user group id [{}] does not exist.", identifier);
             throw new ResourceNotFoundException("The specified user group ID does not exist in this registry.");
@@ -315,8 +314,7 @@ public class AuthorizationService {
     public UserGroup updateUserGroup(final UserGroup userGroup) {
         verifyUserGroupProviderIsConfigurable();
 
-        final org.apache.nifi.registry.security.authorization.Group updatedGroup =
-                configurableUserGroupProvider().updateGroup(userGroupFromDTO(userGroup));
+        final Group updatedGroup = configurableUserGroupProvider().updateGroup(userGroupFromDTO(userGroup));
 
         if (updatedGroup == null) {
             LOGGER.warn("The specified user group id [{}] does not exist.", userGroup.getIdentifier());
@@ -610,8 +608,7 @@ public class AuthorizationService {
         return userDTO;
     }
 
-    private UserGroup userGroupToDTO(
-            final org.apache.nifi.registry.security.authorization.Group userGroup) {
+    private UserGroup userGroupToDTO(final Group userGroup) {
         if (userGroup == null) {
             return null;
         }
@@ -649,7 +646,7 @@ public class AuthorizationService {
         if (user != null) {
             return tenantToDTO(user);
         } else {
-            org.apache.nifi.registry.security.authorization.Group group = userGroupProvider.getGroup(identifier);
+            Group group = userGroupProvider.getGroup(identifier);
             return tenantToDTO(group);
         }
     }
@@ -679,7 +676,7 @@ public class AuthorizationService {
         return tenantDTO;
     }
 
-    private Tenant tenantToDTO(org.apache.nifi.registry.security.authorization.Group group) {
+    private Tenant tenantToDTO(Group group) {
         if (group == null) {
             return null;
         }
@@ -709,12 +706,11 @@ public class AuthorizationService {
                 .build();
     }
 
-    private static org.apache.nifi.registry.security.authorization.Group userGroupFromDTO(
-            final UserGroup userGroupDTO) {
+    private static Group userGroupFromDTO(final UserGroup userGroupDTO) {
         if (userGroupDTO == null) {
             return null;
         }
-        org.apache.nifi.registry.security.authorization.Group.Builder groupBuilder = new org.apache.nifi.registry.security.authorization.Group.Builder()
+        Group.Builder groupBuilder = new Group.Builder()
                 .identifier(userGroupDTO.getIdentifier())
                 .name(userGroupDTO.getIdentity());
         Set<Tenant> users = userGroupDTO.getUsers();

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/provider/extension/TestFileSystemBundlePersistenceProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/provider/extension/TestFileSystemBundlePersistenceProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.registry.provider.extension;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.nifi.registry.extension.BundleCoordinate;
 import org.apache.nifi.registry.extension.BundlePersistenceContext;
@@ -74,7 +75,7 @@ public class TestFileSystemBundlePersistenceProvider {
     public void setup() throws IOException {
         bundleStorageDir = new File(EXTENSION_STORAGE_DIR);
         if (bundleStorageDir.exists()) {
-            org.apache.commons.io.FileUtils.cleanDirectory(bundleStorageDir);
+            FileUtils.cleanDirectory(bundleStorageDir);
             bundleStorageDir.delete();
         }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/provider/flow/TestFileSystemFlowPersistenceProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/provider/flow/TestFileSystemFlowPersistenceProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.registry.provider.flow;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.nifi.registry.flow.FlowPersistenceProvider;
 import org.apache.nifi.registry.flow.FlowSnapshotContext;
@@ -69,7 +70,7 @@ public class TestFileSystemFlowPersistenceProvider {
     public void setup() throws IOException {
         flowStorageDir = new File(FLOW_STORAGE_DIR);
         if (flowStorageDir.exists()) {
-            org.apache.commons.io.FileUtils.cleanDirectory(flowStorageDir);
+            FileUtils.cleanDirectory(flowStorageDir);
             assertTrue(flowStorageDir.delete());
         }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/security/ldap/tenants/LdapUserGroupProviderTest.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/security/ldap/tenants/LdapUserGroupProviderTest.java
@@ -30,7 +30,6 @@ import org.apache.nifi.registry.util.StandardPropertyValue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.security.ldap.server.UnboundIdContainer;
 
@@ -797,7 +796,7 @@ public class LdapUserGroupProviderTest {
     }
 
     private NiFiRegistryProperties getNiFiProperties(final Properties properties) {
-        final NiFiRegistryProperties registryProperties = Mockito.mock(NiFiRegistryProperties.class);
+        final NiFiRegistryProperties registryProperties = mock(NiFiRegistryProperties.class);
         when(registryProperties.getPropertyKeys()).thenReturn(properties.stringPropertyNames());
         when(registryProperties.getProperty(anyString())).then(invocationOnMock -> properties.getProperty((String) invocationOnMock.getArguments()[0]));
         return registryProperties;

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryProperties.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryProperties.java
@@ -392,7 +392,7 @@ public class NiFiRegistryProperties extends ApplicationProperties {
      * @return true if the login identity provider has been configured
      */
     public boolean isLoginIdentityProviderEnabled() {
-        return !StringUtils.isBlank(getProperty(NiFiRegistryProperties.SECURITY_IDENTITY_PROVIDER));
+        return !StringUtils.isBlank(getProperty(SECURITY_IDENTITY_PROVIDER));
     }
 
     /**

--- a/nifi-registry/nifi-registry-core/nifi-registry-provider-api/src/main/java/org/apache/nifi/registry/hook/EventHookProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-provider-api/src/main/java/org/apache/nifi/registry/hook/EventHookProvider.java
@@ -21,7 +21,7 @@ import org.apache.nifi.registry.provider.Provider;
 /**
  * An extension point that will be passed events produced by actions take in the registry.
  *
- * The list of event types can be found in {@link org.apache.nifi.registry.hook.EventType}.
+ * The list of event types can be found in {@link EventType}.
  *
  * NOTE: Although this interface is intended to be an extension point, it is not yet considered stable and thus may
  * change across releases until the registry matures.

--- a/nifi-registry/nifi-registry-core/nifi-registry-security-api/src/main/java/org/apache/nifi/registry/security/authorization/RequestAction.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-security-api/src/main/java/org/apache/nifi/registry/security/authorization/RequestAction.java
@@ -38,15 +38,15 @@ public enum RequestAction {
     }
 
     public static RequestAction valueOfValue(final String action) {
-        if (RequestAction.READ.toString().equalsIgnoreCase(action)) {
-            return RequestAction.READ;
-        } else if (RequestAction.WRITE.toString().equalsIgnoreCase(action)) {
-            return RequestAction.WRITE;
-        } else if (RequestAction.DELETE.toString().equalsIgnoreCase(action)) {
-            return RequestAction.DELETE;
+        if (READ.toString().equalsIgnoreCase(action)) {
+            return READ;
+        } else if (WRITE.toString().equalsIgnoreCase(action)) {
+            return WRITE;
+        } else if (DELETE.toString().equalsIgnoreCase(action)) {
+            return DELETE;
         } else {
             StringJoiner stringJoiner = new StringJoiner(", ");
-            for (RequestAction ra : RequestAction.values()) {
+            for (RequestAction ra : values()) {
                 stringJoiner.add(ra.toString());
             }
             String allowableValues = stringJoiner.toString();

--- a/nifi-registry/nifi-registry-core/nifi-registry-utils/src/main/java/org/apache/nifi/registry/util/FileUtils.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-utils/src/main/java/org/apache/nifi/registry/util/FileUtils.java
@@ -153,23 +153,23 @@ public class FileUtils {
                     fileSize = in.size();
                 } while (bytesWritten < fileSize);
                 out.force(false);
-                FileUtils.closeQuietly(fos);
-                FileUtils.closeQuietly(fis);
+                closeQuietly(fos);
+                closeQuietly(fis);
                 fos = null;
                 fis = null;
-                if (move && !FileUtils.deleteFile(source, null, 5)) {
+                if (move && !deleteFile(source, null, 5)) {
                     if (logger == null) {
-                        FileUtils.deleteFile(destination, null, 5);
+                        deleteFile(destination, null, 5);
                         throw new IOException("Could not remove file " + source.getAbsolutePath());
                     } else {
                         logger.warn("Configured to delete source file when renaming/move not successful.  However, unable to delete file at: {}", source.getAbsolutePath());
                     }
                 }
             } finally {
-                FileUtils.releaseQuietly(inLock);
-                FileUtils.releaseQuietly(outLock);
-                FileUtils.closeQuietly(fos);
-                FileUtils.closeQuietly(fis);
+                releaseQuietly(inLock);
+                releaseQuietly(outLock);
+                closeQuietly(fos);
+                closeQuietly(fis);
             }
         }
         return fileSize;
@@ -189,7 +189,7 @@ public class FileUtils {
      * @throws SecurityException if a security manager denies the needed file operations
      */
     public static long copyFile(final File source, final File destination, final boolean lockInputFile, final boolean lockOutputFile, final Logger logger) throws FileNotFoundException, IOException {
-        return FileUtils.copyFile(source, destination, lockInputFile, lockOutputFile, false, logger);
+        return copyFile(source, destination, lockInputFile, lockOutputFile, false, logger);
     }
 
     public static long copyFile(final File source, final OutputStream stream, final boolean closeOutputStream, final boolean lockInputFile) throws FileNotFoundException, IOException {
@@ -216,10 +216,10 @@ public class FileUtils {
             stream.flush();
             fileSize = in.size();
         } finally {
-            FileUtils.releaseQuietly(inLock);
-            FileUtils.closeQuietly(fis);
+            releaseQuietly(inLock);
+            closeQuietly(fis);
             if (closeOutputStream) {
-                FileUtils.closeQuietly(stream);
+                closeQuietly(stream);
             }
         }
         return fileSize;
@@ -243,7 +243,7 @@ public class FileUtils {
      * @return true if deleted
      */
     public static boolean deleteFile(final File file, final Logger logger) {
-        return FileUtils.deleteFile(file, logger, 1);
+        return deleteFile(file, logger, 1);
     }
 
     /**
@@ -267,7 +267,7 @@ public class FileUtils {
                 for (int i = 0; i < effectiveAttempts && !isGone; i++) {
                     isGone = file.delete() || !file.exists();
                     if (!isGone && (effectiveAttempts - i) > 1) {
-                        FileUtils.sleepQuietly(MILLIS_BETWEEN_ATTEMPTS);
+                        sleepQuietly(MILLIS_BETWEEN_ATTEMPTS);
                     }
                 }
                 if (!isGone && logger != null) {
@@ -294,7 +294,7 @@ public class FileUtils {
      * if an I/O error occurs
      */
     public static void deleteFilesInDirectory(final File directory, final FilenameFilter filter, final Logger logger) throws IOException {
-        FileUtils.deleteFilesInDirectory(directory, filter, logger, false);
+        deleteFilesInDirectory(directory, filter, logger, false);
     }
 
     /**
@@ -310,7 +310,7 @@ public class FileUtils {
      * if an I/O error occurs
      */
     public static void deleteFilesInDirectory(final File directory, final FilenameFilter filter, final Logger logger, final boolean recurse) throws IOException {
-        FileUtils.deleteFilesInDirectory(directory, filter, logger, recurse, false);
+        deleteFilesInDirectory(directory, filter, logger, recurse, false);
     }
 
     /**
@@ -338,12 +338,12 @@ public class FileUtils {
             for (File ingestFile : ingestFiles) {
                 boolean process = (filter == null) ? true : filter.accept(directory, ingestFile.getName());
                 if (ingestFile.isFile() && process) {
-                    FileUtils.deleteFile(ingestFile, logger, 3);
+                    deleteFile(ingestFile, logger, 3);
                 }
                 if (ingestFile.isDirectory() && recurse) {
-                    FileUtils.deleteFilesInDirectory(ingestFile, filter, logger, recurse, deleteEmptyDirectories);
+                    deleteFilesInDirectory(ingestFile, filter, logger, recurse, deleteEmptyDirectories);
                     if (deleteEmptyDirectories && ingestFile.list().length == 0) {
-                        FileUtils.deleteFile(ingestFile, logger, 3);
+                        deleteFile(ingestFile, logger, 3);
                     }
                 }
             }
@@ -359,17 +359,17 @@ public class FileUtils {
      */
     public static void deleteFiles(final Collection<File> files, final boolean recurse) throws IOException {
         for (final File file : files) {
-            FileUtils.deleteFile(file, recurse);
+            deleteFile(file, recurse);
         }
     }
 
     public static void deleteFile(final File file, final boolean recurse) throws IOException {
         final File[] list = file.listFiles();
         if (file.isDirectory() && recurse && list != null) {
-            FileUtils.deleteFiles(Arrays.asList(list), recurse);
+            deleteFiles(Arrays.asList(list), recurse);
         }
         //now delete the file itself regardless of whether it is plain file or a directory
-        if (!FileUtils.deleteFile(file, null, 5)) {
+        if (!deleteFile(file, null, 5)) {
             throw new IOException("Unable to delete " + file.getAbsolutePath());
         }
     }

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/jwt/JwtService.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/jwt/JwtService.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.registry.security.authentication.AuthenticationResponse;
 import org.apache.nifi.registry.security.key.Key;
 import org.apache.nifi.registry.security.key.KeyService;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -48,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class JwtService {
 
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(JwtService.class);
+    private static final Logger logger = LoggerFactory.getLogger(JwtService.class);
 
     private static final MacAlgorithm SIGNATURE_ALGORITHM = Jwts.SIG.HS256;
     private static final String USERNAME_CLAIM = "preferred_username";

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/SecureKerberosIT.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/SecureKerberosIT.java
@@ -136,7 +136,7 @@ public class SecureKerberosIT extends IntegrationTestBase {
         assertEquals("Negotiate", tokenResponse1.getHeaders().get("www-authenticate").get(0));
 
         // When: the /access/token/kerberos endpoint is accessed again with an invalid ticket
-        String invalidTicket = new String(java.util.Base64.getEncoder().encode(invalidKerberosTicket.getBytes(StandardCharsets.UTF_8)));
+        String invalidTicket = new String(Base64.getEncoder().encode(invalidKerberosTicket.getBytes(StandardCharsets.UTF_8)));
         final Response tokenResponse2 = client
                 .target(createURL("/access/token/kerberos"))
                 .request()

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/controllerservice/ControllerServiceApiValidationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/controllerservice/ControllerServiceApiValidationIT.java
@@ -69,9 +69,9 @@ public class ControllerServiceApiValidationIT extends NiFiSystemIT {
     @Test
     public void testNonMatchingControllerService() throws NiFiClientException, IOException, InterruptedException {
         final ControllerServiceEntity controllerService = getClientUtil().createControllerService(
-                NiFiSystemIT.TEST_CS_PACKAGE + ".FakeControllerService2",
+                TEST_CS_PACKAGE + ".FakeControllerService2",
                 "root",
-                NiFiSystemIT.NIFI_GROUP_ID,
+                NIFI_GROUP_ID,
                 "nifi-system-test-extensions2-nar",
                 getNiFiVersion());
 
@@ -90,9 +90,9 @@ public class ControllerServiceApiValidationIT extends NiFiSystemIT {
     @Test
     public void testNonMatchingDynamicPropertyControllerService() throws NiFiClientException, IOException, InterruptedException {
         final ControllerServiceEntity controllerService = getClientUtil().createControllerService(
-                NiFiSystemIT.TEST_CS_PACKAGE + ".FakeControllerService2",
+                TEST_CS_PACKAGE + ".FakeControllerService2",
                 "root",
-                NiFiSystemIT.NIFI_GROUP_ID,
+                NIFI_GROUP_ID,
                 "nifi-system-test-extensions2-nar",
                 getNiFiVersion());
 
@@ -115,9 +115,9 @@ public class ControllerServiceApiValidationIT extends NiFiSystemIT {
     public void testMatchingGenericControllerService() throws NiFiClientException, IOException {
         final ControllerServiceEntity fakeServiceEntity = getClientUtil().createControllerService("FakeControllerService1");
         final ProcessorEntity fakeProcessorEntity = getClientUtil().createProcessor(
-                NiFiSystemIT.TEST_PROCESSORS_PACKAGE + ".FakeGenericProcessor",
+                TEST_PROCESSORS_PACKAGE + ".FakeGenericProcessor",
                 "root",
-                NiFiSystemIT.NIFI_GROUP_ID,
+                NIFI_GROUP_ID,
                 "nifi-system-test-extensions2-nar",
                 getNiFiVersion());
         fakeProcessorEntity.getComponent().getConfig().setProperties(Collections.singletonMap("Fake Service", fakeServiceEntity.getId()));

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/AbstractNiFiRegistryCommand.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/AbstractNiFiRegistryCommand.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.toolkit.cli.impl.command.registry;
 
+import org.apache.commons.cli.MissingOptionException;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.registry.client.FlowSnapshotClient;
@@ -81,7 +82,7 @@ public abstract class AbstractNiFiRegistryCommand<R extends Result> extends Abst
      * but if it wasn't then assume the source is the same registry we already know about
      */
     protected NiFiRegistryClient getSourceClient(final NiFiRegistryClient client, final String srcPropsValue)
-            throws IOException, org.apache.commons.cli.MissingOptionException {
+            throws IOException, MissingOptionException {
         final NiFiRegistryClient srcClient;
         if (!StringUtils.isBlank(srcPropsValue)) {
             final Properties srcProps = new Properties();

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -72,6 +72,7 @@ under the License.
     <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop" />
     <rule ref="category/java/codestyle.xml/UnnecessaryCast" />
     <rule ref="category/java/codestyle.xml/UnnecessaryConstructor" />
+    <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName" />
     <rule ref="category/java/codestyle.xml/UnnecessaryImport" />
     <rule ref="category/java/codestyle.xml/UnnecessaryModifier">
         <!--The following xpath excludes try with resources that use a final modifier when defining variable(s) -->


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16147](https://issues.apache.org/jira/browse/NIFI-16147)

This PR first addressed the use of fully qualified names discovered by Intellij and those uncovered by the PMD rule `UnnecessaryFullyQualifiedName`. The `UnnecessaryFullyQualifiedName` aims to address four categories:

- Already imported types: Using a fully qualified class name when an explicit import statement for that class already exists in the file.
- Same-package classes: Referencing a class with its full package prefix when the referencing class resides in the exact same package.
- Implicitly imported scope: Using full package paths for classes in java.lang or types already in scope via wildcard * imports.
- Enclosing and local scopes: Qualifying elements (such as static fields, methods, or inner classes) that are already directly in scope because they are declared in an enclosing type or current context.

This PR as a result of fixing the aforementioned cases also fixed the seemingly in-congruent use of importing a class while also having static imports of variables in that class.

1. e.g. importing `AzureStorageUtils` and statically importing some of its members in classes 
`AbstractAzureDataLakeStorageProcessor`, `AzureDataLakeStorageFileResourceService`, `AzureStorageCredentialsControllerService_v12`, `FetchAzureBlobStorage_v12`, `FetchAzureDataLakeStorage`, `ListAzureBlobStorage_v12`, `ListAzureDataLakeStorage` and `PutAzureBlobStorage_v12`
2. Importing `Assertions`, `Mockito` or `ArgumentMatchers` and statically importing some of their methods.

In the case of `Assertions`, `Mockito` or `ArgumentMatchers`, this PR made only static imports of the methods in these classes while for `AzureStorageUtils`  it dropped all the static imports.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
