### PR TITLE
NIFI-16198: Re-apply configuration when exiting troubleshooting mode.

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorNode.java
@@ -921,9 +921,10 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
         }
 
         // After confirming all components are stopped or disabled, check if the managed flow can be safely reverted to the
-        // Connector's authoritative flow. This mirrors exactly what endTroubleshooting() will do so that any problem
-        // (e.g. a Connection whose contents cannot be preserved or a component that cannot be replaced) is reported
-        // synchronously rather than surfacing halfway through the state change. This check is intentionally not run by
+        // Connector's authoritative flow. This mirrors the framework restore that endTroubleshooting() performs first so
+        // that any problem (e.g. a Connection whose contents cannot be preserved or a component that cannot be replaced)
+        // is reported synchronously rather than surfacing halfway through the state change. The subsequent apply-time
+        // recompute from the active configuration is not preflighted here. This check is intentionally not run by
         // createEndTroubleshootingAction (which is called on every GET of the Connector entity) because it requires
         // resolving the authoritative flow from the Connector plugin and running a full flow-comparison; that work is
         // only paid by the explicit verify REST endpoint and by endTroubleshooting itself.
@@ -1037,15 +1038,24 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
     @Override
     public void endTroubleshooting() throws FlowUpdateException {
         verifyCanEndTroubleshooting();
-        logger.info("Exiting TROUBLESHOOTING state for {} by restoring Connector's authoritative flow", this);
+        logger.info("Exiting TROUBLESHOOTING state for {} by restoring the authoritative flow and recomputing apply-time state", this);
 
         final VersionedExternalFlow flowToApply = resolveAuthoritativeFlow();
 
-        // Route the update through the ConnectorInitializationContext so that bundle coordinates referenced by the
-        // authoritative flow are resolved against the currently-available bundles. This mirrors how the initial flow
-        // is applied in initializeConnector and avoids failing validation when the Connector hard-codes a bundle
-        // version that differs from the currently-installed NAR (which is common in test Connectors).
+        // Restore the Connector's authoritative flow so that manual managed Process Group edits made during
+        // Troubleshooting are discarded. Route through the ConnectorInitializationContext so that bundle coordinates
+        // referenced by the authoritative flow are resolved against the currently-available bundles.
         initializationContext.updateFlow(activeFlowContext, flowToApply, BundleCompatibility.RESOLVE_BUNDLE);
+
+        // Recompute value-derived flow state from the active configuration. Both arguments are the active FlowContext
+        // so that pending working-configuration changes (which survive Troubleshooting entry) are not applied or
+        // committed. Components are already required to be stopped or disabled by verifyCanEndTroubleshooting.
+        try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(extensionManager, getConnector().getClass(), getIdentifier())) {
+            getConnector().applyUpdate(activeFlowContext, activeFlowContext);
+        } catch (final Throwable t) {
+            logger.error("Failed to recompute apply-time state while exiting TROUBLESHOOTING for {}", this, t);
+            throw new FlowUpdateException("Failed to exit Troubleshooting mode for " + this, t);
+        }
 
         stateTransition.setDesiredState(ConnectorState.STOPPED);
         stateTransition.setCurrentState(ConnectorState.STOPPED);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/TestStandardConnectorNode.java
@@ -124,7 +124,7 @@ public class TestStandardConnectorNode {
                 final ProcessGroupFacadeFactory processGroupFacadeFactory = mock(ProcessGroupFacadeFactory.class);
                 final ParameterContextFacadeFactory parameterContextFacadeFactory = mock(ParameterContextFacadeFactory.class);
 
-                return new StandardFlowContext(managedProcessGroup, currentConfiguration, processGroupFacadeFactory,
+                return new StandardFlowContext(managedProcessGroup, currentConfiguration.clone(), processGroupFacadeFactory,
                     parameterContextFacadeFactory, connectorLogger, FlowContextType.WORKING, bundle);
             }
         };
@@ -1108,6 +1108,64 @@ public class TestStandardConnectorNode {
         assertTrue(node.isModified());
     }
 
