### PR TITLE
NIFI-16159 Add support for FileResourceService in PutFile

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -39,6 +39,21 @@
             <version>2.11.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-resource-transfer</artifactId>
+            <version>2.11.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-file-resource-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-file-resource-service</artifactId>
+            <version>2.11.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
             <scope>test</scope>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -39,6 +39,21 @@
             <version>2.12.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-resource-transfer</artifactId>
+            <version>2.12.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-file-resource-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-file-resource-service</artifactId>
+            <version>2.12.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
             <scope>test</scope>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFile.java
@@ -27,6 +27,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.fileresource.service.api.FileResource;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.logging.ComponentLog;
@@ -36,11 +37,14 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.transfer.ResourceTransferSource;
 import org.apache.nifi.util.StopWatch;
 
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.nio.file.attribute.UserPrincipalLookupService;
@@ -48,10 +52,15 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.apache.nifi.processors.transfer.ResourceTransferProperties.FILE_RESOURCE_SERVICE;
+import static org.apache.nifi.processors.transfer.ResourceTransferProperties.RESOURCE_TRANSFER_SOURCE;
+import static org.apache.nifi.processors.transfer.ResourceTransferUtils.getFileResource;
 
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
@@ -158,7 +167,9 @@ public class PutFile extends AbstractProcessor {
             CHANGE_LAST_MODIFIED_TIME,
             CHANGE_PERMISSIONS,
             CHANGE_OWNER,
-            CHANGE_GROUP
+            CHANGE_GROUP,
+            RESOURCE_TRANSFER_SOURCE,
+            FILE_RESOURCE_SERVICE
     );
 
     public static final int MAX_FILE_LOCK_ATTEMPTS = 10;
@@ -304,7 +315,15 @@ public class PutFile extends AbstractProcessor {
                 }
             }
 
-            session.exportTo(flowFile, dotCopyFile, false);
+            final ResourceTransferSource resourceTransferSource = context.getProperty(RESOURCE_TRANSFER_SOURCE).asAllowableValue(ResourceTransferSource.class);
+            final Optional<FileResource> fileResource = getFileResource(resourceTransferSource, context, flowFile.getAttributes());
+            if (fileResource.isPresent()) {
+                try (InputStream in = fileResource.get().getInputStream()) {
+                    Files.copy(in, dotCopyFile, StandardCopyOption.REPLACE_EXISTING);
+                }
+            } else {
+                session.exportTo(flowFile, dotCopyFile, false);
+            }
 
             final String lastModifiedTime = context.getProperty(CHANGE_LAST_MODIFIED_TIME).evaluateAttributeExpressions(flowFile).getValue();
             if (lastModifiedTime != null && !lastModifiedTime.isBlank()) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFile.java
@@ -27,6 +27,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.fileresource.service.api.FileResource;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.logging.ComponentLog;
@@ -36,11 +37,14 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.transfer.ResourceTransferSource;
 import org.apache.nifi.util.StopWatch;
 
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.nio.file.attribute.UserPrincipalLookupService;
@@ -48,10 +52,15 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.apache.nifi.processors.transfer.ResourceTransferProperties.FILE_RESOURCE_SERVICE;
+import static org.apache.nifi.processors.transfer.ResourceTransferProperties.RESOURCE_TRANSFER_SOURCE;
+import static org.apache.nifi.processors.transfer.ResourceTransferUtils.getFileResource;
 
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
@@ -158,7 +167,9 @@ public class PutFile extends AbstractProcessor {
             CHANGE_LAST_MODIFIED_TIME,
             CHANGE_PERMISSIONS,
             CHANGE_OWNER,
-            CHANGE_GROUP
+            CHANGE_GROUP,
+            RESOURCE_TRANSFER_SOURCE,
+            FILE_RESOURCE_SERVICE
     );
 
     public static final int MAX_FILE_LOCK_ATTEMPTS = 10;
