### PR TITLE
NIFI-16167 Focus referenced parameter when navigating from a property

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.effects.ts
@@ -406,7 +406,12 @@ export class ControllerServicesEffects {
                         selectPropertyVerificationStatus
                     );
 
-                    const goTo = (commands: string[], destination: string, commandBoundary?: string[]): void => {
+                    const goTo = (
+                        commands: string[],
+                        destination: string,
+                        commandBoundary?: string[],
+                        additionalState?: Record<string, unknown>
+                    ): void => {
                         if (editDialogReference.componentInstance.editControllerServiceForm.dirty) {
                             const saveChangesDialogReference = this.dialog.open(YesNoDialog, {
                                 ...SMALL_DIALOG,
@@ -434,11 +439,14 @@ export class ControllerServicesEffects {
                                                 ],
                                                 routeBoundary: commandBoundary,
                                                 context: 'Controller Service'
-                                            } as BackNavigation
+                                            } as BackNavigation,
+                                            ...additionalState
                                         }
                                     });
                                 } else {
-                                    this.router.navigate(commands);
+                                    this.router.navigate(commands, {
+                                        state: { ...additionalState }
+                                    });
                                 }
                             });
                         } else {
@@ -455,11 +463,14 @@ export class ControllerServicesEffects {
                                             ],
                                             routeBoundary: commandBoundary,
                                             context: 'Controller Service'
-                                        } as BackNavigation
+                                        } as BackNavigation,
+                                        ...additionalState
                                     }
                                 });
                             } else {
-                                this.router.navigate(commands);
+                                this.router.navigate(commands, {
+                                    state: { ...additionalState }
+                                });
                             }
                         }
                     };
@@ -473,12 +484,12 @@ export class ControllerServicesEffects {
 
                     if (parameterContext != null) {
                         editDialogReference.componentInstance.parameterContext = parameterContext;
-                        editDialogReference.componentInstance.goToParameter = () => {
+                        editDialogReference.componentInstance.goToParameter = (parameterName: string) => {
                             this.storage.setItem<number>(NiFiCommon.EDIT_PARAMETER_CONTEXT_DIALOG_ID, 1);
 
                             const commandBoundary: string[] = ['/parameter-contexts'];
                             const commands: string[] = [...commandBoundary, parameterContext.id, 'edit'];
-                            goTo(commands, 'Parameter', commandBoundary);
+                            goTo(commands, 'Parameter', commandBoundary, { parameterName });
                         };
 
                         editDialogReference.componentInstance.convertToParameter =

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -1564,7 +1564,12 @@ export class FlowEffects {
                         selectPropertyVerificationStatus
                     );
 
-                    const goTo = (commands: string[], commandBoundary: string[], destination: string): void => {
+                    const goTo = (
+                        commands: string[],
+                        commandBoundary: string[],
+                        destination: string,
+                        additionalState?: Record<string, unknown>
+                    ): void => {
                         if (editDialogReference.componentInstance.editProcessorForm.dirty) {
                             const saveChangesDialogReference = this.dialog.open(YesNoDialog, {
                                 ...SMALL_DIALOG,
@@ -1591,7 +1596,8 @@ export class FlowEffects {
                                             ],
                                             routeBoundary: commandBoundary,
                                             context: 'Processor'
-                                        } as BackNavigation
+                                        } as BackNavigation,
+                                        ...additionalState
                                     }
                                 });
                             });
@@ -1608,7 +1614,8 @@ export class FlowEffects {
                                         ],
                                         routeBoundary: commandBoundary,
                                         context: 'Processor'
-                                    } as BackNavigation
+                                    } as BackNavigation,
+                                    ...additionalState
                                 }
                             });
                         }
