### PR TITLE
NIFI-15758 Add Fragment Attributes to FlowFile format in UnpackContent

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -311,32 +311,13 @@ public class UnpackContent extends AbstractProcessor {
             }
         }
 
-        // set the Unpacker to use for this FlowFile.  FlowFileUnpackager objects maintain state and are not reusable.
-        final Unpacker unpacker;
-        final boolean addFragmentAttrs = switch (packagingFormat) {
-            case TAR_FORMAT -> {
-                unpacker = tarUnpacker;
-                yield true;
-            }
-            case ZIP_FORMAT -> {
-                unpacker = zipUnpacker;
-                yield true;
-            }
-            case FLOWFILE_STREAM_FORMAT_V2 -> {
-                unpacker = new FlowFileStreamUnpacker(new FlowFileUnpackagerV2());
-                yield false;
-            }
-            case FLOWFILE_STREAM_FORMAT_V3 -> {
-                unpacker = new FlowFileStreamUnpacker(new FlowFileUnpackagerV3());
-                yield false;
-            }
-            case FLOWFILE_TAR_FORMAT -> {
-                unpacker = new FlowFileStreamUnpacker(new FlowFileUnpackagerV1());
-                yield false;
-            }
-            default ->
-                // The format of the unpacker should be known before initialization
-                throw new ProcessException(packagingFormat + " is not a valid packaging format");
+        final Unpacker unpacker = switch (packagingFormat) {
+            case TAR_FORMAT -> tarUnpacker;
+            case ZIP_FORMAT -> zipUnpacker;
+            case FLOWFILE_STREAM_FORMAT_V2 -> new FlowFileStreamUnpacker(new FlowFileUnpackagerV2());
+            case FLOWFILE_STREAM_FORMAT_V3 -> new FlowFileStreamUnpacker(new FlowFileUnpackagerV3());
+            case FLOWFILE_TAR_FORMAT -> new FlowFileStreamUnpacker(new FlowFileUnpackagerV1());
+            default -> throw new ProcessException("Format [%s] not supported".formatted(packagingFormat));
         };
 
         final List<FlowFile> unpacked = new ArrayList<>();
@@ -348,9 +329,17 @@ public class UnpackContent extends AbstractProcessor {
                 return;
             }
 
-            if (addFragmentAttrs) {
-                finishFragmentAttributes(session, flowFile, unpacked);
+            // Determine whether Fragment Identifiers are needed based on Unpacker and existing attribute status after unpacking
+            final boolean fragmentIdentifiersRequired;
+            if (unpacker instanceof final FlowFileStreamUnpacker streamUnpacker) {
+                fragmentIdentifiersRequired = !streamUnpacker.isFragmentIdentifierRestored();
+            } else {
+                fragmentIdentifiersRequired = true;
             }
+            if (fragmentIdentifiersRequired) {
+                putFragmentAttributes(session, flowFile, unpacked);
+            }
+
             session.transfer(unpacked, REL_SUCCESS);
             final String fragmentId = !unpacked.isEmpty() ? unpacked.getFirst().getAttribute(FRAGMENT_ID) : null;
             flowFile = FragmentAttributes.copyAttributesToOriginal(session, flowFile, fragmentId, unpacked.size());
@@ -648,8 +637,14 @@ public class UnpackContent extends AbstractProcessor {
 
         private final FlowFileUnpackager unpackager;
 
+        private boolean fragmentIdentifierRestored;
+
         public FlowFileStreamUnpacker(final FlowFileUnpackager unpackager) {
             this.unpackager = unpackager;
+        }
+
+        private boolean isFragmentIdentifierRestored() {
+            return fragmentIdentifierRestored;
         }
 
         @Override
@@ -677,6 +672,13 @@ public class UnpackContent extends AbstractProcessor {
                             // and later unpack it -- in this case, we have two FlowFiles with the same UUID.
                             attributes.remove(CoreAttributes.UUID.key());
 
+                            // Track whether the packaged FlowFile itself carried a fragment identifier. This is evaluated
+                            // against the restored attributes rather than the unpacked FlowFile, because a child created
+                            // from the source inherits the source's attributes and could otherwise report a false positive.
+                            if (attributes.containsKey(FRAGMENT_ID)) {
+                                fragmentIdentifierRestored = true;
+                            }
+
                             if (!attributes.containsKey(CoreAttributes.MIME_TYPE.key())) {
                                 attributes.put(CoreAttributes.MIME_TYPE.key(), OCTET_STREAM);
                             }
@@ -691,33 +693,49 @@ public class UnpackContent extends AbstractProcessor {
         }
     }
 
-    private void finishFragmentAttributes(final ProcessSession session, final FlowFile source, final List<FlowFile> unpacked) {
-        // first pass verifies all FlowFiles have the FRAGMENT_INDEX attribute and gets the total number of fragments
-        int fragmentCount = 0;
-        for (FlowFile ff : unpacked) {
-            String fragmentIndex = ff.getAttribute(FRAGMENT_INDEX);
-            if (fragmentIndex != null) {
-                fragmentCount++;
-            } else {
-                return;
+    private void putFragmentAttributes(
+            final ProcessSession session,
+            final FlowFile source,
+            final List<FlowFile> unpacked
+    ) {
+        final String fragmentId = UUID.randomUUID().toString();
+        final String segmentOriginalFilename = getSegmentOriginalFilename(source);
+        final String fragmentCount = String.valueOf(unpacked.size());
+
+        final List<FlowFile> updated = new ArrayList<>(unpacked.size());
+        int fragmentIndex = 0;
+        for (final FlowFile unpackedFlowFile : unpacked) {
+            fragmentIndex++;
+            final Map<String, String> fragmentAttributes = new HashMap<>();
+
+            final String unpackedFragmentId = unpackedFlowFile.getAttribute(FRAGMENT_ID);
+            if (unpackedFragmentId == null) {
+                // Set Fragment Identifier and Index when absent for FlowFile Formats
+                fragmentAttributes.put(FRAGMENT_ID, fragmentId);
+                fragmentAttributes.put(FRAGMENT_INDEX, String.valueOf(fragmentIndex));
             }
+
+            fragmentAttributes.put(FRAGMENT_COUNT, fragmentCount);
+            fragmentAttributes.put(SEGMENT_ORIGINAL_FILENAME, segmentOriginalFilename);
+
+            updated.add(session.putAllAttributes(unpackedFlowFile, fragmentAttributes));
         }
 
-        String originalFilename = source.getAttribute(CoreAttributes.FILENAME.key());
-        if (originalFilename.endsWith(".tar") || originalFilename.endsWith(".zip") || originalFilename.endsWith(".pkg")) {
-            originalFilename = originalFilename.substring(0, originalFilename.length() - 4);
-        }
-
-        // second pass adds fragment attributes
-        List<FlowFile> newList = new ArrayList<>(unpacked);
         unpacked.clear();
-        for (FlowFile ff : newList) {
-            FlowFile newFF = session.putAllAttributes(ff, Map.of(
-                    FRAGMENT_COUNT, String.valueOf(fragmentCount),
-                    SEGMENT_ORIGINAL_FILENAME, originalFilename
-            ));
-            unpacked.add(newFF);
+        unpacked.addAll(updated);
+    }
+
+    private String getSegmentOriginalFilename(final FlowFile source) {
+        final String filename = source.getAttribute(CoreAttributes.FILENAME.key());
+
+        final String originalFilename;
+        if (filename.endsWith(".tar") || filename.endsWith(".zip") || filename.endsWith(".pkg")) {
+            originalFilename = filename.substring(0, filename.length() - 4);
+        } else {
+            originalFilename = filename;
         }
+
+        return originalFilename;
     }
 
     protected enum PackageFormat implements DescribedValue {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
@@ -45,11 +45,16 @@ import static org.apache.nifi.processors.standard.SplitContent.FRAGMENT_COUNT;
 import static org.apache.nifi.processors.standard.SplitContent.FRAGMENT_ID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestUnpackContent {
 
     private static final String FIRST_FRAGMENT_INDEX = "1";
+
+    private static final String EXISTING_FRAGMENT_ID = "existing-fragment-id";
+
+    private static final String EXISTING_SEGMENT_FILENAME = "original-archive";
 
     private static final Path dataPath = Paths.get("src/test/resources/TestUnpackContent");
 
@@ -449,6 +454,67 @@ public class TestUnpackContent {
 
             flowFile.assertContentEquals(path.toFile());
         }
+    }
+
+    @Test
+    public void testFlowFileStreamAssignsFragmentAttributesWhenAbsent() throws IOException {
+        runner.setProperty(UnpackContent.PACKAGING_FORMAT, UnpackContent.PackageFormat.FLOWFILE_STREAM_FORMAT_V3);
+        runner.enqueue(dataPath.resolve("data.flowfilev3"));
+        runner.run();
+
+        runner.assertTransferCount(UnpackContent.REL_SUCCESS, 2);
+        runner.assertTransferCount(UnpackContent.REL_FAILURE, 0);
+
+        final List<MockFlowFile> unpacked = runner.getFlowFilesForRelationship(UnpackContent.REL_SUCCESS);
+        final String fragmentId = unpacked.getFirst().getAttribute(UnpackContent.FRAGMENT_ID);
+        assertNotNull(fragmentId);
+        for (final MockFlowFile flowFile : unpacked) {
+            flowFile.assertAttributeEquals(UnpackContent.FRAGMENT_ID, fragmentId);
+            flowFile.assertAttributeEquals(UnpackContent.FRAGMENT_COUNT, "2");
+            flowFile.assertAttributeEquals(UnpackContent.SEGMENT_ORIGINAL_FILENAME, "data.flowfilev3");
+        }
+
+        unpacked.get(0).assertAttributeEquals(UnpackContent.FRAGMENT_INDEX, FIRST_FRAGMENT_INDEX);
+        unpacked.get(1).assertAttributeEquals(UnpackContent.FRAGMENT_INDEX, "2");
+    }
+
+    @Test
+    public void testFlowFileStreamPreservesExistingFragmentAttributes() {
+        final TestRunner mergeRunner = TestRunners.newTestRunner(new MergeContent());
+        mergeRunner.setProperty(MergeContent.MERGE_FORMAT, MergeContent.MergeFormat.FLOWFILE_STREAM_V3);
+        mergeRunner.setProperty(MergeContent.MERGE_STRATEGY, MergeContent.MergeStrategy.BIN_PACK);
+        mergeRunner.setProperty(MergeContent.MIN_ENTRIES, "2");
+        mergeRunner.setProperty(MergeContent.MAX_ENTRIES, "2");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(UnpackContent.FRAGMENT_ID, EXISTING_FRAGMENT_ID);
+        attributes.put(UnpackContent.FRAGMENT_COUNT, "2");
+        attributes.put(UnpackContent.SEGMENT_ORIGINAL_FILENAME, EXISTING_SEGMENT_FILENAME);
+        attributes.put(UnpackContent.FRAGMENT_INDEX, FIRST_FRAGMENT_INDEX);
+        mergeRunner.enqueue("Hello ".getBytes(StandardCharsets.UTF_8), attributes);
+        attributes.put(UnpackContent.FRAGMENT_INDEX, "2");
+        mergeRunner.enqueue("World".getBytes(StandardCharsets.UTF_8), attributes);
+        mergeRunner.run();
+
+        mergeRunner.assertTransferCount(MergeContent.REL_MERGED, 1);
+        final MockFlowFile packaged = mergeRunner.getFlowFilesForRelationship(MergeContent.REL_MERGED).getFirst();
+
+        runner.setProperty(UnpackContent.PACKAGING_FORMAT, UnpackContent.PackageFormat.FLOWFILE_STREAM_FORMAT_V3);
+        runner.enqueue(packaged);
+        runner.run();
+
+        runner.assertTransferCount(UnpackContent.REL_SUCCESS, 2);
+        runner.assertTransferCount(UnpackContent.REL_FAILURE, 0);
+
+        final List<MockFlowFile> unpacked = runner.getFlowFilesForRelationship(UnpackContent.REL_SUCCESS);
+        for (final MockFlowFile flowFile : unpacked) {
+            flowFile.assertAttributeEquals(UnpackContent.FRAGMENT_ID, EXISTING_FRAGMENT_ID);
+            flowFile.assertAttributeEquals(UnpackContent.FRAGMENT_COUNT, "2");
+            flowFile.assertAttributeEquals(UnpackContent.SEGMENT_ORIGINAL_FILENAME, EXISTING_SEGMENT_FILENAME);
+        }
+
+        unpacked.get(0).assertAttributeEquals(UnpackContent.FRAGMENT_INDEX, FIRST_FRAGMENT_INDEX);
+        unpacked.get(1).assertAttributeEquals(UnpackContent.FRAGMENT_INDEX, "2");
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-15758](https://issues.apache.org/jira/browse/NIFI-15758) Updates the `UnpackContent` Processor to add `fragment.identifier` and related FlowFile attributes to unpacked FlowFiles when reading FlowFile stream packages.

The changes extended the behavior for unpacking Zip and TAR archives to FlowFile stream packages, adding fragment attributes when the unpacked FlowFiles do not contain existing values for the `fragment.identifier`. This approach preserves current behavior where packaged FlowFile streams may include existing fragment identifiers, which should be preserved instead of being replaced with new values.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [X] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
