### PR TITLE
NIFI-16227 - GenerateTableFetch can leave incoming FlowFiles unacknowledged after processing failures

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
@@ -270,38 +270,37 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
                 return;
             }
         }
-        maxValueProperties = getDefaultMaxValueProperties(context, fileToProcess);
-
         final ComponentLog logger = getLogger();
-
-        final DBCPService dbcpService = context.getProperty(DBCP_SERVICE).asControllerService(DBCPService.class);
-        final DatabaseDialectService databaseDialectService = getDatabaseDialectService(context);
-        final String databaseType = context.getProperty(DB_TYPE).getValue();
-
-        final String tableName = context.getProperty(TABLE_NAME).evaluateAttributeExpressions(fileToProcess).getValue();
-        final String columnNames = context.getProperty(COLUMN_NAMES).evaluateAttributeExpressions(fileToProcess).getValue();
-        final String maxValueColumnNames = context.getProperty(MAX_VALUE_COLUMN_NAMES).evaluateAttributeExpressions(fileToProcess).getValue();
-        final int partitionSize = context.getProperty(PARTITION_SIZE).evaluateAttributeExpressions(fileToProcess).asInteger();
-        final String columnForPartitioning = context.getProperty(COLUMN_FOR_VALUE_PARTITIONING).evaluateAttributeExpressions(fileToProcess).getValue();
-        final boolean useColumnValsForPaging = !StringUtils.isEmpty(columnForPartitioning);
-        final String customWhereClause = context.getProperty(WHERE_CLAUSE).evaluateAttributeExpressions(fileToProcess).getValue();
-        final String customOrderByColumn = context.getProperty(CUSTOM_ORDERBY_COLUMN).evaluateAttributeExpressions(fileToProcess).getValue();
-        final boolean outputEmptyFlowFileOnZeroResults = context.getProperty(OUTPUT_EMPTY_FLOWFILE_ON_ZERO_RESULTS).asBoolean();
-
-        final StateMap stateMap;
-        FlowFile finalFileToProcess = fileToProcess;
-
         try {
-            stateMap = session.getState(Scope.CLUSTER);
-        } catch (final IOException ioe) {
-            logger.error("Failed to retrieve observed maximum values from the State Manager. Will not perform "
-                    + "query until this is accomplished.", ioe);
-            session.rollback();
-            context.yield();
-            return;
-        }
+            maxValueProperties = getDefaultMaxValueProperties(context, fileToProcess);
 
-        try {
+            final DBCPService dbcpService = context.getProperty(DBCP_SERVICE).asControllerService(DBCPService.class);
+            final DatabaseDialectService databaseDialectService = getDatabaseDialectService(context);
+            final String databaseType = context.getProperty(DB_TYPE).getValue();
+
+            final String tableName = context.getProperty(TABLE_NAME).evaluateAttributeExpressions(fileToProcess).getValue();
+            final String columnNames = context.getProperty(COLUMN_NAMES).evaluateAttributeExpressions(fileToProcess).getValue();
+            final String maxValueColumnNames = context.getProperty(MAX_VALUE_COLUMN_NAMES).evaluateAttributeExpressions(fileToProcess).getValue();
+            final int partitionSize = context.getProperty(PARTITION_SIZE).evaluateAttributeExpressions(fileToProcess).asInteger();
+            final String columnForPartitioning = context.getProperty(COLUMN_FOR_VALUE_PARTITIONING).evaluateAttributeExpressions(fileToProcess).getValue();
+            final boolean useColumnValsForPaging = !StringUtils.isEmpty(columnForPartitioning);
+            final String customWhereClause = context.getProperty(WHERE_CLAUSE).evaluateAttributeExpressions(fileToProcess).getValue();
+            final String customOrderByColumn = context.getProperty(CUSTOM_ORDERBY_COLUMN).evaluateAttributeExpressions(fileToProcess).getValue();
+            final boolean outputEmptyFlowFileOnZeroResults = context.getProperty(OUTPUT_EMPTY_FLOWFILE_ON_ZERO_RESULTS).asBoolean();
+
+            final StateMap stateMap;
+            FlowFile finalFileToProcess = fileToProcess;
+
+            try {
+                stateMap = session.getState(Scope.CLUSTER);
+            } catch (final IOException ioe) {
+                logger.error("Failed to retrieve observed maximum values from the State Manager. Will not perform "
+                        + "query until this is accomplished.", ioe);
+                session.rollback();
+                context.yield();
+                return;
+            }
+
             // Make a mutable copy of the current state property map. This will be updated by the result row callback, and eventually
             // set as the current state map (after the session has been committed)
             final Map<String, String> statePropertyMap = new HashMap<>(stateMap.toMap());

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
@@ -296,6 +296,7 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
         } catch (final IOException ioe) {
             logger.error("Failed to retrieve observed maximum values from the State Manager. Will not perform "
                     + "query until this is accomplished.", ioe);
+            session.rollback();
             context.yield();
             return;
         }
@@ -584,6 +585,9 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
             logger.error("Error during processing: {}", t.getMessage(), t);
             session.rollback();
             context.yield();
