### PR TITLE
NIFI-16170 Improve Content-Encoding handling for REST API

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/StandardServerProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/StandardServerProvider.java
@@ -27,6 +27,7 @@ import org.apache.nifi.web.server.log.StandardRequestLogProvider;
 import org.eclipse.jetty.compression.gzip.GzipCompression;
 import org.eclipse.jetty.compression.server.CompressionConfig;
 import org.eclipse.jetty.compression.server.CompressionHandler;
+import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.rewrite.handler.RedirectPatternRule;
 import org.eclipse.jetty.rewrite.handler.RewriteHandler;
 import org.eclipse.jetty.server.Handler;
@@ -161,8 +162,10 @@ class StandardServerProvider implements ServerProvider {
 
         final CompressionConfig compressionConfig = CompressionConfig.builder()
                 .defaults()
+                // Override default inclusion of decompression for POST method
+                .decompressExcludeMethod(HttpMethod.POST.asString())
                 // Disable decompression of requests
-                .decompressExcludeEncoding(gzipCompression.getEncodingName())
+                .decompressExcludePath(ALL_PATHS_PATTERN)
                 .build();
         compressionHandler.putConfiguration(ROOT_PATH, compressionConfig);
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/handler/UnsupportedContentEncodingHandler.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/handler/UnsupportedContentEncodingHandler.java
@@ -23,6 +23,8 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 
+import java.util.List;
+
 /**
  * Handler that rejects requests declaring an unsupported Content-Encoding
  */
@@ -34,14 +36,32 @@ public class UnsupportedContentEncodingHandler extends Handler.Abstract {
 
     @Override
     public boolean handle(final Request request, final Response response, final Callback callback) {
-        final String contentEncoding = request.getHeaders().get(HttpHeader.CONTENT_ENCODING);
+        // Handle one or more Content-Encoding request headers
+        final List<String> contentEncodings = request.getHeaders().getValuesList(HttpHeader.CONTENT_ENCODING);
 
-        // A request without a Content-Encoding, or one declaring only the identity encoding, is passed to later Handlers
-        if (contentEncoding == null || contentEncoding.isBlank() || IDENTITY_ENCODING.equalsIgnoreCase(contentEncoding.trim())) {
-            return false;
+        final boolean handled;
+        if (isContentEncodingUnsupported(contentEncodings)) {
+            Response.writeError(request, response, callback, HttpStatus.UNSUPPORTED_MEDIA_TYPE_415, UNSUPPORTED_MESSAGE);
+            handled = true;
+        } else {
+            handled = false;
         }
 
-        Response.writeError(request, response, callback, HttpStatus.UNSUPPORTED_MEDIA_TYPE_415, UNSUPPORTED_MESSAGE);
-        return true;
+        return handled;
+    }
+
+    private boolean isContentEncodingUnsupported(final List<String> contentEncodings) {
+        // Empty Content-Encoding header is allowed
+        boolean unsupported = false;
+
+        for (final String contentEncoding : contentEncodings) {
+            // Content-Encoding with a value of identity is allowed indicating no encoding
+            if (!IDENTITY_ENCODING.equalsIgnoreCase(contentEncoding)) {
+                unsupported = true;
+                break;
+            }
+        }
+
+        return unsupported;
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
@@ -108,6 +108,11 @@ class StandardServerProviderTest {
 
     private static final String FRONTEND_PATH_TRAILING_SLASH = "/nifi/";
 
+    private static final String ALL_PATHS = "/*";
+    private static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
+    private static final String GZIP_CONTENT_ENCODING = "gzip";
+    private static final String IDENTITY_CONTENT_ENCODING = "identity";
+
     private static final List<String> STANDARD_RESPONSE_HEADERS = List.of(
             "Content-Security-Policy",
             "Strict-Transport-Security",
@@ -177,36 +182,14 @@ class StandardServerProviderTest {
         assertTrue(compressMethods.contains(HttpMethod.GET.asString()));
         assertTrue(compressMethods.contains(HttpMethod.POST.asString()));
 
+        assertFalse(compressionConfig.isDecompressMethodSupported(HttpMethod.POST.asString()));
+        assertFalse(compressionConfig.isDecompressMethodSupported(HttpMethod.PUT.asString()));
+
+        final Set<String> decompressExcludePaths = compressionConfig.getDecompressExcludePaths();
+        assertTrue(decompressExcludePaths.contains(ALL_PATHS));
+
         final UnsupportedContentEncodingHandler unsupportedContentEncodingHandler = handlerCollection.getDescendant(UnsupportedContentEncodingHandler.class);
         assertNotNull(unsupportedContentEncodingHandler);
-    }
-
-    @Timeout(15)
-    @Test
-    void testGetServerRejectsCompressedRequestBody() throws Exception {
-        final Properties applicationProperties = new Properties();
-        applicationProperties.setProperty(NiFiProperties.WEB_HTTP_PORT, RANDOM_PORT);
-        final NiFiProperties properties = NiFiProperties.createBasicNiFiProperties((String) null, applicationProperties);
-
-        final StandardServerProvider provider = new StandardServerProvider(null);
-
-        final Server server = provider.getServer(properties);
-
-        try {
-            startServer(server);
-            final URI localhostUri = UriComponentsBuilder.fromUri(server.getURI()).host(LOCALHOST_NAME).build().toUri();
-
-            try (HttpClient httpClient = HttpClient.newBuilder().connectTimeout(TIMEOUT).build()) {
-                final HttpRequest compressedRequest = HttpRequest.newBuilder(localhostUri)
-                        .version(HttpClient.Version.HTTP_1_1)
-                        .header(HttpHeader.CONTENT_ENCODING.asString(), "gzip")
-                        .POST(HttpRequest.BodyPublishers.ofByteArray(new byte[]{1, 2, 3}))
-                        .build();
-                assertResponseStatusCode(httpClient, compressedRequest, HttpStatus.UNSUPPORTED_MEDIA_TYPE_415);
-            }
-        } finally {
-            server.stop();
-        }
     }
 
     @Test
@@ -317,6 +300,7 @@ class StandardServerProviderTest {
             assertFrontendRedirectRequestsCompleted(httpClient, localhostUri);
             assertBadRequestsCompleted(httpClient, localhostUri);
             assertMisdirectedRequestsCompleted(httpClient, localhostUri);
+            assertContentEncodingRequestsCompleted(httpClient, localhostUri);
 
             assertReplicatedRequestCompleted(httpClient, localhostUri, HttpStatus.MISDIRECTED_REQUEST_421);
             assertForwardedToCoordinatorRequestCompleted(httpClient, localhostUri, HttpStatus.MISDIRECTED_REQUEST_421);
@@ -335,6 +319,7 @@ class StandardServerProviderTest {
             assertRedirectRequestsCompleted(httpClient, localhostUri);
             assertBadRequestsCompleted(httpClient, localhostUri);
             assertMisdirectedRequestsCompleted(httpClient, localhostUri);
+            assertContentEncodingRequestsCompleted(httpClient, localhostUri);
 
             assertReplicatedRequestCompleted(httpClient, localhostUri, HttpStatus.MOVED_TEMPORARILY_302);
             assertForwardedToCoordinatorRequestCompleted(httpClient, localhostUri, HttpStatus.MOVED_TEMPORARILY_302);
@@ -434,6 +419,42 @@ class StandardServerProviderTest {
                 .version(HttpClient.Version.HTTP_1_1)
                 .build();
         assertResponseStatusCode(httpClient, localhostAddressRequest, HttpStatus.BAD_REQUEST_400);
+    }
+
+    void assertContentEncodingRequestsCompleted(final HttpClient httpClient, final URI localhostUri) throws IOException, InterruptedException {
+        final HttpRequest identityContentEncodingRequest = HttpRequest.newBuilder(localhostUri)
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .header(CONTENT_ENCODING_HEADER, IDENTITY_CONTENT_ENCODING)
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+        assertResponseStatusCode(httpClient, identityContentEncodingRequest, HttpStatus.MOVED_TEMPORARILY_302);
+
+        final HttpRequest gzipContentEncodingRequest = HttpRequest.newBuilder(localhostUri)
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .header(CONTENT_ENCODING_HEADER, GZIP_CONTENT_ENCODING)
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+        assertResponseStatusCode(httpClient, gzipContentEncodingRequest, HttpStatus.UNSUPPORTED_MEDIA_TYPE_415);
+
+        final HttpRequest identityGzipContentEncodingRequest = HttpRequest.newBuilder(localhostUri)
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .headers(
+                        CONTENT_ENCODING_HEADER, IDENTITY_CONTENT_ENCODING,
+                        CONTENT_ENCODING_HEADER, GZIP_CONTENT_ENCODING
+                )
+                .version(HttpClient.Version.HTTP_2)
+                .build();
+        assertResponseStatusCode(httpClient, identityGzipContentEncodingRequest, HttpStatus.UNSUPPORTED_MEDIA_TYPE_415);
+
+        final HttpRequest identityGzipUppercasedContentEncodingRequest = HttpRequest.newBuilder(localhostUri)
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .headers(
+                        CONTENT_ENCODING_HEADER, IDENTITY_CONTENT_ENCODING.toUpperCase(),
+                        CONTENT_ENCODING_HEADER, GZIP_CONTENT_ENCODING.toUpperCase()
+                )
+                .version(HttpClient.Version.HTTP_2)
+                .build();
+        assertResponseStatusCode(httpClient, identityGzipUppercasedContentEncodingRequest, HttpStatus.UNSUPPORTED_MEDIA_TYPE_415);
     }
 
     void assertMisdirectedRequestsCompleted(final HttpClient httpClient, final URI localhostUri) throws IOException, InterruptedException {


### PR DESCRIPTION
# Summary

[NIFI-16170](https://issues.apache.org/jira/browse/NIFI-16170) Improves handling of the `Content-Encoding` HTTP request header for the framework REST API.

Following recent changes switching to Jetty for compression of responses, changes include more consistent handling of multiple `Content-Encoding` headers and simplification of the Jetty compression configuration to disable decompression for all request paths.

Additional changes include revising the unit test approach to run multiple HTTP requests with different `Content-Encoding` header values using a single Jetty Server.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
