### PR TITLE
NIFI-15889 Cached Parameter Context name mapping to fix

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContextManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContextManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.parameter;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 
 public class StandardParameterContextManager implements ParameterContextManager {
     private final Map<String, ParameterContext> parameterContexts = new HashMap<>();
+    private Map<String, ParameterContext> nameMappingCache = null;
 
     @Override
     public boolean hasParameterContext(final String id) {
@@ -67,8 +69,25 @@ public class StandardParameterContextManager implements ParameterContextManager 
         return new HashSet<>(parameterContexts.values());
     }
 
-    @Override
-    public Map<String, ParameterContext> getParameterContextNameMapping() {
-        return parameterContexts.values().stream().collect(Collectors.toMap(ParameterContext::getName, Function.identity()));
+    public synchronized Map<String, ParameterContext> getParameterContextNameMapping() {
+        boolean valid = nameMappingCache != null && nameMappingCache.size() == parameterContexts.size();
+        if (valid) {
+            for (final ParameterContext context : parameterContexts.values()) {
+                if (nameMappingCache.get(context.getName()) != context) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+
+        if (!valid) {
+            final Map<String, ParameterContext> mapping = new HashMap<>();
+            for (final ParameterContext context : parameterContexts.values()) {
+                mapping.put(context.getName(), context);
+            }
+            nameMappingCache = Collections.unmodifiableMap(mapping);
+        }
+
+        return nameMappingCache;
     }
 }


### PR DESCRIPTION
…^2) startup synchronization

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-15889](https://issues.apache.org/jira/browse/NIFI-15889)

This PR fixes a severe performance bottleneck during startup synchronization by caching the Parameter Context name mapping.

Previously, `getParameterContextNameMapping()` rebuilt the map using `stream().collect(toMap(...))` on every call, leading to massive object allocation, high GC pressure, and an effective complexity of `O(N_PG x N_PC^2)`.
This fix introduces an `O(N)` zero-allocation validation loop that reuses the cached map unless a context was added, removed, or renamed. The cache is also wrapped in an unmodifiable map to ensure safety.


# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
