### PR TITLE
NIFI-16180 - Ensure Rebalancing Worker Stops Before Returning

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/BlockingSwappablePriorityQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/BlockingSwappablePriorityQueue.java
@@ -51,6 +51,15 @@ public class BlockingSwappablePriorityQueue extends SwappablePriorityQueue {
         }
     }
 
+    @Override
+    public void putBack(final Collection<FlowFileRecord> flowFiles) {
+        super.putBack(flowFiles);
+
+        synchronized (monitor) {
+            monitor.notifyAll();
+        }
+    }
+
     public FlowFileRecord poll(final Set<FlowFileRecord> expiredRecords, final long expirationMillis, final long waitMillis, final PollStrategy pollStrategy) throws InterruptedException {
         final long maxTimestamp = System.currentTimeMillis() + waitMillis;
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
@@ -572,6 +572,34 @@ public class SwappablePriorityQueue {
         }
     }
 
+    public void putBack(final Collection<FlowFileRecord> flowFiles) {
+        final int count = flowFiles.size();
+        final long bytes = flowFiles.stream().mapToLong(FlowFileRecord::getSize).sum();
+
+        writeLock.lock();
+        try {
+            activeQueue.addAll(flowFiles);
+
+            boolean updated;
+            do {
+                final FlowFileQueueSize currentSize = getFlowFileQueueSize();
+                final FlowFileQueueSize updatedSize = new FlowFileQueueSize(
+                        currentSize.getActiveCount() + count,
+                        currentSize.getActiveBytes() + bytes,
+                        currentSize.getSwappedCount(),
+                        currentSize.getSwappedBytes(),
+                        currentSize.getSwapFileCount(),
+                        currentSize.getUnacknowledgedCount() - count,
+                        currentSize.getUnacknowledgedBytes() - bytes);
+                updated = updateSize(currentSize, updatedSize);
+            } while (!updated);
+
+            updateTopPenaltyExpiration();
+        } finally {
+            writeLock.unlock("putBack");
+        }
+    }
+
     public FlowFileRecord poll(final Set<FlowFileRecord> expiredRecords, final long expirationMillis) {
         return poll(expiredRecords, expirationMillis, PollStrategy.UNPENALIZED_FLOWFILES);
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/StandardRebalancingPartition.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/partition/StandardRebalancingPartition.java
@@ -53,13 +53,20 @@ public class StandardRebalancingPartition implements RebalancingPartition {
     private final LoadBalancedFlowFileQueue flowFileQueue;
     private final String description;
 
+    private final Object lifecycleMonitor = new Object();
+
     private volatile boolean stopped = true;
     private RebalanceTask rebalanceTask;
+    private Thread rebalanceThread;
+    private boolean stopping;
 
     public StandardRebalancingPartition(final FlowFileSwapManager swapManager, final int swapThreshold, final EventReporter eventReporter,
                                         final LoadBalancedFlowFileQueue flowFileQueue, final DropFlowFileAction dropAction) {
+        this(new BlockingSwappablePriorityQueue(swapManager, swapThreshold, eventReporter, flowFileQueue, dropAction, SWAP_PARTITION_NAME), flowFileQueue);
+    }
 
-        this.queue = new BlockingSwappablePriorityQueue(swapManager, swapThreshold, eventReporter, flowFileQueue, dropAction, SWAP_PARTITION_NAME);
+    StandardRebalancingPartition(final BlockingSwappablePriorityQueue queue, final LoadBalancedFlowFileQueue flowFileQueue) {
+        this.queue = queue;
         this.queueIdentifier = flowFileQueue.getIdentifier();
         this.flowFileQueue = flowFileQueue;
         this.description = "RebalancingPartition[queueId=" + queueIdentifier + "]";
@@ -131,28 +138,91 @@ public class StandardRebalancingPartition implements RebalancingPartition {
     }
 
     @Override
-    public synchronized void start(final FlowFilePartitioner partitionerUsed) {
-        stopped = false;
-        rebalanceFromQueue();
+    public void start(final FlowFilePartitioner partitionerUsed) {
+        boolean interrupted = false;
+        synchronized (lifecycleMonitor) {
+            while (stopping) {
+                try {
+                    lifecycleMonitor.wait();
+                } catch (final InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+
+            stopped = false;
+            startRebalanceTask();
+        }
+
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     @Override
-    public synchronized void stop() {
-        stopped = true;
+    public void stop() {
+        final RebalanceTask task;
+        final Thread thread;
+        boolean interrupted = false;
 
-        if (this.rebalanceTask != null) {
-            this.rebalanceTask.stop();
+        synchronized (lifecycleMonitor) {
+            while (stopping) {
+                try {
+                    lifecycleMonitor.wait();
+                } catch (final InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+
+            stopped = true;
+            task = rebalanceTask;
+            thread = rebalanceThread;
+            if (task == null || thread == null) {
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+                return;
+            }
+
+            stopping = true;
         }
 
-        this.rebalanceTask = null;
+        task.stop();
+        thread.interrupt();
+
+        while (thread.isAlive()) {
+            try {
+                thread.join();
+            } catch (final InterruptedException e) {
+                interrupted = true;
+            }
+        }
+
+        synchronized (lifecycleMonitor) {
+            if (rebalanceTask == task) {
+                rebalanceTask = null;
+                rebalanceThread = null;
+            }
+            stopping = false;
+            lifecycleMonitor.notifyAll();
+        }
+
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
     }
 
-    private synchronized void rebalanceFromQueue() {
-        if (stopped) {
-            logger.debug("Will not rebalance from queue because {} is stopped", this);
-            return;
-        }
+    private void rebalanceFromQueue() {
+        synchronized (lifecycleMonitor) {
+            if (stopped) {
+                logger.debug("Will not rebalance from queue because {} is stopped", this);
+                return;
+            }
 
+            startRebalanceTask();
+        }
+    }
+
+    private void startRebalanceTask() {
         // If a task is already defined, do nothing. There's already a thread running.
         if (rebalanceTask != null) {
             logger.debug("Rebalance Task already exists for {}", this);
@@ -161,7 +231,7 @@ public class StandardRebalancingPartition implements RebalancingPartition {
 
         this.rebalanceTask = new RebalanceTask();
 
-        final Thread rebalanceThread = new Thread(this.rebalanceTask);
+        rebalanceThread = new Thread(this.rebalanceTask);
         rebalanceThread.setName("Rebalance queued data for Connection " + queueIdentifier);
         rebalanceThread.start();
         logger.debug("No Rebalance Task currently exists for {}. Starting new Rebalance Thread {}", this, rebalanceThread);
@@ -192,13 +262,24 @@ public class StandardRebalancingPartition implements RebalancingPartition {
         return queue.packageForRebalance(newPartitionName);
     }
 
-    private synchronized boolean isComplete() {
-        if (!queue.isEmpty()) {
-            return false;
+    private boolean isQueueEmpty() {
+        synchronized (lifecycleMonitor) {
+            return queue.isEmpty();
         }
+    }
 
-        this.rebalanceTask = null;
-        return true;
+    private void taskCompleted(final RebalanceTask task) {
+        synchronized (lifecycleMonitor) {
+            if (rebalanceTask == task) {
+                rebalanceTask = null;
+                rebalanceThread = null;
+            }
+
+            if (!stopped && !queue.isEmpty()) {
+                startRebalanceTask();
+            }
+            lifecycleMonitor.notifyAll();
+        }
     }
 
     private class RebalanceTask implements Runnable {
@@ -206,53 +287,67 @@ public class StandardRebalancingPartition implements RebalancingPartition {
         private final Set<FlowFileRecord> expiredRecords = new HashSet<>();
         private final long pollWaitMillis = 100L;
 
-        public void stop() {
+        public synchronized void stop() {
             stopped = true;
+        }
+
+        private synchronized boolean distribute(final Collection<FlowFileRecord> flowFiles) {
+            if (stopped) {
+                return false;
+            }
+
+            flowFileQueue.distributeToPartitions(flowFiles);
+            queue.acknowledge(flowFiles);
+            return true;
         }
 
         @Override
         public void run() {
-            while (!stopped) {
-                final FlowFileRecord polled;
+            try {
+                while (!stopped) {
+                    final FlowFileRecord polled;
 
-                expiredRecords.clear();
+                    expiredRecords.clear();
 
-                // Wait up to #pollWaitMillis milliseconds to get a FlowFile. If none, then check if stopped
-                // and if not, poll again.
-                try {
-                    polled = queue.poll(expiredRecords, -1, pollWaitMillis, PollStrategy.ALL_FLOWFILES);
-                } catch (final InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    continue;
-                }
+                    // Wait up to #pollWaitMillis milliseconds to get a FlowFile. If none, then check if stopped
+                    // and if not, poll again.
+                    try {
+                        polled = queue.poll(expiredRecords, -1, pollWaitMillis, PollStrategy.ALL_FLOWFILES);
+                    } catch (final InterruptedException ie) {
+                        flowFileQueue.handleExpiredRecords(expiredRecords);
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
 
-                if (polled == null) {
+                    if (polled == null) {
+                        flowFileQueue.handleExpiredRecords(expiredRecords);
+
+                        if (isQueueEmpty()) {
+                            logger.debug("Rebalance Task completed for {}", this);
+                            return;
+                        } else {
+                            continue;
+                        }
+                    }
+
+                    // We got 1 FlowFile. Try a second poll to obtain up to 999 more (for a total of 1,000).
+                    final List<FlowFileRecord> toDistribute = new ArrayList<>();
+                    toDistribute.add(polled);
+
+                    final List<FlowFileRecord> additionalRecords = queue.poll(999, expiredRecords, -1, PollStrategy.ALL_FLOWFILES);
+                    toDistribute.addAll(additionalRecords);
+
                     flowFileQueue.handleExpiredRecords(expiredRecords);
 
-                    if (isComplete()) {
-                        logger.debug("Rebalance Task completed for {}", this);
+                    logger.debug("{} Rebalancing {}", this, toDistribute);
+
+                    if (!distribute(toDistribute)) {
+                        queue.putBack(toDistribute);
                         return;
-                    } else {
-                        continue;
                     }
                 }
-
-                // We got 1 FlowFile. Try a second poll to obtain up to 999 more (for a total of 1,000).
-                final List<FlowFileRecord> toDistribute = new ArrayList<>();
-                toDistribute.add(polled);
-
-                final List<FlowFileRecord> additionalRecords = queue.poll(999, expiredRecords, -1, PollStrategy.ALL_FLOWFILES);
-                toDistribute.addAll(additionalRecords);
-
-                flowFileQueue.handleExpiredRecords(expiredRecords);
-
-                logger.debug("{} Rebalancing {}", this, toDistribute);
-
-                // Transfer all of the FlowFiles that we got back to the FlowFileQueue itself. This will cause the data to be
-                // re-partitioned and binned appropriately. We also then need to ensure that we acknowledge the data from our
-                // own SwappablePriorityQueue to ensure that the sizes are kept in check.
-                flowFileQueue.distributeToPartitions(toDistribute);
-                queue.acknowledge(toDistribute);
+            } finally {
+                taskCompleted(this);
             }
         }
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/TestSwappablePriorityQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/TestSwappablePriorityQueue.java
@@ -84,6 +84,23 @@ public class TestSwappablePriorityQueue {
     }
 
     @Test
+    public void testPutBackRestoresPolledFlowFiles() {
+        final FlowFileRecord first = new MockFlowFileRecord(10L);
+        final FlowFileRecord second = new MockFlowFileRecord(20L);
+        queue.putAll(List.of(first, second));
+
+        final List<FlowFileRecord> polled = queue.poll(2, Collections.emptySet(), -1, PollStrategy.ALL_FLOWFILES);
+        assertEquals(new QueueSize(2, 30L), queue.size());
+        assertEquals(2, queue.getQueueDiagnostics().getUnacknowledgedQueueSize().getObjectCount());
+
+        queue.putBack(polled);
+
+        assertEquals(new QueueSize(2, 30L), queue.size());
+        assertEquals(0, queue.getQueueDiagnostics().getUnacknowledgedQueueSize().getObjectCount());
+        assertEquals(2, queue.getActiveFlowFiles().size());
+    }
+
+    @Test
     public void testPrioritizersBigQueue() {
         final FlowFilePrioritizer iAttributePrioritizer = (o1, o2) -> {
             final int i1 = Integer.parseInt(o1.getAttribute("i"));

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/partition/TestStandardRebalancingPartition.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/partition/TestStandardRebalancingPartition.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.controller.queue.clustered.partition;
+
+import org.apache.nifi.controller.MockFlowFileRecord;
+import org.apache.nifi.controller.MockSwapManager;
+import org.apache.nifi.controller.queue.BlockingSwappablePriorityQueue;
+import org.apache.nifi.controller.queue.LoadBalancedFlowFileQueue;
+import org.apache.nifi.controller.queue.PollStrategy;
+import org.apache.nifi.controller.queue.QueueSize;
+import org.apache.nifi.controller.repository.FlowFileRecord;
+import org.apache.nifi.events.EventReporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestStandardRebalancingPartition {
+    private LoadBalancedFlowFileQueue flowFileQueue;
+    private ControllableBlockingQueue queue;
+    private StandardRebalancingPartition partition;
+
+    @BeforeEach
+    void setUp() {
+        flowFileQueue = mock(LoadBalancedFlowFileQueue.class);
+        when(flowFileQueue.getIdentifier()).thenReturn("unit-test");
+        queue = new ControllableBlockingQueue(flowFileQueue);
+        partition = new StandardRebalancingPartition(queue, flowFileQueue);
+    }
+
+    @Test
+    @Timeout(10)
+    void testStopInterruptsBlockedPollAndWaitsForWorker() throws Exception {
+        final BlockingPollQueue blockingQueue = new BlockingPollQueue(flowFileQueue);
+        final StandardRebalancingPartition blockingPartition = new StandardRebalancingPartition(blockingQueue, flowFileQueue);
+        blockingPartition.start(mock(FlowFilePartitioner.class));
+        assertTrue(blockingQueue.awaitPoll());
+
+        try (final ExecutorService executor = Executors.newSingleThreadExecutor()) {
+            final Future<?> stopFuture = executor.submit(blockingPartition::stop);
+            assertTrue(blockingQueue.awaitStopInterrupt());
+            assertFalse(stopFuture.isDone());
+
+            blockingQueue.releasePoll();
+            stopFuture.get(5, TimeUnit.SECONDS);
+        }
+
+        verify(flowFileQueue, never()).distributeToPartitions(org.mockito.ArgumentMatchers.anyCollection());
+    }
+
+    @Test
+    @Timeout(10)
+    void testStopRestoresPolledFlowFilesBeforeRestart() throws Exception {
+        final FlowFileRecord flowFile = new MockFlowFileRecord(10L);
+        partition.rebalance(List.of(flowFile));
+        partition.start(mock(FlowFilePartitioner.class));
+
+        assertTrue(queue.awaitBatchPoll());
+
+        try (final ExecutorService executor = Executors.newSingleThreadExecutor()) {
+            final Future<?> stopFuture = executor.submit(partition::stop);
+            assertTrue(queue.awaitStopInterrupt());
+            queue.releaseBatchPoll();
+            stopFuture.get(5, TimeUnit.SECONDS);
+        }
+
+        verify(flowFileQueue, never()).distributeToPartitions(org.mockito.ArgumentMatchers.anyCollection());
+        assertEquals(new QueueSize(1, 10L), partition.size());
+
+        partition.start(mock(FlowFilePartitioner.class));
+        verify(flowFileQueue, timeout(5000).times(1)).distributeToPartitions(List.of(flowFile));
+        partition.stop();
+        assertEquals(new QueueSize(0, 0L), partition.size());
+    }
+
+    @Test
+    @Timeout(10)
+    void testStartWaitsForStopToComplete() throws Exception {
+        final FlowFileRecord flowFile = new MockFlowFileRecord(10L);
+        partition.rebalance(List.of(flowFile));
+        partition.start(mock(FlowFilePartitioner.class));
+        assertTrue(queue.awaitBatchPoll());
+
+        try (final ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            final Future<?> stopFuture = executor.submit(partition::stop);
+            assertTrue(queue.awaitStopInterrupt());
+
+            final CountDownLatch startInvoked = new CountDownLatch(1);
+            final Future<?> startFuture = executor.submit(() -> {
+                startInvoked.countDown();
+                partition.start(mock(FlowFilePartitioner.class));
+            });
+            assertTrue(startInvoked.await(5, TimeUnit.SECONDS));
+            verify(flowFileQueue, never()).distributeToPartitions(org.mockito.ArgumentMatchers.anyCollection());
+            assertFalse(startFuture.isDone());
+
+            queue.releaseBatchPoll();
+            stopFuture.get(5, TimeUnit.SECONDS);
+            startFuture.get(5, TimeUnit.SECONDS);
+        }
+
+        verify(flowFileQueue, timeout(5000).times(1)).distributeToPartitions(List.of(flowFile));
+        partition.stop();
+        assertEquals(new QueueSize(0, 0L), partition.size());
+    }
+
+    private static class ControllableBlockingQueue extends BlockingSwappablePriorityQueue {
+        private final CountDownLatch batchPollEntered = new CountDownLatch(1);
+        private final CountDownLatch stopInterruptObserved = new CountDownLatch(1);
+        private final CountDownLatch releaseBatchPoll = new CountDownLatch(1);
+        private final AtomicBoolean blockBatchPoll = new AtomicBoolean(true);
+
+        ControllableBlockingQueue(final LoadBalancedFlowFileQueue flowFileQueue) {
+            super(new MockSwapManager(), 10000, EventReporter.NO_OP, flowFileQueue, (flowFiles, requestor) -> new QueueSize(0, 0L), "rebalance");
+        }
+
+        @Override
+        public List<FlowFileRecord> poll(final int maxResults, final Set<FlowFileRecord> expiredRecords,
+                                        final long expirationMillis, final PollStrategy pollStrategy) {
+            if (blockBatchPoll.compareAndSet(true, false)) {
+                batchPollEntered.countDown();
+                boolean interrupted = false;
+                while (true) {
+                    try {
+                        releaseBatchPoll.await();
+                        break;
+                    } catch (final InterruptedException e) {
+                        interrupted = true;
+                        stopInterruptObserved.countDown();
+                    }
+                }
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            return Collections.emptyList();
+        }
+
+        boolean awaitBatchPoll() throws InterruptedException {
+            return batchPollEntered.await(5, TimeUnit.SECONDS);
+        }
+
+        boolean awaitStopInterrupt() throws InterruptedException {
+            return stopInterruptObserved.await(5, TimeUnit.SECONDS);
+        }
+
+        void releaseBatchPoll() {
+            releaseBatchPoll.countDown();
+        }
+    }
+
+    private static class BlockingPollQueue extends BlockingSwappablePriorityQueue {
+        private final CountDownLatch pollEntered = new CountDownLatch(1);
+        private final CountDownLatch stopInterruptObserved = new CountDownLatch(1);
+        private final CountDownLatch releasePoll = new CountDownLatch(1);
+
+        BlockingPollQueue(final LoadBalancedFlowFileQueue flowFileQueue) {
+            super(new MockSwapManager(), 10000, EventReporter.NO_OP, flowFileQueue, (flowFiles, requestor) -> new QueueSize(0, 0L), "rebalance");
+        }
+
+        @Override
+        public FlowFileRecord poll(final Set<FlowFileRecord> expiredRecords, final long expirationMillis,
+                                   final long waitMillis, final PollStrategy pollStrategy) throws InterruptedException {
+            pollEntered.countDown();
+            boolean interrupted = false;
+            while (true) {
+                try {
+                    releasePoll.await();
+                    break;
+                } catch (final InterruptedException e) {
+                    interrupted = true;
+                    stopInterruptObserved.countDown();
+                }
+            }
+            if (interrupted) {
+                throw new InterruptedException();
+            }
+            return null;
+        }
+
+        boolean awaitPoll() throws InterruptedException {
+            return pollEntered.await(5, TimeUnit.SECONDS);
+        }
+
+        boolean awaitStopInterrupt() throws InterruptedException {
+            return stopInterruptObserved.await(5, TimeUnit.SECONDS);
+        }
+
+        void releasePoll() {
+            releasePoll.countDown();
+        }
+    }
+}


### PR DESCRIPTION
# Summary

NIFI-16180 - Ensure Rebalancing Worker Stops Before Returning

This change fixes a recurring race in `TestSocketLoadBalancedFlowFileQueue` by ensuring the rebalancing worker has fully stopped before `stop()` returns. It also prevents stop and start operations from overlapping and safely returns any FlowFiles already picked up by the worker so they remain correctly counted and are redistributed once after restart.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
