### PR TITLE
NIFI-16196 - Flaky System Test ClusteredProviderParamFlowSyncIT

### DIFF
--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/parameters/ClusteredProviderParamFlowSyncIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/parameters/ClusteredProviderParamFlowSyncIT.java
@@ -77,6 +77,11 @@ public class ClusteredProviderParamFlowSyncIT extends NiFiSystemIT {
     }
 
     @Override
+    protected boolean isAllowFactoryReuse() {
+        return false;
+    }
+
+    @Override
     protected boolean isDestroyEnvironmentAfterEachTest() {
         // This test intentionally corrupts the persisted flow, so the environment must not be reused.
         return true;

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/state/AbstractStateKeyDropIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/state/AbstractStateKeyDropIT.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public abstract class AbstractStateKeyDropIT extends NiFiSystemIT {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractStateKeyDropIT.class);
@@ -80,6 +82,22 @@ public abstract class AbstractStateKeyDropIT extends NiFiSystemIT {
                 Thread.sleep(RETRY_DELAY_MILLIS);
             }
         }
+    }
+
+    protected void waitForProcessorState(final String processorId, final Scope scope, final Map<String, String> expectedState)
+            throws NiFiClientException, IOException, InterruptedException {
+        final long maxTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(RETRY_TIMEOUT_SECONDS);
+        Map<String, String> currentState;
+
+        do {
+            currentState = getProcessorState(processorId, scope);
+            if (expectedState.equals(currentState)) {
+                return;
+            }
+            Thread.sleep(RETRY_DELAY_MILLIS);
+        } while (System.currentTimeMillis() <= maxTime);
+
+        assertEquals(expectedState, currentState);
     }
 
     /**

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/state/ClusterStateKeyDropIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/state/ClusterStateKeyDropIT.java
@@ -68,8 +68,7 @@ public class ClusterStateKeyDropIT extends AbstractStateKeyDropIT {
 
         runProcessorOnce(processor);
 
-        final Map<String, String> currentState = getProcessorState(processorId, Scope.CLUSTER);
-        assertEquals(Map.of("a", "1", "b", "1", "c", "1"), currentState);
+        waitForProcessorState(processorId, Scope.CLUSTER, Map.of("a", "1", "b", "1", "c", "1"));
 
         // trying to remove key a
         final Map<String, String> newState = Map.of("b", "1", "c", "1");
@@ -90,8 +89,7 @@ public class ClusterStateKeyDropIT extends AbstractStateKeyDropIT {
 
         runProcessorOnce(processor);
 
-        final Map<String, String> currentState = getProcessorState(processorId, Scope.CLUSTER);
-        assertEquals(Map.of("a", "1", "b", "1", "c", "1"), currentState);
+        waitForProcessorState(processorId, Scope.CLUSTER, Map.of("a", "1", "b", "1", "c", "1"));
 
         // trying to remove key "a" but with wrong value for "b"
         assertThrows(NiFiClientException.class, () -> {
@@ -105,8 +103,7 @@ public class ClusterStateKeyDropIT extends AbstractStateKeyDropIT {
         final String processorId = processor.getId();
         runProcessorOnce(processor);
 
-        final Map<String, String> currentState = getProcessorState(processorId, Scope.CLUSTER);
-        assertEquals(Map.of("a", "1", "b", "1", "c", "1"), currentState);
+        waitForProcessorState(processorId, Scope.CLUSTER, Map.of("a", "1", "b", "1", "c", "1"));
 
         // trying to remove two keys
         assertThrows(NiFiClientException.class, () -> {
@@ -120,8 +117,7 @@ public class ClusterStateKeyDropIT extends AbstractStateKeyDropIT {
         final String processorId = processor.getId();
         runProcessorOnce(processor);
 
-        final Map<String, String> currentState = getProcessorState(processorId, Scope.CLUSTER);
-        assertEquals(Map.of("a", "1", "b", "1", "c", "1"), currentState);
+        waitForProcessorState(processorId, Scope.CLUSTER, Map.of("a", "1", "b", "1", "c", "1"));
 
         // trying to remove key a
         final Map<String, String> newState = Map.of("b", "1", "c", "1");
@@ -131,8 +127,7 @@ public class ClusterStateKeyDropIT extends AbstractStateKeyDropIT {
         response.getComponentState().getClusterState().getState().forEach(entry -> updatedState.put(entry.getKey(), entry.getValue()));
         assertEquals(newState, updatedState);
 
-        final Map<String, String> state = getProcessorState(processorId, Scope.CLUSTER);
-        assertEquals(newState, state);
+        waitForProcessorState(processorId, Scope.CLUSTER, newState);
     }
 
     @Test
@@ -141,14 +136,12 @@ public class ClusterStateKeyDropIT extends AbstractStateKeyDropIT {
         final String processorId = processor.getId();
         runProcessorOnce(processor);
 
-        final Map<String, String> currentState = getProcessorState(processorId, Scope.CLUSTER);
-        assertEquals(Map.of("a", "1", "b", "1", "c", "1"), currentState);
+        waitForProcessorState(processorId, Scope.CLUSTER, Map.of("a", "1", "b", "1", "c", "1"));
 
         final ComponentStateEntity response = dropProcessorState(processorId, null);
         assertTrue(response.getComponentState().getClusterState().getState().isEmpty());
 
-        final Map<String, String> state = getProcessorState(processorId, Scope.CLUSTER);
-        assertTrue(state.isEmpty());
+        waitForProcessorState(processorId, Scope.CLUSTER, Map.of());
     }
 
     @Test
@@ -157,13 +150,11 @@ public class ClusterStateKeyDropIT extends AbstractStateKeyDropIT {
         final String processorId = processor.getId();
         runProcessorOnce(processor);
 
-        final Map<String, String> currentState = getProcessorState(processorId, Scope.CLUSTER);
-        assertEquals(Map.of("a", "1", "b", "1", "c", "1"), currentState);
+        waitForProcessorState(processorId, Scope.CLUSTER, Map.of("a", "1", "b", "1", "c", "1"));
 
         final ComponentStateEntity response = dropProcessorState(processorId, Map.of());
         assertTrue(response.getComponentState().getClusterState().getState().isEmpty());
 
-        final Map<String, String> state = getProcessorState(processorId, Scope.CLUSTER);
-        assertTrue(state.isEmpty());
+        waitForProcessorState(processorId, Scope.CLUSTER, Map.of());
     }
 }


### PR DESCRIPTION
# Summary

NIFI-16196 - Flaky System Test ClusteredProviderParamFlowSyncIT

See:

https://github.com/apache/nifi/actions/runs/31689396668/job/94412955804?pr=11535

```
[ERROR] Failures: 
[ERROR]   ClusterStateKeyDropIT.testCanDropSpecificStateKey:124 expected: <{c=1, b=1, a=1}> but was: <{}> 
```

https://github.com/apache/nifi/actions/runs/31689396668/job/94412955775?pr=11535

```
[ERROR] Failures: 
[ERROR]   ClusteredProviderParamFlowSyncIT.testProviderBackedContextWithNonProvidedParameterReconcilesOnFlowSync:140->assertNoNodeLogContains:199 Node log unexpectedly contains: did not Match Cluster Flow ==> expected: <false> but was: <true> 
```

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