+        } catch (final RuntimeException e) {
+            session.rollback();
+            throw e;
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
@@ -18,6 +18,11 @@ package org.apache.nifi.processors.standard;
 
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateManager;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.database.dialect.service.api.DatabaseDialectService;
+import org.apache.nifi.database.dialect.service.api.StatementRequest;
+import org.apache.nifi.database.dialect.service.api.StatementResponse;
+import org.apache.nifi.database.dialect.service.api.StatementType;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.MockProcessSession;
 import org.apache.nifi.util.MockSessionFactory;
@@ -46,6 +51,7 @@ import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor
 import static org.apache.nifi.processors.standard.AbstractDatabaseFetchProcessor.WHERE_CLAUSE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TestGenerateTableFetch extends AbstractDatabaseConnectionServiceTest {
 
@@ -1118,6 +1124,39 @@ class TestGenerateTableFetch extends AbstractDatabaseConnectionServiceTest {
         assertEquals(expectedRenamed, propertyMigrationResult.getPropertiesRenamed());
     }
 
+    @Test
+    void testUncheckedDialectFailureRollsBackIncomingFlowFile() throws Exception {
+        final DatabaseDialectService dialectService = new FailingDatabaseDialectService();
+        runner.addControllerService("failing-dialect", dialectService);
+        runner.enableControllerService(dialectService);
+        runner.setProperty(DB_TYPE, "Database Dialect Service");
+        runner.setProperty(GenerateTableFetch.DATABASE_DIALECT_SERVICE, "failing-dialect");
+        runner.setProperty(GenerateTableFetch.TABLE_NAME, "${tableName}");
+        runner.setIncomingConnection(true);
+        runner.enqueue("", Map.of("tableName", "TEST_QUERY_DB_TABLE"));
+
+        final AssertionError error = assertThrows(AssertionError.class, runner::run);
+        assertEquals(IllegalArgumentException.class, error.getCause().getClass());
+
+        final MockProcessSession session = ((MockSessionFactory) runner.getProcessSessionFactory()).getCreatedSessions().iterator().next();
+        session.assertRolledBack();
+        runner.assertQueueNotEmpty();
+    }
+
+    @Test
+    void testStateReadFailureRollsBackIncomingFlowFile() {
+        runner.setProperty(GenerateTableFetch.TABLE_NAME, "${tableName}");
+        runner.setIncomingConnection(true);
+        runner.enqueue("", Map.of("tableName", "TEST_QUERY_DB_TABLE"));
+        runner.getStateManager().setFailOnStateGet(Scope.CLUSTER, true);
+
+        runner.run();
+
+        final MockProcessSession session = ((MockSessionFactory) runner.getProcessSessionFactory()).getCreatedSessions().iterator().next();
+        session.assertRolledBack();
+        runner.assertQueueNotEmpty();
+    }
+
     private void assertResultsFound(final String query, final int results) throws SQLException {
         int resultsFound = 0;
         try (
@@ -1130,5 +1169,17 @@ class TestGenerateTableFetch extends AbstractDatabaseConnectionServiceTest {
             }
         }
         assertEquals(results, resultsFound);
+    }
+
+    private static class FailingDatabaseDialectService extends AbstractControllerService implements DatabaseDialectService {
+        @Override
+        public StatementResponse getStatement(final StatementRequest statementRequest) {
+            throw new IllegalArgumentException("Order By is required when paging is specified");
+        }
+
+        @Override
+        public Set<StatementType> getSupportedStatementTypes() {
+            return Set.of(StatementType.SELECT);
+        }
     }
 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateTableFetch.java
@@ -23,6 +23,7 @@ import org.apache.nifi.database.dialect.service.api.DatabaseDialectService;
 import org.apache.nifi.database.dialect.service.api.StatementRequest;
 import org.apache.nifi.database.dialect.service.api.StatementResponse;
 import org.apache.nifi.database.dialect.service.api.StatementType;
+import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.MockProcessSession;
 import org.apache.nifi.util.MockSessionFactory;
@@ -1125,7 +1126,7 @@ class TestGenerateTableFetch extends AbstractDatabaseConnectionServiceTest {
     }
 
     @Test
-    void testUncheckedDialectFailureRollsBackIncomingFlowFile() throws Exception {
+    void testUncheckedDialectFailureRollsBackIncomingFlowFile() throws InitializationException {
         final DatabaseDialectService dialectService = new FailingDatabaseDialectService();
         runner.addControllerService("failing-dialect", dialectService);
         runner.enableControllerService(dialectService);
@@ -1137,6 +1138,20 @@ class TestGenerateTableFetch extends AbstractDatabaseConnectionServiceTest {
 
         final AssertionError error = assertThrows(AssertionError.class, runner::run);
         assertEquals(IllegalArgumentException.class, error.getCause().getClass());
+
+        final MockProcessSession session = ((MockSessionFactory) runner.getProcessSessionFactory()).getCreatedSessions().iterator().next();
+        session.assertRolledBack();
+        runner.assertQueueNotEmpty();
+    }
+
+    @Test
+    void testInvalidFlowFilePropertyRollsBackIncomingFlowFile() {
+        runner.setProperty(GenerateTableFetch.TABLE_NAME, "${tableName}");
+        runner.setProperty(GenerateTableFetch.PARTITION_SIZE, "${partSize}");
+        runner.setIncomingConnection(true);
+        runner.enqueue("", Map.of("tableName", "TEST_QUERY_DB_TABLE", "partSize", "invalid"));
+
+        assertThrows(AssertionError.class, runner::run);
 
         final MockProcessSession session = ((MockSessionFactory) runner.getProcessSessionFactory()).getCreatedSessions().iterator().next();
         session.assertRolledBack();


### PR DESCRIPTION
# Summary

NIFI-16227 - GenerateTableFetch can leave incoming FlowFiles unacknowledged after processing failures

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
