### PR TITLE
NIFI-16233 Add Check Build Plan Step to Compliance Workflow

### DIFF
--- a/.github/workflows/code-compliance.yml
+++ b/.github/workflows/code-compliance.yml
@@ -63,6 +63,18 @@ jobs:
           --fail-fast
           --activate-profiles contrib-check
           validate
+      - name: Check Build Plan
+        # Exclude modules referencing ANTLR 3 Plugin
+        run: >
+          ./mvnw
+          --show-version
+          --no-snapshot-updates
+          --no-transfer-progress
+          --activate-profiles apache-release
+          --projects -:nifi-expression-language
+          --projects -:nifi-hl7-query-language
+          --projects -:nifi-record-path
+          artifact:check-buildplan
 
   scan:
     timeout-minutes: 120


### PR DESCRIPTION
# Summary

[NIFI-16233](https://issues.apache.org/jira/browse/NIFI-16233) Adds a `Check Build Plan` step to the GitHub `code-compliance` workflow. The step runs the Maven [artifact:check-buildplan](https://maven.apache.org/plugins/maven-artifact-plugin/check-buildplan-mojo.html) goal to verify that Maven Plugins referenced in the `apache-release` profile meet build reproducibility requirements.

The configuration excludes three project modules that currently use the ANTLR 3 plugin. Those modules include workarounds for reproducibility issues with ANTLR 3, so they can be excluded from checking.

The step itself takes less than a minute, adding a minimal amount of time to ensure that any new plugins do not introduce problems for build reproducibility.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
