### PR TITLE
NIFI-16163 - Bump HTTPClient5 to 5.6.3, Groovy to 5.0.8, JSoup to 1.23.1, and others

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
-                <version>5.6.2</version>
+                <version>5.6.3</version>
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20260712-2.0.0</version>
+            <version>v3-rev20260720-2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.tdunning</groupId>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
@@ -73,7 +73,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
-                <version>5.6.2</version>
+                <version>5.6.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/JoltTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/JoltTransformJSON.java
@@ -16,9 +16,6 @@
  */
 package org.apache.nifi.processors.jolt;
 
-import com.fasterxml.jackson.core.StreamReadConstraints;
-import com.fasterxml.jackson.core.json.JsonWriteFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.joltcommunity.jolt.JoltTransform;
 import io.joltcommunity.jolt.JsonUtil;
 import io.joltcommunity.jolt.JsonUtils;
@@ -44,6 +41,11 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.StopWatch;
 import org.apache.nifi.util.file.classloader.ClassLoaderUtils;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.json.JsonWriteFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -160,15 +162,12 @@ public class JoltTransformJSON extends AbstractJoltTransform {
         final int maxStringLength = context.getProperty(MAX_STRING_LENGTH).asDataSize(DataUnit.B).intValue();
         final StreamReadConstraints streamReadConstraints = StreamReadConstraints.builder().maxStringLength(maxStringLength).build();
 
-        final ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.getFactory().setStreamReadConstraints(streamReadConstraints);
-
         final boolean retainUnicodeEscapeSequences = context.getProperty(RETAIN_UNICODE_ESCAPE_SEQUENCES).asBoolean();
-        if (retainUnicodeEscapeSequences) {
-            objectMapper.getFactory().enable(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature());
-        } else {
-            objectMapper.getFactory().disable(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature());
-        }
+        final JsonFactory jsonFactory = JsonFactory.builder()
+                .streamReadConstraints(streamReadConstraints)
+                .configure(JsonWriteFeature.ESCAPE_NON_ASCII, retainUnicodeEscapeSequences)
+                .build();
+        final ObjectMapper objectMapper = JsonMapper.builder(jsonFactory).build();
 
         jsonUtil = JsonUtils.customJsonUtil(objectMapper);
 

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-transform-json-ui/src/test/java/org/apache/nifi/web/standard/api/transformjson/TestTransformJSONResource.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-transform-json-ui/src/test/java/org/apache/nifi/web/standard/api/transformjson/TestTransformJSONResource.java
@@ -272,7 +272,7 @@ public class TestTransformJSONResource extends JerseyTest {
                 .post(Entity.json(joltSpecificationDTO), String.class);
 
         Object transformedJson = JsonUtils.jsonToObject(responseString);
-        Object compareJson = JsonUtils.jsonToObject("{\"qa\":2}}");
+        Object compareJson = JsonUtils.jsonToObject("{\"qa\":2}");
         assertNotNull(transformedJson);
         assertTrue(diffy.diff(compareJson, transformedJson).isEmpty());
     }

--- a/nifi-extension-bundles/nifi-jolt-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-jolt-bundle/pom.xml
@@ -30,7 +30,7 @@
         <module>nifi-jolt-utils</module>
     </modules>
     <properties>
-        <jolt.version>1.2.0</jolt.version>
+        <jolt.version>1.3.0</jolt.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
@@ -20,8 +20,8 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <snmp4j.version>3.12.2</snmp4j.version>
-        <snmp4j-agent.version>3.9.2</snmp4j-agent.version>
+        <snmp4j.version>3.13.1</snmp4j.version>
+        <snmp4j-agent.version>3.10.1</snmp4j-agent.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <guava.version>33.6.0-jre</guava.version>
         <protobuf.version>4.35.1</protobuf.version>
-        <grpc.version>1.83.0</grpc.version>
+        <grpc.version>1.83.1</grpc.version>
         <snowflake-jdbc-thin.version>4.3.2</snowflake-jdbc-thin.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
@@ -130,13 +130,13 @@
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-matchers</artifactId>
-            <version>2.12.0</version>
+            <version>2.13.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
-            <version>2.12.0</version>
+            <version>2.13.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>9.7.0</version>
+            <version>26.7.0</version>
             <exclusions>
                 <!-- Exclude unused protobuf-java -->
                 <exclusion>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>3.5.9</version>
+            <version>3.5.10</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>4.1.0</spring.boot.version>
-        <flyway.version>13.0.0</flyway.version>
+        <flyway.version>13.1.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.7.1.202607240634-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,13 +122,13 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.49.5</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.50.2</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.8</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
         <!-- Apache Commons -->
         <org.apache.commons.cli.version>1.11.0</org.apache.commons.cli.version>
-        <org.apache.commons.codec.version>1.22.0</org.apache.commons.codec.version>
+        <org.apache.commons.codec.version>1.22.1</org.apache.commons.codec.version>
         <org.apache.commons.collections4.version>4.5.0</org.apache.commons.collections4.version>
         <org.apache.commons.compress.version>1.28.0</org.apache.commons.compress.version>
         <org.apache.commons.configuration.version>2.15.1</org.apache.commons.configuration.version>
@@ -165,7 +165,7 @@
 
         <!-- JVM languages and bytecode -->
         <aspectj.version>1.9.25.1</aspectj.version>
-        <groovy.version>5.0.7</groovy.version>
+        <groovy.version>5.0.8</groovy.version>
         <kotlin.version>2.4.10</kotlin.version>
 
         <!-- Logging and observability -->
@@ -204,7 +204,7 @@
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.security.version>7.1.0</spring.security.version>
         <spring.version>7.0.8</spring.version>
-        <swagger.annotations.version>2.2.52</swagger.annotations.version>
+        <swagger.annotations.version>2.2.53</swagger.annotations.version>
 
         <!-- Testing and quality -->
         <junit.version>6.1.2</junit.version>
@@ -607,7 +607,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.22.2</version>
+                <version>1.23.1</version>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>
@@ -840,7 +840,7 @@
                 <plugin>
                     <groupId>io.swagger.core.v3</groupId>
                     <artifactId>swagger-maven-plugin-jakarta</artifactId>
-                    <version>2.2.52</version>
+                    <version>2.2.53</version>
                 </plugin>
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>


### PR DESCRIPTION
# Summary

NIFI-16163 - Bump HTTPClient5 to 5.6.3, Groovy to 5.0.8, JSoup to 1.23.1, and others

- httpclient5 from 5.6.2 to 5.6.3 - https://downloads.apache.org/httpcomponents/httpclient/RELEASE_NOTES-5.6.x.txt
- google-api-services-drive from v3-rev20260712-2.0.0 to v3-rev20260720-2.0.0 - https://github.com/googleapis/google-api-java-client-services/blob/main/clients/google-api-services-drive/v3/README.md
- jolt from 1.2.0 to 1.3.0 - https://github.com/jolt-community/jolt-community/releases/tag/v1.3.0
- SNMP4J from 3.12.2 to 3.13.1 - https://www.snmp4j.org/CHANGES.txt
- SNMP4J Agent from 3.9.2 to 3.10.1 - https://snmp4j.org/agent/CHANGES.txt
- gRPC from 1.83.0 to 1.83.1 - https://github.com/grpc/grpc
- XMLUnit from 2.12.0 to 2.13.0 - https://github.com/xmlunit/xmlunit/releases/tag/v2.13.0
- MySQL Java Connector from 9.7.0 to 26.7.0 - https://github.com/mysql/mysql-connector-j/releases/tag/26.7.0
- MariaDB Java Client from 3.5.9 to 3.5.10 - https://github.com/mariadb-corporation/mariadb-connector-j/releases/tag/3.5.10
- FlywayDB from 13.0.0 to 13.1.0 - https://github.com/flyway/flyway/releases/tag/flyway-13.1.0
- AWS SDK from 2.49.5 to 2.50.2 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.50.2
- Commons Codec from 1.22.0 to 1.22.1 - https://github.com/apache/commons-codec/releases/tag/rel%2Fcommons-codec-1.22.1
- Groovy from 5.0.7 to 5.0.8 - https://github.com/apache/groovy/releases/tag/GROOVY_5_0_8
- JSoup from 1.22.2 to 1.23.1 - https://github.com/jhy/jsoup/releases/tag/jsoup-1.23.1
- Swagger from 2.2.52 to 2.2.53 - https://github.com/swagger-api/swagger-core/releases/tag/v2.2.53

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