+    @Test
+    public void testEndTroubleshootingReAppliesConnectorConfiguration() throws FlowUpdateException {
+        final TroubleshootingApplyConnector connector = new TroubleshootingApplyConnector();
+        final StandardConnectorNode connectorNode = createConnectorNode(connector);
+        assertEquals(ConnectorState.STOPPED, connectorNode.getCurrentState());
+
+        connectorNode.enterTroubleshooting();
+        assertEquals(ConnectorState.TROUBLESHOOTING, connectorNode.getCurrentState());
+
+        connectorNode.endTroubleshooting();
+
+        assertEquals(ConnectorState.STOPPED, connectorNode.getCurrentState());
+        assertEquals(1, connector.getApplyUpdateInvocations());
+        assertTrue(connector.wasDerivedParameterResolved());
+        assertEquals(FlowContextType.ACTIVE, connector.getLastInheritedContextType());
+        assertEquals(FlowContextType.ACTIVE, connector.getLastActiveContextType());
+    }
+
+    @Test
+    public void testEndTroubleshootingLeavesPendingWorkingConfigurationUnchanged() throws FlowUpdateException {
+        final TroubleshootingApplyConnector connector = new TroubleshootingApplyConnector();
+        final StandardConnectorNode connectorNode = createConnectorNode(connector);
+
+        connectorNode.transitionStateForUpdating();
+        connectorNode.prepareForUpdate();
+        connectorNode.setConfiguration("step1", createStepConfiguration(Map.of("prop1", "active-value")));
+        connectorNode.applyUpdate();
+
+        connectorNode.setConfiguration("step1", createStepConfiguration(Map.of("prop1", "pending-value")));
+
+        final ConnectorConfiguration activeBeforeExit = connectorNode.getActiveFlowContext().getConfigurationContext().toConnectorConfiguration();
+        final ConnectorConfiguration workingBeforeExit = connectorNode.getWorkingFlowContext().getConfigurationContext().toConnectorConfiguration();
+        assertEquals(createTestConfiguration("step1", "prop1", "active-value"), activeBeforeExit);
+        assertEquals(createTestConfiguration("step1", "prop1", "pending-value"), workingBeforeExit);
+
+        connectorNode.enterTroubleshooting();
+        connectorNode.endTroubleshooting();
+
+        assertEquals(ConnectorState.STOPPED, connectorNode.getCurrentState());
+        assertEquals(activeBeforeExit, connectorNode.getActiveFlowContext().getConfigurationContext().toConnectorConfiguration());
+        assertEquals(workingBeforeExit, connectorNode.getWorkingFlowContext().getConfigurationContext().toConnectorConfiguration());
+        assertEquals(FlowContextType.ACTIVE, connector.getLastInheritedContextType());
+        assertEquals(FlowContextType.ACTIVE, connector.getLastActiveContextType());
+    }
+
+    @Test
+    public void testEndTroubleshootingPropagatesApplyUpdateFailure() throws FlowUpdateException {
+        final FailingApplyConnector connector = new FailingApplyConnector();
+        final StandardConnectorNode connectorNode = createConnectorNode(connector);
+
+        connectorNode.enterTroubleshooting();
+        assertEquals(ConnectorState.TROUBLESHOOTING, connectorNode.getCurrentState());
+
+        final FlowUpdateException thrown = assertThrows(FlowUpdateException.class, connectorNode::endTroubleshooting);
+        assertTrue(thrown.getCause() instanceof IllegalStateException);
+        assertEquals(ConnectorState.TROUBLESHOOTING, connectorNode.getCurrentState());
+    }
+
     private static void seedActiveConfiguration(final StandardConnectorNode node, final String stepName, final Map<String, ConnectorValueReference> properties) {
         node.getActiveFlowContext().getConfigurationContext().setProperties(stepName, new StepConfiguration(properties));
     }