@@ -304,7 +315,16 @@ public class PutFile extends AbstractProcessor {
                 }
             }
 
-            session.exportTo(flowFile, dotCopyFile, false);
+            final ResourceTransferSource resourceTransferSource = ResourceTransferSource.valueOf(
+                    context.getProperty(RESOURCE_TRANSFER_SOURCE).getValue());
+            final Optional<FileResource> fileResource = getFileResource(resourceTransferSource, context, flowFile.getAttributes());
+            if (fileResource.isPresent()) {
+                try (InputStream in = fileResource.get().getInputStream()) {
+                    Files.copy(in, dotCopyFile, StandardCopyOption.REPLACE_EXISTING);
+                }
+            } else {
+                session.exportTo(flowFile, dotCopyFile, false);
+            }
 
             final String lastModifiedTime = context.getProperty(CHANGE_LAST_MODIFIED_TIME).evaluateAttributeExpressions(flowFile).getValue();
             if (lastModifiedTime != null && !lastModifiedTime.isBlank()) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutFile.java
@@ -16,7 +16,11 @@
  */
 package org.apache.nifi.processors.standard;
 
+import org.apache.nifi.fileresource.service.StandardFileResourceService;
+import org.apache.nifi.fileresource.service.api.FileResourceService;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processors.transfer.ResourceTransferProperties;
+import org.apache.nifi.processors.transfer.ResourceTransferSource;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.AfterEach;
@@ -24,9 +28,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
@@ -242,6 +248,38 @@ public class TestPutFile {
         targetPath = Paths.get(TARGET_DIRECTORY + "/targetFile.txt");
         content = Files.readAllBytes(targetPath);
         assertEquals("Another file", new String(content));
+    }
+
+    @Test
+    public void testPutFileFromLocalFile(@TempDir final Path sourceDir) throws Exception {
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.REPLACE_RESOLUTION);
+
+        final String attributeName = "file.path";
+        final String serviceId = FileResourceService.class.getSimpleName();
+        final FileResourceService service = new StandardFileResourceService();
+        runner.addControllerService(serviceId, service);
+        runner.setProperty(service, StandardFileResourceService.FILE_PATH, String.format("${%s}", attributeName));
+        runner.enableControllerService(service);
+
+        runner.setProperty(ResourceTransferProperties.RESOURCE_TRANSFER_SOURCE, ResourceTransferSource.FILE_RESOURCE_SERVICE.getValue());
+        runner.setProperty(ResourceTransferProperties.FILE_RESOURCE_SERVICE, serviceId);
+
+        final byte[] fileData = "0123456789".getBytes(StandardCharsets.UTF_8);
+        final Path sourceFilePath = sourceDir.resolve("source.txt");
+        Files.write(sourceFilePath, fileData);
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+        attributes.put(attributeName, sourceFilePath.toString());
+        runner.enqueue(new byte[0], attributes);
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PutFile.REL_SUCCESS, 1);
+        final Path targetPath = Paths.get(TARGET_DIRECTORY + "/targetFile.txt");
+        final byte[] content = Files.readAllBytes(targetPath);
+        assertEquals("0123456789", new String(content, StandardCharsets.UTF_8));
     }
 
     private TestRunner putFileRunner;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutFile.java
@@ -16,7 +16,11 @@
  */
 package org.apache.nifi.processors.standard;
 
