### PR TITLE
NIFI-16231 - Bump Snowflake JDBC to 4.3.3, Reactor to 3.8.7, Avro to 1.12.2, and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -72,7 +72,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.3.6</version>
+                <version>1.3.7</version>
                 <exclusions>
                     <!--
                         Reactor Netty 1.3 includes HTTP/3 support requiring native QUIC libraries.

--- a/nifi-commons/nifi-xml-processing/pom.xml
+++ b/nifi-commons/nifi-xml-processing/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.10.3.0</version>
+                <version>4.10.4.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.8.6</version>
+            <version>3.8.7</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.8.6</version>
+            <version>3.8.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -84,7 +84,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.3.6</version>
+                <version>1.3.7</version>
                 <exclusions>
                     <!--
                         Reactor Netty 1.3 includes HTTP/3 support requiring native QUIC libraries.

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>nifi-graph-test-clients</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <janusgraph.version>1.2.0-20260723-164414.ac0eb23</janusgraph.version>
+        <janusgraph.version>1.2.0-20260818-222253.cbd6fc2</janusgraph.version>
         <guava.version>33.7.0-jre</guava.version>
         <amqp-client.version>5.34.0</amqp-client.version>
     </properties>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <protobuf.version>4.35.1</protobuf.version>
-        <wire.version>6.4.5</wire.version>
+        <wire.version>6.4.6</wire.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -24,7 +24,7 @@
         <guava.version>33.7.0-jre</guava.version>
         <protobuf.version>4.35.1</protobuf.version>
         <grpc.version>1.83.1</grpc.version>
-        <snowflake-jdbc-thin.version>4.3.2</snowflake-jdbc-thin.version>
+        <snowflake-jdbc-thin.version>4.3.3</snowflake-jdbc-thin.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.53.1</software.amazon.awssdk.version>
-        <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
+        <software.amazon.awssdk.version>2.54.0</software.amazon.awssdk.version>
+        <software.amazon.encryption.s3.version>4.0.2</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.8</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
         <!-- Apache Commons -->
@@ -152,7 +152,7 @@
         <!-- Data formats and serialization -->
         <kafka-clients.version>4.3.1</kafka-clients.version>
         <kafka.docker.image>apache/kafka:4.3.1</kafka.docker.image>
-        <avro.version>1.12.1</avro.version>
+        <avro.version>1.12.2</avro.version>
         <calcite.version>1.42.0</calcite.version>
         <com.github.luben.zstd-jni.version>1.5.7-15</com.github.luben.zstd-jni.version>
         <com.jayway.jsonpath.version>3.0.0</com.jayway.jsonpath.version>
@@ -206,7 +206,7 @@
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.security.version>7.1.0</spring.security.version>
         <spring.version>7.0.8</spring.version>
-        <swagger.annotations.version>2.2.53</swagger.annotations.version>
+        <swagger.annotations.version>2.2.54</swagger.annotations.version>
 
         <!-- Testing and quality -->
         <junit.version>6.1.3</junit.version>
@@ -852,7 +852,7 @@
                 <plugin>
                     <groupId>io.swagger.core.v3</groupId>
                     <artifactId>swagger-maven-plugin-jakarta</artifactId>
-                    <version>2.2.53</version>
+                    <version>2.2.54</version>
                 </plugin>
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>


### PR DESCRIPTION
# Summary

NIFI-16231 - Bump Snowflake JDBC to 4.3.3, Reactor to 3.8.7, Avro to 1.12.2, and others

- Reactor Netty HTTP from 1.3.6 to 1.3.7 - https://github.com/reactor/reactor-netty
- Reactor Core from 3.8.6 to 3.8.7 - https://github.com/reactor/reactor-core
- Spotbugs Maven Plugin from 4.10.3.0 to 4.10.4.0 - https://github.com/spotbugs/spotbugs-maven-plugin/releases/tag/spotbugs-maven-plugin-4.10.4.0
- JanusGraph from 1.2.0-20260723-164414.ac0eb23 to 1.2.0-20260818-222253.cbd6fc2 - https://github.com/JanusGraph/janusgraph
- Wire from 6.4.5 to 6.4.6 - https://github.com/square/wire/blob/master/CHANGELOG.md#version-646
- Snowflake JDBC from 4.3.2 to 4.3.3 - https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc-2026#version-433-aug-18-2026
- AWS SDK from 2.53.1 to 2.54.0 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.54.0
- AWS S3 Encryption from 4.0.1 to 4.0.2 - https://github.com/aws/amazon-s3-encryption-client-java
- Apache Avro from 1.12.1 to 1.12.2 - https://github.com/apache/avro/releases/tag/release-1.12.2
- Swagger from 2.2.53 to 2.2.54 - https://github.com/swagger-api/swagger-core/releases/tag/v2.2.54

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
