### PR TITLE
NIFI-16185 - Bump HTTP Client5 to 5.6.4, Logback to 1.6.2, Slack Bolt to 1.50.0, and others

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
-                <version>5.6.3</version>
+                <version>5.6.4</version>
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-parquet-writer/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-parquet-writer/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.5.0</version>
+            <version>${org.apache.commons.collections4.version}</version>
         </dependency>
         <!-- Test dependencies -->
         <dependency>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
@@ -73,7 +73,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
-                <version>5.6.3</version>
+                <version>5.6.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <activemq.version>6.3.0</activemq.version>
+        <activemq.version>6.3.1</activemq.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <spring.data.redis.version>4.0.6</spring.data.redis.version>
-        <jedis.version>7.5.3</jedis.version>
+        <jedis.version>8.0.0</jedis.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-salesforce</artifactId>
-            <version>4.21.0</version>
+            <version>4.22.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.slack.api</groupId>
             <artifactId>bolt-socket-mode</artifactId>
-            <version>1.49.0</version>
+            <version>1.50.0</version>
         </dependency>
         <!-- Required by bolt-socket-mode but the library itself doesn't have the dependency. -->
         <dependency>

--- a/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
-                <version>${org.bouncycastle.version}</version>
+                <version>${org.bouncycastle.provider.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -122,14 +122,14 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.51.2</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.51.4</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.8</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
         <!-- Apache Commons -->
         <org.apache.commons.cli.version>1.11.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.22.1</org.apache.commons.codec.version>
-        <org.apache.commons.collections4.version>4.5.0</org.apache.commons.collections4.version>
+        <org.apache.commons.collections4.version>4.6.0</org.apache.commons.collections4.version>
         <org.apache.commons.compress.version>1.28.0</org.apache.commons.compress.version>
         <org.apache.commons.configuration.version>2.15.1</org.apache.commons.configuration.version>
         <org.apache.commons.csv.version>1.14.1</org.apache.commons.csv.version>
@@ -154,7 +154,7 @@
         <kafka.docker.image>apache/kafka:4.3.1</kafka.docker.image>
         <avro.version>1.12.1</avro.version>
         <calcite.version>1.42.0</calcite.version>
-        <com.github.luben.zstd-jni.version>1.5.7-12</com.github.luben.zstd-jni.version>
+        <com.github.luben.zstd-jni.version>1.5.7-13</com.github.luben.zstd-jni.version>
         <com.jayway.jsonpath.version>3.0.0</com.jayway.jsonpath.version>
         <gson.version>2.14.0</gson.version>
         <jackson.annotations.version>2.22</jackson.annotations.version>
@@ -170,7 +170,7 @@
 
         <!-- Logging and observability -->
         <log4j2.version>2.26.1</log4j2.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.2</logback.version>
         <org.slf4j.version>2.0.18</org.slf4j.version>
         <prometheus.version>0.16.0</prometheus.version>
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
@@ -187,6 +187,7 @@
         <nimbus-jose-jwt.version>10.9.1</nimbus-jose-jwt.version>
         <nimbus-oauth2-oidc.version>11.38.2</nimbus-oauth2-oidc.version>
         <org.bouncycastle.version>1.85</org.bouncycastle.version>
+        <org.bouncycastle.provider.version>1.85.2</org.bouncycastle.provider.version>
 
         <!-- Utilities -->
         <caffeine.version>3.2.4</caffeine.version>
@@ -238,7 +239,7 @@
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
-                <version>${org.bouncycastle.version}</version>
+                <version>${org.bouncycastle.provider.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
# Summary

NIFI-16185 - Bump HTTP Client5 to 5.6.4, Logback to 1.6.2, Slack Bolt to 1.50.0, and others

- HTTP Client5 from 5.6.3 to 5.6.4 - https://downloads.apache.org/httpcomponents/httpclient/RELEASE_NOTES-5.6.x.txt
- Apache Commons Collections from 4.5.0 to 4.6.0 - https://commons.apache.org/proper/commons-collections/changes.html
- ActiveMQ from 6.3.0 to 6.3.1 - https://github.com/apache/activemq/releases/tag/activemq-6.3.1
- Jedis from 7.5.3 to 8.0.0 - https://github.com/redis/jedis/releases
- Apache Camel Salesforce from 4.21.0 to 4.22.0 - https://github.com/apache/camel/releases/tag/camel-4.22.0
- Slack Bolt from 1.49.0 to 1.50.0 - https://github.com/slackapi/java-slack-sdk/releases/tag/v1.50.0
- BouncyCastle bcprov-jdk18on from 1.85 to 1.85.2 - https://github.com/slackapi/java-slack-sdk/releases/tag/v1.50.0
- AWS SDK from 2.51.2 to 2.51.4 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.51.4
- zstd from 1.5.7-12 to 1.5.7-13 - https://github.com/luben/zstd-jni/releases/tag/v1.5.7-13
- Logback from 1.6.1 to 1.6.2 - https://github.com/qos-ch/logback/releases/tag/v_1.6.2


# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
