### PR TITLE
NIFI-15839 Fixed cluster node random disconnects due to transient Com…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/node/NodeClusterCoordinator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/node/NodeClusterCoordinator.java
@@ -129,6 +129,7 @@ public class NodeClusterCoordinator implements ClusterCoordinator, ProtocolHandl
     private final ConcurrentMap<String, NodeConnectionStatus> nodeStatuses = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, CircularFifoQueue<NodeEvent>> nodeEvents = new ConcurrentHashMap<>(); //NOPMD
     private final ConcurrentMap<String, Thread> pendingDisconnections = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Long> nodeRevisionMismatches = new ConcurrentHashMap<>();
 
     private final List<ClusterTopologyEventListener> eventListeners = new CopyOnWriteArrayList<>();
 
@@ -1072,10 +1073,23 @@ public class NodeClusterCoordinator implements ClusterCoordinator, ProtocolHandl
             // This can happen, for instance, if the node connects to the cluster at the same time that a new node is joining and becoming the Cluster Coordinator.
             // This case is very rare but can occur on occasion. As a result, we check for that here and if it occurs, request that the node disconnect so that
             // it can reconnect.
-            final String message = String.format("Node has a Revision Update Count of %s but local value is only %s. Node appears not to have the appropriate set of Component Revisions",
-                heartbeat.getRevisionUpdateCount(), localUpdateCount);
-            logger.warn("Requesting that {} reconnect to the cluster due to: {}", heartbeat.getNodeIdentifier(), message);
-            requestNodeConnect(heartbeat.getNodeIdentifier(), null);
+            // In some cases, a race condition during Two-Phase Commit can cause the node to report an N+1 revision before the coordinator applies it locally.
+            // To handle this, we tolerate an off-by-one mismatch for up to 5 seconds before forcing a disconnect.
+            final long mismatchTime = nodeRevisionMismatches.computeIfAbsent(heartbeat.getNodeIdentifier().getId(), id -> System.currentTimeMillis());
+            final long mismatchDuration = System.currentTimeMillis() - mismatchTime;
+            
+            if (mismatchDuration > 5000L || (nodeUpdateCount - localUpdateCount > 1)) {
+                final String message = String.format("Node has a Revision Update Count of %s but local value is only %s. Node appears not to have the appropriate set of Component Revisions",
+                    heartbeat.getRevisionUpdateCount(), localUpdateCount);
+                logger.warn("Requesting that {} reconnect to the cluster due to: {}", heartbeat.getNodeIdentifier(), message);
+                requestNodeConnect(heartbeat.getNodeIdentifier(), null);
+                nodeRevisionMismatches.remove(heartbeat.getNodeIdentifier().getId());
+            } else {
+                logger.debug("Node {} has a Revision Update Count of {} but local value is only {}. Tolerating mismatch for up to 5 seconds to account for transient replication delays.", 
+                    heartbeat.getNodeIdentifier(), heartbeat.getRevisionUpdateCount(), localUpdateCount);
+            }
+        } else {
+            nodeRevisionMismatches.remove(heartbeat.getNodeIdentifier().getId());
         }
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15839](https://issues.apache.org/jira/projects/NIFI/issues/NIFI-15839)
This PR fixes random cluster node disconnects due to transient off-by-one revision mismatch by adding a 5-second tolerance in NodeClusterCoordinator.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