+import org.apache.nifi.fileresource.service.StandardFileResourceService;
+import org.apache.nifi.fileresource.service.api.FileResourceService;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processors.transfer.ResourceTransferProperties;
+import org.apache.nifi.processors.transfer.ResourceTransferSource;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.AfterEach;
@@ -27,6 +31,7 @@ import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
@@ -242,6 +247,42 @@ public class TestPutFile {
         targetPath = Paths.get(TARGET_DIRECTORY + "/targetFile.txt");
         content = Files.readAllBytes(targetPath);
         assertEquals("Another file", new String(content));
+    }
+
+    @Test
+    public void testPutFileFromLocalFile() throws Exception {
+        final TestRunner runner = TestRunners.newTestRunner(new PutFile());
+        runner.setProperty(PutFile.DIRECTORY, targetDir.getAbsolutePath());
+        runner.setProperty(PutFile.CONFLICT_RESOLUTION, PutFile.REPLACE_RESOLUTION);
+
+        final String attributeName = "file.path";
+        final String serviceId = FileResourceService.class.getSimpleName();
+        final FileResourceService service = new StandardFileResourceService();
+        runner.addControllerService(serviceId, service);
+        runner.setProperty(service, StandardFileResourceService.FILE_PATH, String.format("${%s}", attributeName));
+        runner.enableControllerService(service);
+
+        runner.setProperty(ResourceTransferProperties.RESOURCE_TRANSFER_SOURCE, ResourceTransferSource.FILE_RESOURCE_SERVICE.getValue());
+        runner.setProperty(ResourceTransferProperties.FILE_RESOURCE_SERVICE, serviceId);
+
+        final byte[] fileData = "0123456789".getBytes(StandardCharsets.UTF_8);
+        final Path tempFilePath = Files.createTempFile("PutFile_testPutFileFromLocalFile_", "");
+        Files.write(tempFilePath, fileData);
+
+        try {
+            final Map<String, String> attributes = new HashMap<>();
+            attributes.put(CoreAttributes.FILENAME.key(), "targetFile.txt");
+            attributes.put(attributeName, tempFilePath.toString());
+            runner.enqueue(new byte[0], attributes);
+            runner.run();
+
+            runner.assertAllFlowFilesTransferred(PutFile.REL_SUCCESS, 1);
+            final Path targetPath = Paths.get(TARGET_DIRECTORY + "/targetFile.txt");
+            final byte[] content = Files.readAllBytes(targetPath);
+            assertEquals("0123456789", new String(content, StandardCharsets.UTF_8));
+        } finally {
+            Files.deleteIfExists(tempFilePath);
+        }
     }
 
     private TestRunner putFileRunner;


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16159](https://issues.apache.org/jira/browse/NIFI-16159)

Add support for `FileResourceService` in `PutFile`, matching the `Resource Transfer Source` / `File Resource Service` pattern already available in `PutS3Object` (NIFI-12642), `PutGCSObject` (NIFI-12643), and `PutHDFS` (NIFI-12801).

`PutFile` currently writes only the incoming FlowFile's content to the destination directory. Users who want to stage a file already on the local filesystem (or reachable via a custom `FileResourceService` implementation) have to first pull it into a FlowFile with `FetchFile`/`GetFile`, which is wasteful for large local files.

**Changes**

- Add `Resource Transfer Source` and `File Resource Service` property descriptors to `PutFile`, reusing `ResourceTransferProperties` from `nifi-resource-transfer`.
- When `Resource Transfer Source = File Resource Service`, obtain a `FileResource` via `ResourceTransferUtils.getFileResource(...)` and stream its `InputStream` to the `.<filename>` temp file with `StandardCopyOption.REPLACE_EXISTING` (preserving the overwrite semantics of the original `session.exportTo(...)` call), then proceed with the existing rename / permissions / owner / group / lastModified logic.
- When `Resource Transfer Source = FlowFile Content` (default) the behavior is byte-identical to today.
- Add `nifi-resource-transfer` and `nifi-file-resource-service-api` (compile) and `nifi-file-resource-service` (test) to `nifi-standard-processors/pom.xml`.
- Add `TestPutFile#testPutFileFromLocalFile` covering the `FileResourceService` path using `StandardFileResourceService`.

**Backward compatibility**

`Resource Transfer Source` defaults to `FlowFile Content`, so existing flows are unaffected. `File Resource Service` only appears in the UI when the source is set to `File Resource Service` (declared via `dependsOn`).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [x] Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
