### PR TITLE
NIFI-16175 Document ValidateRecord behavior for zero-record input

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateRecord.java
@@ -90,7 +90,8 @@ import static org.apache.nifi.schema.access.SchemaAccessUtils.SCHEMA_VERSION;
     + "records that do not adhere to the schema are routed to the \"invalid\" relationship. It is therefore possible for a single incoming FlowFile to be split into two individual "
     + "FlowFiles if some records are valid according to the schema and others are not. Any FlowFile that is routed to the \"invalid\" relationship will emit a ROUTE Provenance Event "
     + "with the Details field populated to explain why records were invalid. In addition, to gain further explanation of why records were invalid, DEBUG-level logging can be enabled "
-    + "for the \"org.apache.nifi.processors.standard.ValidateRecord\" logger.")
+    + "for the \"org.apache.nifi.processors.standard.ValidateRecord\" logger. "
+    + "If the incoming FlowFile contains no records, no output FlowFile is produced for any relationship and the incoming FlowFile is removed.")
 @WritesAttributes({
     @WritesAttribute(attribute = "mime.type", description = "Sets the mime.type attribute to the MIME Type specified by the Record Writer"),
     @WritesAttribute(attribute = "record.count", description = "The number of records in the FlowFile routed to a relationship")

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.ValidateRecord/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.ValidateRecord/additionalDetails.md
@@ -15,6 +15,17 @@
 
 # ValidateRecord
 
+## FlowFiles that contain no records
+
+ValidateRecord validates records one at a time as they are read from the incoming FlowFile. If the Record Reader
+returns no records - for example, a CSV input that contains only a header line - the processor has nothing to validate.
+In this case no output is produced: no FlowFile is routed any relationship, and the incoming FlowFile is removed.
+
+If a downstream flow needs to react to empty inputs, detect them before ValidateRecord. For example, a preceding
+record-based processor such as ConvertRecord writes a `record.count` attribute (including `record.count = 0` for empty
+inputs when its *Include Zero Record FlowFiles* property is enabled), which a RouteOnAttribute processor can then use to
+handle empty FlowFiles separately.
+
 ## Examples for the effect of Force Types From Reader's Schema property
 
 The processor first reads the data from the incoming FlowFile using the specified Record Reader, which uses a schema.


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16175](https://issues.apache.org/jira/browse/NIFI-16175)

When a FlowFile reaches ValidateRecord and the configured Record Reader returns no records (e.g. a CSV containing only a header line), the processor produces no output on any relationship.

That is consistent with ScriptedValidateRecord just that it's documented "over there" but not for ValidateRecord.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-16175) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-16175`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-16175`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html) — N/A, no new dependencies
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files — N/A, no new dependencies

### Documentation

- [ ] Documentation formatting appears as expected in rendered files