### PR TITLE
NIFI-16206 connector toggle to handle "true"/"false" strings as booleans

### DIFF
--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.spec.ts
@@ -489,6 +489,16 @@ describe('ConnectorPropertyInput', () => {
             const toggle = fixture.debugElement.query(By.css('[data-qa="property-input-boolean"]'));
             expect(toggle.componentInstance.checked).toBe(false);
         });
+
+        it('does not coerce values for non-BOOLEAN properties', async () => {
+            const { inputComponent } = await setup({
+                property: makeProp({ type: 'STRING' })
+            });
+
+            inputComponent.writeValue('false');
+
+            expect(inputComponent.formControl.value).toBe('false');
+        });
     });
 
     describe('STRING_LIST rendering', () => {

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-property-input/connector-property-input.component.ts
@@ -47,6 +47,7 @@ import {
 } from '../../types';
 import { SearchableSelect } from '../searchable-select/searchable-select.component';
 import { AssetUpload } from '../asset-upload/asset-upload.component';
+import { toBooleanValue } from '../../services/value-reference.helper';
 import { StringListOrphansStrippedEvent } from './connector-property-input.types';
 
 /**
@@ -189,10 +190,9 @@ export class ConnectorPropertyInput implements ControlValueAccessor, DoCheck, On
     }
 
     writeValue(value: unknown): void {
-        let normalized = value;
-        if (this.property()?.type === 'BOOLEAN') {
-            normalized = value === true || value === 'true';
-        }
+        // BOOLEAN values may still arrive as the wire strings "true"/"false". MatSlideToggle
+        // coerces with `!!value`, which would render "false" as checked, so normalize first.
+        const normalized = this.property()?.type === 'BOOLEAN' ? toBooleanValue(value) : value;
         this.formControl.setValue(normalized, { emitEvent: false });
         if (this.property()?.type === 'SECRET') {
             this.selectOptions = this.computeSelectOptions();

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-configuration-step/connector-configuration-step.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-configuration-step/connector-configuration-step.component.spec.ts
@@ -328,6 +328,34 @@ describe('SharedConnectorConfigurationStep', () => {
             expect(component.stepForm.get('enabled')?.value).toBe(false);
         });
 
+        // defaultValue and saved values are wire strings even for BOOLEAN. They must be coerced
+        // to real booleans, otherwise mat-slide-toggle's `!!value` renders "false" as checked.
+        it('coerces a BOOLEAN descriptor defaultValue of "false" to the boolean false', async () => {
+            const stepConfig = makeStepConfig('test-step', [
+                makeProp('enabled', { type: 'BOOLEAN', defaultValue: 'false' })
+            ]);
+            const { component } = await setup({ stepConfig });
+            expect(component.stepForm.get('enabled')?.value).toBe(false);
+        });
+
+        it('coerces a BOOLEAN descriptor defaultValue of "true" to the boolean true', async () => {
+            const stepConfig = makeStepConfig('test-step', [
+                makeProp('enabled', { type: 'BOOLEAN', defaultValue: 'true' })
+            ]);
+            const { component } = await setup({ stepConfig });
+            expect(component.stepForm.get('enabled')?.value).toBe(true);
+        });
+
+        it('coerces a saved BOOLEAN value of "false" to the boolean false', async () => {
+            const stepConfig = makeStepConfig(
+                'test-step',
+                [makeProp('enabled', { type: 'BOOLEAN', defaultValue: 'true' })],
+                { enabled: { value: 'false', valueType: 'STRING_LITERAL' } }
+            );
+            const { component } = await setup({ stepConfig });
+            expect(component.stepForm.get('enabled')?.value).toBe(false);
+        });
+
         it('defaults STRING_LIST properties to empty array', async () => {
             const stepConfig = makeStepConfig('test-step', [makeProp('tags', { type: 'STRING_LIST' })]);
             const { component } = await setup({ stepConfig });
@@ -407,6 +435,43 @@ describe('SharedConnectorConfigurationStep', () => {
 
             expect(component.stepForm.get('advanced-setting')?.enabled).toBe(true);
             expect(component.isPropertyVisible(makeProp('advanced-setting'))).toBe(true);
+        });
+
+        // A BOOLEAN toggle writes a native boolean into the form while dependentValues stays
+        // string[] from the API, so the comparison has to survive the type difference.
+        it('shows a property gated on a BOOLEAN once the toggle is turned on', async () => {
+            const stepConfig = makeStepConfig('test-step', [
+                makeProp('enableImageExtraction', { type: 'BOOLEAN', defaultValue: 'false' }),
+                makeProp('extractionMode', {
+                    dependencies: [{ propertyName: 'enableImageExtraction', dependentValues: ['true'] }]
+                })
+            ]);
+            const { component } = await setup({ stepConfig });
+
+            expect(component.isPropertyVisible(makeProp('extractionMode'))).toBe(false);
+
+            component.setPropertyValue('enableImageExtraction', true);
+            component['computeAllPropertyVisibility']();
+
+            expect(component.stepForm.get('extractionMode')?.enabled).toBe(true);
+            expect(component.isPropertyVisible(makeProp('extractionMode'))).toBe(true);
+        });
+
+        it('hides a property gated on a BOOLEAN again once the toggle is turned back off', async () => {
+            const stepConfig = makeStepConfig('test-step', [
+                makeProp('enableImageExtraction', { type: 'BOOLEAN', defaultValue: 'true' }),
+                makeProp('extractionMode', {
+                    dependencies: [{ propertyName: 'enableImageExtraction', dependentValues: ['true'] }]
+                })
+            ]);
+            const { component } = await setup({ stepConfig });
+
+            expect(component.isPropertyVisible(makeProp('extractionMode'))).toBe(true);
+
+            component.setPropertyValue('enableImageExtraction', false);
+            component['computeAllPropertyVisibility']();
+
+            expect(component.isPropertyVisible(makeProp('extractionMode'))).toBe(false);
         });
 
         it('hides a property when its dependency has no dependentValues and the parent is empty', async () => {
@@ -824,6 +889,42 @@ describe('SharedConnectorConfigurationStep', () => {
             component.stepForm.markAsDirty();
             const result = component.getConfigurationForSave();
             expect(result.isDirty).toBe(false);
+        });
+
+        // initializeForm coerces BOOLEAN wire strings to real booleans. buildChangedConfiguration
+        // must use the same coercion when comparing against descriptor defaults, or an untouched
+        // "false" default would always appear changed (string "false" !== boolean false).
+        it('does not include an untouched BOOLEAN whose defaultValue was the wire string "false"', async () => {
+            const stepConfig = makeStepConfig('test-step', [
+                makeProp('enabled', { type: 'BOOLEAN', defaultValue: 'false' }),
+                makeProp('host')
+            ]);
+            const { component } = await setup({ stepConfig });
+
+            component.stepForm.get('host')?.setValue('changed-host');
+            component.stepForm.markAsDirty();
+
+            const result = component.getConfigurationForSave();
+            const propertyValues = result.configuration?.propertyGroupConfigurations[0]?.propertyValues ?? {};
+            expect(propertyValues['enabled']).toBeUndefined();
+            expect(propertyValues['host']).toBeDefined();
+        });
+
+        it('does not include an untouched BOOLEAN whose saved value was the wire string "false"', async () => {
+            const stepConfig = makeStepConfig(
+                'test-step',
+                [makeProp('enabled', { type: 'BOOLEAN', defaultValue: 'true' }), makeProp('host')],
+                { enabled: { value: 'false', valueType: 'STRING_LITERAL' } }
+            );
+            const { component } = await setup({ stepConfig });
+
+            component.stepForm.get('host')?.setValue('changed-host');
+            component.stepForm.markAsDirty();
+
+            const result = component.getConfigurationForSave();
+            const propertyValues = result.configuration?.propertyGroupConfigurations[0]?.propertyValues ?? {};
+            expect(propertyValues['enabled']).toBeUndefined();
+            expect(propertyValues['host']).toBeDefined();
         });
     });
 

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-configuration-step/connector-configuration-step.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-configuration-step/connector-configuration-step.component.spec.ts
@@ -428,10 +428,11 @@ describe('SharedConnectorConfigurationStep', () => {
                     dependencies: [{ propertyName: 'mode', dependentValues: ['advanced'] }]
                 })
             ]);
-            const { component } = await setup({ stepConfig });
+            const { component, fixture } = await setup({ stepConfig });
+            // setupFormSubscription is deferred with Promise.resolve() — same wait as the form-changes tests
+            await fixture.whenStable();
 
             component.setPropertyValue('mode', 'advanced');
-            component['computeAllPropertyVisibility']();
 
             expect(component.stepForm.get('advanced-setting')?.enabled).toBe(true);
             expect(component.isPropertyVisible(makeProp('advanced-setting'))).toBe(true);
@@ -446,12 +447,12 @@ describe('SharedConnectorConfigurationStep', () => {
                     dependencies: [{ propertyName: 'enableImageExtraction', dependentValues: ['true'] }]
                 })
             ]);
-            const { component } = await setup({ stepConfig });
+            const { component, fixture } = await setup({ stepConfig });
+            await fixture.whenStable();
 
             expect(component.isPropertyVisible(makeProp('extractionMode'))).toBe(false);
 
             component.setPropertyValue('enableImageExtraction', true);
-            component['computeAllPropertyVisibility']();
 
             expect(component.stepForm.get('extractionMode')?.enabled).toBe(true);
             expect(component.isPropertyVisible(makeProp('extractionMode'))).toBe(true);
@@ -464,12 +465,12 @@ describe('SharedConnectorConfigurationStep', () => {
                     dependencies: [{ propertyName: 'enableImageExtraction', dependentValues: ['true'] }]
                 })
             ]);
-            const { component } = await setup({ stepConfig });
+            const { component, fixture } = await setup({ stepConfig });
+            await fixture.whenStable();
 
             expect(component.isPropertyVisible(makeProp('extractionMode'))).toBe(true);
 
             component.setPropertyValue('enableImageExtraction', false);
-            component['computeAllPropertyVisibility']();
 
             expect(component.isPropertyVisible(makeProp('extractionMode'))).toBe(false);
         });
@@ -490,10 +491,10 @@ describe('SharedConnectorConfigurationStep', () => {
                 makeProp('optional-host'),
                 makeProp('host-port', { dependencies: [{ propertyName: 'optional-host' }] })
             ]);
-            const { component } = await setup({ stepConfig });
+            const { component, fixture } = await setup({ stepConfig });
+            await fixture.whenStable();
 
             component.setPropertyValue('optional-host', 'myhost.com');
-            component['computeAllPropertyVisibility']();
 
             expect(component.stepForm.get('host-port')?.enabled).toBe(true);
         });

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-configuration-step/connector-configuration-step.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-configuration-step/connector-configuration-step.component.ts
@@ -53,7 +53,7 @@ import {
     toBooleanValue,
     SecretReferenceOptions
 } from '../../../services/value-reference.helper';
-import { isDependencyValueSatisfied } from '../step-dependency.utils';
+import { isDependencyValueSatisfied } from '../../../utils/dependency-value.utils';
 import {
     AssetInfo,
     AssetReference,

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-configuration-step/connector-configuration-step.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/connector-configuration-step/connector-configuration-step.component.ts
@@ -47,7 +47,13 @@ import { StringListOrphansStrippedEvent } from '../../connector-property-input/c
 import { ErrorBanner } from '../../error-banner/error-banner.component';
 import { StatusBanner } from '../../status-banner/status-banner.component';
 import { StatusBannerDescriptionDirective } from '../../status-banner/status-banner.directives';
-import { fromValueReference, toValueReference, SecretReferenceOptions } from '../../../services/value-reference.helper';
+import {
+    fromValueReference,
+    toValueReference,
+    toBooleanValue,
+    SecretReferenceOptions
+} from '../../../services/value-reference.helper';
+import { isDependencyValueSatisfied } from '../step-dependency.utils';
 import {
     AssetInfo,
     AssetReference,
@@ -472,7 +478,11 @@ export class SharedConnectorConfigurationStep implements SaveableStep, OnInit, O
                     const validators = this.buildValidators(property);
                     formConfig[property.name] = [formValue, validators];
                 } else {
-                    const currentValue = unsavedValue ?? apiValue ?? property.defaultValue ?? fallbackValue;
+                    const resolvedValue = unsavedValue ?? apiValue ?? property.defaultValue ?? fallbackValue;
+                    // The descriptor's defaultValue is a wire string even for BOOLEAN, so coerce
+                    // before it enters the form tree: the toggle renders `!!value` and would show
+                    // a stored "false" as checked.
+                    const currentValue = property.type === 'BOOLEAN' ? toBooleanValue(resolvedValue) : resolvedValue;
                     const validators = this.buildValidators(property);
                     formConfig[property.name] = [currentValue, validators];
                 }
@@ -648,13 +658,7 @@ export class SharedConnectorConfigurationStep implements SaveableStep, OnInit, O
 
             const dependentValue = dependentControl.value;
 
-            if (dependency.dependentValues && dependency.dependentValues.length > 0) {
-                // If specific values are required, check if current value matches
-                return dependency.dependentValues.includes(dependentValue as string);
-            } else {
-                // If no specific values, just check if dependent property has any value
-                return dependentValue !== null && dependentValue !== undefined && dependentValue !== '';
-            }
+            return isDependencyValueSatisfied(dependentValue, dependency.dependentValues);
         });
     }
 
@@ -898,8 +902,12 @@ export class SharedConnectorConfigurationStep implements SaveableStep, OnInit, O
 
                             let originalValue = apiValue ?? property.defaultValue ?? fallbackValue;
 
-                            // Normalize assets so comparison matches the form value shape
-                            if (property.type === 'ASSET') {
+                            // Normalize so comparison matches the form value shape
+                            if (property.type === 'BOOLEAN') {
+                                // initializeForm coerces BOOLEAN values to real booleans; without the
+                                // same coercion here a stored "false" would always look changed.
+                                originalValue = toBooleanValue(originalValue);
+                            } else if (property.type === 'ASSET') {
                                 // fromValueReference returns AssetReference|null; form stores string|null
                                 originalValue = originalValue?.id ?? null;
                             } else if (property.type === 'ASSET_LIST') {

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/step-dependency.utils.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/step-dependency.utils.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { ConfigurationStepConfiguration, ConnectorPropertyDescriptor, ConnectorValueReference } from '../../types';
-import { getVisibleStepNames, isStepDependencySatisfied } from './step-dependency.utils';
+import { getVisibleStepNames, isDependencyValueSatisfied, isStepDependencySatisfied } from './step-dependency.utils';
 
 describe('Step Dependency Utils', () => {
     function createStepConfig(
@@ -120,6 +120,57 @@ describe('Step Dependency Utils', () => {
             const visibleSteps = new Set(['NonExistent']);
 
             expect(isStepDependencySatisfied(dependency, {}, {}, visibleSteps)).toBe(false);
+        });
+
+        // A BOOLEAN toggle puts a native boolean into the form, while dependentValues is always
+        // string[] from the API. Both directions of the toggle must be evaluated correctly.
+        it('should satisfy a boolean dependency when the unsaved value is the boolean true', () => {
+            const dependency = { stepName: 'Step1', propertyName: 'enableCortex', dependentValues: ['true'] };
+            const stepConfigurations = {
+                Step1: createStepConfig('Step1', [], { group1: { enableCortex: 'false' } })
+            };
+            const unsavedValues = { Step1: { enableCortex: true } };
+            const visibleSteps = new Set(['Step1']);
+
+            expect(isStepDependencySatisfied(dependency, stepConfigurations, unsavedValues, visibleSteps)).toBe(true);
+        });
+
+        it('should not satisfy a boolean dependency when the unsaved value is the boolean false', () => {
+            const dependency = { stepName: 'Step1', propertyName: 'enableCortex', dependentValues: ['true'] };
+            const stepConfigurations = {
+                Step1: createStepConfig('Step1', [], { group1: { enableCortex: 'true' } })
+            };
+            const unsavedValues = { Step1: { enableCortex: false } };
+            const visibleSteps = new Set(['Step1']);
+
+            expect(isStepDependencySatisfied(dependency, stepConfigurations, unsavedValues, visibleSteps)).toBe(false);
+        });
+    });
+
+    describe('isDependencyValueSatisfied', () => {
+        it('matches a native boolean against the string dependentValues from the API', () => {
+            expect(isDependencyValueSatisfied(true, ['true'])).toBe(true);
+            expect(isDependencyValueSatisfied(false, ['true'])).toBe(false);
+            expect(isDependencyValueSatisfied(false, ['false'])).toBe(true);
+        });
+
+        it('still matches string values', () => {
+            expect(isDependencyValueSatisfied('true', ['true'])).toBe(true);
+            expect(isDependencyValueSatisfied('other', ['value1', 'value2'])).toBe(false);
+            expect(isDependencyValueSatisfied('value2', ['value1', 'value2'])).toBe(true);
+        });
+
+        it('treats any non-empty value as satisfying an empty dependentValues list', () => {
+            expect(isDependencyValueSatisfied('anything', [])).toBe(true);
+            expect(isDependencyValueSatisfied(false, undefined)).toBe(true);
+            expect(isDependencyValueSatisfied('', [])).toBe(false);
+            expect(isDependencyValueSatisfied(null, [])).toBe(false);
+            expect(isDependencyValueSatisfied(undefined, [])).toBe(false);
+        });
+
+        it('never matches null or undefined against a dependentValues list', () => {
+            expect(isDependencyValueSatisfied(null, ['true'])).toBe(false);
+            expect(isDependencyValueSatisfied(undefined, ['undefined'])).toBe(false);
         });
     });
 

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/step-dependency.utils.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/step-dependency.utils.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { ConfigurationStepConfiguration, ConnectorPropertyDescriptor, ConnectorValueReference } from '../../types';
-import { getVisibleStepNames, isDependencyValueSatisfied, isStepDependencySatisfied } from './step-dependency.utils';
+import { getVisibleStepNames, isStepDependencySatisfied } from './step-dependency.utils';
 
 describe('Step Dependency Utils', () => {
     function createStepConfig(
@@ -144,33 +144,6 @@ describe('Step Dependency Utils', () => {
             const visibleSteps = new Set(['Step1']);
 
             expect(isStepDependencySatisfied(dependency, stepConfigurations, unsavedValues, visibleSteps)).toBe(false);
-        });
-    });
-
-    describe('isDependencyValueSatisfied', () => {
-        it('matches a native boolean against the string dependentValues from the API', () => {
-            expect(isDependencyValueSatisfied(true, ['true'])).toBe(true);
-            expect(isDependencyValueSatisfied(false, ['true'])).toBe(false);
-            expect(isDependencyValueSatisfied(false, ['false'])).toBe(true);
-        });
-
-        it('still matches string values', () => {
-            expect(isDependencyValueSatisfied('true', ['true'])).toBe(true);
-            expect(isDependencyValueSatisfied('other', ['value1', 'value2'])).toBe(false);
-            expect(isDependencyValueSatisfied('value2', ['value1', 'value2'])).toBe(true);
-        });
-
-        it('treats any non-empty value as satisfying an empty dependentValues list', () => {
-            expect(isDependencyValueSatisfied('anything', [])).toBe(true);
-            expect(isDependencyValueSatisfied(false, undefined)).toBe(true);
-            expect(isDependencyValueSatisfied('', [])).toBe(false);
-            expect(isDependencyValueSatisfied(null, [])).toBe(false);
-            expect(isDependencyValueSatisfied(undefined, [])).toBe(false);
-        });
-
-        it('never matches null or undefined against a dependentValues list', () => {
-            expect(isDependencyValueSatisfied(null, ['true'])).toBe(false);
-            expect(isDependencyValueSatisfied(undefined, ['undefined'])).toBe(false);
         });
     });
 

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/step-dependency.utils.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/step-dependency.utils.ts
@@ -17,6 +17,7 @@
 
 import { ConfigurationStepConfiguration, ConfigurationStepDependency, ConnectorPropertyFormValue } from '../../types';
 import { fromValueReference } from '../../services/value-reference.helper';
+import { isDependencyValueSatisfied } from '../../utils/dependency-value.utils';
 
 /**
  * Get the current value of a property from a step.
@@ -55,33 +56,6 @@ function getPropertyValue(
     }
 
     return undefined;
-}
-
-/**
- * Evaluate whether a dependency condition is met by a property's current value.
- *
- * `dependentValues` always arrives from the API as `string[]` (e.g. `["true"]`), while the
- * live value may be a native non-string once a control has been bound -- notably a real
- * `boolean` for BOOLEAN properties. `Array.prototype.includes` uses strict equality and does
- * not coerce, so the value is compared as a string.
- *
- * Shared by step-level dependencies and the configuration step's property-level dependencies
- * so the two sites cannot drift apart.
- *
- * @param value The dependent property's current value
- * @param dependentValues The values that satisfy the dependency; empty means "any non-empty value"
- * @returns boolean indicating if the dependency condition is met
- */
-export function isDependencyValueSatisfied(
-    value: ConnectorPropertyFormValue | undefined,
-    dependentValues: string[] | undefined | null
-): boolean {
-    if (!dependentValues || dependentValues.length === 0) {
-        // No specific values required - any non-empty value satisfies
-        return value !== null && value !== undefined && value !== '';
-    }
-
-    return value !== null && value !== undefined && dependentValues.includes(String(value));
 }
 
 /**

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/step-dependency.utils.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/connector-wizard/step-dependency.utils.ts
@@ -58,6 +58,33 @@ function getPropertyValue(
 }
 
 /**
+ * Evaluate whether a dependency condition is met by a property's current value.
+ *
+ * `dependentValues` always arrives from the API as `string[]` (e.g. `["true"]`), while the
+ * live value may be a native non-string once a control has been bound -- notably a real
+ * `boolean` for BOOLEAN properties. `Array.prototype.includes` uses strict equality and does
+ * not coerce, so the value is compared as a string.
+ *
+ * Shared by step-level dependencies and the configuration step's property-level dependencies
+ * so the two sites cannot drift apart.
+ *
+ * @param value The dependent property's current value
+ * @param dependentValues The values that satisfy the dependency; empty means "any non-empty value"
+ * @returns boolean indicating if the dependency condition is met
+ */
+export function isDependencyValueSatisfied(
+    value: ConnectorPropertyFormValue | undefined,
+    dependentValues: string[] | undefined | null
+): boolean {
+    if (!dependentValues || dependentValues.length === 0) {
+        // No specific values required - any non-empty value satisfies
+        return value !== null && value !== undefined && value !== '';
+    }
+
+    return value !== null && value !== undefined && dependentValues.includes(String(value));
+}
+
+/**
  * Evaluate if a single step dependency is satisfied.
  * A dependency on a hidden step is NOT satisfied (transitive hiding).
  *
@@ -87,14 +114,7 @@ export function isStepDependencySatisfied(
     // Get the current property value
     const value = getPropertyValue(stepName, propertyName, stepConfigurations, unsavedStepValues);
 
-    // Evaluate based on dependentValues
-    if (!dependentValues || dependentValues.length === 0) {
-        // No specific values required - any non-empty value satisfies
-        return value !== null && value !== undefined && value !== '';
-    } else {
-        // Value must be in the allowed list
-        return value != null && dependentValues.includes(String(value));
-    }
+    return isDependencyValueSatisfied(value, dependentValues);
 }
 
 /**

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/property-group-card/property-group-card.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/property-group-card/property-group-card.component.spec.ts
@@ -180,40 +180,66 @@ describe('PropertyGroupCard', () => {
             expect(component.hasValue('Host')).toBe(false);
         });
 
-        it('should return true for SECRET_REFERENCE regardless of value', async () => {
+        it('should return true for a SECRET_REFERENCE with a non-empty composite key', async () => {
             const { component } = await setup({
                 propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Password: { name: 'Password', type: 'SECRET', required: true }
+                    },
                     propertyValues: {
-                        Host: { valueType: 'SECRET_REFERENCE' }
+                        Password: {
+                            valueType: 'SECRET_REFERENCE',
+                            secretProviderId: 'provider-1',
+                            secretProviderName: 'Vault',
+                            fullyQualifiedSecretName: 'group.my-secret'
+                        }
                     }
                 })
             });
-            expect(component.hasValue('Host')).toBe(true);
+            expect(component.hasValue('Password')).toBe(true);
         });
 
-        it('should return true for ASSET_REFERENCE with entries', async () => {
+        it('should return false for a SECRET with only a descriptor default and no saved reference', async () => {
             const { component } = await setup({
                 propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Password: { name: 'Password', type: 'SECRET', required: true, defaultValue: 'changeme' }
+                    },
+                    propertyValues: {}
+                })
+            });
+            expect(component.hasValue('Password')).toBe(false);
+        });
+
+        it('should return true for an ASSET with assetReferences', async () => {
+            const { component } = await setup({
+                propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Cert: { name: 'Cert', type: 'ASSET', required: false }
+                    },
                     propertyValues: {
-                        Host: {
+                        Cert: {
                             valueType: 'ASSET_REFERENCE',
                             assetReferences: [{ id: 'asset-1', name: 'cert.pem' }]
                         }
                     }
                 })
             });
-            expect(component.hasValue('Host')).toBe(true);
+            expect(component.hasValue('Cert')).toBe(true);
         });
 
-        it('should return false for ASSET_REFERENCE with empty array', async () => {
+        it('should return false for an ASSET with empty assetReferences', async () => {
             const { component } = await setup({
                 propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Cert: { name: 'Cert', type: 'ASSET', required: false }
+                    },
                     propertyValues: {
-                        Host: { valueType: 'ASSET_REFERENCE', assetReferences: [] }
+                        Cert: { valueType: 'ASSET_REFERENCE', assetReferences: [] }
                     }
                 })
             });
-            expect(component.hasValue('Host')).toBe(false);
+            expect(component.hasValue('Cert')).toBe(false);
         });
     });
 
@@ -226,19 +252,42 @@ describe('PropertyGroupCard', () => {
         it('should return masked text for SECRET_REFERENCE', async () => {
             const { component } = await setup({
                 propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Password: { name: 'Password', type: 'SECRET', required: true }
+                    },
                     propertyValues: {
-                        Host: { valueType: 'SECRET_REFERENCE' }
+                        Password: {
+                            valueType: 'SECRET_REFERENCE',
+                            secretProviderId: 'provider-1',
+                            secretProviderName: 'Vault',
+                            fullyQualifiedSecretName: 'group.my-secret'
+                        }
                     }
                 })
             });
-            expect(component.getDisplayValueForProperty('Host')).toBe('••••••••');
+            expect(component.getDisplayValueForProperty('Password')).toBe('••••••••');
+        });
+
+        it('should not leak a SECRET descriptor default as visible text', async () => {
+            const { component } = await setup({
+                propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Password: { name: 'Password', type: 'SECRET', required: true, defaultValue: 'changeme' }
+                    },
+                    propertyValues: {}
+                })
+            });
+            expect(component.getDisplayValueForProperty('Password')).toBe('••••••••');
         });
 
         it('should return comma-separated asset names for ASSET_REFERENCE', async () => {
             const { component } = await setup({
                 propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Cert: { name: 'Cert', type: 'ASSET', required: false }
+                    },
                     propertyValues: {
-                        Host: {
+                        Cert: {
                             valueType: 'ASSET_REFERENCE',
                             assetReferences: [
                                 { id: 'a1', name: 'cert.pem' },
@@ -248,21 +297,24 @@ describe('PropertyGroupCard', () => {
                     }
                 })
             });
-            expect(component.getDisplayValueForProperty('Host')).toBe('cert.pem, key.pem');
+            expect(component.getDisplayValueForProperty('Cert')).toBe('cert.pem, key.pem');
         });
 
         it('should fall back to asset id when name is missing', async () => {
             const { component } = await setup({
                 propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Cert: { name: 'Cert', type: 'ASSET', required: false }
+                    },
                     propertyValues: {
-                        Host: {
+                        Cert: {
                             valueType: 'ASSET_REFERENCE',
                             assetReferences: [{ id: 'a1' }]
                         }
                     }
                 })
             });
-            expect(component.getDisplayValueForProperty('Host')).toBe('a1');
+            expect(component.getDisplayValueForProperty('Cert')).toBe('a1');
         });
 
         it('should return empty string when no value reference exists', async () => {

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/property-group-card/property-group-card.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/property-group-card/property-group-card.component.spec.ts
@@ -146,6 +146,18 @@ describe('PropertyGroupCard', () => {
             expect(component.hasValue('Host')).toBe(false);
         });
 
+        it('should return true when no value reference exists but the descriptor has a default', async () => {
+            const { component } = await setup({
+                propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Enabled: { name: 'Enabled', type: 'BOOLEAN', required: false, defaultValue: 'false' }
+                    },
+                    propertyValues: {}
+                })
+            });
+            expect(component.hasValue('Enabled')).toBe(true);
+        });
+
         it('should return false for STRING_LITERAL with null value', async () => {
             const { component } = await setup({
                 propertyGroup: makeGroup({
@@ -259,6 +271,18 @@ describe('PropertyGroupCard', () => {
             });
             expect(component.getDisplayValueForProperty('Host')).toBe('');
         });
+
+        it('should return the descriptor default when no value reference exists', async () => {
+            const { component } = await setup({
+                propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Enabled: { name: 'Enabled', type: 'BOOLEAN', required: false, defaultValue: 'false' }
+                    },
+                    propertyValues: {}
+                })
+            });
+            expect(component.getDisplayValueForProperty('Enabled')).toBe('false');
+        });
     });
 
     describe('fieldErrors computed signal', () => {
@@ -346,6 +370,19 @@ describe('PropertyGroupCard', () => {
             const unsetLabels = query('mat-card-content').queryAll(By.css('.unset'));
             expect(unsetLabels.length).toBe(2);
             expect(unsetLabels[0].nativeElement.textContent.trim()).toBe('No value set');
+        });
+
+        it('should display descriptor defaults when property values are absent', async () => {
+            const { query } = await setup({
+                propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Enabled: { name: 'Enabled', type: 'BOOLEAN', required: false, defaultValue: 'false' }
+                    },
+                    propertyValues: {}
+                })
+            });
+            const value = query('mat-card-content').query(By.css('.tertiary-color'));
+            expect(value.nativeElement.textContent.trim()).toBe('false');
         });
 
         it('should display the property value for properties with values', async () => {

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/property-group-card/property-group-card.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/property-group-card/property-group-card.component.ts
@@ -74,22 +74,23 @@ export class PropertyGroupCard {
 
     hasValue(propertyName: string): boolean {
         const valueRef = this.propertyGroup().propertyValues?.[propertyName];
-        if (!valueRef) return false;
-        if (valueRef.valueType === 'SECRET_REFERENCE') return true;
-        if (valueRef.valueType === 'ASSET_REFERENCE') {
+        if (valueRef?.valueType === 'SECRET_REFERENCE') return true;
+        if (valueRef?.valueType === 'ASSET_REFERENCE') {
             return (valueRef.assetReferences?.length ?? 0) > 0;
         }
-        return valueRef.value !== null && valueRef.value !== undefined && valueRef.value !== '';
+
+        const value = valueRef?.value ?? this.getDescriptor(propertyName)?.defaultValue;
+        return value !== null && value !== undefined && value !== '';
     }
 
     getDisplayValueForProperty(propertyName: string): string {
         const valueRef = this.propertyGroup().propertyValues?.[propertyName];
-        if (!valueRef) return '';
-        if (valueRef.valueType === 'SECRET_REFERENCE') return '••••••••';
-        if (valueRef.valueType === 'ASSET_REFERENCE') {
+        if (valueRef?.valueType === 'SECRET_REFERENCE') return '••••••••';
+        if (valueRef?.valueType === 'ASSET_REFERENCE') {
             const refs = valueRef.assetReferences;
             return refs?.map((r: AssetReference) => r.name || r.id).join(', ') || '';
         }
-        return valueRef.value ?? '';
+
+        return valueRef?.value ?? this.getDescriptor(propertyName)?.defaultValue ?? '';
     }
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/property-group-card/property-group-card.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/property-group-card/property-group-card.component.ts
@@ -25,6 +25,7 @@ import {
     ConnectorPropertyDescriptor,
     PropertyGroupConfiguration
 } from '../../types';
+import { hasPropertyValue } from '../../utils/connector-validation.utils';
 
 /**
  * Read-only display card for a property group's configured values.
@@ -74,23 +75,21 @@ export class PropertyGroupCard {
 
     hasValue(propertyName: string): boolean {
         const valueRef = this.propertyGroup().propertyValues?.[propertyName];
-        if (valueRef?.valueType === 'SECRET_REFERENCE') return true;
-        if (valueRef?.valueType === 'ASSET_REFERENCE') {
-            return (valueRef.assetReferences?.length ?? 0) > 0;
-        }
-
-        const value = valueRef?.value ?? this.getDescriptor(propertyName)?.defaultValue;
-        return value !== null && value !== undefined && value !== '';
+        const descriptor = this.getDescriptor(propertyName);
+        return hasPropertyValue(valueRef, descriptor?.type ?? 'STRING', descriptor?.defaultValue);
     }
 
     getDisplayValueForProperty(propertyName: string): string {
         const valueRef = this.propertyGroup().propertyValues?.[propertyName];
-        if (valueRef?.valueType === 'SECRET_REFERENCE') return '••••••••';
+        const descriptor = this.getDescriptor(propertyName);
+
+        // Mask by type, not just a saved SECRET_REFERENCE, so a SECRET defaultValue cannot leak.
+        if (descriptor?.type === 'SECRET' || valueRef?.valueType === 'SECRET_REFERENCE') return '••••••••';
         if (valueRef?.valueType === 'ASSET_REFERENCE') {
             const refs = valueRef.assetReferences;
             return refs?.map((r: AssetReference) => r.name || r.id).join(', ') || '';
         }
 
-        return valueRef?.value ?? this.getDescriptor(propertyName)?.defaultValue ?? '';
+        return valueRef?.value ?? descriptor?.defaultValue ?? '';
     }
 }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/services/value-reference.helper.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/services/value-reference.helper.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fromValueReference, toBooleanValue } from './value-reference.helper';
+
+describe('Value Reference Helper', () => {
+    describe('toBooleanValue', () => {
+        it('coerces true values case-insensitively to match Boolean.parseBoolean', () => {
+            expect(toBooleanValue(true)).toBe(true);
+            expect(toBooleanValue('true')).toBe(true);
+            expect(toBooleanValue('True')).toBe(true);
+            expect(toBooleanValue('TRUE')).toBe(true);
+        });
+
+        it('coerces all other values to false', () => {
+            expect(toBooleanValue(false)).toBe(false);
+            expect(toBooleanValue('false')).toBe(false);
+            expect(toBooleanValue('anything')).toBe(false);
+            expect(toBooleanValue(null)).toBe(false);
+            expect(toBooleanValue(undefined)).toBe(false);
+        });
+    });
+
+    describe('fromValueReference', () => {
+        it('normalizes BOOLEAN string values case-insensitively', () => {
+            expect(fromValueReference({ value: 'TRUE', valueType: 'STRING_LITERAL' }, 'BOOLEAN')).toBe(true);
+            expect(fromValueReference({ value: 'false', valueType: 'STRING_LITERAL' }, 'BOOLEAN')).toBe(false);
+        });
+
+        it('preserves a null BOOLEAN value so callers can use the descriptor default', () => {
+            expect(fromValueReference({ value: null, valueType: 'STRING_LITERAL' }, 'BOOLEAN')).toBeNull();
+        });
+    });
+});

--- a/nifi-frontend/src/main/frontend/libs/shared/src/services/value-reference.helper.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/services/value-reference.helper.ts
@@ -38,6 +38,19 @@ export interface SecretReferenceOptions {
 }
 
 /**
+ * Coerces a BOOLEAN property value into a real boolean.
+ *
+ * BOOLEAN values cross the wire as the strings `"true"` / `"false"` (both
+ * `ConnectorValueReferenceDTO.value` and `ConnectorPropertyDescriptorDTO.defaultValue`
+ * are declared as String server-side). `MatSlideToggle.writeValue` coerces with a bare
+ * `!!value`, so the string `"false"` is truthy and would render the toggle as checked.
+ * Any value other than `true` / `"true"` is therefore treated as false.
+ */
+export function toBooleanValue(value: unknown): boolean {
+    return value === true || value === 'true';
+}
+
+/**
  * Creates a ConnectorValueReference from a primitive form value.
  * Supports STRING_LITERAL, ASSET_REFERENCE, and SECRET_REFERENCE value types.
  *
@@ -194,6 +207,13 @@ export function fromValueReference(
             return [{ id: rawValue }] as AssetReference[];
         }
         return [];
+    }
+
+    // For BOOLEAN, coerce the wire string ("true"/"false") into a real boolean so the
+    // toggle renders the stored value rather than the truthiness of a non-empty string.
+    // null/undefined is preserved so callers can still fall back to the descriptor default.
+    if (propertyType === 'BOOLEAN' && rawValue !== null && rawValue !== undefined) {
+        return toBooleanValue(rawValue);
     }
 
     // For STRING_LIST, split comma-separated string into array for multi-select

--- a/nifi-frontend/src/main/frontend/libs/shared/src/services/value-reference.helper.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/services/value-reference.helper.ts
@@ -40,14 +40,15 @@ export interface SecretReferenceOptions {
 /**
  * Coerces a BOOLEAN property value into a real boolean.
  *
- * BOOLEAN values cross the wire as the strings `"true"` / `"false"` (both
+ * BOOLEAN values cross the wire as strings (both
  * `ConnectorValueReferenceDTO.value` and `ConnectorPropertyDescriptorDTO.defaultValue`
- * are declared as String server-side). `MatSlideToggle.writeValue` coerces with a bare
- * `!!value`, so the string `"false"` is truthy and would render the toggle as checked.
- * Any value other than `true` / `"true"` is therefore treated as false.
+ * are declared as String server-side). Comparison is case-insensitive to match
+ * `Boolean.parseBoolean`, which the connector framework uses when reading BOOLEAN values.
+ * `MatSlideToggle.writeValue` coerces with a bare `!!value`, so the string `"false"` is truthy
+ * and would otherwise render the toggle as checked.
  */
 export function toBooleanValue(value: unknown): boolean {
-    return value === true || value === 'true';
+    return value === true || (typeof value === 'string' && value.toLowerCase() === 'true');
 }
 
 /**
@@ -140,7 +141,7 @@ export function toValueReference(
  * for use with multi-select form controls.
  *
  * @param valueRef The ConnectorValueReference from the API, or a plain primitive value
- * @param propertyType Optional property type - when 'STRING_LIST', splits comma-separated values into array
+ * @param propertyType Optional property type used to normalize BOOLEAN, STRING_LIST, and ASSET values
  * @returns The primitive value suitable for display
  */
 export function fromValueReference(

--- a/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-validation.utils.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-validation.utils.ts
@@ -23,7 +23,7 @@ import {
     PropertyType,
     buildSecretKey
 } from '../types';
-import { isDependencyValueSatisfied } from '../components/connector-wizard/step-dependency.utils';
+import { isDependencyValueSatisfied } from './dependency-value.utils';
 
 /**
  * Check if a property has a meaningful value set.

--- a/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-validation.utils.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-validation.utils.ts
@@ -23,6 +23,7 @@ import {
     PropertyType,
     buildSecretKey
 } from '../types';
+import { isDependencyValueSatisfied } from '../components/connector-wizard/step-dependency.utils';
 
 /**
  * Check if a property has a meaningful value set.
@@ -139,10 +140,7 @@ function evaluatePropertyVisibility(
 
         const dependentValue = findPropertyValue(dependency.propertyName, propertyGroups);
 
-        if (dependency.dependentValues && dependency.dependentValues.length > 0) {
-            return dependentValue !== null && dependency.dependentValues.includes(dependentValue);
-        }
-        return dependentValue !== null && dependentValue !== '';
+        return isDependencyValueSatisfied(dependentValue, dependency.dependentValues);
     });
 }
 

--- a/nifi-frontend/src/main/frontend/libs/shared/src/utils/dependency-value.utils.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/utils/dependency-value.utils.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isDependencyValueSatisfied } from './dependency-value.utils';
+
+describe('Dependency Value Utils', () => {
+    it('matches native booleans against string dependent values', () => {
+        expect(isDependencyValueSatisfied(true, ['true'])).toBe(true);
+        expect(isDependencyValueSatisfied(false, ['true'])).toBe(false);
+        expect(isDependencyValueSatisfied(false, ['false'])).toBe(true);
+    });
+
+    it('matches string values case-sensitively', () => {
+        expect(isDependencyValueSatisfied('true', ['true'])).toBe(true);
+        expect(isDependencyValueSatisfied('TRUE', ['true'])).toBe(false);
+        expect(isDependencyValueSatisfied('value2', ['value1', 'value2'])).toBe(true);
+    });
+
+    it('treats any non-empty value as satisfying an empty dependent values list', () => {
+        expect(isDependencyValueSatisfied('anything', [])).toBe(true);
+        expect(isDependencyValueSatisfied(false, undefined)).toBe(true);
+        expect(isDependencyValueSatisfied('', [])).toBe(false);
+        expect(isDependencyValueSatisfied(null, [])).toBe(false);
+        expect(isDependencyValueSatisfied(undefined, [])).toBe(false);
+    });
+
+    it('does not match null or undefined against a dependent values list', () => {
+        expect(isDependencyValueSatisfied(null, ['true'])).toBe(false);
+        expect(isDependencyValueSatisfied(undefined, ['undefined'])).toBe(false);
+    });
+});

--- a/nifi-frontend/src/main/frontend/libs/shared/src/utils/dependency-value.utils.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/utils/dependency-value.utils.ts
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConnectorPropertyFormValue } from '../types';
+
+/**
+ * Evaluates whether a dependency condition is met by a property's current value.
+ *
+ * The API represents dependent values as strings, while live form values can be native
+ * booleans. Dependency matching remains case-sensitive to match backend dependency evaluators.
+ *
+ * @param value The dependent property's current value
+ * @param dependentValues Values that satisfy the dependency; empty means any non-empty value
+ * @returns whether the dependency condition is met
+ */
+export function isDependencyValueSatisfied(
+    value: ConnectorPropertyFormValue | undefined,
+    dependentValues: string[] | undefined | null
+): boolean {
+    if (!dependentValues || dependentValues.length === 0) {
+        return value !== null && value !== undefined && value !== '';
+    }
+
+    return value !== null && value !== undefined && dependentValues.includes(String(value));
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->### Description

BOOLEAN properties in the Connector Configuration wizard could misdisplay and fail to update dependents when rendered as slide toggles.

**Symptoms**
- Dependent properties did not update live when a BOOLEAN toggle changed
- Stored or default `"false"` could render as checked
- Dependency-gated properties/steps could stay wrong after toggle, navigation, or reopen

**Root cause**
BOOLEAN values cross the wire as strings (`"true"` / `"false"`) via `ConnectorValueReference` and property defaults. `MatSlideToggle` coerces with `!!value`, so the string `"false"` is truthy. Separately, `dependsOn.dependentValues` is `string[]` from the API while the live form value is a native `boolean`; `Array.prototype.includes` uses strict equality, so `true` does not match `"true"`.

**Fix**
- Coerce BOOLEAN wire values to real booleans via `toBooleanValue` at form init, CVA `writeValue`, and `fromValueReference`
- Shared `isDependencyValueSatisfied` with `String(value)` coercion for step dependencies, property dependencies, and validation visibility
- Keep save-delta comparison symmetric so an untouched BOOLEAN with wire `"false"` is not treated as changed
- Regression unit tests for coercion, BOOLEAN-gated visibility, and dirty-delta behavior

### Jira

https://issues.apache.org/jira/browse/NIFI-16206

### Testing

- [x] Unit tests added/updated under `libs/shared` for value-reference coercion, dependency matching, configuration-step BOOLEAN visibility, and dirty-delta
- [ ] Manual: connector with BOOLEAN + `dependsOn` — default/saved `"false"` renders unchecked; toggle on/off updates dependents; navigate away/back and reopen stays consistent; changing an unrelated field does not send an untouched BOOLEAN as changed