### PR TITLE
NIFI-16193 - Bump MongoDB to 5.9.2, Parquet to 1.18.0, Lucene to 10.5.1, and others

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>9.5.0</elasticsearch.client.version>
+        <elasticsearch.client.version>9.5.1</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-parquet-writer/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-parquet-writer/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>1.17.1</version>
+            <version>1.18.0</version>
         </dependency>
         <!-- Avro provided in shared NAR -->
         <dependency>

--- a/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
@@ -34,6 +34,6 @@
     </modules>
 
     <properties>
-        <mongo.driver.version>5.9.1</mongo.driver.version>
+        <mongo.driver.version>5.9.2</mongo.driver.version>
     </properties>
 </project>

--- a/nifi-extension-bundles/nifi-parquet-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-parquet-bundle/pom.xml
@@ -31,7 +31,7 @@
         <module>nifi-parquet-nar</module>
     </modules>
     <properties>
-        <parquet.version>1.17.1</parquet.version>
+        <parquet.version>1.18.0</parquet.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -34,6 +34,7 @@
         <module>nifi-standard-content-viewer-nar</module>
     </modules>
     <properties>
+        <httpcore5.version>5.4.3</httpcore5.version>
         <tika.version>3.3.2</tika.version>
     </properties>
     <dependencyManagement>
@@ -174,6 +175,16 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>${httpcore5.version}</version>
             </dependency>
             <!-- Override Commons Compiler 3.1.9 from calcite-core -->
             <dependency>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/pom.xml
@@ -27,7 +27,7 @@
         <module>nifi-provenance-repository-nar</module>
     </modules>
     <properties>
-        <lucene.version>10.5.0</lucene.version>
+        <lucene.version>10.5.1</lucene.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.51.4</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.52.1</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.8</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -786,7 +786,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.48.1</version>
+                    <version>0.49.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -846,7 +846,7 @@
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>3.0.81</version>
+                    <version>3.0.82</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
# Summary

NIFI-16193 - Bump MongoDB to 5.9.2, Parquet to 1.18.0, Lucene to 10.5.1, and others

- Elasticsearch from 9.5.0 to 9.5.1 - https://github.com/elastic/elasticsearch-java/releases/tag/v9.5.1
- Apache Parquet from 1.17.1 to 1.18.0 - https://github.com/apache/parquet-java/releases/tag/apache-parquet-1.18.0
- MongoDB from 5.9.1 to 5.9.2 - https://github.com/mongodb/mongo-java-driver/releases/tag/r5.9.2
- Pinning HTTP Core 5 in Calcite to 5.4.3 - https://github.com/apache/httpcomponents-core/releases/tag/rel%2Fv5.4.3
- Apache Lucene from 10.5.0 to 10.5.1 - https://github.com/apache/lucene/releases/tag/releases%2Flucene%2F10.5.1
- AWS SDK from 2.51.4 to 2.52.1 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.52.1
- Docker Maven Plugin from 0.48.1 to 0.49.0 - https://github.com/fabric8io/docker-maven-plugin/releases/tag/v0.49.0
- Swagger Maven Plugin from 3.0.81 to 3.0.82

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
