### PR TITLE
NIFI-16202 Removed Mockito warning that appeared when running the nifi build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,12 +320,14 @@ jobs:
           ${{ env.MAVEN_COMPILE_COMMAND }}
       - name: Maven Verify
         env:
+          NIFI_CI_LOCALE: >-
+            -Duser.language=ja
+            -Duser.country=JP
           SUREFIRE_OPTS: >-
             -Duser.language=ja
             -Duser.country=JP
             -Duser.region=JP
             -Duser.timezone=Asia/Tokyo
-            -DNIFI_CI_LOCALE="-Duser.language=ja -Duser.country=JP"
           MAVEN_OPTS: >-
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
@@ -393,12 +395,14 @@ jobs:
           ${{ env.MAVEN_COMPILE_COMMAND }}
       - name: Maven Verify
         env:
+          NIFI_CI_LOCALE: >-
+            -Duser.language=fr
+            -Duser.country=FR
           SUREFIRE_OPTS: >-
             -Duser.language=fr
             -Duser.country=FR
             -Duser.region=FR
             -Duser.timezone=Europe/Paris
-            -DNIFI_CI_LOCALE="-Duser.language=fr -Duser.country=FR"
           MAVEN_OPTS: >-
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,6 +331,7 @@ jobs:
           MAVEN_OPTS: >-
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
+            -DNIFI_CI_LOCALE="${env.NIFI_CI_LOCALE}"
         run: >-
           ${{ env.MAVEN_COMMAND }}
           ${{ env.MAVEN_VERIFY_COMMAND }}
