### PR TITLE
NIFI-16179 add optional includeReferencingComponents query parameter to parameter context endpoints

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ParameterContextMerger.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/ParameterContextMerger.java
@@ -62,6 +62,8 @@ public class ParameterContextMerger {
     public static void merge(final ParameterContextDTO target, final Map<NodeIdentifier, ParameterContextDTO> entityMap) {
         final Map<String, ProcessGroupEntity> mergedBoundGroups = new HashMap<>();
         final Map<String, Map<String, AffectedComponentEntity>> affectedComponentsByParameterName = new HashMap<>();
+        final Set<String> parameterNamesWithReferencingComponents = new HashSet<>();
+        final Set<String> parameterNamesWithNullReferencingComponents = new HashSet<>();
 
         final Set<String> unwritableParameters = new HashSet<>();
         for (final Map.Entry<NodeIdentifier, ParameterContextDTO> entry : entityMap.entrySet()) {
@@ -94,14 +96,19 @@ public class ParameterContextMerger {
 
                     final Map<String, AffectedComponentEntity> affectedComponentsById = affectedComponentsByParameterName.computeIfAbsent(parameterDto.getName(), key -> new HashMap<>());
 
-                    for (final AffectedComponentEntity referencingComponent : parameterDto.getReferencingComponents()) {
-                        AffectedComponentEntity mergedAffectedComponent = affectedComponentsById.get(referencingComponent.getId());
-                        if (mergedAffectedComponent == null) {
-                            affectedComponentsById.put(referencingComponent.getId(), referencingComponent);
-                            continue;
-                        }
+                    if (parameterDto.getReferencingComponents() != null) {
+                        parameterNamesWithReferencingComponents.add(parameterDto.getName());
+                        for (final AffectedComponentEntity referencingComponent : parameterDto.getReferencingComponents()) {
+                            AffectedComponentEntity mergedAffectedComponent = affectedComponentsById.get(referencingComponent.getId());
+                            if (mergedAffectedComponent == null) {
+                                affectedComponentsById.put(referencingComponent.getId(), referencingComponent);
+                                continue;
+                            }
 
-                        merge(mergedAffectedComponent, referencingComponent);
+                            merge(mergedAffectedComponent, referencingComponent);
+                        }
+                    } else {
+                        parameterNamesWithNullReferencingComponents.add(parameterDto.getName());
                     }
                 }
             }
@@ -117,8 +124,15 @@ public class ParameterContextMerger {
                 parameterEntity.setCanWrite(false);
             }
 
-            final Map<String, AffectedComponentEntity> componentMap = affectedComponentsByParameterName.get(parameterDto.getName());
-            parameterDto.setReferencingComponents(new HashSet<>(componentMap.values()));
+            // Only overwrite referencing components when every node that reported on this parameter agreed it should be
+            // included. If nodes disagree (e.g. version skew during a rolling upgrade, where an older node ignores the
+            // includeReferencingComponents parameter and always returns a populated set while newer nodes return null),
+            // leave the DTO's existing value (null) as-is rather than expose a misleading, single-node-derived partial set.
+            if (parameterNamesWithReferencingComponents.contains(parameterDto.getName())
+                    && !parameterNamesWithNullReferencingComponents.contains(parameterDto.getName())) {
+                final Map<String, AffectedComponentEntity> componentMap = affectedComponentsByParameterName.get(parameterDto.getName());
+                parameterDto.setReferencingComponents(new HashSet<>(componentMap.values()));
+            }
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ParameterContextMergerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/ParameterContextMergerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.cluster.coordination.http.endpoints;
+
+import org.apache.nifi.cluster.protocol.NodeIdentifier;
+import org.apache.nifi.web.api.dto.ParameterContextDTO;
+import org.apache.nifi.web.api.dto.ParameterDTO;
+import org.apache.nifi.web.api.entity.AffectedComponentEntity;
+import org.apache.nifi.web.api.entity.ParameterEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ParameterContextMergerTest {
+
+    @Test
+    void testMergePreservesNullReferencingComponentsWhenExcludedByEveryNode() {
+        final Map<NodeIdentifier, ParameterContextDTO> entityMap = new HashMap<>();
+        entityMap.put(getNodeIdentifier("node1", 8000), createParameterContextDto("param1", null));
+        entityMap.put(getNodeIdentifier("node2", 8010), createParameterContextDto("param1", null));
+
+        final ParameterContextDTO target = createParameterContextDto("param1", null);
+
+        ParameterContextMerger.merge(target, entityMap);
+
+        final ParameterDTO mergedParameter = target.getParameters().iterator().next().getParameter();
+        assertNull(mergedParameter.getReferencingComponents(),
+                "Referencing components should remain null when every node excluded them from its response, rather than being coerced into an empty collection");
+    }
+
+    @Test
+    void testMergeCombinesReferencingComponentsAcrossNodesWhenIncluded() {
+        final Map<NodeIdentifier, ParameterContextDTO> entityMap = new HashMap<>();
+        entityMap.put(getNodeIdentifier("node1", 8000), createParameterContextDto("param1", Set.of(createAffectedComponent("component1"))));
+        entityMap.put(getNodeIdentifier("node2", 8010), createParameterContextDto("param1", Set.of(createAffectedComponent("component2"))));
+
+        final ParameterContextDTO target = createParameterContextDto("param1", Set.of());
+
+        ParameterContextMerger.merge(target, entityMap);
+
+        final ParameterDTO mergedParameter = target.getParameters().iterator().next().getParameter();
+        assertNotNull(mergedParameter.getReferencingComponents());
+        assertEquals(2, mergedParameter.getReferencingComponents().size());
+    }
+
+    @Test
+    void testMergeLeavesReferencingComponentsNullWhenNodesDisagree() {
+        // node1 reports a populated set, node2 reports null for the same parameter (e.g. version skew during
+        // a rolling upgrade where an older node ignores includeReferencingComponents and always returns full data).
+        final Map<NodeIdentifier, ParameterContextDTO> entityMap = new HashMap<>();
+        entityMap.put(getNodeIdentifier("node1", 8000), createParameterContextDto("param1", Set.of(createAffectedComponent("component1"))));
+        entityMap.put(getNodeIdentifier("node2", 8010), createParameterContextDto("param1", null));
+
+        final ParameterContextDTO target = createParameterContextDto("param1", null);
+
+        ParameterContextMerger.merge(target, entityMap);
+
+        final ParameterDTO mergedParameter = target.getParameters().iterator().next().getParameter();
+        assertNull(mergedParameter.getReferencingComponents(),
+                "Referencing components should stay null when nodes disagree, rather than exposing a partial single-node set");
+    }
+
+    private ParameterContextDTO createParameterContextDto(final String parameterName, final Set<AffectedComponentEntity> referencingComponents) {
+        final ParameterDTO parameterDto = new ParameterDTO();
+        parameterDto.setName(parameterName);
+        parameterDto.setReferencingComponents(referencingComponents);
+
+        final ParameterEntity parameterEntity = new ParameterEntity();
+        parameterEntity.setParameter(parameterDto);
+        parameterEntity.setCanWrite(true);
+
+        final ParameterContextDTO contextDto = new ParameterContextDTO();
+        contextDto.setId("context1");
+        contextDto.setParameters(new HashSet<>(Set.of(parameterEntity)));
+        contextDto.setBoundProcessGroups(new HashSet<>());
+
+        return contextDto;
+    }
+
+    private AffectedComponentEntity createAffectedComponent(final String id) {
+        final AffectedComponentEntity entity = new AffectedComponentEntity();
+        entity.setId(id);
+        return entity;
+    }
+
+    private NodeIdentifier getNodeIdentifier(final String id, final int port) {
+        return new NodeIdentifier(id, "localhost", port, "localhost", port + 1, "localhost", port + 2, port + 3, true);
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -294,11 +294,12 @@ public interface NiFiServiceFacade {
      * Returns the parameter context bound to the specified process group within the connector's hierarchy. Sensitive parameter values are masked
      * by the underlying DTO factory.
      *
-     * @param connectorId the connector id
-     * @param processGroupId the process group id within the connector's hierarchy
+     * @param connectorId       the connector id
+     * @param processGroupId    the process group id within the connector's hierarchy
+     * @param includeReferences whether to include parameters' referencing components
      * @return the parameter context entity with effective parameters (inherited included), or {@code null} if the process group has no bound parameter context
      */
-    ParameterContextEntity getConnectorParameterContext(String connectorId, String processGroupId);
+    ParameterContextEntity getConnectorParameterContext(String connectorId, String processGroupId, boolean includeReferences);
 
     void verifyCanVerifyConnectorConfigurationStep(String connectorId, String configurationStepName);
 
@@ -1407,9 +1408,10 @@ public interface NiFiServiceFacade {
 
     /**
      * Returns the Set of all Parameter Context Entities for the current user
+     * @param includeReferences whether to include parameters' referencing components
      * @return the Set of all Parameter Context Entities for the current user
      */
-    Set<ParameterContextEntity> getParameterContexts();
+    Set<ParameterContextEntity> getParameterContexts(boolean includeReferences);
 
     /**
      * Returns the Parameter Context with the given name
@@ -1425,33 +1427,39 @@ public interface NiFiServiceFacade {
      * @param parameterContextId the ID of the Parameter Context
      * @param includeInheritedParameters Whether to include inherited parameters (and thus overridden values)
      * @param user the user on whose behalf the Parameter Context is being retrieved
+     * @param includeReferences whether to include parameters' referencing components
      * @return the ParameterContextEntity
      */
-    ParameterContextEntity getParameterContext(String parameterContextId, boolean includeInheritedParameters, NiFiUser user);
+    ParameterContextEntity getParameterContext(String parameterContextId, boolean includeInheritedParameters, NiFiUser user, boolean includeReferences);
 
     /**
      * Creates a new Parameter Context
-     * @param revision the revision for the newly created Parameter Context
-     * @param parameterContext the Parameter Context
+     *
+     * @param revision          the revision for the newly created Parameter Context
+     * @param parameterContext  the Parameter Context
+     * @param includeReferences whether to include parameters' referencing components
      * @return a ParameterContextEntity representing the newly created ParameterContext
      */
-    ParameterContextEntity createParameterContext(Revision revision, ParameterContextDTO parameterContext);
+    ParameterContextEntity createParameterContext(Revision revision, ParameterContextDTO parameterContext, boolean includeReferences);
 
     /**
      * Updates the Parameter Context
      * @param revision the current revision of the Parameter Context
      * @param parameterContext the updated version of the ParameterContext
+     * @param includeReferences whether to include parameters' referencing components
      * @return the updated Parameter Context Entity
      */
-    ParameterContextEntity updateParameterContext(Revision revision, ParameterContextDTO parameterContext);
+    ParameterContextEntity updateParameterContext(Revision revision, ParameterContextDTO parameterContext, boolean includeReferences);
 
     /**
      * Deletes the Parameter Context
-     * @param revision the revision of the Parameter Context
+     *
+     * @param revision           the revision of the Parameter Context
      * @param parameterContextId the ID of the Parameter Context
+     * @param includeReferences  whether to include parameters' referencing components
      * @return a Parameter Context Entity that represents the Parameter Context that was deleted
      */
-    ParameterContextEntity deleteParameterContext(Revision revision, String parameterContextId);
+    ParameterContextEntity deleteParameterContext(Revision revision, String parameterContextId, boolean includeReferences);
 
     /**
      * Performs validation of all components that make use of the Parameter Context with the same ID as the given DTO, but validating against the Parameters
@@ -2736,12 +2744,16 @@ public interface NiFiServiceFacade {
     /**
      * Returns a list of ParameterContext entities representing updates needed in order to apply the fetched
      * parameters from the parameter provider to the referencing parameter contexts
-     * @param parameterProviderId parameter provider id
+     *
+     * @param parameterProviderId          parameter provider id
      * @param parameterGroupConfigurations Configuration for each fetched Parameter Group.  Any parameters not found in this set will not be included in the update.
+     * @param includeReferences            whether to include parameters' referencing components
      * @return The list of ParameterContextEntity objects representing required updates to referencing
      * parameter contexts
      */
-    List<ParameterContextEntity> getParameterContextUpdatesForAppliedParameters(String parameterProviderId, Collection<ParameterGroupConfiguration> parameterGroupConfigurations);
+    List<ParameterContextEntity> getParameterContextUpdatesForAppliedParameters(String parameterProviderId,
+                                                                                Collection<ParameterGroupConfiguration> parameterGroupConfigurations,
+                                                                                boolean includeReferences);
 
     /**
      * Gets the references for specified parameter provider.

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -1378,13 +1378,13 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public ParameterContextEntity updateParameterContext(final Revision revision, final ParameterContextDTO parameterContextDto) {
+    public ParameterContextEntity updateParameterContext(final Revision revision, final ParameterContextDTO parameterContextDto, final boolean includeReferences) {
         // get the component, ensure we have access to it, and perform the update request
         final ParameterContext parameterContext = parameterContextDAO.getParameterContext(parameterContextDto.getId());
         final RevisionUpdate<ParameterContextDTO> snapshot = updateComponent(revision,
                 parameterContext,
                 () -> parameterContextDAO.updateParameterContext(parameterContextDto),
-                context -> dtoFactory.createParameterContextDto(context, revisionManager, false, parameterContextDAO));
+                context -> dtoFactory.createParameterContextDto(context, revisionManager, false, parameterContextDAO, includeReferences));
 
         final PermissionsDTO permissions = dtoFactory.createPermissionsDto(parameterContext);
         final RevisionDTO revisionDto = dtoFactory.createRevisionDTO(snapshot.getLastModification());
@@ -1393,17 +1393,17 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public ParameterContextEntity getParameterContext(final String parameterContextId, final boolean includeInheritedParameters, final NiFiUser user) {
+    public ParameterContextEntity getParameterContext(final String parameterContextId, final boolean includeInheritedParameters, final NiFiUser user, final boolean includeReferences) {
         final ParameterContext parameterContext = parameterContextDAO.getParameterContext(parameterContextId);
-        return createParameterContextEntity(parameterContext, includeInheritedParameters, user, parameterContextDAO);
+        return createParameterContextEntity(parameterContext, includeInheritedParameters, user, parameterContextDAO, includeReferences);
     }
 
     @Override
-    public Set<ParameterContextEntity> getParameterContexts() {
+    public Set<ParameterContextEntity> getParameterContexts(final boolean includeReferences) {
         final NiFiUser user = NiFiUserUtils.getNiFiUser();
 
         final Set<ParameterContextEntity> entities = parameterContextDAO.getParameterContexts().stream()
-                .map(context -> createParameterContextEntity(context, false, user, parameterContextDAO))
+                .map(context -> createParameterContextEntity(context, false, user, parameterContextDAO, includeReferences))
                 .collect(Collectors.toSet());
 
         return entities;
@@ -1432,11 +1432,11 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     private ParameterContextEntity createParameterContextEntity(final ParameterContext parameterContext, final boolean includeInheritedParameters, final NiFiUser user,
-                                                                final ParameterContextLookup parameterContextLookup) {
+                                                                final ParameterContextLookup parameterContextLookup, final boolean includeReferences) {
         final PermissionsDTO permissions = dtoFactory.createPermissionsDto(parameterContext, user);
         final RevisionDTO revisionDto = dtoFactory.createRevisionDTO(revisionManager.getRevision(parameterContext.getIdentifier()));
         final ParameterContextDTO parameterContextDto = dtoFactory.createParameterContextDto(parameterContext, revisionManager, includeInheritedParameters,
-                parameterContextLookup);
+                parameterContextLookup, includeReferences);
         final ParameterContextEntity entity = entityFactory.createParameterContextEntity(parameterContextDto, revisionDto, permissions);
         return entity;
     }
@@ -1538,7 +1538,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public ParameterContextEntity createParameterContext(final Revision revision, final ParameterContextDTO parameterContextDto) {
+    public ParameterContextEntity createParameterContext(final Revision revision, final ParameterContextDTO parameterContextDto, final boolean includeReferences) {
         final NiFiUser user = NiFiUserUtils.getNiFiUser();
 
         // request claim for component to be created... revision already verified (version == 0)
@@ -1553,7 +1553,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
             controllerFacade.save();
 
             final ParameterContextDTO dto = dtoFactory.createParameterContextDto(parameterContext, revisionManager, false,
-                    parameterContextDAO);
+                    parameterContextDAO, includeReferences);
             final FlowModification lastMod = new FlowModification(revision.incrementRevision(revision.getClientId()), user.getIdentity());
             return new StandardRevisionUpdate<>(dto, lastMod);
         });
@@ -1570,7 +1570,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public ParameterContextEntity deleteParameterContext(final Revision revision, final String parameterContextId) {
+    public ParameterContextEntity deleteParameterContext(final Revision revision, final String parameterContextId, final boolean includeReferences) {
         final ParameterContext parameterContext = parameterContextDAO.getParameterContext(parameterContextId);
         final PermissionsDTO permissions = dtoFactory.createPermissionsDto(parameterContext);
         final ParameterContextDTO snapshot = deleteComponent(
@@ -1578,7 +1578,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
                 parameterContext.getResource(),
                 () -> parameterContextDAO.deleteParameterContext(parameterContextId),
                 true,
-                dtoFactory.createParameterContextDto(parameterContext, revisionManager, false, parameterContextDAO));
+                dtoFactory.createParameterContextDto(parameterContext, revisionManager, false, parameterContextDAO, includeReferences));
 
         return entityFactory.createParameterContextEntity(snapshot, null, permissions);
 
@@ -4132,7 +4132,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public ParameterContextEntity getConnectorParameterContext(final String connectorId, final String processGroupId) {
+    public ParameterContextEntity getConnectorParameterContext(final String connectorId, final String processGroupId, final boolean includeReferences) {
         final ConnectorNode connectorNode = connectorDAO.getConnector(connectorId, ConnectorSyncMode.LOCAL_ONLY);
         final ProcessGroup managedProcessGroup = connectorNode.getActiveFlowContext().getManagedProcessGroup();
         final ProcessGroup targetProcessGroup = managedProcessGroup.findProcessGroup(processGroupId);
@@ -4149,7 +4149,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         // global flow's ParameterContextManager, so a DAO-backed lookup would fail to resolve inherited parameters.
         // The DTO factory walks the in-memory inheritance graph reachable from the supplied context to resolve
         // parameter source contexts for connector-managed flows, making an empty lookup safe here.
-        return createParameterContextEntity(parameterContext, true, NiFiUserUtils.getNiFiUser(), ParameterContextLookup.EMPTY);
+        return createParameterContextEntity(parameterContext, true, NiFiUserUtils.getNiFiUser(), ParameterContextLookup.EMPTY, includeReferences);
     }
 
     @Override
@@ -4437,7 +4437,9 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public List<ParameterContextEntity> getParameterContextUpdatesForAppliedParameters(final String parameterProviderId, final Collection<ParameterGroupConfiguration> parameterGroupConfigurations) {
+    public List<ParameterContextEntity> getParameterContextUpdatesForAppliedParameters(final String parameterProviderId,
+                                                                                       final Collection<ParameterGroupConfiguration> parameterGroupConfigurations,
+                                                                                       final boolean includeReferences) {
         final NiFiUser user = NiFiUserUtils.getNiFiUser();
         final Map<String, ParameterGroupConfiguration> parameterGroupConfigurationMap = parameterGroupConfigurations.stream()
                 .collect(Collectors.toMap(ParameterGroupConfiguration::getParameterContextName, Function.identity()));
@@ -4448,7 +4450,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
                 .map(parametersApplication -> {
                     final ParameterContext parameterContext = parametersApplication.getParameterContext();
                     final ParameterGroupConfiguration parameterGroupConfiguration = parameterGroupConfigurationMap.get(parameterContext.getName());
-                    final ParameterContextEntity entity = createParameterContextEntity(parameterContext, false, user, parameterContextDAO);
+                    final ParameterContextEntity entity = createParameterContextEntity(parameterContext, false, user, parameterContextDAO, includeReferences);
                     final ParameterProviderConfigurationDTO parameterProviderConfiguration = entity.getComponent().getParameterProviderConfiguration().getComponent();
                     parameterProviderConfiguration.setSynchronized(parameterGroupConfiguration.isSynchronized());
 
@@ -4477,7 +4479,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
                                 updatedParameterEntities.add(parameterEntity);
                             }
                         } else {
-                            parameterEntity = dtoFactory.createParameterEntity(parameterContext, parameter, revisionManager, parameterContextDAO);
+                            parameterEntity = dtoFactory.createParameterEntity(parameterContext, parameter, revisionManager, parameterContextDAO, includeReferences);
                             // Need to unmask in order to actually apply the value
                             if (parameterEntity.getParameter() != null && parameterEntity.getParameter().getSensitive() != null
                                     && parameterEntity.getParameter().getSensitive()) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
@@ -122,6 +122,7 @@ public abstract class ApplicationResource {
     public static final String VERSION = "version";
     public static final String CLIENT_ID = "clientId";
     public static final String DISCONNECTED_NODE_ACKNOWLEDGED = "disconnectedNodeAcknowledged";
+    public static final String INCLUDE_REFERENCING_COMPONENTS = "includeReferencingComponents";
 
     protected static final String NON_GUARANTEED_ENDPOINT = "Note: This endpoint is subject to change as NiFi and it's REST API evolve.";
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ConnectorResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ConnectorResource.java
@@ -2061,7 +2061,7 @@ public class ConnectorResource extends ApplicationResource {
             @QueryParam("includeDescendantGroups")
             @DefaultValue("false") final boolean includeDescendantGroups,
             @Parameter(description = "Whether or not to include services' referencing components in the response")
-            @QueryParam("includeReferencingComponents")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS)
             @DefaultValue("true") final boolean includeReferences) {
 
         if (isReplicateRequest()) {
@@ -2123,7 +2123,9 @@ public class ConnectorResource extends ApplicationResource {
             @Parameter(description = "The connector id.", required = true)
             @PathParam("connectorId") final String connectorId,
             @Parameter(description = "The process group id.", required = true)
-            @PathParam("processGroupId") final String processGroupId) {
+            @PathParam("processGroupId") final String processGroupId,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
 
         if (isReplicateRequest()) {
             return replicate(HttpMethod.GET);
@@ -2135,7 +2137,7 @@ public class ConnectorResource extends ApplicationResource {
             connector.authorize(authorizer, RequestAction.READ, NiFiUserUtils.getNiFiUser());
         });
 
-        final ParameterContextEntity entity = serviceFacade.getConnectorParameterContext(connectorId, processGroupId);
+        final ParameterContextEntity entity = serviceFacade.getConnectorParameterContext(connectorId, processGroupId, includeReferences);
         if (entity == null) {
             return Response.noContent().build();
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
@@ -648,7 +648,7 @@ public class FlowResource extends ApplicationResource {
     )
     public Response getControllerServicesFromController(
             @Parameter(description = "Whether or not to include services' referencing components in the response")
-            @QueryParam("includeReferencingComponents") @DefaultValue("true")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true")
             boolean includeReferences,
             @QueryParam("uiOnly") @DefaultValue("false")
             final boolean uiOnly) {
@@ -711,7 +711,7 @@ public class FlowResource extends ApplicationResource {
             @QueryParam("includeDescendantGroups")
             @DefaultValue("false") final boolean includeDescendantGroups,
             @Parameter(description = "Whether or not to include services' referencing components in the response")
-            @QueryParam("includeReferencingComponents")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS)
             @DefaultValue("true") final boolean includeReferences,
             @QueryParam("uiOnly")
             @DefaultValue("false") final boolean uiOnly) {
@@ -3839,14 +3839,16 @@ public class FlowResource extends ApplicationResource {
                     @SecurityRequirement(name = "Read - /parameter-contexts/{id} for each Parameter Context")
             }
     )
-    public Response getParameterContexts() {
+    public Response getParameterContexts(
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
         authorizeFlow();
 
         if (isReplicateRequest()) {
             return replicate(HttpMethod.GET);
         }
 
-        final Set<ParameterContextEntity> parameterContexts = serviceFacade.getParameterContexts();
+        final Set<ParameterContextEntity> parameterContexts = serviceFacade.getParameterContexts(includeReferences);
         parameterContexts.forEach(entity -> entity.setUri(generateResourceUri("parameter-contexts", entity.getId())));
 
         final ParameterContextsEntity entity = new ParameterContextsEntity();

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ParameterContextResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ParameterContextResource.java
@@ -246,7 +246,9 @@ public class ParameterContextResource extends AbstractParameterResource {
                     description = "Whether or not to include inherited parameters from other parameter contexts, and therefore also overridden values.  " +
                             "If true, the result will be the 'effective' parameter context."
             ) @QueryParam("includeInheritedParameters")
-            @DefaultValue("false") final boolean includeInheritedParameters) {
+            @DefaultValue("false") final boolean includeInheritedParameters,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
         // authorize access
         authorizeReadParameterContext(parameterContextId);
 
@@ -255,7 +257,7 @@ public class ParameterContextResource extends AbstractParameterResource {
         }
 
         // get the specified parameter context
-        final ParameterContextEntity entity = serviceFacade.getParameterContext(parameterContextId, includeInheritedParameters, NiFiUserUtils.getNiFiUser());
+        final ParameterContextEntity entity = serviceFacade.getParameterContext(parameterContextId, includeInheritedParameters, NiFiUserUtils.getNiFiUser(), includeReferences);
         entity.setUri(generateResourceUri("parameter-contexts", entity.getId()));
 
         // generate the response
@@ -281,7 +283,9 @@ public class ParameterContextResource extends AbstractParameterResource {
             }
     )
     public Response createParameterContext(
-            @Parameter(description = "The Parameter Context.", required = true) final ParameterContextEntity requestEntity) {
+            @Parameter(description = "The Parameter Context.", required = true) final ParameterContextEntity requestEntity,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
 
         if (requestEntity == null || requestEntity.getComponent() == null) {
             throw new IllegalArgumentException("Parameter Context must be specified");
@@ -317,7 +321,7 @@ public class ParameterContextResource extends AbstractParameterResource {
                     entity.getComponent().setId(contextId);
 
                     final Revision revision = getRevision(entity.getRevision(), contextId);
-                    final ParameterContextEntity contextEntity = serviceFacade.createParameterContext(revision, entity.getComponent());
+                    final ParameterContextEntity contextEntity = serviceFacade.createParameterContext(revision, entity.getComponent(), includeReferences);
 
                     // generate a 201 created response
                     final String uri = generateResourceUri("parameter-contexts", contextEntity.getId());
@@ -354,7 +358,9 @@ public class ParameterContextResource extends AbstractParameterResource {
     )
     public Response updateParameterContext(
             @PathParam("id") String contextId,
-            @Parameter(description = "The updated Parameter Context", required = true) final ParameterContextEntity requestEntity) {
+            @Parameter(description = "The updated Parameter Context", required = true) final ParameterContextEntity requestEntity,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
 
         // Validate request
         if (requestEntity.getId() == null) {
@@ -395,7 +401,7 @@ public class ParameterContextResource extends AbstractParameterResource {
                 lookup -> authorizeReadWriteParameterContextWithComponents(lookup, contextId, requestEntity, affectedComponents, user),
                 () -> serviceFacade.verifyUpdateParameterContext(updateDto, true),
                 (rev, entity) -> {
-                    final ParameterContextEntity updatedEntity = serviceFacade.updateParameterContext(rev, entity.getComponent());
+                    final ParameterContextEntity updatedEntity = serviceFacade.updateParameterContext(rev, entity.getComponent(), includeReferences);
 
                     updatedEntity.setUri(generateResourceUri("parameter-contexts", entity.getId()));
                     return generateOkResponse(updatedEntity).build();
@@ -458,7 +464,7 @@ public class ParameterContextResource extends AbstractParameterResource {
 
         // Get the context or throw ResourceNotFoundException
         final NiFiUser user = NiFiUserUtils.getNiFiUser();
-        final ParameterContextEntity contextEntity = serviceFacade.getParameterContext(contextId, false, user);
+        final ParameterContextEntity contextEntity = serviceFacade.getParameterContext(contextId, false, user, false);
         final Set<AffectedComponentEntity> affectedComponents = serviceFacade.getComponentsAffectedByParameterContextUpdate(Collections.singletonList(contextEntity.getComponent()));
         final Optional<Asset> previousAsset = assetManager.getAssets(contextId).stream().filter(asset -> asset.getName().equals(sanitizedAssetName)).findAny();
 
@@ -653,7 +659,7 @@ public class ParameterContextResource extends AbstractParameterResource {
 
         // Get the context or throw ResourceNotFoundException
         final NiFiUser user = NiFiUserUtils.getNiFiUser();
-        final ParameterContextEntity contextEntity = serviceFacade.getParameterContext(parameterContextId, false, user);
+        final ParameterContextEntity contextEntity = serviceFacade.getParameterContext(parameterContextId, false, user, false);
 
         final AssetDTO assetDTO = new AssetDTO();
         assetDTO.setId(assetId);
@@ -711,7 +717,9 @@ public class ParameterContextResource extends AbstractParameterResource {
     )
     public Response submitParameterContextUpdate(
             @PathParam("contextId") final String contextId,
-            @Parameter(description = "The updated version of the parameter context.", required = true) final ParameterContextEntity requestEntity) {
+            @Parameter(description = "The updated version of the parameter context.", required = true) final ParameterContextEntity requestEntity,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
 
         if (requestEntity == null) {
             throw new IllegalArgumentException("Parameter Context must be specified.");
@@ -773,7 +781,7 @@ public class ParameterContextResource extends AbstractParameterResource {
                     // Verify Request
                     serviceFacade.verifyUpdateParameterContext(contextDto, false);
                 },
-                this::submitUpdateRequest
+                (rev, wrapper) -> submitUpdateRequest(rev, wrapper, includeReferences)
         );
     }
 
@@ -914,11 +922,13 @@ public class ParameterContextResource extends AbstractParameterResource {
             @Parameter(description = "The ID of the Parameter Context")
             @PathParam("contextId") final String contextId,
             @Parameter(description = "The ID of the Update Request")
-            @PathParam("requestId") final String updateRequestId) {
+            @PathParam("requestId") final String updateRequestId,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
 
         authorizeReadParameterContext(contextId);
 
-        return retrieveUpdateRequest("update-requests", contextId, updateRequestId);
+        return retrieveUpdateRequest("update-requests", contextId, updateRequestId, includeReferences);
     }
 
     @DELETE
@@ -950,10 +960,12 @@ public class ParameterContextResource extends AbstractParameterResource {
             @Parameter(description = "The ID of the ParameterContext")
             @PathParam("contextId") final String contextId,
             @Parameter(description = "The ID of the Update Request")
-            @PathParam("requestId") final String updateRequestId) {
+            @PathParam("requestId") final String updateRequestId,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
 
         authorizeReadParameterContext(contextId);
-        return deleteUpdateRequest("update-requests", contextId, updateRequestId, disconnectedNodeAcknowledged.booleanValue());
+        return deleteUpdateRequest("update-requests", contextId, updateRequestId, disconnectedNodeAcknowledged.booleanValue(), includeReferences);
     }
 
     @DELETE
@@ -993,7 +1005,9 @@ public class ParameterContextResource extends AbstractParameterResource {
             @QueryParam(DISCONNECTED_NODE_ACKNOWLEDGED)
             @DefaultValue("false") final Boolean disconnectedNodeAcknowledged,
             @Parameter(description = "The Parameter Context ID.")
-            @PathParam("id") final String parameterContextId) {
+            @PathParam("id") final String parameterContextId,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
 
         if (isReplicateRequest()) {
             return replicate(HttpMethod.DELETE);
@@ -1010,7 +1024,7 @@ public class ParameterContextResource extends AbstractParameterResource {
                     authorizeReadWriteParameterContext(parameterContextId);
 
                     final NiFiUser user = NiFiUserUtils.getNiFiUser();
-                    final ParameterContextEntity contextEntity = serviceFacade.getParameterContext(parameterContextId, false, user);
+                    final ParameterContextEntity contextEntity = serviceFacade.getParameterContext(parameterContextId, false, user, false);
                     for (final ProcessGroupEntity boundGroupEntity : contextEntity.getComponent().getBoundProcessGroups()) {
                         final String groupId = boundGroupEntity.getId();
                         final Authorizable groupAuthorizable = lookup.getProcessGroup(groupId).getAuthorizable();
@@ -1021,7 +1035,7 @@ public class ParameterContextResource extends AbstractParameterResource {
                 () -> serviceFacade.verifyDeleteParameterContext(parameterContextId),
                 (revision, groupEntity) -> {
                     // disconnect from version control
-                    final ParameterContextEntity entity = serviceFacade.deleteParameterContext(revision, parameterContextId);
+                    final ParameterContextEntity entity = serviceFacade.deleteParameterContext(revision, parameterContextId, includeReferences);
 
                     // generate the response
                     return generateOkResponse(entity).build();
@@ -1095,7 +1109,7 @@ public class ParameterContextResource extends AbstractParameterResource {
     }
 
     private void authorizeReferencingComponents(final String parameterContextId, final AuthorizableLookup lookup, final NiFiUser user) {
-        final ParameterContextEntity context = serviceFacade.getParameterContext(parameterContextId, false, NiFiUserUtils.getNiFiUser());
+        final ParameterContextEntity context = serviceFacade.getParameterContext(parameterContextId, false, NiFiUserUtils.getNiFiUser(), true);
 
         for (final ParameterEntity parameterEntity : context.getComponent().getParameters()) {
             final ParameterDTO dto = parameterEntity.getParameter();
@@ -1235,7 +1249,7 @@ public class ParameterContextResource extends AbstractParameterResource {
         return resultsEntity;
     }
 
-    private Response submitUpdateRequest(final Revision requestRevision, final InitiateChangeParameterContextRequestWrapper requestWrapper) {
+    private Response submitUpdateRequest(final Revision requestRevision, final InitiateChangeParameterContextRequestWrapper requestWrapper, final boolean includeReferences) {
         // Create an asynchronous request that will occur in the background, because this request may
         // result in stopping components, which can take an indeterminate amount of time.
         final String requestId = UUID.randomUUID().toString();
@@ -1266,7 +1280,7 @@ public class ParameterContextResource extends AbstractParameterResource {
         updateRequestManager.submitRequest("update-requests", requestId, request, updateTask);
 
         // Generate the response.
-        final ParameterContextUpdateRequestEntity updateRequestEntity = createUpdateRequestEntity(request, "update-requests", contextId, requestId);
+        final ParameterContextUpdateRequestEntity updateRequestEntity = createUpdateRequestEntity(request, "update-requests", contextId, requestId, includeReferences);
         return generateOkResponse(updateRequestEntity).build();
     }
 
@@ -1333,7 +1347,7 @@ public class ParameterContextResource extends AbstractParameterResource {
         return entity;
     }
 
-    private Response retrieveUpdateRequest(final String requestType, final String contextId, final String requestId) {
+    private Response retrieveUpdateRequest(final String requestType, final String contextId, final String requestId, final boolean includeReferences) {
         if (requestId == null) {
             throw new IllegalArgumentException("Request ID must be specified.");
         }
@@ -1342,11 +1356,12 @@ public class ParameterContextResource extends AbstractParameterResource {
 
         // request manager will ensure that the current is the user that submitted this request
         final AsynchronousWebRequest<List<ParameterContextEntity>, List<ParameterContextEntity>> asyncRequest = updateRequestManager.getRequest(requestType, requestId, user);
-        final ParameterContextUpdateRequestEntity updateRequestEntity = createUpdateRequestEntity(asyncRequest, requestType, contextId, requestId);
+        final ParameterContextUpdateRequestEntity updateRequestEntity = createUpdateRequestEntity(asyncRequest, requestType, contextId, requestId, includeReferences);
         return generateOkResponse(updateRequestEntity).build();
     }
 
-    private Response deleteUpdateRequest(final String requestType, final String contextId, final String requestId, final boolean disconnectedNodeAcknowledged) {
+    private Response deleteUpdateRequest(final String requestType, final String contextId, final String requestId, final boolean disconnectedNodeAcknowledged,
+                                         final boolean includeReferences) {
         if (requestId == null) {
             throw new IllegalArgumentException("Request ID must be specified.");
         }
@@ -1367,12 +1382,12 @@ public class ParameterContextResource extends AbstractParameterResource {
             asyncRequest.cancel();
         }
 
-        final ParameterContextUpdateRequestEntity updateRequestEntity = createUpdateRequestEntity(asyncRequest, requestType, contextId, requestId);
+        final ParameterContextUpdateRequestEntity updateRequestEntity = createUpdateRequestEntity(asyncRequest, requestType, contextId, requestId, includeReferences);
         return generateOkResponse(updateRequestEntity).build();
     }
 
     private ParameterContextUpdateRequestEntity createUpdateRequestEntity(final AsynchronousWebRequest<List<ParameterContextEntity>, List<ParameterContextEntity>> asyncRequest,
-                                                                          final String requestType, final String contextId, final String requestId) {
+                                                                          final String requestType, final String contextId, final String requestId, final boolean includeReferences) {
         final List<ParameterContextEntity> initialRequestList = asyncRequest.getRequest();
         // Safe because this is from the request, not the response
         final ParameterContextEntity initialEntity = initialRequestList.get(0);
@@ -1398,14 +1413,19 @@ public class ParameterContextResource extends AbstractParameterResource {
         // The AffectedComponentEntity itself does not evaluate equality based on component information. As a result, we want to de-dupe the entities based on their identifiers.
         final Map<String, AffectedComponentEntity> affectedComponents = new HashMap<>();
         for (final ParameterEntity entity : initialEntity.getComponent().getParameters()) {
-            for (final AffectedComponentEntity affectedComponentEntity : entity.getParameter().getReferencingComponents()) {
+            final Set<AffectedComponentEntity> referencingComponents = entity.getParameter().getReferencingComponents();
+            if (referencingComponents == null) {
+                continue;
+            }
+
+            for (final AffectedComponentEntity affectedComponentEntity : referencingComponents) {
                 affectedComponents.put(affectedComponentEntity.getId(), serviceFacade.getUpdatedAffectedComponentEntity(affectedComponentEntity));
             }
         }
         updateRequestDto.setReferencingComponents(new HashSet<>(affectedComponents.values()));
 
         // Populate the Affected Components
-        final ParameterContextEntity contextEntity = serviceFacade.getParameterContext(asyncRequest.getComponentId(), false, NiFiUserUtils.getNiFiUser());
+        final ParameterContextEntity contextEntity = serviceFacade.getParameterContext(asyncRequest.getComponentId(), false, NiFiUserUtils.getNiFiUser(), includeReferences);
         final ParameterContextUpdateRequestEntity updateRequestEntity = new ParameterContextUpdateRequestEntity();
 
         // If the request is complete, include the new representation of the Parameter Context along with its new Revision. Otherwise, do not include the information, since it is 'stale'

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ParameterProviderResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ParameterProviderResource.java
@@ -785,7 +785,9 @@ public class ParameterProviderResource extends AbstractParameterResource {
             @Parameter(
                     description = "The parameter fetch request.",
                     required = true
-            ) final ParameterProviderParameterFetchEntity fetchParametersEntity) {
+            ) final ParameterProviderParameterFetchEntity fetchParametersEntity,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
 
         if (fetchParametersEntity.getId() == null) {
             throw new IllegalArgumentException("The ID of the Parameter Provider must be specified");
@@ -815,7 +817,7 @@ public class ParameterProviderResource extends AbstractParameterResource {
         final Collection<ParameterContextDTO> referencingParameterContextDtos = new HashSet<>();
         references.forEach(referencingEntity -> {
             final String parameterContextId = referencingEntity.getComponent().getId();
-            final ParameterContextEntity parameterContextEntity = serviceFacade.getParameterContext(parameterContextId, true, user);
+            final ParameterContextEntity parameterContextEntity = serviceFacade.getParameterContext(parameterContextId, true, user, true);
             parameterContextEntity.getComponent().getParameters().stream()
                     .filter(dto -> Boolean.TRUE.equals(dto.getParameter().getProvided()))
                     .forEach(p -> referencingComponents.addAll(p.getParameter().getReferencingComponents()));
@@ -854,7 +856,8 @@ public class ParameterProviderResource extends AbstractParameterResource {
                         parameterGroupConfigurations.add(new ParameterGroupConfiguration(group.getGroupName(), group.getParameterContextName(),
                                 updatedSensitivities, group.isSynchronized()));
                     });
-                    final List<ParameterContextEntity> parameterContextUpdates = serviceFacade.getParameterContextUpdatesForAppliedParameters(parameterProviderId, parameterGroupConfigurations);
+                    final List<ParameterContextEntity> parameterContextUpdates =
+                            serviceFacade.getParameterContextUpdatesForAppliedParameters(parameterProviderId, parameterGroupConfigurations, includeReferences);
 
                     final Set<ParameterEntity> removedParameters = parameterContextUpdates.stream()
                             .flatMap(context -> context.getComponent().getParameters().stream())
@@ -867,7 +870,7 @@ public class ParameterProviderResource extends AbstractParameterResource {
                     if (!affectedComponents.isEmpty()) {
                         entity.getComponent().setAffectedComponents(affectedComponents);
                     }
-                    final Set<ParameterStatusDTO> parameterStatus = getParameterStatus(entity, parameterContextUpdates, removedParameters, user);
+                    final Set<ParameterStatusDTO> parameterStatus = getParameterStatus(entity, parameterContextUpdates, removedParameters, user, includeReferences);
                     if (!parameterStatus.isEmpty()) {
                         entity.getComponent().setParameterStatus(parameterStatus);
                     }
@@ -879,7 +882,7 @@ public class ParameterProviderResource extends AbstractParameterResource {
     }
 
     private void authorizeReferencingComponents(final String parameterContextId, final AuthorizableLookup lookup, final NiFiUser user) {
-        final ParameterContextEntity context = serviceFacade.getParameterContext(parameterContextId, false, NiFiUserUtils.getNiFiUser());
+        final ParameterContextEntity context = serviceFacade.getParameterContext(parameterContextId, false, NiFiUserUtils.getNiFiUser(), true);
 
         for (final ParameterEntity parameterEntity : context.getComponent().getParameters()) {
             final ParameterDTO dto = parameterEntity.getParameter();
@@ -922,7 +925,9 @@ public class ParameterProviderResource extends AbstractParameterResource {
     public Response submitApplyParameters(
             @Parameter(description = "The ID of the Parameter Provider")
             @PathParam("providerId") final String parameterProviderId,
-            @Parameter(description = "The apply parameters request.", required = true) final ParameterProviderParameterApplicationEntity requestEntity) {
+            @Parameter(description = "The apply parameters request.", required = true) final ParameterProviderParameterApplicationEntity requestEntity,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
 
         if (requestEntity == null) {
             throw new IllegalArgumentException("Apply Parameters Request must be specified.");
@@ -967,14 +972,14 @@ public class ParameterProviderResource extends AbstractParameterResource {
                 .forEach(parameterGroupConfiguration -> {
                     final ParameterContextEntity newParameterContext = getNewParameterContextEntity(parameterProviderId, parameterGroupConfiguration);
                     try {
-                        performParameterContextCreate(user, getAbsolutePath(), replicateRequest, newParameterContext);
+                        performParameterContextCreate(user, getAbsolutePath(), replicateRequest, newParameterContext, includeReferences);
                     } catch (final LifecycleManagementException e) {
                         throw new RuntimeException("Failed to create Parameter Context " + parameterGroupConfiguration.getGroupName(), e);
                     }
                 });
 
         // Get a list of parameter context entities representing changes needed in order to apply the fetched parameters
-        final List<ParameterContextEntity> parameterContextUpdates = serviceFacade.getParameterContextUpdatesForAppliedParameters(parameterProviderId, parameterGroupConfigurations);
+        final List<ParameterContextEntity> parameterContextUpdates = serviceFacade.getParameterContextUpdatesForAppliedParameters(parameterProviderId, parameterGroupConfigurations, includeReferences);
 
         final Set<AffectedComponentEntity> affectedComponents = getAffectedComponentEntities(parameterContextUpdates);
         logger.debug("Received Apply Request for Parameter Provider: {}; the following {} components will be affected: {}", requestEntity, affectedComponents.size(), affectedComponents);
@@ -1005,7 +1010,7 @@ public class ParameterProviderResource extends AbstractParameterResource {
                     // Verify Request
                     serviceFacade.verifyCanApplyParameters(parameterProviderId, parameterGroupConfigurations);
                 },
-                this::submitApplyRequest
+                (rev, wrapper) -> submitApplyRequest(rev, wrapper, includeReferences)
         );
     }
 
@@ -1017,7 +1022,7 @@ public class ParameterProviderResource extends AbstractParameterResource {
     }
 
     private Set<ParameterStatusDTO> getParameterStatus(final ParameterProviderEntity parameterProvider, final List<ParameterContextEntity> parameterContextUpdates,
-                                                       final Set<ParameterEntity> removedParameters, final NiFiUser niFiUser) {
+                                                       final Set<ParameterEntity> removedParameters, final NiFiUser niFiUser, final boolean includeReferences) {
         final Set<ParameterStatusDTO> parameterStatus = new HashSet<>();
         if (parameterProvider.getComponent() == null || parameterProvider.getComponent().getReferencingParameterContexts() == null) {
             return parameterStatus;
@@ -1034,7 +1039,7 @@ public class ParameterProviderResource extends AbstractParameterResource {
 
         for (final ParameterProviderReferencingComponentEntity reference : parameterProvider.getComponent().getReferencingParameterContexts()) {
             final String parameterContextId = reference.getComponent().getId();
-            final ParameterContextEntity parameterContext = serviceFacade.getParameterContext(parameterContextId, false, niFiUser);
+            final ParameterContextEntity parameterContext = serviceFacade.getParameterContext(parameterContextId, false, niFiUser, includeReferences);
             if (parameterContext.getComponent() == null) {
                 continue;
             }
@@ -1080,6 +1085,9 @@ public class ParameterProviderResource extends AbstractParameterResource {
                 if (parameterDTO.getValue() != null && parameterDTO.getSensitive() != null && parameterDTO.getSensitive()) {
                     parameterDTO.setValue(DtoFactory.SENSITIVE_VALUE_MASK);
                 }
+                if (!includeReferences) {
+                    parameterDTO.setReferencingComponents(null);
+                }
             });
         }
         return parameterStatus;
@@ -1108,11 +1116,13 @@ public class ParameterProviderResource extends AbstractParameterResource {
     )
     public Response getParameterProviderApplyParametersRequest(
             @Parameter(description = "The ID of the Parameter Provider") @PathParam("providerId") final String parameterProviderId,
-            @Parameter(description = "The ID of the Apply Parameters Request") @PathParam("requestId") final String applyParametersRequestId) {
+            @Parameter(description = "The ID of the Apply Parameters Request") @PathParam("requestId") final String applyParametersRequestId,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
 
         authorizeReadParameterProvider(parameterProviderId);
 
-        return retrieveApplyParametersRequest("apply-parameters-requests", parameterProviderId, applyParametersRequestId);
+        return retrieveApplyParametersRequest("apply-parameters-requests", parameterProviderId, applyParametersRequestId, includeReferences);
     }
 
     @DELETE
@@ -1142,10 +1152,12 @@ public class ParameterProviderResource extends AbstractParameterResource {
             )
             @QueryParam(DISCONNECTED_NODE_ACKNOWLEDGED) @DefaultValue("false") final Boolean disconnectedNodeAcknowledged,
             @Parameter(description = "The ID of the Parameter Provider") @PathParam("providerId") final String parameterProviderId,
-            @Parameter(description = "The ID of the Apply Parameters Request") @PathParam("requestId") final String applyParametersRequestId) {
+            @Parameter(description = "The ID of the Apply Parameters Request") @PathParam("requestId") final String applyParametersRequestId,
+            @Parameter(description = "Whether or not to include parameters' referencing components in the response")
+            @QueryParam(INCLUDE_REFERENCING_COMPONENTS) @DefaultValue("true") final boolean includeReferences) {
 
         authorizeReadParameterProvider(parameterProviderId);
-        return deleteApplyParametersRequest("apply-parameters-requests", parameterProviderId, applyParametersRequestId, disconnectedNodeAcknowledged.booleanValue());
+        return deleteApplyParametersRequest("apply-parameters-requests", parameterProviderId, applyParametersRequestId, disconnectedNodeAcknowledged.booleanValue(), includeReferences);
     }
 
     @POST
@@ -1424,7 +1436,7 @@ public class ParameterProviderResource extends AbstractParameterResource {
         return entity;
     }
 
-    private Response retrieveApplyParametersRequest(final String requestType, final String parameterProviderId, final String requestId) {
+    private Response retrieveApplyParametersRequest(final String requestType, final String parameterProviderId, final String requestId, final boolean includeReferences) {
         if (requestId == null) {
             throw new IllegalArgumentException("Request ID must be specified.");
         }
@@ -1433,11 +1445,13 @@ public class ParameterProviderResource extends AbstractParameterResource {
 
         // request manager will ensure that the current is the user that submitted this request
         final AsynchronousWebRequest<List<ParameterContextEntity>, List<ParameterContextEntity>> asyncRequest = updateRequestManager.getRequest(requestType, requestId, user);
-        final ParameterProviderApplyParametersRequestEntity applyParametersRequestEntity = createApplyParametersRequestEntity(asyncRequest, requestType, parameterProviderId, requestId);
+        final ParameterProviderApplyParametersRequestEntity applyParametersRequestEntity =
+                createApplyParametersRequestEntity(asyncRequest, requestType, parameterProviderId, requestId, includeReferences);
         return generateOkResponse(applyParametersRequestEntity).build();
     }
 
-    private Response deleteApplyParametersRequest(final String requestType, final String parameterProviderId, final String requestId, final boolean disconnectedNodeAcknowledged) {
+    private Response deleteApplyParametersRequest(final String requestType, final String parameterProviderId, final String requestId, final boolean disconnectedNodeAcknowledged,
+                                                  final boolean includeReferences) {
         if (requestId == null) {
             throw new IllegalArgumentException("Request ID must be specified.");
         }
@@ -1458,12 +1472,14 @@ public class ParameterProviderResource extends AbstractParameterResource {
             asyncRequest.cancel();
         }
 
-        final ParameterProviderApplyParametersRequestEntity applyParametersRequestEntity = createApplyParametersRequestEntity(asyncRequest, requestType, parameterProviderId, requestId);
+        final ParameterProviderApplyParametersRequestEntity applyParametersRequestEntity =
+                createApplyParametersRequestEntity(asyncRequest, requestType, parameterProviderId, requestId, includeReferences);
         return generateOkResponse(applyParametersRequestEntity).build();
     }
 
     private ParameterProviderApplyParametersRequestEntity createApplyParametersRequestEntity(final AsynchronousWebRequest<List<ParameterContextEntity>, List<ParameterContextEntity>> asyncRequest,
-                                                                                             final String requestType, final String parameterProviderId, final String requestId) {
+                                                                                             final String requestType, final String parameterProviderId, final String requestId,
+                                                                                             final boolean includeReferences) {
         final ParameterProviderApplyParametersRequestEntity applyParametersRequestEntity = new ParameterProviderApplyParametersRequestEntity();
         final ParameterProviderApplyParametersRequestDTO applyParametersRequestDTO = new ParameterProviderApplyParametersRequestDTO();
         applyParametersRequestDTO.setComplete(asyncRequest.isComplete());
@@ -1495,7 +1511,12 @@ public class ParameterProviderResource extends AbstractParameterResource {
             // The AffectedComponentEntity itself does not evaluate equality based on component information. As a result, we want to de-dupe the entities based on their identifiers.
             final Map<String, AffectedComponentEntity> affectedComponents = new HashMap<>();
             for (final ParameterEntity entity : parameterContextEntity.getComponent().getParameters()) {
-                for (final AffectedComponentEntity affectedComponentEntity : entity.getParameter().getReferencingComponents()) {
+                final Set<AffectedComponentEntity> referencingComponents = entity.getParameter().getReferencingComponents();
+                if (referencingComponents == null) {
+                    continue;
+                }
+
+                for (final AffectedComponentEntity affectedComponentEntity : referencingComponents) {
                     final AffectedComponentEntity updatedAffectedComponentEntity = serviceFacade.getUpdatedAffectedComponentEntity(affectedComponentEntity);
                     final String affectedComponentEntityId = affectedComponentEntity.getId();
 
@@ -1505,7 +1526,7 @@ public class ParameterProviderResource extends AbstractParameterResource {
             }
 
             // Populate the Affected Components
-            final ParameterContextEntity contextEntity = serviceFacade.getParameterContext(parameterContextEntity.getId(), false, NiFiUserUtils.getNiFiUser());
+            final ParameterContextEntity contextEntity = serviceFacade.getParameterContext(parameterContextEntity.getId(), false, NiFiUserUtils.getNiFiUser(), includeReferences);
             final ParameterContextUpdateEntity parameterContextUpdate = new ParameterContextUpdateEntity();
             parameterContextUpdate.setReferencingComponents(new HashSet<>(affectedComponents.values()));
 
@@ -1583,7 +1604,7 @@ public class ParameterProviderResource extends AbstractParameterResource {
         return parameterContextEntity;
     }
 
-    private Response submitApplyRequest(final Revision requestRevision, final InitiateParameterProviderApplyParametersRequestWrapper requestWrapper) {
+    private Response submitApplyRequest(final Revision requestRevision, final InitiateParameterProviderApplyParametersRequestWrapper requestWrapper, final boolean includeReferences) {
         // Create an asynchronous request that will occur in the background, because this request may
         // result in stopping components, which can take an indeterminate amount of time.
         final String requestId = UUID.randomUUID().toString();
@@ -1614,12 +1635,12 @@ public class ParameterProviderResource extends AbstractParameterResource {
 
         // Generate the response.
         final ParameterProviderApplyParametersRequestEntity applicationRequestEntity = createApplyParametersRequestEntity(
-                request, "apply-parameters-requests", parameterProviderId, requestId);
+                request, "apply-parameters-requests", parameterProviderId, requestId, includeReferences);
         return generateOkResponse(applicationRequestEntity).build();
     }
 
     private ParameterContextEntity performParameterContextCreate(final NiFiUser user, final URI exampleUri, final boolean replicateRequest,
-                                                                 final ParameterContextEntity parameterContext) throws LifecycleManagementException {
+                                                                 final ParameterContextEntity parameterContext, final boolean includeReferences) throws LifecycleManagementException {
 
         if (replicateRequest) {
             final URI updateUri;
@@ -1644,14 +1665,14 @@ public class ParameterProviderResource extends AbstractParameterResource {
             }
             final String parameterContextId = ParameterUpdateManager.getResponseEntity(clusterResponse, ParameterContextEntity.class).getId();
 
-            return serviceFacade.getParameterContext(parameterContextId, false, user);
+            return serviceFacade.getParameterContext(parameterContextId, false, user, includeReferences);
         } else {
             serviceFacade.verifyCreateParameterContext(parameterContext.getComponent());
             final String contextId = generateUuid();
             parameterContext.getComponent().setId(contextId);
 
             final Revision revision = getRevision(parameterContext.getRevision(), contextId);
-            return serviceFacade.createParameterContext(revision, parameterContext.getComponent());
+            return serviceFacade.createParameterContext(revision, parameterContext.getComponent(), includeReferences);
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
@@ -1087,7 +1087,7 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
 
             // Step 4: Replace parameter contexts if necessary
             if (ParameterContextHandlingStrategy.REPLACE.equals(parameterContextHandlingStrategy)) {
-                parameterContextReplacer.replaceParameterContexts(flowSnapshot, serviceFacade.getParameterContexts());
+                parameterContextReplacer.replaceParameterContexts(flowSnapshot, serviceFacade.getParameterContexts(false));
             }
 
             // Step 5: Resolve Bundle info

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -1505,7 +1505,7 @@ public final class DtoFactory {
     }
 
     public ParameterContextDTO createParameterContextDto(final ParameterContext parameterContext, final RevisionManager revisionManager,
-                                                        final boolean includeInheritedParameters, final ParameterContextLookup parameterContextLookup) {
+                                                         final boolean includeInheritedParameters, final ParameterContextLookup parameterContextLookup, final boolean includeReferences) {
         final ParameterContextDTO dto = new ParameterContextDTO();
         dto.setId(parameterContext.getIdentifier());
         dto.setName(parameterContext.getName());
@@ -1525,7 +1525,7 @@ public final class DtoFactory {
         final Map<ParameterDescriptor, Parameter> parameters = includeInheritedParameters ? parameterContext.getRawEffectiveParameters()
                 : parameterContext.getParameters();
         for (final Parameter parameter : parameters.values()) {
-            parameterEntities.add(createParameterEntity(parameterContext, parameter, revisionManager, parameterContextLookup));
+            parameterEntities.add(createParameterEntity(parameterContext, parameter, revisionManager, parameterContextLookup, includeReferences));
         }
 
         final List<ParameterContextReferenceEntity> parameterContextRefs = new ArrayList<>();
@@ -1585,19 +1585,34 @@ public final class DtoFactory {
     }
 
     public ParameterEntity createParameterEntity(final ParameterContext parameterContext, final Parameter parameter, final RevisionManager revisionManager,
-                                                final ParameterContextLookup parameterContextLookup) {
-        final ParameterDTO dto = createParameterDto(parameterContext, parameter, revisionManager, parameterContextLookup);
+                                                 final ParameterContextLookup parameterContextLookup) {
+        return createParameterEntity(parameterContext, parameter, revisionManager, parameterContextLookup, true);
+    }
+
+    public ParameterEntity createParameterEntity(final ParameterContext parameterContext, final Parameter parameter, final RevisionManager revisionManager,
+                                                 final ParameterContextLookup parameterContextLookup, final boolean includeReferences) {
+        // canWrite depends on the permissions of every component referencing this parameter, so it must always be determined,
+        // even when includeReferences is false and the full AffectedComponentEntity set is not built for the response. Compute
+        // it once here and pass it through so createParameterDto doesn't need to recompute it when includeReferences is true.
+        final Set<ComponentNode> referencingComponents = getReferencingComponents(parameterContext, parameter.getDescriptor());
+        final ParameterDTO dto = createParameterDto(parameterContext, parameter, revisionManager, parameterContextLookup, includeReferences, referencingComponents);
         final ParameterEntity entity = new ParameterEntity();
         entity.setParameter(dto);
-
-        final boolean canWrite = isWritable(dto.getReferencingComponents());
-        entity.setCanWrite(canWrite);
+        entity.setCanWrite(isWritable(referencingComponents));
 
         return entity;
     }
 
     public ParameterDTO createParameterDto(final ParameterContext parameterContext, final Parameter parameter,
-                                          final RevisionManager revisionManager, final ParameterContextLookup parameterContextLookup) {
+                                           final RevisionManager revisionManager, final ParameterContextLookup parameterContextLookup, final boolean includeReferences) {
+        final Set<ComponentNode> referencingComponents = includeReferences
+                ? getReferencingComponents(parameterContext, parameter.getDescriptor())
+                : Set.of();
+        return createParameterDto(parameterContext, parameter, revisionManager, parameterContextLookup, includeReferences, referencingComponents);
+    }
+
+    private ParameterDTO createParameterDto(final ParameterContext parameterContext, final Parameter parameter, final RevisionManager revisionManager,
+                                            final ParameterContextLookup parameterContextLookup, final boolean includeReferences, final Set<ComponentNode> referencingComponents) {
         final ParameterDescriptor descriptor = parameter.getDescriptor();
 
         final ParameterDTO dto = new ParameterDTO();
@@ -1611,14 +1626,10 @@ public final class DtoFactory {
         final List<Asset> assets = parameter.getReferencedAssets();
         dto.setReferencedAssets(assets == null ? List.of() : parameter.getReferencedAssets().stream().map(this::createAssetReferenceDto).toList());
 
-        final ParameterReferenceManager parameterReferenceManager = parameterContext.getParameterReferenceManager();
-
-        final Set<ComponentNode> referencingComponents = new HashSet<>();
-        referencingComponents.addAll(parameterReferenceManager.getProcessorsReferencing(parameterContext, descriptor.getName()));
-        referencingComponents.addAll(parameterReferenceManager.getControllerServicesReferencing(parameterContext, descriptor.getName()));
-
-        final Set<AffectedComponentEntity> referencingComponentEntities = createAffectedComponentEntities(referencingComponents, revisionManager);
-        dto.setReferencingComponents(referencingComponentEntities);
+        if (includeReferences) {
+            final Set<AffectedComponentEntity> referencingComponentEntities = createAffectedComponentEntities(referencingComponents, revisionManager);
+            dto.setReferencingComponents(referencingComponentEntities);
+        }
 
         final ParameterContext containingParameterContext = resolveContainingParameterContext(parameterContext, parameter, parameterContextLookup);
 
@@ -3255,10 +3266,19 @@ public final class DtoFactory {
         return bulletins;
     }
 
-    private boolean isWritable(final Collection<AffectedComponentEntity> affectedComponentEntities) {
-        for (final AffectedComponentEntity affectedComponent : affectedComponentEntities) {
-            final PermissionsDTO permissions = affectedComponent.getPermissions();
-            if (!permissions.getCanRead() || !permissions.getCanWrite()) {
+    private Set<ComponentNode> getReferencingComponents(final ParameterContext parameterContext, final ParameterDescriptor descriptor) {
+        final ParameterReferenceManager parameterReferenceManager = parameterContext.getParameterReferenceManager();
+
+        final Set<ComponentNode> referencingComponents = new HashSet<>();
+        referencingComponents.addAll(parameterReferenceManager.getProcessorsReferencing(parameterContext, descriptor.getName()));
+        referencingComponents.addAll(parameterReferenceManager.getControllerServicesReferencing(parameterContext, descriptor.getName()));
+        return referencingComponents;
+    }
+
+    private boolean isWritable(final Set<ComponentNode> referencingComponents) {
+        final NiFiUser user = NiFiUserUtils.getNiFiUser();
+        for (final ComponentNode referencingComponent : referencingComponents) {
+            if (!referencingComponent.isAuthorized(authorizer, RequestAction.READ, user) || !referencingComponent.isAuthorized(authorizer, RequestAction.WRITE, user)) {
                 return false;
             }
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/ParameterUpdateManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/ParameterUpdateManager.java
@@ -233,10 +233,10 @@ public class ParameterUpdateManager {
                 throw new LifecycleManagementException("Failed to update Flow on all nodes in cluster due to " + explanation);
             }
 
-            return serviceFacade.getParameterContext(updatedContext.getId(), false, user);
+            return serviceFacade.getParameterContext(updatedContext.getId(), false, user, false);
         } else {
             serviceFacade.verifyUpdateParameterContext(updatedContext.getComponent(), true);
-            return serviceFacade.updateParameterContext(revision, updatedContext.getComponent());
+            return serviceFacade.updateParameterContext(revision, updatedContext.getComponent(), false);
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/StandardNiFiServiceFacadeTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/StandardNiFiServiceFacadeTest.java
@@ -2444,19 +2444,19 @@ public class StandardNiFiServiceFacadeTest {
         final ParameterContextDTO parameterContextDto = new ParameterContextDTO();
         parameterContextDto.setId(parameterContextId);
         parameterContextDto.setName("context-name");
-        when(dtoFactory.createParameterContextDto(eq(parameterContext), eq(revisionManager), eq(true), any(ParameterContextLookup.class)))
+        when(dtoFactory.createParameterContextDto(eq(parameterContext), eq(revisionManager), eq(true), any(ParameterContextLookup.class), eq(true)))
                 .thenReturn(parameterContextDto);
         when(dtoFactory.createPermissionsDto(eq(parameterContext), any())).thenReturn(null);
         when(dtoFactory.createRevisionDTO(any(Revision.class))).thenReturn(new RevisionDTO());
         when(revisionManager.getRevision(parameterContextId)).thenReturn(new Revision(1L, null, parameterContextId));
 
-        final ParameterContextEntity entity = serviceFacade.getConnectorParameterContext(connectorId, processGroupId);
+        final ParameterContextEntity entity = serviceFacade.getConnectorParameterContext(connectorId, processGroupId, true);
 
         assertNotNull(entity);
         assertEquals(parameterContextId, entity.getId());
 
         final ArgumentCaptor<ParameterContextLookup> lookupCaptor = ArgumentCaptor.forClass(ParameterContextLookup.class);
-        verify(dtoFactory).createParameterContextDto(eq(parameterContext), eq(revisionManager), eq(true), lookupCaptor.capture());
+        verify(dtoFactory).createParameterContextDto(eq(parameterContext), eq(revisionManager), eq(true), lookupCaptor.capture(), eq(true));
         assertNotNull(lookupCaptor.getValue());
         assertNull(lookupCaptor.getValue().getParameterContext("any-id"));
         assertFalse(lookupCaptor.getValue().hasParameterContext("any-id"));
@@ -2483,7 +2483,7 @@ public class StandardNiFiServiceFacadeTest {
         when(managedProcessGroup.findProcessGroup(processGroupId)).thenReturn(targetProcessGroup);
         when(targetProcessGroup.getParameterContext()).thenReturn(null);
 
-        final ParameterContextEntity entity = serviceFacade.getConnectorParameterContext(connectorId, processGroupId);
+        final ParameterContextEntity entity = serviceFacade.getConnectorParameterContext(connectorId, processGroupId, true);
 
         assertNull(entity);
         verifyNoInteractions(dtoFactory);
@@ -2841,7 +2841,7 @@ public class StandardNiFiServiceFacadeTest {
         when(flowContext.getManagedProcessGroup()).thenReturn(managedProcessGroup);
         when(managedProcessGroup.findProcessGroup(processGroupId)).thenReturn(null);
 
-        assertThrows(ResourceNotFoundException.class, () -> serviceFacade.getConnectorParameterContext(connectorId, processGroupId));
+        assertThrows(ResourceNotFoundException.class, () -> serviceFacade.getConnectorParameterContext(connectorId, processGroupId, true));
     }
 
     private StandardNiFiServiceFacade createBranchTestFacade(final ProcessGroupDAO branchProcessGroupDAO, final FlowRegistryDAO flowRegistryDAO,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/TestConnectorResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/TestConnectorResource.java
@@ -771,27 +771,27 @@ public class TestConnectorResource {
     @Test
     public void testGetParameterContextForConnectorProcessGroup() {
         final ParameterContextEntity responseEntity = createParameterContextEntity();
-        when(serviceFacade.getConnectorParameterContext(CONNECTOR_ID, PROCESS_GROUP_ID)).thenReturn(responseEntity);
+        when(serviceFacade.getConnectorParameterContext(CONNECTOR_ID, PROCESS_GROUP_ID, true)).thenReturn(responseEntity);
 
-        try (Response response = connectorResource.getParameterContextForConnectorProcessGroup(CONNECTOR_ID, PROCESS_GROUP_ID)) {
+        try (Response response = connectorResource.getParameterContextForConnectorProcessGroup(CONNECTOR_ID, PROCESS_GROUP_ID, true)) {
             assertEquals(200, response.getStatus());
             assertEquals(responseEntity, response.getEntity());
         }
 
         verify(serviceFacade).authorizeAccess(any(AuthorizeAccess.class));
-        verify(serviceFacade).getConnectorParameterContext(CONNECTOR_ID, PROCESS_GROUP_ID);
+        verify(serviceFacade).getConnectorParameterContext(CONNECTOR_ID, PROCESS_GROUP_ID, true);
     }
 
     @Test
     public void testGetParameterContextForConnectorProcessGroupReturnsNoContentWhenUnbound() {
-        when(serviceFacade.getConnectorParameterContext(CONNECTOR_ID, PROCESS_GROUP_ID)).thenReturn(null);
+        when(serviceFacade.getConnectorParameterContext(CONNECTOR_ID, PROCESS_GROUP_ID, true)).thenReturn(null);
 
-        try (Response response = connectorResource.getParameterContextForConnectorProcessGroup(CONNECTOR_ID, PROCESS_GROUP_ID)) {
+        try (Response response = connectorResource.getParameterContextForConnectorProcessGroup(CONNECTOR_ID, PROCESS_GROUP_ID, true)) {
             assertEquals(204, response.getStatus());
         }
 
         verify(serviceFacade).authorizeAccess(any(AuthorizeAccess.class));
-        verify(serviceFacade).getConnectorParameterContext(CONNECTOR_ID, PROCESS_GROUP_ID);
+        verify(serviceFacade).getConnectorParameterContext(CONNECTOR_ID, PROCESS_GROUP_ID, true);
     }
 
     @Test
@@ -799,10 +799,10 @@ public class TestConnectorResource {
         doThrow(AccessDeniedException.class).when(serviceFacade).authorizeAccess(any(AuthorizeAccess.class));
 
         assertThrows(AccessDeniedException.class, () ->
-            connectorResource.getParameterContextForConnectorProcessGroup(CONNECTOR_ID, PROCESS_GROUP_ID));
+            connectorResource.getParameterContextForConnectorProcessGroup(CONNECTOR_ID, PROCESS_GROUP_ID, true));
 
         verify(serviceFacade).authorizeAccess(any(AuthorizeAccess.class));
-        verify(serviceFacade, never()).getConnectorParameterContext(anyString(), anyString());
+        verify(serviceFacade, never()).getConnectorParameterContext(anyString(), anyString(), eq(true));
     }
 
     @Test

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/dto/DtoFactoryTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/dto/DtoFactoryTest.java
@@ -27,6 +27,8 @@ import org.apache.nifi.connectable.Connectable;
 import org.apache.nifi.connectable.ConnectableType;
 import org.apache.nifi.connectable.Connection;
 import org.apache.nifi.controller.ControllerService;
+import org.apache.nifi.controller.ProcessorNode;
+import org.apache.nifi.controller.ScheduledState;
 import org.apache.nifi.controller.queue.FlowFileQueue;
 import org.apache.nifi.controller.queue.LoadBalanceCompression;
 import org.apache.nifi.controller.queue.LoadBalanceStrategy;
@@ -50,10 +52,15 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.registry.flow.FlowRegistryClientNode;
 import org.apache.nifi.registry.flow.diff.DifferenceType;
 import org.apache.nifi.registry.flow.diff.FlowDifference;
+import org.apache.nifi.reporting.Bulletin;
+import org.apache.nifi.util.MockBulletinRepository;
 import org.apache.nifi.web.ResourceNotFoundException;
+import org.apache.nifi.web.Revision;
 import org.apache.nifi.web.api.entity.AllowableValueEntity;
+import org.apache.nifi.web.api.entity.ComponentEntity;
 import org.apache.nifi.web.api.entity.ParameterContextReferenceEntity;
 import org.apache.nifi.web.revision.RevisionManager;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -777,7 +784,7 @@ public class DtoFactoryTest {
         final ParameterContextLookup lookup = mock(ParameterContextLookup.class);
 
         final DtoFactory dtoFactory = newDtoFactoryForParameters();
-        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), lookup);
+        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), lookup, true);
 
         assertEquals("param-name", dto.getName());
         assertEquals("param-value", dto.getValue());
@@ -804,7 +811,7 @@ public class DtoFactoryTest {
         final ParameterContextLookup lookup = mock(ParameterContextLookup.class);
 
         final DtoFactory dtoFactory = newDtoFactoryForParameters();
-        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), lookup);
+        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), lookup, true);
 
         assertFalse(dto.getInherited());
         assertEquals(contextId, dto.getParameterContext().getId());
@@ -829,7 +836,7 @@ public class DtoFactoryTest {
         final ParameterContextLookup lookup = mock(ParameterContextLookup.class);
 
         final DtoFactory dtoFactory = newDtoFactoryForParameters();
-        final ParameterDTO dto = dtoFactory.createParameterDto(childContext, parameter, mock(RevisionManager.class), lookup);
+        final ParameterDTO dto = dtoFactory.createParameterDto(childContext, parameter, mock(RevisionManager.class), lookup, true);
 
         assertTrue(dto.getInherited());
         assertEquals(parentId, dto.getParameterContext().getId());
@@ -856,7 +863,7 @@ public class DtoFactoryTest {
         final ParameterContextLookup lookup = mock(ParameterContextLookup.class);
 
         final DtoFactory dtoFactory = newDtoFactoryForParameters();
-        final ParameterDTO dto = dtoFactory.createParameterDto(childContext, parameter, mock(RevisionManager.class), lookup);
+        final ParameterDTO dto = dtoFactory.createParameterDto(childContext, parameter, mock(RevisionManager.class), lookup, true);
 
         assertTrue(dto.getInherited());
         assertEquals(grandparentId, dto.getParameterContext().getId());
@@ -883,7 +890,7 @@ public class DtoFactoryTest {
         when(lookup.getParameterContext(externalId)).thenReturn(externalContext);
 
         final DtoFactory dtoFactory = newDtoFactoryForParameters();
-        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), lookup);
+        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), lookup, true);
 
         assertTrue(dto.getInherited());
         assertEquals(externalId, dto.getParameterContext().getId());
@@ -906,7 +913,7 @@ public class DtoFactoryTest {
                 .build();
 
         final DtoFactory dtoFactory = newDtoFactoryForParameters();
-        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), ParameterContextLookup.EMPTY);
+        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), ParameterContextLookup.EMPTY, true);
 
         assertFalse(dto.getInherited());
         assertEquals(contextId, dto.getParameterContext().getId());
@@ -930,7 +937,7 @@ public class DtoFactoryTest {
         when(lookup.getParameterContext(missingSourceId)).thenThrow(new AssertionError("Lookup getter should not be called for a missing source context"));
 
         final DtoFactory dtoFactory = newDtoFactoryForParameters();
-        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), lookup);
+        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), lookup, true);
 
         assertFalse(dto.getInherited());
         assertEquals(contextId, dto.getParameterContext().getId());
@@ -957,7 +964,7 @@ public class DtoFactoryTest {
         when(lookup.getParameterContext(missingSourceId)).thenThrow(new ResourceNotFoundException("Source context was removed"));
 
         final DtoFactory dtoFactory = newDtoFactoryForParameters();
-        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), lookup);
+        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), lookup, true);
 
         assertFalse(dto.getInherited());
         assertEquals(contextId, dto.getParameterContext().getId());
@@ -985,7 +992,7 @@ public class DtoFactoryTest {
                 .build();
 
         final DtoFactory dtoFactory = newDtoFactoryForParameters();
-        final ParameterDTO dto = dtoFactory.createParameterDto(contextA, parameter, mock(RevisionManager.class), ParameterContextLookup.EMPTY);
+        final ParameterDTO dto = dtoFactory.createParameterDto(contextA, parameter, mock(RevisionManager.class), ParameterContextLookup.EMPTY, true);
 
         assertTrue(dto.getInherited());
         assertEquals(contextDId, dto.getParameterContext().getId());
@@ -1016,7 +1023,7 @@ public class DtoFactoryTest {
         when(lookup.getParameterContext(missingId)).thenReturn(fallbackContext);
 
         final DtoFactory dtoFactory = newDtoFactoryForParameters();
-        final ParameterDTO dto = dtoFactory.createParameterDto(childContext, parameter, mock(RevisionManager.class), lookup);
+        final ParameterDTO dto = dtoFactory.createParameterDto(childContext, parameter, mock(RevisionManager.class), lookup, true);
 
         assertTrue(dto.getInherited());
         assertEquals(missingId, dto.getParameterContext().getId());
@@ -1037,10 +1044,66 @@ public class DtoFactoryTest {
                 .build();
 
         final DtoFactory dtoFactory = newDtoFactoryForParameters();
-        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), mock(ParameterContextLookup.class));
+        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, mock(RevisionManager.class), mock(ParameterContextLookup.class), true);
 
         assertTrue(dto.getSensitive());
         assertEquals(DtoFactory.SENSITIVE_VALUE_MASK, dto.getValue());
+    }
+
+
+
+    @Test
+    void testCreateParameterDtoReferencesIncluded() {
+        final String processorId = "processor-1";
+        final String controllerId = "controller-1";
+
+        final ParameterDTO dto = getDtoForParameterWithReferences(processorId, controllerId, true);
+
+        Set<String> referencedIdSet = dto.getReferencingComponents().stream().map(ComponentEntity::getId).collect(Collectors.toSet());
+        assertEquals(Set.of(processorId, controllerId), referencedIdSet);
+    }
+
+    @Test
+    void testCreateParameterDtoReferencesExcluded() {
+        final String processorId = "processor-1";
+        final String controllerId = "controller-1";
+
+        final ParameterDTO dto = getDtoForParameterWithReferences(processorId, controllerId, false);
+
+        assertNull(dto.getReferencingComponents());
+    }
+
+    private static @NonNull ParameterDTO getDtoForParameterWithReferences(String processorId, String controllerId, boolean includeReferences) {
+        final String contextId = "context-1";
+        ProcessorNode referencingProcessor = mock(ProcessorNode.class);
+        when(referencingProcessor.getIdentifier()).thenReturn(processorId);
+        when(referencingProcessor.getDesiredState()).thenReturn(ScheduledState.RUNNING);
+        ControllerServiceNode referencingControllerService = mock(ControllerServiceNode.class);
+        when(referencingControllerService.getIdentifier()).thenReturn(controllerId);
+        when(referencingControllerService.getState()).thenReturn(ControllerServiceState.ENABLED);
+        RevisionManager revisionManager = mock(RevisionManager.class);
+        when(revisionManager.getRevision(eq(processorId))).thenReturn(new Revision(0L, "client-1", processorId));
+        when(revisionManager.getRevision(eq(controllerId))).thenReturn(new Revision(0L, "client-1", controllerId));
+
+        final ParameterContext parameterContext = createMockParameterContextWithRefs(contextId, "context-1-name",
+                Collections.emptyList(), Set.of(referencingControllerService), Set.of(referencingProcessor));
+
+        final Parameter parameter = new Parameter.Builder()
+                .name("my-param")
+                .value("my-value")
+                .sensitive(false)
+                .build();
+
+        final DtoFactory dtoFactory = newDtoFactoryForParameters();
+        dtoFactory.setBulletinRepository(new MockBulletinRepository() {
+            @Override
+            public List<Bulletin> findBulletinsForSource(String sourceId, String groupId) {
+                return List.of();
+            }
+        });
+
+        final ParameterDTO dto = dtoFactory.createParameterDto(parameterContext, parameter, revisionManager, mock(ParameterContextLookup.class), includeReferences);
+        return dto;
     }
 
     private static DtoFactory newDtoFactoryForParameters() {
@@ -1056,10 +1119,29 @@ public class DtoFactoryTest {
         return context;
     }
 
+    private static ParameterContext createMockParameterContextWithRefs(final String id, final String name, final List<ParameterContext> inherited,
+                                                                       Set<ControllerServiceNode> controllerRefs, Set<ProcessorNode> processorRefs) {
+        final ParameterContext context = mock(ParameterContext.class);
+        configureBaseParameterContextWithRefs(context, id, name, controllerRefs, processorRefs);
+        when(context.getInheritedParameterContexts()).thenReturn(inherited);
+        return context;
+    }
+
+
     private static void configureBaseParameterContext(final ParameterContext context, final String id, final String name) {
         when(context.getIdentifier()).thenReturn(id);
         when(context.getName()).thenReturn(name);
         when(context.getParameterReferenceManager()).thenReturn(ParameterReferenceManager.EMPTY);
     }
 
+    private static void configureBaseParameterContextWithRefs(final ParameterContext context, final String id, final String name,
+                                                              Set<ControllerServiceNode> controllerRefs, Set<ProcessorNode> processorRefs) {
+        when(context.getIdentifier()).thenReturn(id);
+        when(context.getName()).thenReturn(name);
+        ParameterReferenceManager parameterReferenceManager = mock(ParameterReferenceManager.class);
+        when(parameterReferenceManager.getProcessGroupsBound(any(ParameterContext.class))).thenReturn(Set.of());
+        when(parameterReferenceManager.getControllerServicesReferencing(any(ParameterContext.class), anyString())).thenReturn(controllerRefs);
+        when(parameterReferenceManager.getProcessorsReferencing(any(ParameterContext.class), anyString())).thenReturn(processorRefs);
+        when(context.getParameterReferenceManager()).thenReturn(parameterReferenceManager);
+    }
 }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/service/connector.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/service/connector.service.ts
@@ -134,12 +134,13 @@ export class ConnectorService {
 
     getConnectorParameterContext(
         connectorId: string,
-        processGroupId: string
+        processGroupId: string,
+        includeReferencingComponents: boolean
     ): Observable<ParameterContextEntity | null> {
         return this.httpClient
             .get<ParameterContextEntity>(
                 `${ConnectorService.API}/connectors/${connectorId}/flow/process-groups/${processGroupId}/parameter-context`,
-                { observe: 'response' }
+                { observe: 'response', params: { includeReferencingComponents } }
             )
             .pipe(map((response) => (response.status === 204 ? null : response.body)));
     }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.spec.ts
@@ -1452,7 +1452,11 @@ describe('ConnectorCanvasEffects', () => {
 
             const result = await firstValueFrom(effects.loadConnectorParameterContext$);
 
-            expect(mockConnectorService.getConnectorParameterContext).toHaveBeenCalledWith('connector-123', 'pg-abc');
+            expect(mockConnectorService.getConnectorParameterContext).toHaveBeenCalledWith(
+                'connector-123',
+                'pg-abc',
+                false
+            );
             expect(result).toEqual(loadConnectorParameterContextSuccess({ parameterContext }));
         });
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/connectors/state/connector-canvas/connector-canvas.effects.ts
@@ -264,21 +264,23 @@ export class ConnectorCanvasEffects {
         this.actions$.pipe(
             ofType(ConnectorCanvasActions.loadConnectorParameterContext),
             switchMap((action) =>
-                this.connectorService.getConnectorParameterContext(action.connectorId, action.processGroupId).pipe(
-                    map((parameterContext) =>
-                        ConnectorCanvasActions.loadConnectorParameterContextSuccess({ parameterContext })
-                    ),
-                    catchError((error) =>
-                        of(
-                            ConnectorCanvasActions.loadConnectorParameterContextFailure({
-                                errorContext: {
-                                    errors: [this.errorHelper.getErrorString(error)],
-                                    context: action.errorContext
-                                }
-                            })
+                this.connectorService
+                    .getConnectorParameterContext(action.connectorId, action.processGroupId, false)
+                    .pipe(
+                        map((parameterContext) =>
+                            ConnectorCanvasActions.loadConnectorParameterContextSuccess({ parameterContext })
+                        ),
+                        catchError((error) =>
+                            of(
+                                ConnectorCanvasActions.loadConnectorParameterContextFailure({
+                                    errorContext: {
+                                        errors: [this.errorHelper.getErrorString(error)],
+                                        context: action.errorContext
+                                    }
+                                })
+                            )
                         )
                     )
-                )
             )
         )
     );

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/parameter-helper.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/parameter-helper.service.ts
@@ -59,7 +59,7 @@ export class ParameterHelperService {
         parameterContextId: string
     ): (name: string, sensitive: boolean, value: string | null) => Observable<ConvertToParameterResponse> {
         return (name: string, sensitive: boolean, value: string | null) => {
-            return this.parameterContextService.getParameterContext(parameterContextId, false).pipe(
+            return this.parameterContextService.getParameterContext(parameterContextId, false, false).pipe(
                 catchError((errorResponse: HttpErrorResponse) => {
                     this.store.dispatch(
                         ErrorActions.snackBarError({ error: this.errorHelper.getErrorString(errorResponse) })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/parameter.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/parameter.service.ts
@@ -28,31 +28,50 @@ export class ParameterService {
 
     private static readonly API: string = '../nifi-api';
 
-    getParameterContext(id: string, includeInheritedParameters: boolean): Observable<any> {
+    getParameterContext(
+        id: string,
+        includeInheritedParameters: boolean,
+        includeReferencingComponents: boolean
+    ): Observable<any> {
         return this.httpClient.get(`${ParameterService.API}/parameter-contexts/${id}`, {
             params: {
-                includeInheritedParameters
+                includeInheritedParameters,
+                includeReferencingComponents
             }
         });
     }
 
-    submitParameterContextUpdate(configureParameterContext: SubmitParameterContextUpdate): Observable<any> {
+    submitParameterContextUpdate(
+        configureParameterContext: SubmitParameterContextUpdate,
+        includeReferencingComponents: boolean
+    ): Observable<any> {
         return this.httpClient.post(
             `${ParameterService.API}/parameter-contexts/${configureParameterContext.id}/update-requests`,
-            configureParameterContext.payload
+            configureParameterContext.payload,
+            { params: { includeReferencingComponents } }
         );
     }
 
-    pollParameterContextUpdate(parameterContextId: string, requestId: string): Observable<any> {
+    pollParameterContextUpdate(
+        parameterContextId: string,
+        requestId: string,
+        includeReferencingComponents: boolean
+    ): Observable<any> {
         return this.httpClient.get(
-            `${ParameterService.API}/parameter-contexts/${parameterContextId}/update-requests/${requestId}`
+            `${ParameterService.API}/parameter-contexts/${parameterContextId}/update-requests/${requestId}`,
+            { params: { includeReferencingComponents } }
         );
     }
 
-    deleteParameterContextUpdate(parameterContextId: string, requestId: string): Observable<any> {
+    deleteParameterContextUpdate(
+        parameterContextId: string,
+        requestId: string,
+        includeReferencingComponents: boolean
+    ): Observable<any> {
         const params = new HttpParams({
             fromObject: {
-                disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged()
+                disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged(),
+                includeReferencingComponents
             }
         });
         return this.httpClient.delete(

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.effects.ts
@@ -350,7 +350,7 @@ export class ControllerServicesEffects {
                 switchMap(([request, parameterContextReference, processGroupId]) => {
                     if (parameterContextReference && parameterContextReference.permissions.canRead) {
                         return from(
-                            this.parameterContextService.getParameterContext(parameterContextReference.id, true)
+                            this.parameterContextService.getParameterContext(parameterContextReference.id, true, false)
                         ).pipe(
                             map((parameterContext) => {
                                 return [request, parameterContext, processGroupId];

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -352,7 +352,7 @@ export class FlowEffects {
                     case ComponentType.Processor:
                         return of(FlowActions.openNewProcessorDialog({ request }));
                     case ComponentType.ProcessGroup:
-                        return from(this.parameterContextService.getParameterContexts()).pipe(
+                        return from(this.parameterContextService.getParameterContexts(false)).pipe(
                             concatLatestFrom(() => this.store.select(selectCurrentParameterContext)),
                             map(([response, parameterContext]) => {
                                 const dialogRequest: CreateProcessGroupDialogRequest = {
@@ -648,7 +648,7 @@ export class FlowEffects {
             map((action) => action.request),
             concatLatestFrom(() => this.store.select(selectCurrentProcessGroupId)),
             switchMap(([request]) =>
-                from(this.parameterContextService.getParameterContexts()).pipe(
+                from(this.parameterContextService.getParameterContexts(false)).pipe(
                     concatLatestFrom(() => this.store.select(selectCurrentParameterContext)),
                     map(([response, parameterContext]) => {
                         const dialogRequest: GroupComponentsDialogRequest = {
@@ -1322,7 +1322,7 @@ export class FlowEffects {
                     case ComponentType.Connection:
                         return of(FlowActions.openEditConnectionDialog({ request }));
                     case ComponentType.ProcessGroup:
-                        return from(this.parameterContextService.getParameterContexts()).pipe(
+                        return from(this.parameterContextService.getParameterContexts(false)).pipe(
                             map((response) => {
                                 const editComponentDialogRequest = {
                                     ...request,
@@ -1356,7 +1356,7 @@ export class FlowEffects {
             ofType(FlowActions.editCurrentProcessGroup),
             map((action) => action.request),
             switchMap((request) => {
-                return from(this.parameterContextService.getParameterContexts()).pipe(
+                return from(this.parameterContextService.getParameterContexts(false)).pipe(
                     switchMap((parameterContextResponse) =>
                         from(this.flowService.getProcessGroup(request.id)).pipe(
                             map((response) =>
@@ -1507,7 +1507,7 @@ export class FlowEffects {
                 switchMap(([request, parameterContextReference, processGroupId]) => {
                     if (parameterContextReference && parameterContextReference.permissions.canRead) {
                         return from(
-                            this.parameterContextService.getParameterContext(parameterContextReference.id)
+                            this.parameterContextService.getParameterContext(parameterContextReference.id, true, false)
                         ).pipe(
                             map((parameterContext) => {
                                 return [request, parameterContext, processGroupId];

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/parameter/parameter.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/parameter/parameter.effects.ts
@@ -65,7 +65,7 @@ export class ParameterEffects {
             ofType(ParameterActions.submitParameterContextUpdateRequest),
             map((action) => action.request),
             switchMap((request) =>
-                from(this.parameterService.submitParameterContextUpdate(request)).pipe(
+                from(this.parameterService.submitParameterContextUpdate(request, false)).pipe(
                     map((response) =>
                         ParameterActions.submitParameterContextUpdateRequestSuccess({
                             response: {
@@ -123,7 +123,8 @@ export class ParameterEffects {
                 from(
                     this.parameterService.pollParameterContextUpdate(
                         parameterContextId,
-                        updateRequest.request.requestId
+                        updateRequest.request.requestId,
+                        false
                     )
                 ).pipe(
                     map((response) =>
@@ -173,7 +174,8 @@ export class ParameterEffects {
                     return from(
                         this.parameterService.deleteParameterContextUpdate(
                             parameterContextId,
-                            updateRequest.request.requestId
+                            updateRequest.request.requestId,
+                            false
                         )
                     ).pipe(
                         map(() => ParameterActions.editParameterContextComplete()),
@@ -279,7 +281,7 @@ export class ParameterEffects {
             ofType(ParameterActions.createParameterContext),
             map((action) => action.request),
             switchMap((request) =>
-                from(this.parameterContextService.createParameterContext(request)).pipe(
+                from(this.parameterContextService.createParameterContext(request, false)).pipe(
                     map((response) =>
                         ParameterActions.createParameterContextSuccess({
                             response: {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/service/parameter-contexts.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/service/parameter-contexts.service.ts
@@ -31,42 +31,63 @@ export class ParameterContextService {
 
     private static readonly API: string = '../nifi-api';
 
-    getParameterContexts(): Observable<any> {
-        return this.httpClient.get(`${ParameterContextService.API}/flow/parameter-contexts`);
+    getParameterContexts(includeReferencingComponents: boolean): Observable<any> {
+        return this.httpClient.get(`${ParameterContextService.API}/flow/parameter-contexts`, {
+            params: { includeReferencingComponents }
+        });
     }
 
-    createParameterContext(createParameterContext: CreateParameterContextRequest): Observable<any> {
+    createParameterContext(
+        createParameterContext: CreateParameterContextRequest,
+        includeReferencingComponents: boolean
+    ): Observable<any> {
         return this.httpClient.post(
             `${ParameterContextService.API}/parameter-contexts`,
-            createParameterContext.payload
+            createParameterContext.payload,
+            { params: { includeReferencingComponents } }
         );
     }
 
-    getParameterContext(id: string, includeInheritedParameters = true): Observable<any> {
+    getParameterContext(id: string, includeInheritedParameters: boolean, includeReferencingComponents: boolean): Observable<any> {
         return this.httpClient.get(`${ParameterContextService.API}/parameter-contexts/${id}`, {
             params: {
-                includeInheritedParameters
+                includeInheritedParameters,
+                includeReferencingComponents
             }
         });
     }
 
-    submitParameterContextUpdate(configureParameterContext: SubmitParameterContextUpdate): Observable<any> {
+    submitParameterContextUpdate(
+        configureParameterContext: SubmitParameterContextUpdate,
+        includeReferencingComponents: boolean
+    ): Observable<any> {
         return this.httpClient.post(
             `${ParameterContextService.API}/parameter-contexts/${configureParameterContext.id}/update-requests`,
-            configureParameterContext.payload
+            configureParameterContext.payload,
+            { params: { includeReferencingComponents } }
         );
     }
 
-    pollParameterContextUpdate(parameterContextId: string, requestId: string): Observable<any> {
+    pollParameterContextUpdate(
+        parameterContextId: string,
+        requestId: string,
+        includeReferencingComponents: boolean
+    ): Observable<any> {
         return this.httpClient.get(
-            `${ParameterContextService.API}/parameter-contexts/${parameterContextId}/update-requests/${requestId}`
+            `${ParameterContextService.API}/parameter-contexts/${parameterContextId}/update-requests/${requestId}`,
+            { params: { includeReferencingComponents } }
         );
     }
 
-    deleteParameterContextUpdate(parameterContextId: string, requestId: string): Observable<any> {
+    deleteParameterContextUpdate(
+        parameterContextId: string,
+        requestId: string,
+        includeReferencingComponents: boolean
+    ): Observable<any> {
         const params = new HttpParams({
             fromObject: {
-                disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged()
+                disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged(),
+                includeReferencingComponents
             }
         });
         return this.httpClient.delete(
@@ -75,12 +96,16 @@ export class ParameterContextService {
         );
     }
 
-    deleteParameterContext(deleteParameterContext: DeleteParameterContextRequest): Observable<any> {
+    deleteParameterContext(
+        deleteParameterContext: DeleteParameterContextRequest,
+        includeReferencingComponents: boolean
+    ): Observable<any> {
         const entity: ParameterContextEntity = deleteParameterContext.parameterContext;
         const params = new HttpParams({
             fromObject: {
                 ...this.client.getRevision(entity),
-                disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged()
+                disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged(),
+                includeReferencingComponents
             }
         });
         return this.httpClient.delete(`${ParameterContextService.API}/parameter-contexts/${entity.id}`, { params });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.spec.ts
@@ -396,7 +396,8 @@ describe('ParameterContextListingEffects', () => {
             effects.deleteParameterContextUpdateRequest$.subscribe(() => {
                 expect(parameterContextService.deleteParameterContextUpdate).toHaveBeenCalledWith(
                     parameterContextId,
-                    mockUpdateRequest.requestId
+                    mockUpdateRequest.requestId,
+                    false
                 );
             });
         });
@@ -419,7 +420,8 @@ describe('ParameterContextListingEffects', () => {
             effects.deleteParameterContextUpdateRequest$.subscribe(() => {
                 expect(parameterContextService.deleteParameterContextUpdate).toHaveBeenCalledWith(
                     parameterContextId,
-                    mockUpdateRequest.requestId
+                    mockUpdateRequest.requestId,
+                    false
                 );
             });
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
@@ -85,7 +85,7 @@ export class ParameterContextListingEffects {
             ofType(ParameterContextListingActions.loadParameterContexts),
             concatLatestFrom(() => this.store.select(selectParameterContextLoadedTimestamp)),
             switchMap(([, loadedTimestamp]) =>
-                from(this.parameterContextService.getParameterContexts()).pipe(
+                from(this.parameterContextService.getParameterContexts(false)).pipe(
                     map((response) =>
                         ParameterContextListingActions.loadParameterContextsSuccess({
                             response: {
@@ -206,7 +206,7 @@ export class ParameterContextListingEffects {
             ofType(ParameterContextListingActions.createParameterContext),
             map((action) => action.request),
             switchMap((request) =>
-                from(this.parameterContextService.createParameterContext(request)).pipe(
+                from(this.parameterContextService.createParameterContext(request, false)).pipe(
                     map((response) =>
                         ParameterContextListingActions.createParameterContextSuccess({
                             response: {
@@ -302,7 +302,7 @@ export class ParameterContextListingEffects {
             ofType(ParameterContextListingActions.getEffectiveParameterContextAndOpenDialog),
             map((action) => action.request),
             switchMap((request) =>
-                from(this.parameterContextService.getParameterContext(request.id, true)).pipe(
+                from(this.parameterContextService.getParameterContext(request.id, true, true)).pipe(
                     map((response) =>
                         ParameterContextListingActions.openParameterContextDialog({
                             request: {
@@ -497,7 +497,7 @@ export class ParameterContextListingEffects {
             ofType(ParameterContextListingActions.submitParameterContextUpdateRequest),
             map((action) => action.request),
             switchMap((request) =>
-                from(this.parameterContextService.submitParameterContextUpdate(request)).pipe(
+                from(this.parameterContextService.submitParameterContextUpdate(request, false)).pipe(
                     map((response) =>
                         ParameterContextListingActions.submitParameterContextUpdateRequestSuccess({
                             response: {
@@ -564,7 +564,8 @@ export class ParameterContextListingEffects {
                 from(
                     this.parameterContextService.pollParameterContextUpdate(
                         parameterContextId,
-                        updateRequest.request.requestId
+                        updateRequest.request.requestId,
+                        false
                     )
                 ).pipe(
                     map((response) =>
@@ -620,7 +621,7 @@ export class ParameterContextListingEffects {
                 ]),
                 tap(([, parameterContextId, updateRequest]) => {
                     this.parameterContextService
-                        .deleteParameterContextUpdate(parameterContextId, updateRequest.request.requestId)
+                        .deleteParameterContextUpdate(parameterContextId, updateRequest.request.requestId, false)
                         .subscribe((response) => {
                             this.store.dispatch(
                                 ParameterContextListingActions.deleteParameterContextUpdateRequestSuccess({
@@ -669,7 +670,7 @@ export class ParameterContextListingEffects {
             ofType(ParameterContextListingActions.deleteParameterContext),
             map((action) => action.request),
             switchMap((request) =>
-                from(this.parameterContextService.deleteParameterContext(request)).pipe(
+                from(this.parameterContextService.deleteParameterContext(request, false)).pipe(
                     map((response) =>
                         ParameterContextListingActions.deleteParameterContextSuccess({
                             response: {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/service/parameter-provider.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/service/parameter-provider.service.ts
@@ -96,7 +96,10 @@ export class ParameterProviderService implements PropertyDescriptorRetriever {
         );
     }
 
-    fetchParameters(request: FetchParameterProviderParametersRequest): Observable<any> {
+    fetchParameters(
+        request: FetchParameterProviderParametersRequest,
+        includeReferencingComponents: boolean
+    ): Observable<any> {
         return this.httpClient.post(
             `${ParameterProviderService.API}/parameter-providers/${request.id}/parameters/fetch-requests`,
             {
@@ -104,31 +107,44 @@ export class ParameterProviderService implements PropertyDescriptorRetriever {
                 revision: request.revision,
                 disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged()
             },
-            { params: { disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged() } }
+            {
+                params: {
+                    disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged(),
+                    includeReferencingComponents
+                }
+            }
         );
     }
 
-    applyParameters(request: ParameterProviderParameterApplicationEntity): Observable<any> {
+    applyParameters(
+        request: ParameterProviderParameterApplicationEntity,
+        includeReferencingComponents: boolean
+    ): Observable<any> {
         return this.httpClient.post(
             `${ParameterProviderService.API}/parameter-providers/${request.id}/apply-parameters-requests`,
-            request
+            request,
+            { params: { includeReferencingComponents } }
         );
     }
 
     pollParameterProviderParametersUpdateRequest(
-        updateRequest: ParameterProviderApplyParametersRequest
+        updateRequest: ParameterProviderApplyParametersRequest,
+        includeReferencingComponents: boolean
     ): Observable<any> {
         return this.httpClient.get(
-            `${ParameterProviderService.API}/parameter-providers/${updateRequest.parameterProvider.id}/apply-parameters-requests/${updateRequest.requestId}`
+            `${ParameterProviderService.API}/parameter-providers/${updateRequest.parameterProvider.id}/apply-parameters-requests/${updateRequest.requestId}`,
+            { params: { includeReferencingComponents } }
         );
     }
 
     deleteParameterProviderParametersUpdateRequest(
-        updateRequest: ParameterProviderApplyParametersRequest
+        updateRequest: ParameterProviderApplyParametersRequest,
+        includeReferencingComponents: boolean
     ): Observable<any> {
         const params = new HttpParams({
             fromObject: {
-                disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged()
+                disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged(),
+                includeReferencingComponents
             }
         });
         return this.httpClient.delete(

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/state/parameter-providers/parameter-providers.effects.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/state/parameter-providers/parameter-providers.effects.spec.ts
@@ -469,7 +469,7 @@ describe('ParameterProvidersEffects', () => {
                     response: { parameterProvider: mockResponse }
                 })
             );
-            expect(mockParameterProviderService.fetchParameters).toHaveBeenCalledWith(mockRequest);
+            expect(mockParameterProviderService.fetchParameters).toHaveBeenCalledWith(mockRequest, true);
         });
 
         it('should handle error when fetching parameters fails', async () => {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/state/parameter-providers/parameter-providers.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/state/parameter-providers/parameter-providers.effects.ts
@@ -550,7 +550,7 @@ export class ParameterProvidersEffects {
             ofType(ParameterProviderActions.fetchParameterProviderParametersAndOpenDialog),
             map((action) => action.request),
             switchMap((request) =>
-                from(this.parameterProviderService.fetchParameters(request)).pipe(
+                from(this.parameterProviderService.fetchParameters(request, true)).pipe(
                     map((response: ParameterProviderEntity) =>
                         ParameterProviderActions.fetchParameterProviderParametersSuccess({
                             response: { parameterProvider: response }
@@ -680,7 +680,7 @@ export class ParameterProvidersEffects {
             map((action) => action.request),
             switchMap((request) =>
                 from(
-                    this.parameterProviderService.applyParameters(request).pipe(
+                    this.parameterProviderService.applyParameters(request, false).pipe(
                         map((response: any) =>
                             ParameterProviderActions.submitParameterProviderParametersUpdateRequestSuccess({
                                 response: {
@@ -739,7 +739,10 @@ export class ParameterProvidersEffects {
             switchMap(([, updateRequest]) => {
                 if (updateRequest) {
                     return from(
-                        this.parameterProviderService.pollParameterProviderParametersUpdateRequest(updateRequest)
+                        this.parameterProviderService.pollParameterProviderParametersUpdateRequest(
+                            updateRequest,
+                            false
+                        )
                     ).pipe(
                         map((response) =>
                             ParameterProviderActions.pollParameterProviderParametersUpdateRequestSuccess({
@@ -789,7 +792,7 @@ export class ParameterProvidersEffects {
                 tap(([, updateRequest]) => {
                     if (updateRequest) {
                         this.parameterProviderService
-                            .deleteParameterProviderParametersUpdateRequest(updateRequest)
+                            .deleteParameterProviderParametersUpdateRequest(updateRequest, false)
                             .subscribe();
                     }
                 })


### PR DESCRIPTION

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16179](https://issues.apache.org/jira/browse/NIFI-16179)

Added optional includeReferencingComponents query parameter in requests for ParameterContexts. This can reduce the response size greatly when a parameter is referenced by many components and the user does not need the references.

The headline change in this PR is https://github.com/apache/nifi/pull/11523/changes#diff-c7e8b2b7db75b382b5bd3502beea74000480ea54e5a41b4045d1893f15b72502R1629-R1632 which conditionally adds the referencing components to the parameter DTO. The rest of the changes are either plumbing to either add `includeReferences` as a parameter or to deal with the possibility that referencing components may be null or UI changes to request the parameter contexts while excluding referencing components.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [x] JDK 25

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
