### PR TITLE
NIFI-16181 Make MockProcessSession#commitAsync null safe

### DIFF
--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
@@ -370,11 +370,15 @@ public class MockProcessSession implements ProcessSession {
             commitInternal();
         } catch (final Throwable t) {
             rollback();
-            onFailure.accept(t);
+            if (onFailure != null) {
+                onFailure.accept(t);
+            }
             throw t;
         }
 
-        onSuccess.run();
+        if (onSuccess != null) {
+            onSuccess.run();
+        }
     }
 
     /**

--- a/nifi-mock/src/test/java/org/apache/nifi/util/TestMockProcessSession.java
+++ b/nifi-mock/src/test/java/org/apache/nifi/util/TestMockProcessSession.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
@@ -599,6 +600,69 @@ public class TestMockProcessSession {
 
             sessionOfStatefulProcessor.commitAsync();
             assertEquals(expectedState, sessionOfStatefulProcessor.getState(Scope.CLUSTER).toMap());
+        }
+    }
+
+    @Nested
+    class RegardingCommitAsync {
+
+        @Test
+        void invokesOnSuccess() {
+            final AtomicBoolean successInvoked = new AtomicBoolean();
+
+            session.commitAsync(() -> successInvoked.set(true), failure -> fail("onFailure should not be invoked"));
+
+            assertTrue(successInvoked.get());
+            session.assertCommitted();
+        }
+
+        @Test
+        void allowsNullCallbacks() {
+            assertDoesNotThrow(() -> session.commitAsync(null, null));
+
+            session.assertCommitted();
+        }
+
+        @Test
+        void invokesOnFailure() {
+            final MockProcessSession failingSession = MockProcessSession.builder(sharedState, processor)
+                    .stateManager(stateManager)
+                    .failCommit()
+                    .build();
+            final AtomicBoolean failureInvoked = new AtomicBoolean();
+
+            final FlowFileHandlingException thrown = assertThrows(FlowFileHandlingException.class,
+                    () -> failingSession.commitAsync(
+                            () -> fail("onSuccess should not be invoked"),
+                            failure -> failureInvoked.set(true)));
+
+            assertTrue(failureInvoked.get());
+            assertEquals("Cannot commit session because the session was requested to fail by a test", thrown.getMessage());
+            failingSession.assertNotCommitted();
+        }
+
+        @Test
+        void throwsWithNullOnFailure() {
+            final MockProcessSession failingSession = MockProcessSession.builder(sharedState, processor)
+                    .stateManager(stateManager)
+                    .failCommit()
+                    .build();
+
+            assertThrows(FlowFileHandlingException.class, () -> failingSession.commitAsync(() -> { }, null));
+
+            failingSession.assertNotCommitted();
+        }
+
+        @Test
+        void throwsWithSingleCallback() {
+            final MockProcessSession failingSession = MockProcessSession.builder(sharedState, processor)
+                    .stateManager(stateManager)
+                    .failCommit()
+                    .build();
+
+            assertThrows(FlowFileHandlingException.class, () -> failingSession.commitAsync(() -> { }));
+
+            failingSession.assertNotCommitted();
         }
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16181](https://issues.apache.org/jira/browse/NIFI-16181)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