@@ -406,6 +407,7 @@ jobs:
           MAVEN_OPTS: >-
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
+            -DNIFI_CI_LOCALE="${env.NIFI_CI_LOCALE}"
         run: >-
           ${{ env.MAVEN_COMMAND_WINDOWS }}
           ${{ env.MAVEN_VERIFY_COMMAND }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,18 +320,15 @@ jobs:
           ${{ env.MAVEN_COMPILE_COMMAND }}
       - name: Maven Verify
         env:
-          NIFI_CI_LOCALE: >-
-            -Duser.language=ja
-            -Duser.country=JP
           SUREFIRE_OPTS: >-
             -Duser.language=ja
             -Duser.country=JP
             -Duser.region=JP
             -Duser.timezone=Asia/Tokyo
+            -DNIFI_CI_LOCALE="-Duser.language=ja -Duser.country=JP"
           MAVEN_OPTS: >-
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
-            -DNIFI_CI_LOCALE="${env.NIFI_CI_LOCALE}"
         run: >-
           ${{ env.MAVEN_COMMAND }}
           ${{ env.MAVEN_VERIFY_COMMAND }}
@@ -396,18 +393,15 @@ jobs:
           ${{ env.MAVEN_COMPILE_COMMAND }}
       - name: Maven Verify
         env:
-          NIFI_CI_LOCALE: >-
-            -Duser.language=fr
-            -Duser.country=FR
           SUREFIRE_OPTS: >-
             -Duser.language=fr
             -Duser.country=FR
             -Duser.region=FR
             -Duser.timezone=Europe/Paris
+            -DNIFI_CI_LOCALE="-Duser.language=fr -Duser.country=FR"
           MAVEN_OPTS: >-
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -DargLine=${env.SUREFIRE_OPTS}
-            -DNIFI_CI_LOCALE="${env.NIFI_CI_LOCALE}"
         run: >-
           ${{ env.MAVEN_COMMAND_WINDOWS }}
           ${{ env.MAVEN_VERIFY_COMMAND }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ env:
     -Xmx3g
     -Daether.connector.http.retryHandler.count=5
     -Daether.connector.http.connectionMaxTtl=30
+  NO_JAVA_AGENT_OPT: >-
+    -DskipMockitoAgent=true
   MAVEN_COMPILE_COMMAND: >-
     test-compile
     --show-version
@@ -334,6 +336,7 @@ jobs:
         run: >-
           ${{ env.MAVEN_COMMAND }}
           ${{ env.MAVEN_VERIFY_COMMAND }}
+          ${{ env.NO_JAVA_AGENT_OPT }}
           -P python-unit-tests
       - name: Upload Test Reports
         uses: actions/upload-artifact@v5
@@ -409,6 +412,7 @@ jobs:
         run: >-
           ${{ env.MAVEN_COMMAND_WINDOWS }}
           ${{ env.MAVEN_VERIFY_COMMAND }}
+          ${{ env.NO_JAVA_AGENT_OPT }}
       - name: Upload Test Reports
         uses: actions/upload-artifact@v5
         with:

--- a/nifi-manifest/nifi-runtime-manifest/pom.xml
+++ b/nifi-manifest/nifi-runtime-manifest/pom.xml
@@ -95,6 +95,10 @@
                         <!-- Binds the execution to a non-existent phase so it never runs -->
                         <phase>none</phase>
                     </execution>
+                    <execution>
+                        <id>resolve-mockito-agent-path</id>
+                        <phase>none</phase>
+                    </execution>
                 </executions>
                 <dependencies>
                     <dependency>

--- a/nifi-manifest/nifi-runtime-manifest/pom.xml
+++ b/nifi-manifest/nifi-runtime-manifest/pom.xml
@@ -89,6 +89,12 @@
                             </artifactItems>
                         </configuration>
                     </execution>
+                    <execution>
+                        <!-- Must exactly match the ID from the top-level parent POM -->
+                        <id>copy-mockito-core</id>
+                        <!-- Binds the execution to a non-existent phase so it never runs -->
+                        <phase>none</phase>
+                    </execution>
                 </executions>
                 <dependencies>
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,8 @@
         <checkstyle.version>14.0.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
+        <!--Default value for argLine in order to prevent surefire failure if syntax @{argLine} does not resolve-->
+        <argLine/>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -730,12 +732,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
+                        <environmentVariables>
+                            <!-- Map the GitHub host environment variable directly into the test environment -->
+                            <NIFI_CI_LOCALE>${env.NIFI_CI_LOCALE}</NIFI_CI_LOCALE>
+                        </environmentVariables>
                         <systemPropertyVariables>
                             <java.awt.headless>true</java.awt.headless>
-                            <user.language>${user.language}</user.language>
-                            <user.country>${user.country}</user.country>
-                            <user.region>${user.region}</user.region>
-                            <user.timezone>${user.timezone}</user.timezone>
                         </systemPropertyVariables>
                         <includes>
                             <include>**/*Test.class</include>
@@ -746,9 +748,9 @@
                             <exclude>**/*ITSpec.class</exclude>
                         </excludes>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        <!-- Explicitly tie the properties together inside the fork line and
+                        <!-- Preserve the incoming command-line with the syntax @{argLine} and
                             configure mockito-core as a Java Agent to enable explicit attachment to processes. -->
-                        <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+                        <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -742,6 +742,8 @@
                             <exclude>**/*ITSpec.class</exclude>
                         </excludes>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <!-- Configure mockito-core as Java Agent to enable explicit attachment to processes -->
+                        <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1012,20 +1014,47 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <ignoredPackagings>
-                        <ignoredPackaging>nar</ignoredPackaging>
-                    </ignoredPackagings>
-                    <ignoredDependencies combine.children="append">
-                        <dependency>org.junit.jupiter:junit-jupiter-engine</dependency>
-                        <dependency>org.junit.jupiter:junit-jupiter-params</dependency>
-                        <dependency>org.junit.jupiter:junit-jupiter-api</dependency>
-                        <dependency>org.mockito:mockito-core</dependency>
-                        <dependency>org.mockito:mockito-junit-jupiter</dependency>
-                        <dependency>org.junit.platform:junit-platform-commons</dependency>
-                        <dependency>org.slf4j:slf4j-simple</dependency>
-                    </ignoredDependencies>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>analyze-dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <ignoredPackagings>
+                                <ignoredPackaging>nar</ignoredPackaging>
+                            </ignoredPackagings>
+                            <ignoredDependencies combine.children="append">
+                                <dependency>org.junit.jupiter:junit-jupiter-engine</dependency>
+                                <dependency>org.junit.jupiter:junit-jupiter-params</dependency>
+                                <dependency>org.junit.jupiter:junit-jupiter-api</dependency>
+                                <dependency>org.mockito:mockito-core</dependency>
+                                <dependency>org.mockito:mockito-junit-jupiter</dependency>
+                                <dependency>org.junit.platform:junit-platform-commons</dependency>
+                                <dependency>org.slf4j:slf4j-simple</dependency>
+                            </ignoredDependencies>
+                        </configuration>
+                    </execution>
+                    <!-- Copy mockito-core library to target directory to avoid warnings in IntelliJ for agent loading -->
+                    <execution>
+                        <id>copy-mockito-core</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.mockito</groupId>
+                                    <artifactId>mockito-core</artifactId>
+                                    <outputDirectory>${project.build.directory}/agents</outputDirectory>
+                                    <destFileName>mockito-core.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -745,8 +745,10 @@
                         </excludes>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <!-- Preserve the incoming command-line with the syntax @{argLine} and
-                            configure mockito-core as a Java Agent to enable explicit attachment to processes. -->
-                        <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+                            configure mockito-core as a Java Agent to enable explicit attachment to processes.
+                            Path for javaagent is wrapped in double quotes in order for the OS to treat the entire path as a single argument string
+                            -->
+                        <argLine>@{argLine} -javaagent:"${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar"</argLine>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -743,7 +743,7 @@
                         </excludes>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <!-- Configure mockito-core as Java Agent to enable explicit attachment to processes -->
-                        <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+                        <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -216,8 +216,6 @@
         <checkstyle.version>14.0.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
-        <!--Default value for argLine in order to prevent surefire failure if syntax @{argLine} does not resolve-->
-        <argLine/>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -744,11 +742,6 @@
                             <exclude>**/*ITSpec.class</exclude>
                         </excludes>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        <!-- Preserve the incoming command-line with the syntax @{argLine} and
-                            configure mockito-core as a Java Agent to enable explicit attachment to processes.
-                            Path for javaagent is wrapped in double quotes in order for the OS to treat the entire path as a single argument string
-                            -->
-                        <argLine>@{argLine} -javaagent:"${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar"</argLine>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1041,24 +1034,6 @@
                             </ignoredDependencies>
                         </configuration>
                     </execution>
-                    <!-- Copy mockito-core library to target directory to avoid warnings in IntelliJ for agent loading -->
-                    <execution>
-                        <id>copy-mockito-core</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.mockito</groupId>
-                                    <artifactId>mockito-core</artifactId>
-                                    <outputDirectory>${project.build.directory}/agents</outputDirectory>
-                                    <destFileName>mockito-core.jar</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -1318,6 +1293,60 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>configure-mockito-agent</id>
+            <activation>
+                <property>
+                    <!-- Activates by default, but disables if you pass -DskipMockitoAgent=true -->
+                    <name>!skipMockitoAgent</name>
+                </property>
+            </activation>
+            <properties>
+                <mockitoAgentOpts>-javaagent:"${org.mockito:mockito-core:jar}"</mockitoAgentOpts>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>resolve-mockito-agent-path</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>properties</goal>
+                                </goals>
+                            </execution>
+                            <!-- Copy mockito-core library to target directory to avoid warnings in IntelliJ for agent loading -->
+                            <execution>
+                                <id>copy-mockito-core</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.mockito</groupId>
+                                            <artifactId>mockito-core</artifactId>
+                                            <outputDirectory>${project.build.directory}/agents</outputDirectory>
+                                            <destFileName>mockito-core.jar</destFileName>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>${mockitoAgentOpts}</argLine>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,8 @@
         <checkstyle.version>14.0.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
+        <!-- Default baseline: provides a safe JVM flag so the variable is never null -->
+        <argLine>-ea</argLine>
         <mockitoArgLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</mockitoArgLine>
     </properties>
     <dependencyManagement>
@@ -744,7 +746,7 @@
                         </excludes>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <!-- Configure mockito-core as Java Agent to enable explicit attachment to processes -->
-                        <argLine>@{argLine} ${mockitoArgLine}</argLine>
+                        <argLine>${argLine} ${mockitoArgLine}</argLine>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,7 @@
         <checkstyle.version>14.0.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
+        <argLine></argLine>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -732,10 +732,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
-                        <environmentVariables>
-                            <!-- Map the GitHub host environment variable directly into the test environment -->
-                            <NIFI_CI_LOCALE>${env.NIFI_CI_LOCALE}</NIFI_CI_LOCALE>
-                        </environmentVariables>
                         <systemPropertyVariables>
                             <java.awt.headless>true</java.awt.headless>
                         </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -216,9 +216,12 @@
         <checkstyle.version>14.0.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
-        <!-- Default baseline: provides a safe JVM flag so the variable is never null -->
-        <argLine>-ea</argLine>
-        <mockitoArgLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</mockitoArgLine>
+        <!-- Define the CI/CD properties with a baseline default
+             This stops Maven from breaking if they aren't provided -->
+        <user.language>en</user.language>
+        <user.country>US</user.country>
+        <user.region>US</user.region>
+        <user.timezone>America/New_York</user.timezone>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -745,8 +748,15 @@
                             <exclude>**/*ITSpec.class</exclude>
                         </excludes>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        <!-- Configure mockito-core as Java Agent to enable explicit attachment to processes -->
-                        <argLine>${argLine} ${mockitoArgLine}</argLine>
+                        <!-- Explicitly tie the properties together inside the fork line and
+                            configure mockito-core as a Java Agent to enable explicit attachment to processes. -->
+                        <argLine>
+                            -Duser.language=${user.language}
+                            -Duser.country=${user.country}
+                            -Duser.region=${user.region}
+                            -Duser.timezone=${user.timezone}
+                            -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+                        </argLine>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -216,12 +216,6 @@
         <checkstyle.version>14.0.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
-        <!-- Define the CI/CD properties with a baseline default
-             This stops Maven from breaking if they aren't provided -->
-        <user.language>en</user.language>
-        <user.country>US</user.country>
-        <user.region>US</user.region>
-        <user.timezone>America/New_York</user.timezone>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -738,6 +732,10 @@
                     <configuration>
                         <systemPropertyVariables>
                             <java.awt.headless>true</java.awt.headless>
+                            <user.language>${user.language}</user.language>
+                            <user.country>${user.country}</user.country>
+                            <user.region>${user.region}</user.region>
+                            <user.timezone>${user.timezone}</user.timezone>
                         </systemPropertyVariables>
                         <includes>
                             <include>**/*Test.class</include>
@@ -750,13 +748,7 @@
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <!-- Explicitly tie the properties together inside the fork line and
                             configure mockito-core as a Java Agent to enable explicit attachment to processes. -->
-                        <argLine>
-                            -Duser.language=${user.language}
-                            -Duser.country=${user.country}
-                            -Duser.region=${user.region}
-                            -Duser.timezone=${user.timezone}
-                            -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
-                        </argLine>
+                        <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <checkstyle.version>14.0.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
-        <argLine></argLine>
+        <mockitoArgLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</mockitoArgLine>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -744,7 +744,7 @@
                         </excludes>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <!-- Configure mockito-core as Java Agent to enable explicit attachment to processes -->
-                        <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+                        <argLine>@{argLine} ${mockitoArgLine}</argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16202](https://issues.apache.org/jira/browse/NIFI-16202)
Without the changes in this PR one can see running

`grep -r -i "Mockito is currently" --include="*output.txt" .`

from the build directory after running the build will result in many hits e.g.

`./nifi-commons/nifi-security-ssl/target/surefire-reports/org.apache.nifi.security.ssl.EphemeralKeyStoreBuilderTest-output.txt:Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3`

but after running the build with this PR the above grep command will result in nothing. In addition, the Mockito message will not be seen when running any of these tests in Intellij.

The changes in this PR involved the follow changes in the top level pom.xml and the build.yml files:

- Created a separate profile which controls the use of mockito-core as a Java Agent
- Added an environment variable which controls turning off the use of mockito-core as a Java Agent (in the aforementioned profile) for those environments where `VerifyBuildLocaleTest` is run as there was no viable way to add an `argLine` configuration as was done for the nifi-api in [NIFI-15999](https://issues.apache.org/jira/browse/NIFI-15999) since inevitably it blows away the argLine setting set in  in the environment variable `SUREFIRE_OPTS` in the CI/CD build.
- Placed the configuration that existed for the `maven-dependency-plugin` in its own `execution` block
-  Within the added profile, added two  `execution` blocks in the  `maven-dependency-plugin`  to resolve the location of mockito agent path (to help remove the Mockito warning messages from the Surefire Maven plugin output) and in order to copy the mockito-core library to the target directory (to prevent the Mockito warning messages when running in an IDE).
- Added an `argLine` to the `maven-surefire-plugin` to configure mockito-core as a Java Agent to enable explicit attachment to processes.


# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