@@ -1705,6 +1763,107 @@ public class TestStandardConnectorNode {
 
         public boolean wasStopCalled() {
             return stopCalled;
+        }
+    }
+
+    /**
+     * Test connector that resolves value-derived flow state during {@code applyUpdate} and records the FlowContext
+     * arguments passed by the framework when exiting Troubleshooting.
+     */
+    private static class TroubleshootingApplyConnector extends AbstractConnector {
+        private int applyUpdateInvocations;
+        private boolean derivedParameterResolved;
+        private FlowContextType lastInheritedContextType;
+        private FlowContextType lastActiveContextType;
+
+        @Override
+        public VersionedExternalFlow getInitialFlow() {
+            return null;
+        }
+
+        @Override
+        public VersionedExternalFlow getActiveFlow(final FlowContext activeFlowContext) {
+            return null;
+        }
+
+        @Override
+        public void prepareForUpdate(final FlowContext workingContext, final FlowContext activeContext) {
+        }
+
+        @Override
+        public List<ConfigurationStep> getConfigurationSteps() {
+            return List.of();
+        }
+
+        @Override
+        public void applyUpdate(final FlowContext workingContext, final FlowContext activeContext) {
+            applyUpdateInvocations++;
+            lastInheritedContextType = workingContext.getType();
+            lastActiveContextType = activeContext.getType();
+            derivedParameterResolved = true;
+        }
+
+        @Override
+        protected void onStepConfigured(final String stepName, final FlowContext workingContext) {
+        }
+
+        @Override
+        public List<ConfigVerificationResult> verifyConfigurationStep(final String stepName, final Map<String, String> overrides, final FlowContext flowContext) {
+            return List.of();
+        }
+
+        public int getApplyUpdateInvocations() {
+            return applyUpdateInvocations;
+        }
+
+        public boolean wasDerivedParameterResolved() {
+            return derivedParameterResolved;
+        }
+
+        public FlowContextType getLastInheritedContextType() {
+            return lastInheritedContextType;
+        }
+
+        public FlowContextType getLastActiveContextType() {
+            return lastActiveContextType;
+        }
+    }
+
+    /**
+     * Test connector whose {@code applyUpdate} fails so that Troubleshooting exit error handling can be verified.
+     */
+    private static class FailingApplyConnector extends AbstractConnector {
+        @Override
+        public VersionedExternalFlow getInitialFlow() {
+            return null;
+        }
+
+        @Override
+        public VersionedExternalFlow getActiveFlow(final FlowContext activeFlowContext) {
+            return null;
+        }
+
+        @Override
+        public void prepareForUpdate(final FlowContext workingContext, final FlowContext activeContext) {
+        }
+
+        @Override
+        public List<ConfigurationStep> getConfigurationSteps() {
+            return List.of();
+        }
+
+        @Override
+        public void applyUpdate(final FlowContext workingContext, final FlowContext activeContext) {
+            throw new IllegalStateException("Simulated applyUpdate failure");
+        }
+
+        @Override
+        protected void onStepConfigured(final String stepName, final FlowContext workingContext) {
+        }
+
+        @Override
+        public List<ConfigVerificationResult> verifyConfigurationStep(final String stepName, final Map<String, String> overrides, final FlowContext flowContext) {
+            return List.of();
         }
     }
 

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/connectors/tests/system/DeferredParameterConnector.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/connectors/tests/system/DeferredParameterConnector.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.connectors.tests.system;
+
+import org.apache.nifi.components.ConfigVerificationResult;
+import org.apache.nifi.components.connector.AbstractConnector;
+import org.apache.nifi.components.connector.BundleCompatibility;
+import org.apache.nifi.components.connector.ConfigurationStep;
+import org.apache.nifi.components.connector.ConnectorPropertyDescriptor;
+import org.apache.nifi.components.connector.ConnectorPropertyGroup;
+import org.apache.nifi.components.connector.FlowUpdateException;
+import org.apache.nifi.components.connector.PropertyType;
+import org.apache.nifi.components.connector.components.FlowContext;
+import org.apache.nifi.components.connector.components.ParameterValue;
+import org.apache.nifi.components.connector.util.VersionedFlowUtils;
+import org.apache.nifi.flow.VersionedExternalFlow;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A test connector that resolves value-derived flow state onto its managed Parameter Context during
+ * {@link #applyUpdate(FlowContext, FlowContext)} while leaving that value blank in the side-effect-free
+ * {@link #getActiveFlow(FlowContext)}.
+ *
+ * <p>The managed flow contains a single {@code WriteToFile} processor whose required {@code Filename} property
+ * references the Parameter {@code #{resolved_value}}. {@code getActiveFlow} declares that Parameter as blank, so a
+ * restore of the authoritative flow alone leaves the processor INVALID. {@code applyUpdate} resolves
+ * {@code resolved_value} from the inherited configuration onto the live Parameter Context, making the processor and
+ * Connector valid and startable.
+ */
+public class DeferredParameterConnector extends AbstractConnector {
+
+    private static final String CONFIGURATION_STEP_NAME = "Deferred Parameter Configuration";
+    private static final String RESOLVED_PARAMETER_NAME = "resolved_value";
+    private static final String FLOW_RESOURCE = "flows/deferred-parameter-flow.json";
+
+    static final ConnectorPropertyDescriptor RESOLVED_VALUE = new ConnectorPropertyDescriptor.Builder()
+            .name("Resolved Value")
+            .description("The value that applyUpdate resolves onto the managed Parameter Context. It is intentionally "
+                    + "absent from the authoritative flow returned by getActiveFlow, which declares the Parameter as blank.")
+            .required(true)
+            .type(PropertyType.STRING)
+            .defaultValue("resolved-content")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    private static final ConnectorPropertyGroup PROPERTY_GROUP = new ConnectorPropertyGroup.Builder()
+            .name("Deferred Parameter Configuration")
+            .description("Configuration for deferred parameter resolution testing")
+            .properties(List.of(RESOLVED_VALUE))
+            .build();
+
+    private static final ConfigurationStep CONFIG_STEP = new ConfigurationStep.Builder()
+            .name(CONFIGURATION_STEP_NAME)
+            .description("Configure the value that applyUpdate resolves onto the managed Parameter Context")
+            .propertyGroups(List.of(PROPERTY_GROUP))
+            .build();
+
+    @Override
+    protected void onStepConfigured(final String stepName, final FlowContext workingContext) throws FlowUpdateException {
+    }
+
+    @Override
+    public VersionedExternalFlow getInitialFlow() {
+        return buildFlow();
+    }
+
+    @Override
+    public VersionedExternalFlow getActiveFlow(final FlowContext activeFlowContext) {
+        // Declares the derived Parameter as blank. Apply-time resolution happens only in applyUpdate.
+        return buildFlow();
+    }
+
+    @Override
+    public List<ConfigVerificationResult> verifyConfigurationStep(final String stepName, final Map<String, String> propertyValueOverrides, final FlowContext flowContext) {
+        return List.of();
+    }
+
+    @Override
+    public List<ConfigurationStep> getConfigurationSteps() {
+        return List.of(CONFIG_STEP);
+    }
+
+    @Override
+    public void applyUpdate(final FlowContext workingContext, final FlowContext activeContext) throws FlowUpdateException {
+        final VersionedExternalFlow flow = buildFlow();
+        getInitializationContext().updateFlow(activeContext, flow, BundleCompatibility.RESOLVE_BUNDLE);
+
+        // Resolve the derived Parameter onto the live managed Parameter Context so that the processor's required
+        // property becomes valid. Installing the flow above first resets the Parameter to its blank authoritative
+        // value, so this resolution must run afterward.
+        final String resolvedValue = workingContext.getConfigurationContext().getProperty(CONFIG_STEP, RESOLVED_VALUE).getValue();
+        activeContext.getParameterContext().updateParameters(List.of(
+                new ParameterValue.Builder().name(RESOLVED_PARAMETER_NAME).value(resolvedValue).sensitive(false).build()));
+    }
+
+    private VersionedExternalFlow buildFlow() {
+        // The managed flow is defined declaratively in the JSON resource: a single WriteToFile processor whose required
+        // Filename property references #{resolved_value}, plus a Parameter Context that declares resolved_value as blank.
+        return VersionedFlowUtils.loadFlowFromResource(FLOW_RESOURCE);
+    }
+}

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.components.connector.Connector
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/META-INF/services/org.apache.nifi.components.connector.Connector
@@ -20,6 +20,7 @@ org.apache.nifi.connectors.tests.system.BundleResolutionConnector
 org.apache.nifi.connectors.tests.system.CalculateConnector
 org.apache.nifi.connectors.tests.system.ComponentLifecycleConnector
 org.apache.nifi.connectors.tests.system.DataQueuingConnector
+org.apache.nifi.connectors.tests.system.DeferredParameterConnector
 org.apache.nifi.connectors.tests.system.GatedDataQueuingConnector
 org.apache.nifi.connectors.tests.system.FailingConfigurationMigrationConnector
 org.apache.nifi.connectors.tests.system.FailingStateMigrationConnector

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/flows/deferred-parameter-flow.json
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/resources/flows/deferred-parameter-flow.json
@@ -1,0 +1,91 @@
+{
+  "flowContents": {
+    "identifier": "deferred-parameter-root",
+    "name": "Deferred Parameter Flow",
+    "comments": "",
+    "position": {
+      "x": 0.0,
+      "y": 0.0
+    },
+    "processGroups": [],
+    "remoteProcessGroups": [],
+    "processors": [
+      {
+        "identifier": "c1d2e3f4-0000-1000-8000-000000000001",
+        "name": "WriteToFile",
+        "comments": "",
+        "position": {
+          "x": 0.0,
+          "y": 0.0
+        },
+        "type": "org.apache.nifi.processors.tests.system.WriteToFile",
+        "bundle": {
+          "group": "org.apache.nifi",
+          "artifact": "nifi-system-test-extensions-nar",
+          "version": "2.12.0-SNAPSHOT"
+        },
+        "properties": {
+          "Filename": "#{resolved_value}"
+        },
+        "propertyDescriptors": {},
+        "style": {},
+        "schedulingPeriod": "0 sec",
+        "schedulingStrategy": "TIMER_DRIVEN",
+        "executionNode": "ALL",
+        "penaltyDuration": "30 sec",
+        "yieldDuration": "1 sec",
+        "bulletinLevel": "WARN",
+        "runDurationMillis": 25,
+        "concurrentlySchedulableTaskCount": 1,
+        "autoTerminatedRelationships": [
+          "success",
+          "failure"
+        ],
+        "scheduledState": "ENABLED",
+        "retryCount": 10,
+        "retriedRelationships": [],
+        "backoffMechanism": "PENALIZE_FLOWFILE",
+        "maxBackoffPeriod": "10 mins",
+        "componentType": "PROCESSOR",
+        "groupIdentifier": "deferred-parameter-root"
+      }
+    ],
+    "inputPorts": [],
+    "outputPorts": [],
+    "connections": [],
+    "labels": [],
+    "funnels": [],
+    "controllerServices": [],
+    "parameterContextName": "Deferred Parameter Context",
+    "defaultFlowFileExpiration": "0 sec",
+    "defaultBackPressureObjectThreshold": 10000,
+    "defaultBackPressureDataSizeThreshold": "1 GB",
+    "scheduledState": "ENABLED",
+    "executionEngine": "INHERITED",
+    "maxConcurrentTasks": 1,
+    "statelessFlowTimeout": "1 min",
+    "flowFileConcurrency": "UNBOUNDED",
+    "flowFileOutboundPolicy": "STREAM_WHEN_AVAILABLE",
+    "componentType": "PROCESS_GROUP"
+  },
+  "externalControllerServices": {},
+  "parameterContexts": {
+    "Deferred Parameter Context": {
+      "name": "Deferred Parameter Context",
+      "parameters": [
+        {
+          "name": "resolved_value",
+          "description": "",
+          "sensitive": false,
+          "provided": false,
+          "value": ""
+        }
+      ],
+      "inheritedParameterContexts": [],
+      "componentType": "PARAMETER_CONTEXT"
+    }
+  },
+  "flowEncodingVersion": "1.0",
+  "parameterProviders": {},
+  "latest": false
+}

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/connectors/ConnectorTroubleshootingIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/connectors/ConnectorTroubleshootingIT.java
@@ -114,6 +114,60 @@ public class ConnectorTroubleshootingIT extends NiFiSystemIT {
     }
 
     /**
+     * A Connector may resolve value-derived flow state during its apply path while leaving that value blank in
+     * getActiveFlow. Exiting Troubleshooting must recompute that derived state onto the managed flow so that a required,
+     * Parameter-bound processor property becomes valid and the Connector can start.
+     */
+    @Test
+    public void testExitTroubleshootingReappliesDerivedParameters() throws NiFiClientException, IOException, InterruptedException {
+        final ConnectorEntity connector = getClientUtil().createConnector("DeferredParameterConnector");
+        final String connectorId = connector.getId();
+
+        getClientUtil().configureConnector(connector, "Deferred Parameter Configuration", Map.of("Resolved Value", "resolved-content"));
+        getClientUtil().applyConnectorUpdate(connector);
+
+        // applyUpdate resolves the derived Parameter onto the managed Parameter Context, so the WriteToFile processor's
+        // required Filename property (which references #{resolved_value}) becomes valid and the Connector is valid.
+        getClientUtil().waitForValidConnector(connectorId);
+
+        getClientUtil().enterTroubleshooting(connectorId);
+        assertConnectorState(connectorId, ConnectorState.TROUBLESHOOTING);
+
+        getClientUtil().endTroubleshooting(connectorId);
+        assertConnectorState(connectorId, ConnectorState.STOPPED);
+
+        getClientUtil().waitForValidConnector(connectorId);
+        getClientUtil().startConnector(connectorId);
+        assertConnectorState(connectorId, ConnectorState.RUNNING);
+    }
+
+    /**
+     * A Connector whose applyUpdate does not reinstall the managed flow must still discard manual Process Group edits
+     * when exiting Troubleshooting, because the framework restores the authoritative flow before recomputing apply-time
+     * state.
+     */
+    @Test
+    public void testExitTroubleshootingDiscardsManualEditsForNopConnector() throws NiFiClientException, IOException, InterruptedException {
+        final ConnectorEntity connector = getClientUtil().createConnector("NopConnector");
+        final String connectorId = connector.getId();
+
+        getClientUtil().applyConnectorUpdate(connector);
+        getClientUtil().waitForValidConnector(connectorId);
+
+        getClientUtil().enterTroubleshooting(connectorId);
+        assertConnectorState(connectorId, ConnectorState.TROUBLESHOOTING);
+
+        final String managedGroupId = getNifiClient().getConnectorClient().getConnector(connectorId).getComponent().getManagedProcessGroupId();
+        final ProcessorEntity troubleshootingProcessor = getClientUtil().createProcessor("Sleep", managedGroupId);
+        final String troubleshootingProcessorId = troubleshootingProcessor.getId();
+        assertTrue(containsProcessorId(connectorId, troubleshootingProcessorId));
+
+        getClientUtil().endTroubleshooting(connectorId);
+        assertConnectorState(connectorId, ConnectorState.STOPPED);
+        assertFalse(containsProcessorId(connectorId, troubleshootingProcessorId));
+    }
+
+    /**
      * Transition into Troubleshooting, add a new Connection, queue up data in that Connection, and verify that ending
      * Troubleshooting fails with a 409. Restart NiFi and verify the data is still queued. Drop all FlowFiles, then end
      * Troubleshooting successfully.


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16198](https://issues.apache.org/jira/browse/NIFI-16198)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
