### PR TITLE
NIFI-16229 - Fixed inherited asset Parameter Context updates

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -1810,12 +1810,20 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
                 parameterEntity = dtoFactory.createParameterEntity(parameterContext, parameter, revisionManager, parameterContextDAO);
             }
 
-            // Parameter is inherited if either this is the removal of a parameter not directly in this context, or it's parameter not specified directly in the DTO
-            final boolean isInherited = (parameter == null && !parameterContext.getParameters().containsKey(new ParameterDescriptor.Builder().name(parameterName).build()))
-                    || (parameter != null && !parameterEntities.containsKey(parameterName));
-            parameterEntity.getParameter().setInherited(isInherited);
+            parameterEntity.getParameter().setInherited(isInheritedParameterUpdate(parameter, parameterContext, parameterEntities, parameterName));
             parameterContextDto.getParameters().add(parameterEntity);
         }
+    }
+
+    static boolean isInheritedParameterUpdate(final Parameter parameter, final ParameterContext parameterContext,
+                                               final Map<String, ParameterEntity> originalParameterEntities, final String parameterName) {
+        if (parameter == null) {
+            return !parameterContext.getParameters().containsKey(new ParameterDescriptor.Builder().name(parameterName).build());
+        }
+
+        final ParameterEntity originalParameterEntity = originalParameterEntities.get(parameterName);
+        return originalParameterEntity == null || originalParameterEntity.getParameter() != null
+                && Boolean.TRUE.equals(originalParameterEntity.getParameter().getInherited());
     }
 
     private void addReferencingComponents(final ControllerServiceNode service, final Set<ComponentNode> affectedComponents, final List<ParameterDTO> affectedParameterDtos,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/StandardNiFiServiceFacadeTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/StandardNiFiServiceFacadeTest.java
@@ -130,6 +130,7 @@ import org.apache.nifi.web.api.dto.CountersSnapshotDTO;
 import org.apache.nifi.web.api.dto.DtoFactory;
 import org.apache.nifi.web.api.dto.EntityFactory;
 import org.apache.nifi.web.api.dto.ParameterContextDTO;
+import org.apache.nifi.web.api.dto.ParameterDTO;
 import org.apache.nifi.web.api.dto.ProcessGroupDTO;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupDTO;
 import org.apache.nifi.web.api.dto.RevisionDTO;
@@ -148,6 +149,7 @@ import org.apache.nifi.web.api.entity.ConnectorEntity;
 import org.apache.nifi.web.api.entity.CopyRequestEntity;
 import org.apache.nifi.web.api.entity.CopyResponseEntity;
 import org.apache.nifi.web.api.entity.ParameterContextEntity;
+import org.apache.nifi.web.api.entity.ParameterEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupEntity;
 import org.apache.nifi.web.api.entity.SecretsEntity;
 import org.apache.nifi.web.api.entity.StatusHistoryEntity;
@@ -2789,6 +2791,71 @@ public class StandardNiFiServiceFacadeTest {
         when(connectorNode.getCurrentState()).thenReturn(ConnectorState.STOPPED);
 
         serviceFacade.verifyCanReportConnectorBacklog(connectorId);
+    }
+
+    @Test
+    public void testGeneratedEffectiveParameterUpdateIsInherited() {
+        final ParameterContext parameterContext = mock(ParameterContext.class);
+        final Parameter inheritedParameter = new Parameter.Builder().name("fileToIngest").parameterContextId("parent-id").build();
+
+        assertTrue(StandardNiFiServiceFacade.isInheritedParameterUpdate(inheritedParameter, parameterContext, Map.of(), "fileToIngest"));
+    }
+
+    @Test
+    public void testRepeatedEffectiveParameterUpdatePreservesInheritedFlag() {
+        final ParameterContext parameterContext = mock(ParameterContext.class);
+        final Parameter parameter = new Parameter.Builder().name("fileToIngest").parameterContextId("parent-id").build();
+        final ParameterEntity originalEntity = createParameterEntity("fileToIngest", true);
+
+        assertTrue(StandardNiFiServiceFacade.isInheritedParameterUpdate(parameter, parameterContext,
+                Map.of("fileToIngest", originalEntity), "fileToIngest"));
+    }
+
+    @Test
+    public void testClientSubmittedParameterUpdateIsLocal() {
+        final ParameterContext parameterContext = mock(ParameterContext.class);
+        final Parameter parameter = new Parameter.Builder().name("fileToIngest").parameterContextId("child-id").build();
+        final ParameterEntity originalEntity = createParameterEntity("fileToIngest", false);
+
+        assertFalse(StandardNiFiServiceFacade.isInheritedParameterUpdate(parameter, parameterContext,
+                Map.of("fileToIngest", originalEntity), "fileToIngest"));
+    }
+
+    @Test
+    public void testClientSubmittedDeletionRemainsLocalWhenInheritedParameterBecomesEffective() {
+        final ParameterContext parameterContext = mock(ParameterContext.class);
+        final Parameter inheritedParameter = new Parameter.Builder().name("shared").parameterContextId("parent-id").build();
+        final ParameterEntity deletionEntity = createParameterEntity("shared", null);
+
+        assertFalse(StandardNiFiServiceFacade.isInheritedParameterUpdate(inheritedParameter, parameterContext,
+                Map.of("shared", deletionEntity), "shared"));
+    }
+
+    @Test
+    public void testInheritedParameterRemovalUsesLocalParameterDefinitions() {
+        final ParameterContext parameterContext = mock(ParameterContext.class);
+        when(parameterContext.getParameters()).thenReturn(Map.of());
+
+        assertTrue(StandardNiFiServiceFacade.isInheritedParameterUpdate(null, parameterContext, Map.of(), "fileToIngest"));
+    }
+
+    @Test
+    public void testLocalParameterRemovalUsesLocalParameterDefinitions() {
+        final ParameterContext parameterContext = mock(ParameterContext.class);
+        final ParameterDescriptor descriptor = new ParameterDescriptor.Builder().name("fileToIngest").build();
+        when(parameterContext.getParameters()).thenReturn(Map.of(descriptor, new Parameter.Builder().descriptor(descriptor).value("value").build()));
+
+        assertFalse(StandardNiFiServiceFacade.isInheritedParameterUpdate(null, parameterContext, Map.of(), "fileToIngest"));
+    }
+
+    private static ParameterEntity createParameterEntity(final String name, final Boolean inherited) {
+        final ParameterDTO parameterDto = new ParameterDTO();
+        parameterDto.setName(name);
+        parameterDto.setInherited(inherited);
+
+        final ParameterEntity parameterEntity = new ParameterEntity();
+        parameterEntity.setParameter(parameterDto);
+        return parameterEntity;
     }
 
     @Test

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/parameters/ParameterContextIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/parameters/ParameterContextIT.java
@@ -24,6 +24,7 @@ import org.apache.nifi.tests.system.NiFiSystemIT;
 import org.apache.nifi.toolkit.client.NiFiClientException;
 import org.apache.nifi.toolkit.client.ParamContextClient;
 import org.apache.nifi.web.api.dto.ParameterContextDTO;
+import org.apache.nifi.web.api.dto.ParameterContextReferenceDTO;
 import org.apache.nifi.web.api.dto.ParameterDTO;
 import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
 import org.apache.nifi.web.api.entity.AffectedComponentEntity;
@@ -32,6 +33,7 @@ import org.apache.nifi.web.api.entity.AssetsEntity;
 import org.apache.nifi.web.api.entity.ConnectionEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceEntity;
 import org.apache.nifi.web.api.entity.ParameterContextEntity;
+import org.apache.nifi.web.api.entity.ParameterContextReferenceEntity;
 import org.apache.nifi.web.api.entity.ParameterContextUpdateRequestEntity;
 import org.apache.nifi.web.api.entity.ParameterEntity;
 import org.apache.nifi.web.api.entity.ParameterGroupConfigurationEntity;
@@ -56,6 +58,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1108,6 +1111,120 @@ public class ParameterContextIT extends NiFiSystemIT {
         final ParameterContextEntity updatedParent = getNifiClient().getParamContextClient().getParamContext(parentContext.getId(), false);
         assertEquals(1, updatedParent.getComponent().getInheritedParameterContexts().size());
         assertEquals(childContext2.getId(), updatedParent.getComponent().getInheritedParameterContexts().get(0).getId());
+    }
+
+    @Test
+    public void testAddInheritedContextWithAssetReference() throws NiFiClientException, IOException, InterruptedException {
+        final ParameterContextEntity parentContext = getClientUtil().createParameterContext("parentContext", Map.of("fileToIngest", ""));
+        final File assetFile = new File("src/test/resources/sample-assets/helloworld.txt");
+        final AssetEntity asset = createAsset(parentContext.getId(), assetFile);
+
+        final ParameterContextUpdateRequestEntity referenceAssetUpdateRequest = getClientUtil().updateParameterAssetReferences(
+                parentContext, Map.of("fileToIngest", List.of(asset.getAsset().getId())));
+        getClientUtil().waitForParameterContextRequestToComplete(parentContext.getId(), referenceAssetUpdateRequest.getRequest().getRequestId());
+
+        final ParameterContextEntity childContext = getClientUtil().createParameterContext("childContext", Map.of("otherParam", "otherValue"));
+        final ParameterContextEntity fetchedChild = getNifiClient().getParamContextClient().getParamContext(childContext.getId(), true);
+        fetchedChild.getComponent().setParameters(Set.of());
+
+        final ParameterContextReferenceEntity parentReference = new ParameterContextReferenceEntity();
+        parentReference.setId(parentContext.getId());
+        final ParameterContextReferenceDTO parentReferenceDto = new ParameterContextReferenceDTO();
+        parentReferenceDto.setId(parentContext.getId());
+        parentReferenceDto.setName(parentContext.getComponent().getName());
+        parentReference.setComponent(parentReferenceDto);
+        fetchedChild.getComponent().setInheritedParameterContexts(List.of(parentReference));
+
+        final ParameterContextUpdateRequestEntity addInheritanceRequest =
+                getNifiClient().getParamContextClient().updateParamContext(fetchedChild);
+        getClientUtil().waitForParameterContextRequestToComplete(childContext.getId(), addInheritanceRequest.getRequest().getRequestId());
+
+        final ParameterContextEntity updatedChildLocal = getNifiClient().getParamContextClient().getParamContext(childContext.getId(), false);
+        assertEquals(1, updatedChildLocal.getComponent().getInheritedParameterContexts().size());
+        assertEquals(parentContext.getId(), updatedChildLocal.getComponent().getInheritedParameterContexts().getFirst().getId());
+        assertTrue(updatedChildLocal.getComponent().getParameters().stream()
+                .noneMatch(parameter -> "fileToIngest".equals(parameter.getParameter().getName())));
+
+        final ParameterContextEntity updatedChildEffective = getNifiClient().getParamContextClient().getParamContext(childContext.getId(), true);
+        final ParameterEntity inheritedAssetParameter = updatedChildEffective.getComponent().getParameters().stream()
+                .filter(parameter -> "fileToIngest".equals(parameter.getParameter().getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(inheritedAssetParameter);
+        assertTrue(inheritedAssetParameter.getParameter().getInherited());
+        assertEquals(parentContext.getId(), inheritedAssetParameter.getParameter().getParameterContext().getId());
+        assertEquals(asset.getAsset().getId(), inheritedAssetParameter.getParameter().getReferencedAssets().getFirst().getId());
+
+        final ParameterContextUpdateRequestEntity resubmitRequest =
+                getNifiClient().getParamContextClient().updateParamContext(updatedChildEffective);
+        getClientUtil().waitForParameterContextRequestToComplete(childContext.getId(), resubmitRequest.getRequest().getRequestId());
+
+        final ParameterContextEntity resubmittedChild = getNifiClient().getParamContextClient().getParamContext(childContext.getId(), true);
+        final ParameterEntity resubmittedAssetParameter = resubmittedChild.getComponent().getParameters().stream()
+                .filter(parameter -> "fileToIngest".equals(parameter.getParameter().getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(resubmittedAssetParameter);
+        assertTrue(resubmittedAssetParameter.getParameter().getInherited());
+        assertEquals(parentContext.getId(), resubmittedAssetParameter.getParameter().getParameterContext().getId());
+    }
+
+    @Test
+    public void testDeleteLocalParameterOverrideRevealsInheritedParameter() throws NiFiClientException, IOException, InterruptedException {
+        final ParameterContextEntity parentContext = getClientUtil().createParameterContext("overrideParent", Map.of("shared", "parent-value"));
+        final ParameterContextEntity childContext = getClientUtil().createParameterContext("overrideChild",
+                Map.of("shared", "child-value"), List.of(parentContext.getId()), null);
+
+        final ParameterContextEntity fetchedChild = getNifiClient().getParamContextClient().getParamContext(childContext.getId(), true);
+        final ParameterEntity localOverride = fetchedChild.getComponent().getParameters().stream()
+                .filter(parameter -> "shared".equals(parameter.getParameter().getName()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(localOverride);
+        assertFalse(Boolean.TRUE.equals(localOverride.getParameter().getInherited()));
+        assertEquals("child-value", localOverride.getParameter().getValue());
+
+        final ParameterDTO deletionDto = new ParameterDTO();
+        deletionDto.setName("shared");
+        final ParameterEntity deletionEntity = new ParameterEntity();
+        deletionEntity.setParameter(deletionDto);
+        fetchedChild.getComponent().setParameters(Set.of(deletionEntity));
+
+        final ParameterContextUpdateRequestEntity deleteRequest = getNifiClient().getParamContextClient().updateParamContext(fetchedChild);
+        getClientUtil().waitForParameterContextRequestToComplete(childContext.getId(), deleteRequest.getRequest().getRequestId());
+
+        final ParameterContextEntity updatedChildLocal = getNifiClient().getParamContextClient().getParamContext(childContext.getId(), false);
+        assertTrue(updatedChildLocal.getComponent().getParameters().stream()
+                .noneMatch(parameter -> "shared".equals(parameter.getParameter().getName())));
+
+        final ParameterContextEntity updatedChildEffective = getNifiClient().getParamContextClient().getParamContext(childContext.getId(), true);
+        final ParameterEntity inheritedParameter = updatedChildEffective.getComponent().getParameters().stream()
+                .filter(parameter -> "shared".equals(parameter.getParameter().getName()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(inheritedParameter);
+        assertTrue(inheritedParameter.getParameter().getInherited());
+        assertEquals("parent-value", inheritedParameter.getParameter().getValue());
+        assertEquals(parentContext.getId(), inheritedParameter.getParameter().getParameterContext().getId());
+    }
+
+    @Test
+    public void testUpdateReferencedLocalParameterPreservesRawReference() throws NiFiClientException, IOException, InterruptedException {
+        final ParameterContextEntity context = getClientUtil().createParameterContext("localReferenceContext",
+                Map.of("X", "original", "Y", "#{X}"));
+
+        final ParameterContextUpdateRequestEntity updateRequest = updateParameterContext(context, "X", "updated");
+        getClientUtil().waitForParameterContextRequestToComplete(context.getId(), updateRequest.getRequest().getRequestId());
+
+        final ParameterContextEntity updatedContext = getNifiClient().getParamContextClient().getParamContext(context.getId(), false);
+        final Map<String, ParameterDTO> parameters = updatedContext.getComponent().getParameters().stream()
+                .map(ParameterEntity::getParameter)
+                .collect(Collectors.toMap(ParameterDTO::getName, Function.identity()));
+
+        assertEquals("updated", parameters.get("X").getValue());
+        assertEquals("#{X}", parameters.get("Y").getValue());
     }
 
     @Test


### PR DESCRIPTION
Preserve inherited Parameter classification during repeated effective Parameter enrichment so clustered updates continue to accept assets owned by the source context.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16229](https://issues.apache.org/jira/browse/NIFI-16229)

Parameter Context updates calculate changes to effective Parameters before applying them. In a cluster, an enriched update is replicated to the nodes and processed again. The existing classification inferred that a Parameter was inherited when it was absent from the incoming DTO. After the first enrichment added the inherited Parameter to the DTO, the second pass incorrectly classified it as local.

This change determines inheritance from the effective Parameter's source context instead. A Parameter is inherited when its source Parameter Context differs from the Parameter Context being updated. This preserves the classification across repeated enrichment while retaining the existing handling for effective Parameter removals.

The regression test updates an existing child Parameter Context to inherit a parent containing an asset-backed Parameter. It verifies the local and effective views, then resubmits the effective DTO to exercise repeated enrichment. The same test runs in standalone and clustered configurations. Existing tests confirm that removing an inherited asset context remains supported and that a local Parameter still cannot reference an Asset owned by another context.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-16229`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-16229`
- [x] Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [ ] JDK 25

Targeted verification completed using JDK 21:

- [x] `StandardNiFiServiceFacadeTest`
- [x] `ParameterContextIT#testAddInheritedContextWithAssetReference`
- [x] `ClusteredParameterContextIT#testAddInheritedContextWithAssetReference`
- [x] `ClusteredParameterContextIT#testRemoveInheritedContextWithAssetReference`
- [x] `ClusteredParameterContextIT#testAssetReferenceFromDifferentContext`

### Licensing

- [x] No new dependencies introduced
- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] No documentation changes required
- [x] Documentation formatting appears as expected in rendered files