@@ -1616,12 +1623,12 @@ export class FlowEffects {
 
                     if (parameterContext != null) {
                         editDialogReference.componentInstance.parameterContext = parameterContext;
-                        editDialogReference.componentInstance.goToParameter = () => {
+                        editDialogReference.componentInstance.goToParameter = (parameterName: string) => {
                             this.storage.setItem<number>(NiFiCommon.EDIT_PARAMETER_CONTEXT_DIALOG_ID, 1);
 
                             const commandBoundary: string[] = ['/parameter-contexts'];
                             const commands: string[] = [...commandBoundary, parameterContext.id, 'edit'];
-                            goTo(commands, commandBoundary, 'Parameter');
+                            goTo(commands, commandBoundary, 'Parameter', { parameterName });
                         };
 
                         editDialogReference.componentInstance.convertToParameter =

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
@@ -16,6 +16,7 @@
  */
 
 import { Injectable, inject } from '@angular/core';
+import { Location } from '@angular/common';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { concatLatestFrom } from '@ngrx/operators';
 import * as ParameterContextListingActions from './parameter-context-listing.actions';
@@ -67,6 +68,7 @@ export class ParameterContextListingEffects {
     private parameterContextService = inject(ParameterContextService);
     private dialog = inject(MatDialog);
     private router = inject(Router);
+    private location = inject(Location);
     private errorHelper = inject(ErrorHelper);
 
     loadParameterContexts$ = createEffect(() =>
@@ -323,12 +325,21 @@ export class ParameterContextListingEffects {
 
                     this.storage.setItem<number>(NiFiCommon.EDIT_PARAMETER_CONTEXT_DIALOG_ID, 1);
 
+                    const navigationState = this.location.getState() as { parameterName?: string } | null;
+                    const selectedParameterName = navigationState?.parameterName;
+
                     const editDialogReference = this.dialog.open(EditParameterContext, {
                         ...XL_DIALOG,
                         data: {
                             parameterContext: request.parameterContext
                         }
                     });
+
+                    if (selectedParameterName) {
+                        // Parameters tab
+                        editDialogReference.componentInstance.selectedIndex = 1;
+                        editDialogReference.componentInstance.selectedParameterName = selectedParameterName;
+                    }
 
                     editDialogReference.componentInstance.updateRequest = this.store.select(selectUpdateRequest);
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.html
@@ -172,7 +172,8 @@
                         (click)="selectParameter(row)"
                         (dblclick)="doubleClicked(row)"
                         [class.selected]="isSelected(row)"
-                        [class.even]="even"></tr>
+                        [class.even]="even"
+                        [attr.data-parameter-name]="row.originalEntity.parameter.name"></tr>
                 </table>
             </div>
         </div>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AfterViewInit, ChangeDetectorRef, Component, forwardRef, Input, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, forwardRef, Input, inject } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -74,11 +74,13 @@ export class ParameterTable implements AfterViewInit, ControlValueAccessor {
     private store = inject<Store<ParameterContextListingState>>(Store);
     private changeDetector = inject(ChangeDetectorRef);
     private nifiCommon = inject(NiFiCommon);
+    private elementRef = inject(ElementRef);
 
     @Input() createNewParameter!: (existingParameters: string[]) => Observable<EditParameterResponse>;
     @Input() editParameter!: (parameter: Parameter) => Observable<EditParameterResponse>;
     @Input() canAddParameters = true;
     @Input() inheritsParameters = false;
+    @Input() selectedParameterName?: string;
 
     protected readonly TextTip = TextTip;
 
@@ -165,6 +167,28 @@ export class ParameterTable implements AfterViewInit, ControlValueAccessor {
     private setPropertyItems(parameterItems: ParameterItem[]): void {
         this.dataSource.data = this.sortEntities(parameterItems, this.activeSort);
         this.initFilter();
+        this.selectAndScrollToParameter(this.selectedParameterName);
+    }
+
+    private selectAndScrollToParameter(parameterName: string | undefined): void {
+        if (!parameterName) {
+            return;
+        }
+
+        const item = this.dataSource.data.find((i) => i.originalEntity.parameter.name === parameterName);
+        if (!item) {
+            return;
+        }
+
+        this.selectParameter(item);
+
+        // wait for the table rows to render before attempting to scroll
+        setTimeout(() => {
+            const row: HTMLElement | null = this.elementRef.nativeElement.querySelector(
+                `tr[data-parameter-name="${parameterName}"]`
+            );
+            row?.scrollIntoView({ block: 'center' });
+        });
     }
 
     private sortEntities(parameters: ParameterItem[], sort: Sort): ParameterItem[] {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/parameter-context/edit-parameter-context/edit-parameter-context.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/parameter-context/edit-parameter-context/edit-parameter-context.component.html
@@ -157,7 +157,8 @@
                             [canAddParameters]="!request.parameterContext?.component?.parameterProviderConfiguration"
                             [inheritsParameters]="inheritsParameters(request.parameterContext?.component?.parameters)"
                             [createNewParameter]="createNewParameter"
-                            [editParameter]="editParameter"></parameter-table>
+                            [editParameter]="editParameter"
+                            [selectedParameterName]="selectedParameterName"></parameter-table>
                     </div>
                 </mat-dialog-content>
             </mat-tab>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/parameter-context/edit-parameter-context/edit-parameter-context.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/parameter-context/edit-parameter-context/edit-parameter-context.component.ts
@@ -96,6 +96,7 @@ export class EditParameterContext extends TabbedDialog {
     @Input() updateRequest!: Observable<ParameterContextUpdateRequestEntity | null>;
     @Input() availableParameterContexts$!: Observable<ParameterContextEntity[]>;
     @Input() saving$!: Observable<boolean>;
+    @Input() selectedParameterName?: string;
 
     @Output() addParameterContext: EventEmitter<any> = new EventEmitter<any>();
     @Output() editParameterContext: EventEmitter<any> = new EventEmitter<any>();

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/property-table/property-table.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/property-table/property-table.component.spec.ts
@@ -74,13 +74,13 @@ describe('PropertyTable', () => {
             expect(() => component.goToParameterClicked(mockItem)).not.toThrow();
         });
 
-        it('should invoke goToParameter callback when supplied and item.value is non-null', () => {
+        it('should invoke goToParameter callback with the extracted parameter name when supplied and item.value is non-null', () => {
             const goToParameterSpy = vi.fn();
             component.goToParameter = goToParameterSpy;
 
             component.goToParameterClicked(mockItem);
 
-            expect(goToParameterSpy).toHaveBeenCalledWith('#{some-param}');
+            expect(goToParameterSpy).toHaveBeenCalledWith('some-param');
         });
 
         it('should not invoke goToParameter callback when item.value is null', () => {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/property-table/property-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/property-table/property-table.component.ts
@@ -108,6 +108,7 @@ export class PropertyTable implements AfterViewInit, ControlValueAccessor {
     @Input() supportsParameters = true;
 
     private static readonly PARAM_REF_REGEX: RegExp = /#{(['"]?)[a-zA-Z0-9-_. ]+\1}/;
+    private static readonly PARAM_REF_NAME_REGEX: RegExp = /#{(['"]?)([a-zA-Z0-9-_. ]+)\1}/;
 
     private destroyRef = inject(DestroyRef);
 
@@ -517,9 +518,6 @@ export class PropertyTable implements AfterViewInit, ControlValueAccessor {
     }
 
     canGoToParameter(item: PropertyItem): boolean {
-        // TODO - currently parameter context route does not support navigating
-        // directly to a specific parameter so the parameter context link
-        // is not item specific.
         if (this.parameterContext && this.goToParameter && item.value) {
             return this.parameterContext.permissions.canRead && PropertyTable.PARAM_REF_REGEX.test(item.value);
         }
@@ -531,7 +529,16 @@ export class PropertyTable implements AfterViewInit, ControlValueAccessor {
         if (!this.goToParameter || item.value == null) {
             return;
         }
-        this.goToParameter(item.value);
+
+        const parameterName = this.extractParameterName(item.value);
+        if (parameterName) {
+            this.goToParameter(parameterName);
+        }
+    }
+
+    private extractParameterName(value: string): string | null {
+        const match = PropertyTable.PARAM_REF_NAME_REGEX.exec(value);
+        return match ? match[2] : null;
     }
 
     canConvertToParameter(item: PropertyItem): boolean {


### PR DESCRIPTION
Clicking "Go to" on a processor or controller service property that references a parameter (e.g. #{my-param}) opened the Parameter Context edit dialog but did not focus the referenced parameter, requiring users to manually search the parameter list to find and update it. This restores the NiFi 1.x behavior of automatically selecting and scrolling to the referenced parameter.

- PropertyTable now extracts the parameter name from the #{...} reference syntax before invoking the goToParameter callback, instead of passing the raw reference literal.
- The goToParameter callbacks in the processor and controller service effects forward the parameter name as router navigation state alongside the existing back-navigation state.
- The Parameter Context listing effect reads the parameter name from navigation state when opening the Edit Parameter Context dialog, switches to the Parameters tab, and passes it to the dialog.
- EditParameterContext forwards the selected parameter name to ParameterTable, which selects the matching row and scrolls it into view once the table data is populated.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16167](https://issues.apache.org/jira/browse/NIFI-16167)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
