### PR TITLE
NIFI-16236 - Validate versioned Parameter names and allow removal of legacy invalid Parameters.

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ParameterNameValidator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ParameterNameValidator.java
@@ -1,0 +1,17 @@
+package org.apache.nifi.web.api.dto;
+
+import java.util.regex.Pattern;
+
+public final class ParameterNameValidator {
+    private static final Pattern VALID_PARAMETER_NAME_PATTERN = Pattern.compile("[A-Za-z0-9 ._\\-]+");
+
+    private ParameterNameValidator() {
+    }
+
+    public static void validate(final String parameterName) {
+        if (parameterName == null || !VALID_PARAMETER_NAME_PATTERN.matcher(parameterName).matches()) {
+            throw new IllegalArgumentException("Request contains an illegal Parameter Name (" + parameterName
+                    + "). Parameter names may only include letters, numbers, spaces, and the special characters .-_");
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
@@ -111,6 +111,7 @@ import org.apache.nifi.util.FlowDifferenceFilters;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.util.file.FileUtils;
 import org.apache.nifi.web.api.dto.BundleDTO;
+import org.apache.nifi.web.api.dto.ParameterNameValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -953,6 +954,7 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
 
         final Map<String, Parameter> parameters = new HashMap<>();
         for (final VersionedParameter versioned : versionedParameterContext.getParameters()) {
+            ParameterNameValidator.validate(versioned.getName());
             final boolean provided = providerBacked || versioned.isProvided();
             final String parameterValue;
             final String rawValue = versioned.getValue();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizerTest.java
@@ -368,6 +368,50 @@ class VersionedFlowSynchronizerTest {
                 "Parameter value must be re-sourced from the Parameter Provider, not the corrupted serialized value or null");
     }
 
+    @Test
+    void testSyncRejectsParameterNameRejectedByRestApi() {
+        setRootGroup();
+        setFlowController();
+
+        final String contextName = "pc_snowflake_secret";
+        final String invalidParameterName = "OPENFLOW_NETJETS_SECRET_{{ envi }}";
+
+        final StandardParameterContextManager contextManager = new StandardParameterContextManager();
+        when(flowManager.getParameterContextManager()).thenReturn(contextManager);
+        doAnswer(invocation -> {
+            invocation.getArgument(0, Runnable.class).run();
+            return null;
+        }).when(flowManager).withParameterContextResolution(any());
+        doAnswer(invocation -> {
+            final String id = invocation.getArgument(0);
+            final String name = invocation.getArgument(1);
+            final Map<String, Parameter> parameters = invocation.getArgument(3);
+            final StandardParameterContext context = new StandardParameterContext.Builder()
+                    .id(id)
+                    .name(name)
+                    .parameterReferenceManager(ParameterReferenceManager.EMPTY)
+                    .build();
+            context.setParameters(parameters);
+            contextManager.addParameterContext(context);
+            return context;
+        }).when(flowManager).createParameterContext(any(), any(), any(), any(), any(), any());
+
+        final VersionedParameter versionedParameter = new VersionedParameter();
+        versionedParameter.setName(invalidParameterName);
+        versionedParameter.setSensitive(true);
+        versionedParameter.setValue("secret-value");
+
+        final VersionedParameterContext versionedParameterContext = new VersionedParameterContext();
+        versionedParameterContext.setInstanceIdentifier("provider-backed-context");
+        versionedParameterContext.setName(contextName);
+        versionedParameterContext.setParameters(Collections.singleton(versionedParameter));
+        when(versionedDataflow.getParameterContexts()).thenReturn(List.of(versionedParameterContext));
+
+        final FlowSynchronizationException exception = assertThrows(FlowSynchronizationException.class, () ->
+                versionedFlowSynchronizer.sync(flowController, dataFlow, flowService, BundleUpdateStrategy.USE_SPECIFIED_OR_GHOST));
+        assertTrue(exception.getCause().getMessage().contains(invalidParameterName));
+    }
+
     private void setRootGroup() {
         when(flowController.getFlowManager()).thenReturn(flowManager);
         when(flowManager.getRootGroup()).thenReturn(rootGroup);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ParameterContextResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ParameterContextResource.java
@@ -81,6 +81,7 @@ import org.apache.nifi.web.api.dto.ParameterContextUpdateRequestDTO;
 import org.apache.nifi.web.api.dto.ParameterContextUpdateStepDTO;
 import org.apache.nifi.web.api.dto.ParameterContextValidationRequestDTO;
 import org.apache.nifi.web.api.dto.ParameterDTO;
+import org.apache.nifi.web.api.dto.ParameterNameValidator;
 import org.apache.nifi.web.api.dto.RevisionDTO;
 import org.apache.nifi.web.api.entity.AffectedComponentEntity;
 import org.apache.nifi.web.api.entity.AssetEntity;
@@ -121,7 +122,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Controller
@@ -129,7 +129,6 @@ import java.util.stream.Collectors;
 @Tag(name = "ParameterContexts")
 public class ParameterContextResource extends AbstractParameterResource {
     private static final Logger logger = LoggerFactory.getLogger(ParameterContextResource.class);
-    private static final Pattern VALID_PARAMETER_NAME_PATTERN = Pattern.compile("[A-Za-z0-9 ._\\-]+");
     private static final String FILENAME_HEADER = "Filename";
     private static final String CONTENT_TYPE_HEADER = "Content-Type";
     private static final String UPLOAD_CONTENT_TYPE = "application/octet-stream";
@@ -875,17 +874,19 @@ public class ParameterContextResource extends AbstractParameterResource {
     private void validateParameterNames(final ParameterContextDTO parameterContextDto) {
         if (parameterContextDto.getParameters() != null) {
             for (final ParameterEntity entity : parameterContextDto.getParameters()) {
-                final String parameterName = entity.getParameter().getName();
-                if (!isLegalParameterName(parameterName)) {
-                    throw new IllegalArgumentException("Request contains an illegal Parameter Name (" + parameterName
-                            + "). Parameter names may only include letters, numbers, spaces, and the special characters .-_");
+                final ParameterDTO parameter = entity.getParameter();
+                if (!isParameterDeletion(parameter)) {
+                    ParameterNameValidator.validate(parameter.getName());
                 }
             }
         }
     }
 
-    private boolean isLegalParameterName(final String parameterName) {
-        return VALID_PARAMETER_NAME_PATTERN.matcher(parameterName).matches();
+    private boolean isParameterDeletion(final ParameterDTO parameter) {
+        return parameter.getDescription() == null
+                && parameter.getSensitive() == null
+                && parameter.getValue() == null
+                && parameter.getReferencedAssets() == null;
     }
 
     @GET

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/ParameterContextResourceTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/ParameterContextResourceTest.java
@@ -1,0 +1,54 @@
+package org.apache.nifi.web.api;
+
+import org.apache.nifi.web.api.dto.ParameterContextDTO;
+import org.apache.nifi.web.api.dto.ParameterDTO;
+import org.apache.nifi.web.api.entity.ParameterEntity;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ParameterContextResourceTest {
+    @Test
+    void testMutationAllowsRemovalOfParameterNameLoadedFromVersionedFlow() throws NoSuchMethodException {
+        final String invalidParameterName = "OPENFLOW_NETJETS_SECRET_{{ envi }}";
+        final ParameterDTO parameter = new ParameterDTO();
+        parameter.setName(invalidParameterName);
+
+        final ParameterEntity parameterEntity = new ParameterEntity();
+        parameterEntity.setParameter(parameter);
+
+        final ParameterContextDTO parameterContext = new ParameterContextDTO();
+        parameterContext.setParameters(Set.of(parameterEntity));
+
+        final Method validateParameterNames = ParameterContextResource.class.getDeclaredMethod("validateParameterNames", ParameterContextDTO.class);
+        validateParameterNames.setAccessible(true);
+
+        assertDoesNotThrow(() -> validateParameterNames.invoke(new ParameterContextResource(), parameterContext));
+    }
+
+    @Test
+    void testMutationRejectsNewIllegalParameterName() throws NoSuchMethodException {
+        final ParameterDTO parameter = new ParameterDTO();
+        parameter.setName("OPENFLOW_NETJETS_SECRET_{{ envi }}");
+        parameter.setSensitive(true);
+
+        final ParameterEntity parameterEntity = new ParameterEntity();
+        parameterEntity.setParameter(parameter);
+
+        final ParameterContextDTO parameterContext = new ParameterContextDTO();
+        parameterContext.setParameters(Set.of(parameterEntity));
+
+        final Method validateParameterNames = ParameterContextResource.class.getDeclaredMethod("validateParameterNames", ParameterContextDTO.class);
+        validateParameterNames.setAccessible(true);
+
+        final InvocationTargetException exception = assertThrows(InvocationTargetException.class,
+                () -> validateParameterNames.invoke(new ParameterContextResource(), parameterContext));
+        assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16236](https://issues.apache.org/jira/browse/NIFI-16236)

Validates Parameter names while synchronizing versioned flows so invalid names cannot enter live Parameter Contexts. Allows deletion requests for legacy invalid Parameters so affected contexts can be repaired, while continuing to reject creation or modification of invalid names.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-16236) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [ ] Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

Focused tests completed using JDK 21:

- `VersionedFlowSynchronizerTest`: 13 tests passed
- `ParameterContextResourceTest`: 2 tests passed

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

No new dependencies were added, so no `LICENSE` or `NOTICE` changes are required.

### Documentation

- [x] Documentation formatting appears as expected in rendered files

No documentation files were changed.