### PR TITLE
NIFI-16125 Parallelize initial component validation at startup

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/validation/ParallelTriggerValidationTask.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/validation/ParallelTriggerValidationTask.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.components.validation;
+
+import org.apache.nifi.components.connector.ConnectorNode;
+import org.apache.nifi.controller.ComponentNode;
+import org.apache.nifi.controller.flow.FlowManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * Triggers validation of every component and Connector by submitting each one to an {@link ExecutorService} and
+ * waiting for all of them to complete, instead of validating one at a time on the calling thread. Each
+ * {@link ComponentNode} tracks its own validation state independently, so validating distinct components
+ * concurrently is safe.
+ * <p>
+ * This is intended for the one-time initial validation sweep performed when a flow is loaded during
+ * {@code FlowController} initialization, where the number of components can be large and validating them one at a
+ * time on a single thread can noticeably slow down startup. The periodic re-validation performed thereafter
+ * continues to use the serial {@link TriggerValidationTask}.
+ */
+public class ParallelTriggerValidationTask implements Runnable {
+    private static final Logger logger = LoggerFactory.getLogger(ParallelTriggerValidationTask.class);
+
+    private final FlowManager flowManager;
+    private final ValidationTrigger validationTrigger;
+    private final ExecutorService executorService;
+    private volatile boolean completed = false;
+
+    public ParallelTriggerValidationTask(final FlowManager flowManager, final ValidationTrigger validationTrigger, final ExecutorService executorService) {
+        this.flowManager = Objects.requireNonNull(flowManager, "FlowManager is required");
+        this.validationTrigger = Objects.requireNonNull(validationTrigger, "ValidationTrigger is required");
+        this.executorService = Objects.requireNonNull(executorService, "ExecutorService is required");
+    }
+
+    /**
+     * @return <code>true</code> if the most recent call to {@link #run()} triggered validation of every component
+     *         and waited for it to complete; <code>false</code> if that call was interrupted, or the
+     *         {@link ExecutorService} rejected work, before validation of every component could be triggered and
+     *         completed.
+     */
+    public boolean isValidationComplete() {
+        return completed;
+    }
+
+    @Override
+    public void run() {
+        completed = false;
+
+        try {
+            logger.debug("Triggering validation of all components in parallel");
+
+            final List<ComponentNode> nodes = ValidatableComponents.getComponentNodes(flowManager);
+            final List<ConnectorNode> connectors = ValidatableComponents.getConnectors(flowManager);
+
+            completed = triggerInParallel(nodes, connectors);
+        } catch (final Throwable t) {
+            logger.error("Encountered unexpected error when attempting to validate components", t);
+        }
+    }
+
+    /**
+     * Submits validation of every given component and Connector to the executor and waits for all of it to
+     * complete before returning.
+     *
+     * @return <code>true</code> if every component and Connector was successfully submitted for validation and
+     *         validation of all of them completed; <code>false</code> otherwise.
+     */
+    private boolean triggerInParallel(final List<ComponentNode> nodes, final List<ConnectorNode> connectors) {
+        final List<Future<?>> futures = new ArrayList<>(nodes.size() + connectors.size());
+        boolean allSubmitted = true;
+
+        for (final ComponentNode node : nodes) {
+            if (!submit(futures, () -> validationTrigger.trigger(node))) {
+                allSubmitted = false;
+                break;
+            }
+        }
+
+        if (allSubmitted) {
+            for (final ConnectorNode connector : connectors) {
+                if (!submit(futures, () -> connector.validateComponents(validationTrigger))) {
+                    allSubmitted = false;
+                    break;
+                }
+            }
+        }
+
+        final boolean allAwaited = awaitAll(futures);
+        return allSubmitted && allAwaited;
+    }
+
+    private boolean submit(final List<Future<?>> futures, final Runnable task) {
+        try {
+            futures.add(executorService.submit(task));
+            return true;
+        } catch (final RejectedExecutionException e) {
+            logger.warn("Validation thread pool rejected further work while triggering initial validation; not all components were submitted for validation");
+            return false;
+        }
+    }
+
+    /**
+     * Waits for every given Future to complete. If interrupted while waiting, does not block any further:
+     * the remaining, not-yet-started Futures are cancelled and this method returns immediately, so that shutdown
+     * is not delayed.
+     *
+     * @return <code>true</code> if every Future completed (whether successfully or with an exception);
+     *         <code>false</code> if interrupted before all of them completed.
+     */
+    private boolean awaitAll(final List<Future<?>> futures) {
+        for (int i = 0; i < futures.size(); i++) {
+            try {
+                futures.get(i).get();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.warn("Interrupted while waiting for initial component validation to complete; {} of {} validation tasks had not yet finished",
+                        futures.size() - i, futures.size());
+
+                for (int j = i; j < futures.size(); j++) {
+                    futures.get(j).cancel(false);
+                }
+
+                return false;
+            } catch (final ExecutionException e) {
+                logger.error("Failed to validate a component during initial validation", e.getCause());
+            }
+        }
+
+        return true;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/validation/TriggerValidationTask.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/validation/TriggerValidationTask.java
@@ -23,155 +23,31 @@ import org.apache.nifi.controller.flow.FlowManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionException;
-
 public class TriggerValidationTask implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(TriggerValidationTask.class);
 
     private final FlowManager flowManager;
     private final ValidationTrigger validationTrigger;
-    private final ExecutorService executorService;
-    private volatile boolean completed = false;
 
     public TriggerValidationTask(final FlowManager flowManager, final ValidationTrigger validationTrigger) {
-        this(flowManager, validationTrigger, null);
-    }
-
-    /**
-     * @param executorService when non-null, each component's (and Connector's) validation is submitted to this
-     *                        executor and this task blocks in {@link #run()} until all of them complete, allowing
-     *                        components to be validated concurrently instead of one at a time. When null,
-     *                        components are validated serially on the calling thread, preserving the original
-     *                        behavior. This is intended for the initial validation performed when a flow is loaded,
-     *                        where the number of components can be large and validating them one at a time on a
-     *                        single thread can noticeably slow down startup.
-     */
-    public TriggerValidationTask(final FlowManager flowManager, final ValidationTrigger validationTrigger, final ExecutorService executorService) {
         this.flowManager = flowManager;
         this.validationTrigger = validationTrigger;
-        this.executorService = executorService;
-    }
-
-    /**
-     * @return <code>true</code> if the most recent call to {@link #run()} triggered validation of every component
-     *         and waited for it to complete; <code>false</code> if that call was interrupted, or the supplied
-     *         {@link ExecutorService} rejected work, before validation of every component could be triggered and
-     *         completed. Only meaningful when an <code>ExecutorService</code> was supplied to the constructor -
-     *         serial validation always completes synchronously within {@link #run()}.
-     */
-    public boolean isValidationComplete() {
-        return completed;
     }
 
     @Override
     public void run() {
-        completed = false;
-
         try {
             logger.debug("Triggering validation of all components");
 
-            final List<ComponentNode> nodes = new ArrayList<>();
-            nodes.addAll(flowManager.getAllControllerServices());
-            nodes.addAll(flowManager.getAllReportingTasks());
-            nodes.addAll(flowManager.getAllFlowAnalysisRules());
-            nodes.addAll(flowManager.getAllParameterProviders());
-            nodes.addAll(flowManager.getRootGroup().findAllProcessors());
-            nodes.addAll(flowManager.getAllFlowRegistryClients());
+            for (final ComponentNode node : ValidatableComponents.getComponentNodes(flowManager)) {
+                validationTrigger.trigger(node);
+            }
 
-            final List<ConnectorNode> connectors = new ArrayList<>(flowManager.getAllConnectors());
-
-            if (executorService == null) {
-                for (final ComponentNode node : nodes) {
-                    validationTrigger.trigger(node);
-                }
-
-                for (final ConnectorNode connector : connectors) {
-                    connector.validateComponents(validationTrigger);
-                }
-
-                completed = true;
-            } else {
-                completed = triggerInParallel(nodes, connectors);
+            for (final ConnectorNode connector : ValidatableComponents.getConnectors(flowManager)) {
+                connector.validateComponents(validationTrigger);
             }
         } catch (final Throwable t) {
             logger.error("Encountered unexpected error when attempting to validate components", t);
         }
-    }
-
-    /**
-     * Submits validation of every given component and Connector to the executor and waits for all of it to
-     * complete before returning. Each component maintains its own validation state independently, so validating
-     * distinct components concurrently on the executor is safe.
-     *
-     * @return <code>true</code> if every component and Connector was successfully submitted for validation and
-     *         validation of all of them completed; <code>false</code> otherwise.
-     */
-    private boolean triggerInParallel(final List<ComponentNode> nodes, final List<ConnectorNode> connectors) {
-        final List<Future<?>> futures = new ArrayList<>(nodes.size() + connectors.size());
-        boolean allSubmitted = true;
-
-        for (final ComponentNode node : nodes) {
-            if (!submit(futures, () -> validationTrigger.trigger(node))) {
-                allSubmitted = false;
-                break;
-            }
-        }
-
-        if (allSubmitted) {
-            for (final ConnectorNode connector : connectors) {
-                if (!submit(futures, () -> connector.validateComponents(validationTrigger))) {
-                    allSubmitted = false;
-                    break;
-                }
-            }
-        }
-
-        final boolean allAwaited = awaitAll(futures);
-        return allSubmitted && allAwaited;
-    }
-
-    private boolean submit(final List<Future<?>> futures, final Runnable task) {
-        try {
-            futures.add(executorService.submit(task));
-            return true;
-        } catch (final RejectedExecutionException e) {
-            logger.warn("Validation thread pool rejected further work while triggering initial validation; not all components were submitted for validation");
-            return false;
-        }
-    }
-
-    /**
-     * Waits for every given Future to complete. If interrupted while waiting, does not block any further:
-     * the remaining, not-yet-started Futures are cancelled and this method returns immediately, so that shutdown
-     * is not delayed.
-     *
-     * @return <code>true</code> if every Future completed (whether successfully or with an exception);
-     *         <code>false</code> if interrupted before all of them completed.
-     */
-    private boolean awaitAll(final List<Future<?>> futures) {
-        for (int i = 0; i < futures.size(); i++) {
-            try {
-                futures.get(i).get();
-            } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-                logger.warn("Interrupted while waiting for initial component validation to complete; {} of {} validation tasks had not yet finished",
-                        futures.size() - i, futures.size());
-
-                for (int j = i; j < futures.size(); j++) {
-                    futures.get(j).cancel(false);
-                }
-
-                return false;
-            } catch (final ExecutionException e) {
-                logger.error("Failed to validate a component during initial validation", e.getCause());
-            }
-        }
-
-        return true;
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/validation/TriggerValidationTask.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/validation/TriggerValidationTask.java
@@ -23,51 +23,155 @@ import org.apache.nifi.controller.flow.FlowManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+
 public class TriggerValidationTask implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(TriggerValidationTask.class);
 
     private final FlowManager flowManager;
     private final ValidationTrigger validationTrigger;
+    private final ExecutorService executorService;
+    private volatile boolean completed = false;
 
     public TriggerValidationTask(final FlowManager flowManager, final ValidationTrigger validationTrigger) {
+        this(flowManager, validationTrigger, null);
+    }
+
+    /**
+     * @param executorService when non-null, each component's (and Connector's) validation is submitted to this
+     *                        executor and this task blocks in {@link #run()} until all of them complete, allowing
+     *                        components to be validated concurrently instead of one at a time. When null,
+     *                        components are validated serially on the calling thread, preserving the original
+     *                        behavior. This is intended for the initial validation performed when a flow is loaded,
+     *                        where the number of components can be large and validating them one at a time on a
+     *                        single thread can noticeably slow down startup.
+     */
+    public TriggerValidationTask(final FlowManager flowManager, final ValidationTrigger validationTrigger, final ExecutorService executorService) {
         this.flowManager = flowManager;
         this.validationTrigger = validationTrigger;
+        this.executorService = executorService;
+    }
+
+    /**
+     * @return <code>true</code> if the most recent call to {@link #run()} triggered validation of every component
+     *         and waited for it to complete; <code>false</code> if that call was interrupted, or the supplied
+     *         {@link ExecutorService} rejected work, before validation of every component could be triggered and
+     *         completed. Only meaningful when an <code>ExecutorService</code> was supplied to the constructor -
+     *         serial validation always completes synchronously within {@link #run()}.
+     */
+    public boolean isValidationComplete() {
+        return completed;
     }
 
     @Override
     public void run() {
+        completed = false;
+
         try {
             logger.debug("Triggering validation of all components");
 
-            for (final ComponentNode node : flowManager.getAllControllerServices()) {
-                validationTrigger.trigger(node);
-            }
+            final List<ComponentNode> nodes = new ArrayList<>();
+            nodes.addAll(flowManager.getAllControllerServices());
+            nodes.addAll(flowManager.getAllReportingTasks());
+            nodes.addAll(flowManager.getAllFlowAnalysisRules());
+            nodes.addAll(flowManager.getAllParameterProviders());
+            nodes.addAll(flowManager.getRootGroup().findAllProcessors());
+            nodes.addAll(flowManager.getAllFlowRegistryClients());
 
-            for (final ComponentNode node : flowManager.getAllReportingTasks()) {
-                validationTrigger.trigger(node);
-            }
+            final List<ConnectorNode> connectors = new ArrayList<>(flowManager.getAllConnectors());
 
-            for (final ComponentNode node : flowManager.getAllFlowAnalysisRules()) {
-                validationTrigger.trigger(node);
-            }
+            if (executorService == null) {
+                for (final ComponentNode node : nodes) {
+                    validationTrigger.trigger(node);
+                }
 
-            for (final ComponentNode node : flowManager.getAllParameterProviders()) {
-                validationTrigger.trigger(node);
-            }
+                for (final ConnectorNode connector : connectors) {
+                    connector.validateComponents(validationTrigger);
+                }
 
-            for (final ComponentNode node : flowManager.getRootGroup().findAllProcessors()) {
-                validationTrigger.trigger(node);
-            }
-
-            for (final ComponentNode node : flowManager.getAllFlowRegistryClients()) {
-                validationTrigger.trigger(node);
-            }
-
-            for (final ConnectorNode connector : flowManager.getAllConnectors()) {
-                connector.validateComponents(validationTrigger);
+                completed = true;
+            } else {
+                completed = triggerInParallel(nodes, connectors);
             }
         } catch (final Throwable t) {
             logger.error("Encountered unexpected error when attempting to validate components", t);
         }
+    }
+
+    /**
+     * Submits validation of every given component and Connector to the executor and waits for all of it to
+     * complete before returning. Each component maintains its own validation state independently, so validating
+     * distinct components concurrently on the executor is safe.
+     *
+     * @return <code>true</code> if every component and Connector was successfully submitted for validation and
+     *         validation of all of them completed; <code>false</code> otherwise.
+     */
+    private boolean triggerInParallel(final List<ComponentNode> nodes, final List<ConnectorNode> connectors) {
+        final List<Future<?>> futures = new ArrayList<>(nodes.size() + connectors.size());
+        boolean allSubmitted = true;
+
+        for (final ComponentNode node : nodes) {
+            if (!submit(futures, () -> validationTrigger.trigger(node))) {
+                allSubmitted = false;
+                break;
+            }
+        }
+
+        if (allSubmitted) {
+            for (final ConnectorNode connector : connectors) {
+                if (!submit(futures, () -> connector.validateComponents(validationTrigger))) {
+                    allSubmitted = false;
+                    break;
+                }
+            }
+        }
+
+        final boolean allAwaited = awaitAll(futures);
+        return allSubmitted && allAwaited;
+    }
+
+    private boolean submit(final List<Future<?>> futures, final Runnable task) {
+        try {
+            futures.add(executorService.submit(task));
+            return true;
+        } catch (final RejectedExecutionException e) {
+            logger.warn("Validation thread pool rejected further work while triggering initial validation; not all components were submitted for validation");
+            return false;
+        }
+    }
+
+    /**
+     * Waits for every given Future to complete. If interrupted while waiting, does not block any further:
+     * the remaining, not-yet-started Futures are cancelled and this method returns immediately, so that shutdown
+     * is not delayed.
+     *
+     * @return <code>true</code> if every Future completed (whether successfully or with an exception);
+     *         <code>false</code> if interrupted before all of them completed.
+     */
+    private boolean awaitAll(final List<Future<?>> futures) {
+        for (int i = 0; i < futures.size(); i++) {
+            try {
+                futures.get(i).get();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.warn("Interrupted while waiting for initial component validation to complete; {} of {} validation tasks had not yet finished",
+                        futures.size() - i, futures.size());
+
+                for (int j = i; j < futures.size(); j++) {
+                    futures.get(j).cancel(false);
+                }
+
+                return false;
+            } catch (final ExecutionException e) {
+                logger.error("Failed to validate a component during initial validation", e.getCause());
+            }
+        }
+
+        return true;
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/validation/ValidatableComponents.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/validation/ValidatableComponents.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.components.validation;
+
+import org.apache.nifi.components.connector.ConnectorNode;
+import org.apache.nifi.controller.ComponentNode;
+import org.apache.nifi.controller.flow.FlowManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Gathers the components subject to the initial and periodic validation sweeps, so that
+ * {@link TriggerValidationTask} and {@link ParallelTriggerValidationTask} validate exactly the same set of
+ * components without duplicating the collection logic in both places.
+ */
+final class ValidatableComponents {
+
+    private ValidatableComponents() {
+    }
+
+    static List<ComponentNode> getComponentNodes(final FlowManager flowManager) {
+        final List<ComponentNode> nodes = new ArrayList<>();
+        nodes.addAll(flowManager.getAllControllerServices());
+        nodes.addAll(flowManager.getAllReportingTasks());
+        nodes.addAll(flowManager.getAllFlowAnalysisRules());
+        nodes.addAll(flowManager.getAllParameterProviders());
+        nodes.addAll(flowManager.getRootGroup().findAllProcessors());
+        nodes.addAll(flowManager.getAllFlowRegistryClients());
+        return nodes;
+    }
+
+    static List<ConnectorNode> getConnectors(final FlowManager flowManager) {
+        return new ArrayList<>(flowManager.getAllConnectors());
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -1515,10 +1515,16 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
             if (flowAnalyzer != null) {
                 new TriggerFlowAnalysisTask(flowAnalyzer, rootProcessGroupSupplier).run();
             }
-            new TriggerValidationTask(flowManager, triggerIfValidating).run();
+            final TriggerValidationTask initialValidationTask = new TriggerValidationTask(flowManager, triggerIfValidating, validationThreadPool);
+            initialValidationTask.run();
 
             final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-            LOG.info("Performed initial validation of all components in {} milliseconds", millis);
+            if (initialValidationTask.isValidationComplete()) {
+                LOG.info("Performed initial validation of all components in {} milliseconds", millis);
+            } else {
+                LOG.warn("Initial validation of components did not complete for all components after {} milliseconds " +
+                        "(interrupted or validation thread pool unavailable); some components may still report a VALIDATING status", millis);
+            }
 
             scheduleBackgroundFlowAnalysis(rootProcessGroupSupplier);
             // Trigger component validation to occur every 5 seconds.

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -71,6 +71,7 @@ import org.apache.nifi.components.state.StateManagerProvider;
 import org.apache.nifi.components.state.StateProvider;
 import org.apache.nifi.components.validation.StandardValidationTrigger;
 import org.apache.nifi.components.validation.StandardVerifiableComponentFactory;
+import org.apache.nifi.components.validation.ParallelTriggerValidationTask;
 import org.apache.nifi.components.validation.TriggerValidationTask;
 import org.apache.nifi.components.validation.ValidationStatus;
 import org.apache.nifi.components.validation.ValidationTrigger;
@@ -1515,7 +1516,7 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
             if (flowAnalyzer != null) {
                 new TriggerFlowAnalysisTask(flowAnalyzer, rootProcessGroupSupplier).run();
             }
-            final TriggerValidationTask initialValidationTask = new TriggerValidationTask(flowManager, triggerIfValidating, validationThreadPool);
+            final ParallelTriggerValidationTask initialValidationTask = new ParallelTriggerValidationTask(flowManager, triggerIfValidating, validationThreadPool);
             initialValidationTask.run();
 
             final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -69,9 +69,9 @@ import org.apache.nifi.components.connector.secrets.StandardSecretsManagerInitia
 import org.apache.nifi.components.monitor.LongRunningTaskMonitor;
 import org.apache.nifi.components.state.StateManagerProvider;
 import org.apache.nifi.components.state.StateProvider;
+import org.apache.nifi.components.validation.ParallelTriggerValidationTask;
 import org.apache.nifi.components.validation.StandardValidationTrigger;
 import org.apache.nifi.components.validation.StandardVerifiableComponentFactory;
-import org.apache.nifi.components.validation.ParallelTriggerValidationTask;
 import org.apache.nifi.components.validation.TriggerValidationTask;
 import org.apache.nifi.components.validation.ValidationStatus;
 import org.apache.nifi.components.validation.ValidationTrigger;

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/validation/ParallelTriggerValidationTaskTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/validation/ParallelTriggerValidationTaskTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.components.validation;
+
+import org.apache.nifi.components.connector.ConnectorNode;
+import org.apache.nifi.controller.ComponentNode;
+import org.apache.nifi.controller.FlowAnalysisRuleNode;
+import org.apache.nifi.controller.ParameterProviderNode;
+import org.apache.nifi.controller.ProcessorNode;
+import org.apache.nifi.controller.ReportingTaskNode;
+import org.apache.nifi.controller.flow.FlowManager;
+import org.apache.nifi.controller.service.ControllerServiceNode;
+import org.apache.nifi.groups.ProcessGroup;
+import org.apache.nifi.registry.flow.FlowRegistryClientNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ParallelTriggerValidationTaskTest {
+
+    private ExecutorService executorService;
+
+    @AfterEach
+    void shutdownExecutor() {
+        if (executorService != null) {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void testConstructorRequiresExecutorService() {
+        final Fixture fixture = new Fixture();
+        final ValidationTrigger trigger = recordingTrigger(new CopyOnWriteArrayList<>());
+
+        assertThrows(NullPointerException.class, () -> new ParallelTriggerValidationTask(fixture.flowManager, trigger, null));
+    }
+
+    @Test
+    void testRunTriggersEveryComponentAndCompletes() throws InterruptedException {
+        final Fixture fixture = new Fixture();
+        final List<ComponentNode> triggered = new CopyOnWriteArrayList<>();
+        final ValidationTrigger trigger = recordingTrigger(triggered);
+        executorService = Executors.newFixedThreadPool(4);
+
+        final ParallelTriggerValidationTask task = new ParallelTriggerValidationTask(fixture.flowManager, trigger, executorService);
+        task.run();
+
+        assertTrue(task.isValidationComplete());
+        assertEquals(new HashSet<>(fixture.expectedComponentNodes()), new HashSet<>(triggered));
+        verify(fixture.connector, times(1)).validateComponents(trigger);
+    }
+
+    @Test
+    void testRunReportsIncompleteWhenExecutorRejectsWork() {
+        final Fixture fixture = new Fixture();
+        final List<ComponentNode> triggered = new CopyOnWriteArrayList<>();
+        final ValidationTrigger trigger = recordingTrigger(triggered);
+
+        executorService = Executors.newFixedThreadPool(2);
+        executorService.shutdown(); // no longer accepts new work; submit() will throw RejectedExecutionException
+
+        final ParallelTriggerValidationTask task = new ParallelTriggerValidationTask(fixture.flowManager, trigger, executorService);
+        task.run();
+
+        assertFalse(task.isValidationComplete());
+    }
+
+    @Test
+    void testRunReportsIncompleteWhenInterruptedWhileAwaitingCompletion() throws InterruptedException {
+        final FlowManager flowManager = mock(FlowManager.class);
+        final ProcessGroup rootGroup = mock(ProcessGroup.class);
+        final ProcessorNode slowProcessor = mock(ProcessorNode.class);
+
+        when(flowManager.getRootGroup()).thenReturn(rootGroup);
+        when(rootGroup.findAllProcessors()).thenReturn(List.of(slowProcessor));
+        when(flowManager.getAllControllerServices()).thenReturn(Collections.emptySet());
+        when(flowManager.getAllReportingTasks()).thenReturn(Collections.emptySet());
+        when(flowManager.getAllFlowAnalysisRules()).thenReturn(Collections.emptySet());
+        when(flowManager.getAllParameterProviders()).thenReturn(Collections.emptySet());
+        when(flowManager.getAllFlowRegistryClients()).thenReturn(Collections.emptySet());
+        when(flowManager.getAllConnectors()).thenReturn(Collections.emptyList());
+
+        final CountDownLatch validationStarted = new CountDownLatch(1);
+        final CountDownLatch releaseValidation = new CountDownLatch(1);
+        final ValidationTrigger trigger = new ValidationTrigger() {
+            @Override
+            public void triggerAsync(final ComponentNode component) {
+            }
+
+            @Override
+            public void trigger(final ComponentNode component) {
+                validationStarted.countDown();
+                try {
+                    // Simulate a component validation that is still in progress when the calling
+                    // thread is interrupted; the pool thread itself is not interrupted.
+                    releaseValidation.await();
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        };
+
+        executorService = Executors.newSingleThreadExecutor();
+        final ParallelTriggerValidationTask task = new ParallelTriggerValidationTask(flowManager, trigger, executorService);
+
+        final AtomicBoolean interruptStatusRestored = new AtomicBoolean(false);
+        final Thread runner = new Thread(() -> {
+            task.run();
+            interruptStatusRestored.set(Thread.currentThread().isInterrupted());
+        });
+
+        try {
+            runner.start();
+            assertTrue(validationStarted.await(5, TimeUnit.SECONDS), "Validation did not start within the timeout");
+
+            runner.interrupt();
+            runner.join(5_000);
+
+            assertFalse(runner.isAlive(), "ParallelTriggerValidationTask did not return promptly after being interrupted");
+            assertFalse(task.isValidationComplete());
+            assertTrue(interruptStatusRestored.get(), "Interrupt status should be restored on the thread that called run()");
+        } finally {
+            releaseValidation.countDown();
+        }
+    }
+
+    private static ValidationTrigger recordingTrigger(final List<ComponentNode> triggered) {
+        return new ValidationTrigger() {
+            @Override
+            public void triggerAsync(final ComponentNode component) {
+                triggered.add(component);
+            }
+
+            @Override
+            public void trigger(final ComponentNode component) {
+                triggered.add(component);
+            }
+        };
+    }
+
+    /**
+     * Provides a FlowManager mock with exactly one component of each type that ParallelTriggerValidationTask is
+     * expected to validate, so tests can assert that every category is covered.
+     */
+    private static final class Fixture {
+        private final FlowManager flowManager = mock(FlowManager.class);
+        private final ControllerServiceNode controllerService = mock(ControllerServiceNode.class);
+        private final ReportingTaskNode reportingTask = mock(ReportingTaskNode.class);
+        private final FlowAnalysisRuleNode flowAnalysisRule = mock(FlowAnalysisRuleNode.class);
+        private final ParameterProviderNode parameterProvider = mock(ParameterProviderNode.class);
+        private final FlowRegistryClientNode flowRegistryClient = mock(FlowRegistryClientNode.class);
+        private final ProcessorNode processor = mock(ProcessorNode.class);
+        private final ConnectorNode connector = mock(ConnectorNode.class);
+        private final ProcessGroup rootGroup = mock(ProcessGroup.class);
+
+        private Fixture() {
+            when(flowManager.getAllControllerServices()).thenReturn(Set.of(controllerService));
+            when(flowManager.getAllReportingTasks()).thenReturn(Set.of(reportingTask));
+            when(flowManager.getAllFlowAnalysisRules()).thenReturn(Set.of(flowAnalysisRule));
+            when(flowManager.getAllParameterProviders()).thenReturn(Set.of(parameterProvider));
+            when(flowManager.getAllFlowRegistryClients()).thenReturn(Set.of(flowRegistryClient));
+            when(flowManager.getAllConnectors()).thenReturn(List.of(connector));
+            when(flowManager.getRootGroup()).thenReturn(rootGroup);
+            when(rootGroup.findAllProcessors()).thenReturn(List.of(processor));
+        }
+
+        private List<ComponentNode> expectedComponentNodes() {
+            return List.of(controllerService, reportingTask, flowAnalysisRule, parameterProvider, processor, flowRegistryClient);
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/validation/TriggerValidationTaskTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/validation/TriggerValidationTaskTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.components.validation;
+
+import org.apache.nifi.components.connector.ConnectorNode;
+import org.apache.nifi.controller.ComponentNode;
+import org.apache.nifi.controller.FlowAnalysisRuleNode;
+import org.apache.nifi.controller.ParameterProviderNode;
+import org.apache.nifi.controller.ProcessorNode;
+import org.apache.nifi.controller.ReportingTaskNode;
+import org.apache.nifi.controller.flow.FlowManager;
+import org.apache.nifi.controller.service.ControllerServiceNode;
+import org.apache.nifi.groups.ProcessGroup;
+import org.apache.nifi.registry.flow.FlowRegistryClientNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TriggerValidationTaskTest {
+
+    private ExecutorService executorService;
+
+    @AfterEach
+    void shutdownExecutor() {
+        if (executorService != null) {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void testSerialConstructorTriggersEveryComponentOnCallingThread() {
+        final Fixture fixture = new Fixture();
+        final List<ComponentNode> triggered = new CopyOnWriteArrayList<>();
+        final ValidationTrigger trigger = recordingTrigger(triggered);
+
+        final TriggerValidationTask task = new TriggerValidationTask(fixture.flowManager, trigger);
+        task.run();
+
+        assertTrue(task.isValidationComplete());
+        assertEquals(new HashSet<>(fixture.expectedComponentNodes()), new HashSet<>(triggered));
+        verify(fixture.connector, times(1)).validateComponents(trigger);
+    }
+
+    @Test
+    void testParallelConstructorTriggersEveryComponentAndCompletes() throws InterruptedException {
+        final Fixture fixture = new Fixture();
+        final List<ComponentNode> triggered = new CopyOnWriteArrayList<>();
+        final ValidationTrigger trigger = recordingTrigger(triggered);
+        executorService = Executors.newFixedThreadPool(4);
+
+        final TriggerValidationTask task = new TriggerValidationTask(fixture.flowManager, trigger, executorService);
+        task.run();
+
+        assertTrue(task.isValidationComplete());
+        assertEquals(new HashSet<>(fixture.expectedComponentNodes()), new HashSet<>(triggered));
+        verify(fixture.connector, times(1)).validateComponents(trigger);
+    }
+
+    @Test
+    void testParallelConstructorReportsIncompleteWhenExecutorRejectsWork() {
+        final Fixture fixture = new Fixture();
+        final List<ComponentNode> triggered = new CopyOnWriteArrayList<>();
+        final ValidationTrigger trigger = recordingTrigger(triggered);
+
+        executorService = Executors.newFixedThreadPool(2);
+        executorService.shutdown(); // no longer accepts new work; submit() will throw RejectedExecutionException
+
+        final TriggerValidationTask task = new TriggerValidationTask(fixture.flowManager, trigger, executorService);
+        task.run();
+
+        assertFalse(task.isValidationComplete());
+    }
+
+    @Test
+    void testParallelConstructorReportsIncompleteWhenInterruptedWhileAwaitingCompletion() throws InterruptedException {
+        final FlowManager flowManager = mock(FlowManager.class);
+        final ProcessGroup rootGroup = mock(ProcessGroup.class);
+        final ProcessorNode slowProcessor = mock(ProcessorNode.class);
+
+        when(flowManager.getRootGroup()).thenReturn(rootGroup);
+        when(rootGroup.findAllProcessors()).thenReturn(List.of(slowProcessor));
+        when(flowManager.getAllControllerServices()).thenReturn(Collections.emptySet());
+        when(flowManager.getAllReportingTasks()).thenReturn(Collections.emptySet());
+        when(flowManager.getAllFlowAnalysisRules()).thenReturn(Collections.emptySet());
+        when(flowManager.getAllParameterProviders()).thenReturn(Collections.emptySet());
+        when(flowManager.getAllFlowRegistryClients()).thenReturn(Collections.emptySet());
+        when(flowManager.getAllConnectors()).thenReturn(Collections.emptyList());
+
+        final CountDownLatch validationStarted = new CountDownLatch(1);
+        final CountDownLatch releaseValidation = new CountDownLatch(1);
+        final ValidationTrigger trigger = new ValidationTrigger() {
+            @Override
+            public void triggerAsync(final ComponentNode component) {
+            }
+
+            @Override
+            public void trigger(final ComponentNode component) {
+                validationStarted.countDown();
+                try {
+                    // Simulate a component validation that is still in progress when the calling
+                    // thread is interrupted; the pool thread itself is not interrupted.
+                    releaseValidation.await();
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        };
+
+        executorService = Executors.newSingleThreadExecutor();
+        final TriggerValidationTask task = new TriggerValidationTask(flowManager, trigger, executorService);
+
+        final AtomicBoolean interruptStatusRestored = new AtomicBoolean(false);
+        final Thread runner = new Thread(() -> {
+            task.run();
+            interruptStatusRestored.set(Thread.currentThread().isInterrupted());
+        });
+
+        try {
+            runner.start();
+            assertTrue(validationStarted.await(5, TimeUnit.SECONDS), "Validation did not start within the timeout");
+
+            runner.interrupt();
+            runner.join(5_000);
+
+            assertFalse(runner.isAlive(), "TriggerValidationTask did not return promptly after being interrupted");
+            assertFalse(task.isValidationComplete());
+            assertTrue(interruptStatusRestored.get(), "Interrupt status should be restored on the thread that called run()");
+        } finally {
+            releaseValidation.countDown();
+        }
+    }
+
+    private static ValidationTrigger recordingTrigger(final List<ComponentNode> triggered) {
+        return new ValidationTrigger() {
+            @Override
+            public void triggerAsync(final ComponentNode component) {
+                triggered.add(component);
+            }
+
+            @Override
+            public void trigger(final ComponentNode component) {
+                triggered.add(component);
+            }
+        };
+    }
+
+    /**
+     * Provides a FlowManager mock with exactly one component of each type that TriggerValidationTask is expected
+     * to validate, so tests can assert that every category is covered.
+     */
+    private static final class Fixture {
+        private final FlowManager flowManager = mock(FlowManager.class);
+        private final ControllerServiceNode controllerService = mock(ControllerServiceNode.class);
+        private final ReportingTaskNode reportingTask = mock(ReportingTaskNode.class);
+        private final FlowAnalysisRuleNode flowAnalysisRule = mock(FlowAnalysisRuleNode.class);
+        private final ParameterProviderNode parameterProvider = mock(ParameterProviderNode.class);
+        private final FlowRegistryClientNode flowRegistryClient = mock(FlowRegistryClientNode.class);
+        private final ProcessorNode processor = mock(ProcessorNode.class);
+        private final ConnectorNode connector = mock(ConnectorNode.class);
+        private final ProcessGroup rootGroup = mock(ProcessGroup.class);
+
+        private Fixture() {
+            when(flowManager.getAllControllerServices()).thenReturn(Set.of(controllerService));
+            when(flowManager.getAllReportingTasks()).thenReturn(Set.of(reportingTask));
+            when(flowManager.getAllFlowAnalysisRules()).thenReturn(Set.of(flowAnalysisRule));
+            when(flowManager.getAllParameterProviders()).thenReturn(Set.of(parameterProvider));
+            when(flowManager.getAllFlowRegistryClients()).thenReturn(Set.of(flowRegistryClient));
+            when(flowManager.getAllConnectors()).thenReturn(List.of(connector));
+            when(flowManager.getRootGroup()).thenReturn(rootGroup);
+            when(rootGroup.findAllProcessors()).thenReturn(List.of(processor));
+        }
+
+        private List<ComponentNode> expectedComponentNodes() {
+            return List.of(controllerService, reportingTask, flowAnalysisRule, parameterProvider, processor, flowRegistryClient);
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/validation/TriggerValidationTaskTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/validation/TriggerValidationTaskTest.java
@@ -27,23 +27,14 @@ import org.apache.nifi.controller.flow.FlowManager;
 import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.registry.flow.FlowRegistryClientNode;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -51,17 +42,8 @@ import static org.mockito.Mockito.when;
 
 class TriggerValidationTaskTest {
 
-    private ExecutorService executorService;
-
-    @AfterEach
-    void shutdownExecutor() {
-        if (executorService != null) {
-            executorService.shutdownNow();
-        }
-    }
-
     @Test
-    void testSerialConstructorTriggersEveryComponentOnCallingThread() {
+    void testRunTriggersEveryComponentOnCallingThread() {
         final Fixture fixture = new Fixture();
         final List<ComponentNode> triggered = new CopyOnWriteArrayList<>();
         final ValidationTrigger trigger = recordingTrigger(triggered);
@@ -69,98 +51,8 @@ class TriggerValidationTaskTest {
         final TriggerValidationTask task = new TriggerValidationTask(fixture.flowManager, trigger);
         task.run();
 
-        assertTrue(task.isValidationComplete());
         assertEquals(new HashSet<>(fixture.expectedComponentNodes()), new HashSet<>(triggered));
         verify(fixture.connector, times(1)).validateComponents(trigger);
-    }
-
-    @Test
-    void testParallelConstructorTriggersEveryComponentAndCompletes() throws InterruptedException {
-        final Fixture fixture = new Fixture();
-        final List<ComponentNode> triggered = new CopyOnWriteArrayList<>();
-        final ValidationTrigger trigger = recordingTrigger(triggered);
-        executorService = Executors.newFixedThreadPool(4);
-
-        final TriggerValidationTask task = new TriggerValidationTask(fixture.flowManager, trigger, executorService);
-        task.run();
-
-        assertTrue(task.isValidationComplete());
-        assertEquals(new HashSet<>(fixture.expectedComponentNodes()), new HashSet<>(triggered));
-        verify(fixture.connector, times(1)).validateComponents(trigger);
-    }
-
-    @Test
-    void testParallelConstructorReportsIncompleteWhenExecutorRejectsWork() {
-        final Fixture fixture = new Fixture();
-        final List<ComponentNode> triggered = new CopyOnWriteArrayList<>();
-        final ValidationTrigger trigger = recordingTrigger(triggered);
-
-        executorService = Executors.newFixedThreadPool(2);
-        executorService.shutdown(); // no longer accepts new work; submit() will throw RejectedExecutionException
-
-        final TriggerValidationTask task = new TriggerValidationTask(fixture.flowManager, trigger, executorService);
-        task.run();
-
-        assertFalse(task.isValidationComplete());
-    }
-
-    @Test
-    void testParallelConstructorReportsIncompleteWhenInterruptedWhileAwaitingCompletion() throws InterruptedException {
-        final FlowManager flowManager = mock(FlowManager.class);
-        final ProcessGroup rootGroup = mock(ProcessGroup.class);
-        final ProcessorNode slowProcessor = mock(ProcessorNode.class);
-
-        when(flowManager.getRootGroup()).thenReturn(rootGroup);
-        when(rootGroup.findAllProcessors()).thenReturn(List.of(slowProcessor));
-        when(flowManager.getAllControllerServices()).thenReturn(Collections.emptySet());
-        when(flowManager.getAllReportingTasks()).thenReturn(Collections.emptySet());
-        when(flowManager.getAllFlowAnalysisRules()).thenReturn(Collections.emptySet());
-        when(flowManager.getAllParameterProviders()).thenReturn(Collections.emptySet());
-        when(flowManager.getAllFlowRegistryClients()).thenReturn(Collections.emptySet());
-        when(flowManager.getAllConnectors()).thenReturn(Collections.emptyList());
-
-        final CountDownLatch validationStarted = new CountDownLatch(1);
-        final CountDownLatch releaseValidation = new CountDownLatch(1);
-        final ValidationTrigger trigger = new ValidationTrigger() {
-            @Override
-            public void triggerAsync(final ComponentNode component) {
-            }
-
-            @Override
-            public void trigger(final ComponentNode component) {
-                validationStarted.countDown();
-                try {
-                    // Simulate a component validation that is still in progress when the calling
-                    // thread is interrupted; the pool thread itself is not interrupted.
-                    releaseValidation.await();
-                } catch (final InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            }
-        };
-
-        executorService = Executors.newSingleThreadExecutor();
-        final TriggerValidationTask task = new TriggerValidationTask(flowManager, trigger, executorService);
-
-        final AtomicBoolean interruptStatusRestored = new AtomicBoolean(false);
-        final Thread runner = new Thread(() -> {
-            task.run();
-            interruptStatusRestored.set(Thread.currentThread().isInterrupted());
-        });
-
-        try {
-            runner.start();
-            assertTrue(validationStarted.await(5, TimeUnit.SECONDS), "Validation did not start within the timeout");
-
-            runner.interrupt();
-            runner.join(5_000);
-
-            assertFalse(runner.isAlive(), "TriggerValidationTask did not return promptly after being interrupted");
-            assertFalse(task.isValidationComplete());
-            assertTrue(interruptStatusRestored.get(), "Interrupt status should be restored on the thread that called run()");
-        } finally {
-            releaseValidation.countDown();
-        }
     }
 
     private static ValidationTrigger recordingTrigger(final List<ComponentNode> triggered) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16125](https://issues.apache.org/jira/browse/NIFI-16125)

`FlowController.initializeFlow()` performs the initial validation of every component (Controller
 Services, Reporting Tasks, Flow Analysis Rules, Parameter Providers, Processors, Flow Registry
 Clients, and Connectors) sequentially on a single thread via `TriggerValidationTask`. For flows
 with a large number of components, this can make up a significant portion of startup time.

Per review feedback, this is now split into two dedicated `Runnable` implementations instead of
 branching a single class on whether an `ExecutorService` was supplied:

- `TriggerValidationTask` is restored to its original serial-only behavior and continues to serve
  the periodic re-validation task scheduled every 5 seconds.
- `ParallelTriggerValidationTask` is a new class dedicated to the one-time initial sweep performed
  during `FlowController` initialization. It submits each component's and Connector's validation to
  the existing `validationThreadPool` and waits for all of them to complete before returning.
  Validating distinct components concurrently is safe because each `ComponentNode` tracks its own
  validation state independently.

Both classes share a small package-private helper, `ValidatableComponents`, that gathers the same
 set of components (Controller Services, Reporting Tasks, Flow Analysis Rules, Parameter Providers,
 Processors, Flow Registry Clients, and Connectors) for both sweeps, so the two Task implementations
 cannot silently drift apart on which components they validate. Happy to inline this back into both
 classes instead if you'd rather they stay fully independent.

`ParallelTriggerValidationTask.isValidationComplete()` reports whether the most recent run actually
 validated every component. It returns `false` if the run was interrupted, or the executor rejected
 work, before every component could be validated — `FlowController` logs a warning in that case
 instead of unconditionally logging success, avoiding a silent partial-completion that the previous
 implementation would not have surfaced.

Unit tests were split accordingly: `TriggerValidationTaskTest` covers the serial path (unchanged
 behavior), and the new `ParallelTriggerValidationTaskTest` covers the parallel happy path, executor
 rejection, interruption while awaiting completion, and the constructor's null-argument checks.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
