### PR TITLE
NIFI-16189 Deprecated StreamUtils#read(InputStream,byte[] destination, int)

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/stream/io/StreamUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/stream/io/StreamUtils.java
@@ -120,7 +120,9 @@ public class StreamUtils {
      * @throws IllegalArgumentException if the given byte array is smaller than <code>byteCount</code> elements.
      * @throws EOFException if the InputStream does not have <code>byteCount</code> bytes in the InputStream
      * @throws IOException if unable to read from the InputStream
+     * @deprecated Use {@link InputStream#readNBytes(byte[], int, int)} instead.
      */
+    @Deprecated(since = "2.12.0", forRemoval = true)
     public static void read(final InputStream source, final byte[] destination, final int byteCount) throws IOException {
         if (destination.length < byteCount) {
             throw new IllegalArgumentException();

--- a/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/pcap/SplitPCAP.java
+++ b/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/pcap/SplitPCAP.java
@@ -35,7 +35,6 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.io.InputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.stream.io.StreamUtils;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -196,7 +195,7 @@ public class SplitPCAP extends AbstractProcessor {
 
         private Packet getNextPacket(final BufferedInputStream bufferedStream, final PCAP templatePcap, final int totalPackets) throws IOException {
             final byte[] packetHeader = new byte[Packet.PACKET_HEADER_LENGTH];
-            StreamUtils.read(bufferedStream, packetHeader, Packet.PACKET_HEADER_LENGTH);
+            bufferedStream.readNBytes(packetHeader, 0, Packet.PACKET_HEADER_LENGTH);
 
             final Packet currentPacket = new Packet(packetHeader, templatePcap);
 
@@ -206,7 +205,7 @@ public class SplitPCAP extends AbstractProcessor {
 
             final int expectedLength = (int) currentPacket.expectedLength();
             final byte[] packetBody = new byte[expectedLength];
-            StreamUtils.read(bufferedStream, packetBody, expectedLength);
+            bufferedStream.readNBytes(packetBody, 0, expectedLength);
             currentPacket.setBody(packetBody);
 
             if (currentPacket.isInvalid()) {
@@ -227,7 +226,7 @@ public class SplitPCAP extends AbstractProcessor {
             }
 
             final byte[] pcapHeader = new byte[PCAPHeader.PCAP_HEADER_LENGTH];
-            StreamUtils.read(bufferedStream, pcapHeader, PCAPHeader.PCAP_HEADER_LENGTH);
+            bufferedStream.readNBytes(pcapHeader, 0, PCAPHeader.PCAP_HEADER_LENGTH);
 
             int currentPcapTotalLength = PCAPHeader.PCAP_HEADER_LENGTH;
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/server/StandardLoadBalanceProtocol.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/server/StandardLoadBalanceProtocol.java
@@ -452,7 +452,7 @@ public class StandardLoadBalanceProtocol implements LoadBalanceProtocol {
 
     private long readChecksum(final InputStream in) throws IOException {
         final byte[] buffer = getDataBuffer();
-        StreamUtils.read(in, buffer, 8);
+        in.readNBytes(buffer, 0, 8);
         return ByteBuffer.wrap(buffer, 0, 8).getLong();
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16189](https://issues.apache.org/jira/browse/NIFI-16189)
The implementations of the `read` method in `org.apache.nifi.stream.io.StreamUtils`  and  `readNBytes(byte[], int, int)` in `java.io.Inputstream` method are almost identical. The big difference is when bytes cannot be read from the `InputStream` where  `read` throws an `EOFException` while `readNBytes` breaks out of the while loop and returns the number of byes read even though it may be 0 or -1. Although there is this difference, it seems where `read` was used in `SplitPCAP` and `StandardLoadBalanceProtocol` there are subsequent checks in the code, hence even though an exception is not thrown if there is something wrong it will be noted.

For ease of review, the implementations are brought below.
```
public static void read(final InputStream source, final byte[] destination, final int byteCount) throws IOException {
        if (destination.length < byteCount) {
            throw new IllegalArgumentException();
        }

        int bytesRead = 0;
        int len;
        while (bytesRead < byteCount) {
            len = source.read(destination, bytesRead, byteCount - bytesRead);
            if (len < 0) {
                throw new EOFException("Expected to consume " + byteCount + " bytes but consumed only " + bytesRead);
            }

            bytesRead += len;
        }
    } 
```

```
public int readNBytes(byte[] b, int off, int len) throws IOException {
        Objects.checkFromIndexSize(off, len, b.length);

        int n = 0;
        while (n < len) {
            int count = read(b, off + n, len - n);
            if (count < 0)
                break;
            n += count;
        }
        return n;
    }
```

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
