### PR TITLE
NIFI-16216 - Bump Logback to 1.6.3, OkHTTP to 5.5.0, Jackson to 2.22.2, and others

### DIFF
--- a/nifi-commons/pom.xml
+++ b/nifi-commons/pom.xml
@@ -71,7 +71,7 @@
         <module>nifi-connector-common</module>
     </modules>
     <properties>
-        <guava.version>33.6.0-jre</guava.version>
+        <guava.version>33.7.0-jre</guava.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -27,7 +27,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <guava.version>33.6.0-jre</guava.version>
+        <guava.version>33.7.0-jre</guava.version>
         <protobuf.version>4.35.1</protobuf.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -60,7 +60,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.6.0-jre</version>
+                <version>33.7.0-jre</version>
             </dependency>
             <!-- Override Apache Qpid Proton J for Azure EventHubs to resolve PROTON-2347 -->
             <dependency>

--- a/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.6.0-jre</version>
+            <version>33.7.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.6.0-jre</version>
+                <version>33.7.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
     <properties>
         <janusgraph.version>1.2.0-20260723-164414.ac0eb23</janusgraph.version>
-        <guava.version>33.6.0-jre</guava.version>
+        <guava.version>33.7.0-jre</guava.version>
         <amqp-client.version>5.34.0</amqp-client.version>
     </properties>
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.6.0-jre</version>
+                <version>33.7.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
@@ -34,6 +34,6 @@
     </modules>
 
     <properties>
-        <mongo.driver.version>5.9.2</mongo.driver.version>
+        <mongo.driver.version>5.10.0</mongo.driver.version>
     </properties>
 </project>

--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
@@ -40,7 +40,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.6.0-jre</version>
+                <version>33.7.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/pom.xml
@@ -37,7 +37,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.6.0-jre</version>
+                <version>33.7.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -21,7 +21,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <guava.version>33.6.0-jre</guava.version>
+        <guava.version>33.7.0-jre</guava.version>
         <protobuf.version>4.35.1</protobuf.version>
         <grpc.version>1.83.1</grpc.version>
         <snowflake-jdbc-thin.version>4.3.2</snowflake-jdbc-thin.version>

--- a/nifi-extension-bundles/nifi-sql-reporting-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-sql-reporting-bundle/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>nifi-sql-reporting-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <guava.version>33.6.0-jre</guava.version>
+        <guava.version>33.7.0-jre</guava.version>
     </properties>
     <modules>
         <module>nifi-sql-reporting-tasks</module>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -219,7 +219,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.6.0-jre</version>
+                <version>33.7.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.networknt</groupId>

--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -24,7 +24,7 @@
     <packaging>pom</packaging>
     <description>NiFi: Framework Bundle</description>
     <properties>
-        <guava.version>33.6.0-jre</guava.version>
+        <guava.version>33.7.0-jre</guava.version>
         <org.opensaml.version>5.1.6</org.opensaml.version>
     </properties>
     <modules>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -114,7 +114,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.6.0-jre</version>
+                <version>33.7.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>4.1.0</spring.boot.version>
-        <flyway.version>13.2.0</flyway.version>
+        <flyway.version>13.3.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.7.1.202607240634-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.52.1</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.53.1</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.8</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -154,12 +154,12 @@
         <kafka.docker.image>apache/kafka:4.3.1</kafka.docker.image>
         <avro.version>1.12.1</avro.version>
         <calcite.version>1.42.0</calcite.version>
-        <com.github.luben.zstd-jni.version>1.5.7-13</com.github.luben.zstd-jni.version>
+        <com.github.luben.zstd-jni.version>1.5.7-15</com.github.luben.zstd-jni.version>
         <com.jayway.jsonpath.version>3.0.0</com.jayway.jsonpath.version>
         <gson.version>2.14.0</gson.version>
         <jackson.annotations.version>2.22</jackson.annotations.version>
-        <jackson.bom.version>2.22.1</jackson.bom.version>
-        <jackson3.bom.version>3.2.1</jackson3.bom.version>
+        <jackson.bom.version>2.22.2</jackson.bom.version>
+        <jackson3.bom.version>3.2.2</jackson3.bom.version>
         <json.smart.version>2.6.0</json.smart.version>
         <snakeyaml.version>2.6</snakeyaml.version>
 
@@ -170,14 +170,14 @@
 
         <!-- Logging and observability -->
         <log4j2.version>2.26.1</log4j2.version>
-        <logback.version>1.6.2</logback.version>
+        <logback.version>1.6.3</logback.version>
         <org.slf4j.version>2.0.18</org.slf4j.version>
         <prometheus.version>0.16.0</prometheus.version>
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
 
         <!-- Networking and transport -->
         <netty.4.version>4.2.17.Final</netty.4.version>
-        <okhttp.version>5.4.0</okhttp.version>
+        <okhttp.version>5.5.0</okhttp.version>
         <okio.version>3.18.1</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
@@ -212,7 +212,7 @@
         <junit.version>6.1.3</junit.version>
         <mockito.version>5.23.0</mockito.version>
         <pmd.version>7.26.0</pmd.version>
-        <checkstyle.version>13.9.0</checkstyle.version>
+        <checkstyle.version>13.11.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
     </properties>


### PR DESCRIPTION
# Summary

NIFI-16216 - Bump Logback to 1.6.3, OkHTTP to 5.5.0, Jackson to 2.22.2, and others

- Guava from 33.6.0-jre to 33.7.0-jre - https://github.com/google/guava/releases/tag/v33.7.0
- MongoDB Driver from 5.9.2 to 5.10.0 - https://github.com/mongodb/mongo-java-driver/releases/tag/r5.10.0
- FlywayDB from 13.2.0 to 13.3.0 - https://github.com/flyway/flyway/releases/tag/flyway-13.3.0
- AWS SDK from 2.52.1 to 2.53.1 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.53.1
- zstd from 1.5.7-13 to 1.5.7-15 - https://github.com/luben/zstd-jni/releases/tag/v1.5.7-15
- Jackson 2 from 2.22.1 to 2.22.2 - https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.22.2
- Jackson 3 from 3.2.1 to 3.2.2 - https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.2.2
- Logback from 1.6.2 to 1.6.3 - https://github.com/qos-ch/logback/releases/tag/v_1.6.3
- OkHTTP from 5.4.0 to 5.5.0 - https://github.com/lysine-dev/okhttp/blob/main/CHANGELOG.md#version-550
- Checkstyle from 13.9.0 to 13.11.0 - https://github.com/checkstyle/checkstyle/releases/tag/checkstyle-13.11.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
