### PR TITLE
NIFI-16180 Impove unstable test for FlowFile Queue rebalancing

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/TestSocketLoadBalancedFlowFileQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/TestSocketLoadBalancedFlowFileQueue.java
@@ -78,6 +78,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestSocketLoadBalancedFlowFileQueue {
+    /**
+     * Prefix of the name that {@code StandardRebalancingPartition} assigns to the thread that redistributes
+     * FlowFiles held by the rebalancing partition. The remainder of the name is the queue identifier.
+     */
+    private static final String REBALANCE_THREAD_NAME_PREFIX = "Rebalance queued data for Connection ";
+    private static final long REBALANCE_TERMINATION_TIMEOUT = 10_000L;
+    private static final long REBALANCE_TERMINATION_POLL_INTERVAL = 10L;
 
     private FlowFileRepository flowFileRepo;
     private ContentRepository contentRepo;
@@ -764,16 +771,26 @@ public class TestSocketLoadBalancedFlowFileQueue {
     }
 
     @Test
-    public void testGetQueueSnapshotIncludesRebalancingPartition() {
+    @Timeout(30)
+    public void testGetQueueSnapshotIncludesRebalancingPartition() throws InterruptedException {
         // Route FlowFiles to the local partition, then move every partition's contents into the rebalancing
         // partition and prevent it from redistributing them. FlowFiles sitting in the rebalancing partition
         // (being redistributed across the cluster) must still be counted in the snapshot's total QueueSize.
         final int localPartitionIndex = determineLocalPartitionIndex();
         queue.setFlowFilePartitioner(new StaticFlowFilePartitioner(localPartitionIndex));
 
-        // Toggle load balancing so the rebalancing partition is stopped and will not drain FlowFiles moved into it.
+        // The rebalancing partition runs a background thread from the time the queue is created, so load balancing
+        // must be started and stopped to mark the rebalancing partition as stopped. The background thread observes
+        // the stopped state only after its in-flight poll returns, and it redistributes whatever that poll returns.
+        // FlowFiles are therefore only guaranteed to remain in the rebalancing partition once the thread terminates.
         queue.startLoadBalancing();
         queue.stopLoadBalancing();
+        final long terminationExpiration = System.currentTimeMillis() + REBALANCE_TERMINATION_TIMEOUT;
+        while (isRebalanceThreadRunning() && System.currentTimeMillis() < terminationExpiration) {
+            Thread.sleep(REBALANCE_TERMINATION_POLL_INTERVAL);
+        }
+
+        assertFalse(isRebalanceThreadRunning(), "Rebalancing Partition thread not terminated");
 
         final long bytesPerFlowFile = 5L;
         final int flowFileCount = 4;
@@ -793,6 +810,18 @@ public class TestSocketLoadBalancedFlowFileQueue {
         assertEquals(flowFileCount * bytesPerFlowFile, snapshot.queueSize().getByteCount());
         assertEquals(queue.size(), snapshot.queueSize());
         assertTrue(snapshot.activeFlowFiles().isEmpty());
+    }
+
+    private boolean isRebalanceThreadRunning() {
+        final String rebalanceThreadName = REBALANCE_THREAD_NAME_PREFIX + queue.getIdentifier();
+
+        for (final Thread thread : Thread.getAllStackTraces().keySet()) {
+            if (thread.isAlive() && rebalanceThreadName.equals(thread.getName())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void assertPartitionSizes(final int[] expectedSizes) {


### PR DESCRIPTION
# Summary

[NIFI-16180](https://issues.apache.org/jira/browse/NIFI-16180) Improves the behavior of the unstable `TestSocketLoadBalanceFlowFileQueue` class for the `testGetQueueSnapshotIncludesRebalancingPartition` method.

Rather than changing functional behavior, the changes add a check for current `Thread` instances, looking for rebalancing threads by name, indicating current activity. This approach enables the test method to wait for completion before asserting expected status.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
