### PR TITLE
NIFI-16237 Fix order for Null Value options in JSON Path Processor

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractJsonPathProcessor.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractJsonPathProcessor.java
@@ -61,7 +61,7 @@ public abstract class AbstractJsonPathProcessor extends AbstractProcessor {
             .name("Null Value Representation")
             .description("Indicates the desired representation of JSON Path expressions resulting in a null value.")
             .required(true)
-            .allowableValues(NULL_REPRESENTATION_MAP.keySet())
+            .allowableValues(EMPTY_STRING_OPTION, NULL_STRING_OPTION)
             .defaultValue(EMPTY_STRING_OPTION)
             .build();
 


### PR DESCRIPTION
# Summary

[NIFI-16237](https://issues.apache.org/jira/browse/NIFI-16237) Corrects the order of allowable values in the `Null Value Representation` property of JSON Path Processors to use an explicit list for deterministic ordering.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
