### PR TITLE
NIFI-16211 Configure Deterministic Build for Registry Web UI

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webpack.common.js
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webpack.common.js
@@ -40,7 +40,9 @@ module.exports = {
     output: {
         // add the content hash for auto cache-busting
         filename: '[name].[contenthash].js',
-        path: path.resolve(__dirname, './')
+        path: path.resolve(__dirname, './'),
+        // Pin the hashing algorithm so bundle names do not depend on the Node/OpenSSL default
+        hashFunction: 'sha256'
     },
 
     optimization: {

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webpack.prod.js
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webpack.prod.js
@@ -54,9 +54,13 @@ module.exports = merge(commonConfig, {
     },
 
     optimization: {
+        // Deterministic module and chunk identifiers so repeated builds emit byte-identical
+        // bundles, keeping the [contenthash] in the output file names stable across builds
+        moduleIds: 'hashed',
+        chunkIds: 'named',
         minimizer: [
-            // Minify JavaScript
-            new TerserJSPlugin({}),
+            // Minify JavaScript; disable parallelism so minified output ordering is deterministic
+            new TerserJSPlugin({ parallel: false }),
 
             // Minify CSS
             new OptimizeCSSAssetsPlugin({})


### PR DESCRIPTION
# Summary

[NIFI-16211](https://issues.apache.org/jira/browse/NIFI-16211) Configures deterministic building for Webpack in the NiFi Registry Web UI. Although the NiFi Registry is deprecated for subsequent removal, this minor build adjustment closes another gap in the current project build process to promote reproducible binaries from the same source commit hash.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
