### PR TITLE
NIFI-16210 Adjust GetSplunk Time Zone Validator

### DIFF
--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/GetSplunk.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/GetSplunk.java
@@ -40,6 +40,7 @@ import org.apache.nifi.components.ClassloaderIsolationKeyProvider;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.context.PropertyContext;
@@ -193,10 +194,24 @@ public class GetSplunk extends AbstractProcessor implements ClassloaderIsolation
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .required(false)
             .build();
+
+    private static final Set<String> AVAILABLE_TIME_ZONE_IDS = Set.of(TimeZone.getAvailableIDs());
+
+    private static final Validator TIME_ZONE_VALIDATOR = (subject, input, context) -> new ValidationResult.Builder()
+            .subject(subject)
+            .input(input)
+            .valid(input != null && AVAILABLE_TIME_ZONE_IDS.contains(input))
+            .explanation("must be a valid time zone identifier such as UTC or America/New_York")
+            .build();
+
     public static final PropertyDescriptor TIME_ZONE = new PropertyDescriptor.Builder()
             .name("Time Zone")
-            .description("The Time Zone to use for formatting dates when performing a search. Only used with Managed time strategies.")
-            .allowableValues(TimeZone.getAvailableIDs())
+            .description("""
+                    The Time Zone to use for formatting dates when performing a search. Only used with Managed time strategies.
+                    The value must be a valid Java time zone identifier, such as UTC or America/New_York.
+                    """
+            )
+            .addValidator(TIME_ZONE_VALIDATOR)
             .defaultValue("UTC")
             .required(true)
             .build();

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestGetSplunk.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestGetSplunk.java
@@ -85,6 +85,24 @@ public class TestGetSplunk {
     }
 
     @Test
+    public void testTimeZoneValidation() {
+        runner.setProperty(GetSplunk.QUERY, "search tcp:7879");
+        runner.setProperty(GetSplunk.EARLIEST_TIME, "-1h");
+        runner.setProperty(GetSplunk.LATEST_TIME, "now");
+        runner.setProperty(GetSplunk.OUTPUT_MODE, GetSplunk.ATOM_VALUE.getValue());
+        runner.assertValid();
+
+        runner.setProperty(GetSplunk.TIME_ZONE, "Not/AValidZone");
+        runner.assertNotValid();
+
+        runner.setProperty(GetSplunk.TIME_ZONE, "America/New_York");
+        runner.assertValid();
+
+        runner.setProperty(GetSplunk.TIME_ZONE, "UTC");
+        runner.assertValid();
+    }
+
+    @Test
     public void testGetWithProvidedTime() {
         final String query = "search tcp:7879";
         final String providedEarliest = "-1h";


### PR DESCRIPTION
# Summary

[NIFI-16210](https://issues.apache.org/jira/browse/NIFI-16210) Adjusts the `Time Zone` property in the `GetSplunk` Processor to use a custom `Validator` instead of a list of allowable values.

The Time Zone data varies from one Java version to another, resulting in non-deterministic builds due to potential changes in the list of supported time zones.

The Validator strategy retains compatibility with existing flow configurations.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
