### PR TITLE
NIFI-16208 Sort Manifest Extension Files for Deterministic Ordering

### DIFF
--- a/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/DirectoryExtensionManifestProvider.java
+++ b/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/DirectoryExtensionManifestProvider.java
@@ -30,6 +30,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,8 +63,16 @@ public class DirectoryExtensionManifestProvider implements ExtensionManifestProv
 
         LOGGER.info("Loading extension manifests from: {}", baseDir.getAbsolutePath());
 
+        final File[] manifestDirs = baseDir.listFiles();
+        if (manifestDirs == null) {
+            throw new IllegalStateException("Unable to list files in manifest directory [%s]".formatted(baseDir.getAbsolutePath()));
+        }
+
+        // Sort by name so the generated runtime manifest is deterministic regardless of filesystem listing order
+        Arrays.sort(manifestDirs, Comparator.comparing(File::getName));
+
         final List<ExtensionManifestContainer> extensionManifests = new ArrayList<>();
-        for (final File manifestDir : baseDir.listFiles()) {
+        for (final File manifestDir : manifestDirs) {
             if (!manifestDir.isDirectory()) {
                 LOGGER.debug("Skipping [{}], not a directory...", manifestDir.getAbsolutePath());
                 continue;
@@ -102,7 +112,15 @@ public class DirectoryExtensionManifestProvider implements ExtensionManifestProv
             return additionalDetailsMap;
         }
 
-        for (final File additionalDetailsTypeDir : additionalDetailsDir.listFiles()) {
+        final File[] additionalDetailsTypeDirs = additionalDetailsDir.listFiles();
+        if (additionalDetailsTypeDirs == null) {
+            throw new IllegalStateException("Unable to list files in additional-details directory [%s]".formatted(additionalDetailsDir.getAbsolutePath()));
+        }
+
+        // Sort by name so the additional details are added in a deterministic order regardless of filesystem listing order
+        Arrays.sort(additionalDetailsTypeDirs, Comparator.comparing(File::getName));
+
+        for (final File additionalDetailsTypeDir : additionalDetailsTypeDirs) {
             if (!additionalDetailsTypeDir.isDirectory()) {
                 LOGGER.debug("Skipping [{}], not a directory...", additionalDetailsTypeDir.getAbsolutePath());
                 continue;

--- a/nifi-manifest/nifi-runtime-manifest-core/src/test/java/org/apache/nifi/runtime/manifest/impl/DirectoryExtensionManifestProviderTest.java
+++ b/nifi-manifest/nifi-runtime-manifest-core/src/test/java/org/apache/nifi/runtime/manifest/impl/DirectoryExtensionManifestProviderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.runtime.manifest.impl;
+
+import org.apache.nifi.extension.manifest.ExtensionManifest;
+import org.apache.nifi.extension.manifest.parser.ExtensionManifestParser;
+import org.apache.nifi.runtime.manifest.ExtensionManifestContainer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DirectoryExtensionManifestProviderTest {
+
+    private static final String MANIFEST_RELATIVE_PATH = "META-INF/docs/extension-manifest.xml";
+    private static final String ADDITIONAL_DETAILS_RELATIVE_PATH = "META-INF/docs/additional-details";
+
+    private final ExtensionManifestParser artifactIdParser = new ArtifactIdExtensionManifestParser();
+
+    @Test
+    void testExtensionManifestsReturnedInSortedOrderRegardlessOfCreationOrder(@TempDir final Path baseDir) throws IOException {
+        final List<String> creationOrder = List.of("nifi-standard-nar", "nifi-aws-nar", "nifi-kafka-nar", "nifi-azure-nar");
+        for (final String bundleArtifactId : creationOrder) {
+            createBundleManifest(baseDir, bundleArtifactId);
+        }
+
+        final DirectoryExtensionManifestProvider provider = new DirectoryExtensionManifestProvider(baseDir.toFile(), artifactIdParser);
+        final List<ExtensionManifestContainer> containers = provider.getExtensionManifests();
+
+        final List<String> returnedArtifactIds = new ArrayList<>();
+        for (final ExtensionManifestContainer container : containers) {
+            returnedArtifactIds.add(container.getManifest().getArtifactId());
+        }
+
+        final List<String> expectedArtifactIds = List.of("nifi-aws-nar", "nifi-azure-nar", "nifi-kafka-nar", "nifi-standard-nar");
+        assertEquals(expectedArtifactIds, returnedArtifactIds);
+    }
+
+    @Test
+    void testAdditionalDetailsReturnedInSortedOrderRegardlessOfCreationOrder(@TempDir final Path baseDir) throws IOException {
+        final Path bundleDir = createBundleManifest(baseDir, "nifi-standard-nar");
+
+        final List<String> creationOrder = List.of("org.apache.nifi.ZProcessor", "org.apache.nifi.AProcessor", "org.apache.nifi.MProcessor");
+        for (final String extensionType : creationOrder) {
+            final Path additionalDetailsTypeDir = bundleDir.resolve(ADDITIONAL_DETAILS_RELATIVE_PATH).resolve(extensionType);
+            Files.createDirectories(additionalDetailsTypeDir);
+            Files.writeString(additionalDetailsTypeDir.resolve("additionalDetails.md"), extensionType);
+        }
+
+        final DirectoryExtensionManifestProvider provider = new DirectoryExtensionManifestProvider(baseDir.toFile(), artifactIdParser);
+        final List<ExtensionManifestContainer> containers = provider.getExtensionManifests();
+
+        assertEquals(1, containers.size());
+
+        final List<String> returnedTypes = new ArrayList<>(containers.getFirst().getAdditionalDetails().keySet());
+        final List<String> expectedTypes = List.of("org.apache.nifi.AProcessor", "org.apache.nifi.MProcessor", "org.apache.nifi.ZProcessor");
+        assertEquals(expectedTypes, returnedTypes);
+    }
+
+    private Path createBundleManifest(final Path baseDir, final String bundleArtifactId) throws IOException {
+        final Path bundleDir = baseDir.resolve(bundleArtifactId);
+        final Path manifestFile = bundleDir.resolve(MANIFEST_RELATIVE_PATH);
+        Files.createDirectories(manifestFile.getParent());
+        Files.writeString(manifestFile, bundleArtifactId);
+        return bundleDir;
+    }
+
+    /**
+     * Parser that reads the entire manifest content as the artifact identifier, allowing the test to correlate a
+     * returned container with the directory that produced it without depending on the full manifest XML schema.
+     */
+    private static class ArtifactIdExtensionManifestParser implements ExtensionManifestParser {
+        @Override
+        public ExtensionManifest parse(final InputStream inputStream) {
+            try {
+                final String artifactId = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+                final ExtensionManifest extensionManifest = new ExtensionManifest();
+                extensionManifest.setGroupId("org.apache.nifi");
+                extensionManifest.setArtifactId(artifactId);
+                extensionManifest.setVersion("2.12.0");
+                return extensionManifest;
+            } catch (final IOException e) {
+                throw new RuntimeException("Unable to read manifest content", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-16208](https://issues.apache.org/jira/browse/NIFI-16208) Sorts the Extension Manifest and Additional Details files when generating the Extension Manifest for components to ensure deterministic ordering. Deterministic ordering is a required for reproducible builds and provides consistent output for generated documentation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
