### PR TITLE
NIFI-16161 Added the ability to validate Json schemas before use in ValidateJson

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateJson.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateJson.java
@@ -61,6 +61,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -286,21 +287,34 @@ public class ValidateJson extends AbstractProcessor {
                     .build());
         }
 
+        if (schemaAccessStrategy.equals(JsonSchemaStrategy.SCHEMA_CONTENT_PROPERTY) && validationContext.getProperty(SCHEMA_CONTENT).isSet()) {
+            try {
+                readSchema(validationContext);
+            } catch (final Exception e) {
+                final String reason;
+                final Throwable cause = e.getCause();
+                if (cause == null) {
+                    reason = e.getMessage();
+                } else {
+                    reason = "%s [%s]".formatted(cause.getMessage(), e.getMessage());
+                }
+
+                final String message = "JSON schema not valid: %s".formatted(reason);
+                validationResults.add(new ValidationResult.Builder()
+                        .valid(false)
+                        .subject(SCHEMA_CONTENT.getDisplayName())
+                        .explanation(message)
+                        .build());
+            }
+        }
         return validationResults;
     }
 
     @OnScheduled
     public void onScheduled(final ProcessContext context) throws IOException {
         switch (getSchemaAccessStrategy(context)) {
-            case SCHEMA_NAME_PROPERTY ->
-                jsonSchemaRegistry = context.getProperty(SCHEMA_REGISTRY).asControllerService(JsonSchemaRegistry.class);
-            case SCHEMA_CONTENT_PROPERTY -> {
-                try (final InputStream inputStream = context.getProperty(SCHEMA_CONTENT).asResource().read()) {
-                    final SchemaVersion schemaVersion = SchemaVersion.valueOf(context.getProperty(SCHEMA_VERSION).getValue());
-                    final SchemaRegistry registry = schemaRegistries.get(schemaVersion);
-                    schema = registry.getSchema(inputStream);
-                }
-            }
+            case SCHEMA_NAME_PROPERTY -> jsonSchemaRegistry = context.getProperty(SCHEMA_REGISTRY).asControllerService(JsonSchemaRegistry.class);
+            case SCHEMA_CONTENT_PROPERTY -> schema = readSchema(context);
         }
 
         final int maxStringLength = context.getProperty(MAX_STRING_LENGTH).asDataSize(DataUnit.B).intValue();
@@ -336,6 +350,16 @@ public class ValidateJson extends AbstractProcessor {
             validateFlowFile(session, flowFile);
         } else {
             validateJsonLines(session, flowFile);
+        }
+    }
+
+    private Schema readSchema(final PropertyContext context) {
+        try (final InputStream inputStream = context.getProperty(SCHEMA_CONTENT).asResource().read()) {
+            final SchemaVersion schemaVersion = SchemaVersion.valueOf(context.getProperty(SCHEMA_VERSION).getValue());
+            final SchemaRegistry registry = schemaRegistries.get(schemaVersion);
+            return registry.getSchema(inputStream);
+        } catch (final IOException ioe) {
+            throw new UncheckedIOException("Read JSON schema failed", ioe);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateJson.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateJson.java
@@ -16,7 +16,7 @@
  */
 package org.apache.nifi.processors.standard;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.json.schema.JsonSchema;
 import org.apache.nifi.json.schema.SchemaVersion;
@@ -40,6 +40,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -259,11 +260,11 @@ class TestValidateJson {
         runner.setProperty(ValidateJson.SCHEMA_CONTENT, schema);
         runner.setProperty(JsonSchemaRegistryComponent.SCHEMA_VERSION, SCHEMA_VERSION);
         runner.enqueue(getFileContent("simple-example-with-comments.json"));
-        runner.assertValid();
 
-        final AssertionFailedError assertionFailedError = assertThrows(AssertionFailedError.class, () -> runner.run());
-        final String stackTrace = ExceptionUtils.getStackTrace(assertionFailedError);
-        assertTrue(stackTrace.contains("JsonParseException") && !stackTrace.contains("FileNotFoundException"));
+        runner.assertNotValid();
+        final Collection<ValidationResult> validationResults = runner.validate();
+        final String explanation = validationResults.iterator().next().getExplanation();
+        assertTrue(explanation.contains("JsonParseException") && !explanation.contains("FileNotFoundException"));
     }
 
     @ParameterizedTest
@@ -272,11 +273,11 @@ class TestValidateJson {
         runner.setProperty(ValidateJson.SCHEMA_CONTENT, schema);
         runner.setProperty(JsonSchemaRegistryComponent.SCHEMA_VERSION, SCHEMA_VERSION);
         runner.enqueue(getFileContent("simple-example-with-comments.json"));
-        runner.assertValid();
 
-        final AssertionFailedError assertionFailedError = assertThrows(AssertionFailedError.class, () -> runner.run());
-        final String stackTrace = ExceptionUtils.getStackTrace(assertionFailedError);
-        assertTrue(stackTrace.contains("JsonParseException"));
+        runner.assertNotValid();
+        final Collection<ValidationResult> validationResults = runner.validate();
+        final String explanation = validationResults.iterator().next().getExplanation();
+        assertTrue(explanation.contains("JsonParseException"));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16161](https://issues.apache.org/jira/browse/NIFI-16161)
This MR aims to align the `ValidateJson` processor with processors `JoltTransformJSON` and `JSLTTransformJSON` whereby validation occurs on a  schema before its used much like the Jolt and JSLT transforms are validated before use.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
