### PR TITLE
NIFI-16209 Set Deterministic Build Timestamp

### DIFF
--- a/nifi-docs/pom.xml
+++ b/nifi-docs/pom.xml
@@ -72,6 +72,7 @@
                         <idseparator>-</idseparator>
                         <docinfo1>true</docinfo1>
                         <stylesheet>asciidoc-mod.css</stylesheet>
+                        <reproducible>true</reproducible>
                     </attributes>
                 </configuration>
             </plugin>

--- a/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/RuntimeManifestGenerator.java
+++ b/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/RuntimeManifestGenerator.java
@@ -40,7 +40,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -56,10 +56,7 @@ public class RuntimeManifestGenerator {
     private static final String PROJECT_VERSION_PROPERTY = "Project-Version";
     private static final String BUILD_REVISION = "Build-Revision";
     private static final String BUILD_TIMESTAMP = "Build-Timestamp";
-    private static final String BUILD_TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
     private static final String BUILD_JDK = "Build-Jdk";
-    private static final String BUILD_JDK_VENDOR = "Build-Jdk-Vendor";
-    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern(BUILD_TIMESTAMP_FORMAT);
 
     private final File extensionManifestBaseDir;
     private final File buildPropertiesFile;
@@ -84,20 +81,12 @@ public class RuntimeManifestGenerator {
         final String buildRevision = buildProperties.getProperty(BUILD_REVISION);
         final String buildTimestamp = buildProperties.getProperty(BUILD_TIMESTAMP);
         final String buildJdk = buildProperties.getProperty(BUILD_JDK);
-        final String buildJdkVendor = buildProperties.getProperty(BUILD_JDK_VENDOR);
-
-        long buildTimestampMillis;
-        try {
-            buildTimestampMillis = OffsetDateTime.parse(buildTimestamp, TIMESTAMP_FORMATTER).toInstant().toEpochMilli();
-        } catch (Exception e) {
-            buildTimestampMillis = System.currentTimeMillis();
-        }
 
         final BuildInfo buildInfo = new BuildInfo();
         buildInfo.setVersion(runtimeVersion);
         buildInfo.setRevision(buildRevision);
-        buildInfo.setTimestamp(buildTimestampMillis);
-        buildInfo.setCompiler(buildJdkVendor + " " + buildJdk);
+        buildInfo.setTimestamp(parseBuildTimestampMillis(buildTimestamp));
+        buildInfo.setCompiler(buildJdk);
 
         final List<ExtensionManifestContainer> extensionsManifests = extensionManifestProvider.getExtensionManifests();
 
@@ -137,6 +126,23 @@ public class RuntimeManifestGenerator {
                     Files.write(additionalDetailsFile.toPath(), additionalDetails.getBytes(StandardCharsets.UTF_8));
                 }
             }
+        }
+    }
+
+    private long parseBuildTimestampMillis(final String buildTimestamp) {
+        if (buildTimestamp == null || buildTimestamp.isBlank()) {
+            return 0L;
+        }
+
+        // project.build.outputTimestamp may be provided as seconds since the epoch or as an ISO-8601 timestamp
+        if (buildTimestamp.chars().allMatch(Character::isDigit)) {
+            return Long.parseLong(buildTimestamp) * 1000L;
+        }
+
+        try {
+            return OffsetDateTime.parse(buildTimestamp).toInstant().toEpochMilli();
+        } catch (final DateTimeParseException e) {
+            return 0L;
         }
     }
 

--- a/nifi-manifest/nifi-runtime-manifest/src/main/resources/build.properties
+++ b/nifi-manifest/nifi-runtime-manifest/src/main/resources/build.properties
@@ -16,10 +16,10 @@
 Project-Version:${project.version}
 Build-Branch:${buildBranch}
 Build-Revision:${buildRevision}
-Build-Timestamp:${maven.build.timestamp}
+Build-Timestamp:${project.build.outputTimestamp}
 Maven-Version:${maven.version}
 Created-By:${maven.build.version}
-Build-Jdk:${java.version}
-Build-Jdk-Vendor:${java.vendor}
-Build-Arch:${os.arch}
-Build-Os:${os.name}
+Build-Jdk:${maven.compiler.release}
+Build-Jdk-Vendor:JDK
+Build-Arch:UNSPECIFIED
+Build-Os:UNSPECIFIED

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>37</version>
+        <version>39</version>
         <relativePath />
     </parent>
     <groupId>org.apache.nifi</groupId>


### PR DESCRIPTION
# Summary

[NIFI-16209](https://issues.apache.org/jira/browse/NIFI-16209) Sets a deterministic build timestamp using `project.build.outputTimestamp` and also sets static values for JDK and operating system properties.

This approach promotes reproducible builds as it relates to project runtime manifest generation.

Changes also include setting the `reproducible` flag on the documentation plugin to avoid writing timestamps specific to a particular build.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
