### PR TITLE
NIFI-16183 Add active-polling stopConnector(Duration) to connector mock framework

### DIFF
--- a/nifi-connector-mock-bundle/nifi-connector-mock-api/src/main/java/org/apache/nifi/mock/connector/server/ConnectorTestRunner.java
+++ b/nifi-connector-mock-bundle/nifi-connector-mock-api/src/main/java/org/apache/nifi/mock/connector/server/ConnectorTestRunner.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 public interface ConnectorTestRunner extends Closeable {
 
@@ -143,6 +144,19 @@ public interface ConnectorTestRunner extends Closeable {
      * Stops the Connector, halting all data processing in its managed flow.
      */
     void stopConnector();
+
+    /**
+     * Stops the Connector, waiting up to the given timeout for it to reach a stopped state. Implementations
+     * should actively poll the Connector's state until it is stopped or the timeout elapses, which is more
+     * tolerant of a flow that takes a while to quiesce (for example a failed table still draining) than the
+     * default stop budget.
+     *
+     * @param timeout the maximum duration to wait for the Connector to stop
+     * @throws TimeoutException if the timeout elapses before the Connector stops
+     */
+    default void stopConnector(final Duration timeout) throws TimeoutException {
+        stopConnector();
+    }
 
     /**
      * Blocks until the Connector has received at least one FlowFile, or until the specified timeout elapses.

--- a/nifi-connector-mock-bundle/nifi-connector-mock-server/src/main/java/org/apache/nifi/mock/connector/server/StandardConnectorMockServer.java
+++ b/nifi-connector-mock-bundle/nifi-connector-mock-server/src/main/java/org/apache/nifi/mock/connector/server/StandardConnectorMockServer.java
@@ -102,7 +102,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.jar.JarFile;
 import java.util.stream.Stream;
 
@@ -113,6 +113,8 @@ public class StandardConnectorMockServer implements ConnectorMockServer {
     private static final String NAR_DEPENDENCIES_PATH = "NAR-INF/bundled-dependencies";
     private static final String CONNECTOR_WAR_MANIFEST_PATH = "META-INF/nifi-connector";
     private static final String WAR_EXTENSION = ".war";
+    private static final Duration DEFAULT_STOP_TIMEOUT = Duration.ofSeconds(60);
+    private static final long STOP_POLL_INTERVAL_MILLIS = 250L;
 
     private Bundle systemBundle;
     private Set<Bundle> bundles;
@@ -362,13 +364,35 @@ public class StandardConnectorMockServer implements ConnectorMockServer {
 
     @Override
     public void stopConnector() {
+        // The no-arg convenience method keeps its unchecked contract: a timeout at the default budget is not
+        // something a caller is expected to recover from, so wrap the checked TimeoutException.
         try {
-            connectorNode.stop(flowEngine).get(10, TimeUnit.SECONDS);
-        } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while waiting for connector to stop", e);
-        } catch (final Exception e) {
-            throw new RuntimeException("Failed to stop Connector", e);
+            stopConnector(DEFAULT_STOP_TIMEOUT);
+        } catch (final TimeoutException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void stopConnector(final Duration maxWaitTime) throws TimeoutException {
+        // Initiate the asynchronous stop, then actively poll the Connector's state until it reports STOPPED.
+        // The node flips its state to STOPPED at the same point it completes the stop future, and it retries a
+        // failed component stop internally (every 10 seconds), so polling the state rides through those retries
+        // up to maxWaitTime instead of being capped by a single fixed blocking wait.
+        connectorNode.stop(flowEngine);
+
+        final long expirationTime = System.currentTimeMillis() + maxWaitTime.toMillis();
+        while (connectorNode.getCurrentState() != ConnectorState.STOPPED) {
+            if (System.currentTimeMillis() > expirationTime) {
+                throw new TimeoutException("Timed out waiting for the Connector to stop after " + maxWaitTime);
+            }
+
+            try {
+                Thread.sleep(STOP_POLL_INTERVAL_MILLIS);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for the Connector to stop", e);
+            }
         }
     }
 

--- a/nifi-connector-mock-bundle/nifi-connector-mock-test-bundle/nifi-connector-mock-integration-tests/src/test/java/org/apache/nifi/mock/connectors/tests/CreateConnectorIT.java
+++ b/nifi-connector-mock-bundle/nifi-connector-mock-test-bundle/nifi-connector-mock-integration-tests/src/test/java/org/apache/nifi/mock/connectors/tests/CreateConnectorIT.java
@@ -28,10 +28,12 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -62,6 +64,25 @@ public class CreateConnectorIT {
 
             testRunner.startConnector();
             testRunner.stopConnector();
+        }
+    }
+
+    @Test
+    public void testStopConnectorWithTimeoutStopsRunningConnector() throws IOException {
+        try (final ConnectorTestRunner testRunner = new StandardConnectorTestRunner.Builder()
+                .connectorClassName("org.apache.nifi.mock.connectors.GenerateAndLog")
+                .narLibraryDirectory(new File("target/libDir"))
+                .build()) {
+
+            testRunner.startConnector();
+
+            // Exercises the timeout-aware overload: it initiates the asynchronous stop and actively polls the
+            // Connector's state until it reaches STOPPED, returning as soon as it does rather than after a single
+            // fixed blocking wait. Because start is asynchronous, a stop issued immediately afterwards may have to
+            // ride through the node's internal stop retries (every 10 seconds) before the state settles, so the
+            // budget is generous enough to stay deterministic on a slow CI runner; the poll still returns the
+            // instant the Connector reports STOPPED.
+            assertDoesNotThrow(() -> testRunner.stopConnector(Duration.ofSeconds(120)));
         }
     }
 

--- a/nifi-connector-mock-bundle/nifi-connector-mock/src/main/java/org/apache/nifi/mock/connector/StandardConnectorTestRunner.java
+++ b/nifi-connector-mock-bundle/nifi-connector-mock/src/main/java/org/apache/nifi/mock/connector/StandardConnectorTestRunner.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 
 public class StandardConnectorTestRunner implements ConnectorTestRunner, Closeable {
     private final File narLibraryDirectory;
@@ -196,6 +197,11 @@ public class StandardConnectorTestRunner implements ConnectorTestRunner, Closeab
     @Override
     public void stopConnector() {
         mockServer.stopConnector();
+    }
+
+    @Override
+    public void stopConnector(final Duration timeout) throws TimeoutException {
+        mockServer.stopConnector(timeout);
     }
 
     @Override


### PR DESCRIPTION
# Summary

Tracked by [NIFI-16183](https://issues.apache.org/jira/browse/NIFI-16183).

The connector mock server previously stopped a Connector with a single fixed 10-second blocking wait (`connectorNode.stop(flowEngine).get(10, TimeUnit.SECONDS)`). On slower shutdown paths (for example, a failed table still draining) that wait can expire even though the Connector node retries its stop internally and eventually reaches `STOPPED`, so an otherwise-passing test fails during teardown with a `TimeoutException`.

This change adds a timeout-aware, active-polling stop to the connector mock framework:

- `ConnectorTestRunner`: adds a `default void stopConnector(Duration timeout)` overload that delegates to the no-arg method, keeping it backward compatible for existing implementors.
- `StandardConnectorMockServer`: initiates the asynchronous stop and then polls the Connector state until it reports `STOPPED` within the supplied timeout, instead of a single fixed blocking wait. The node flips its state to `STOPPED` at the same point it completes the stop future and retries a failed component stop internally, so polling rides through those retries up to the timeout. Defaults: 60-second budget, 250 ms poll interval; a healthy stop still returns immediately.
- `StandardConnectorTestRunner`: passes the timeout through to the mock server.
- `CreateConnectorIT`: adds an integration test that exercises the new overload end-to-end against the real `GenerateAndLog` connector.

# Tracking

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-16183) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [x] Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

Note: `contrib-check` was run on JDK 21 (Temurin 21.0.5), scoped to the affected connector-mock bundle reactor (`./mvnw -f nifi-connector-mock-bundle/pom.xml clean install -P contrib-check`, all 9 modules). Checkstyle (0 violations), apache-rat, PMD, and the enforcer rules all pass; external dependencies were resolved from the local repository. The new integration test was run separately via the `integration-tests` profile: `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0` for `CreateConnectorIT#testStopConnectorWithTimeoutStopsRunningConnector`. A full-repo `contrib-check` and a JDK 25 build have not been run.

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html) (no new dependencies are introduced)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files (no new dependencies are introduced)

### Documentation

- [x] Documentation formatting appears as expected in rendered files (no documentation changes)




