### PR TITLE
NIFI-16241 Fix PublishAMQP handling of blank Routing Key

### DIFF
--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -204,9 +204,12 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
         }
 
         final String routingKey = context.getProperty(ROUTING_KEY).evaluateAttributeExpressions(flowFile).getValue();
-        if (routingKey == null) {
-            throw new IllegalArgumentException("Failed to determine 'routing key' with provided value '"
-                + context.getProperty(ROUTING_KEY) + "' after evaluating it as expression against incoming FlowFile.");
+        if (routingKey == null || routingKey.isBlank()) {
+            getLogger().error("Failed to determine a non-empty Routing Key with configured value '{}' "
+                    + "after evaluating it against incoming FlowFile {}; routing to failure",
+                    context.getProperty(ROUTING_KEY), flowFile);
+            session.transfer(flowFile, REL_FAILURE);
+            return;
         }
 
         InputHeaderSource selectedHeaderSource = context.getProperty(HEADERS_SOURCE).asAllowableValue(InputHeaderSource.class);

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
@@ -201,6 +201,60 @@ public class PublishAMQPTest {
     }
 
     @Test
+    public void validateBlankRoutingKeyAndTransferToFailure() {
+        setConnectionProperties(runner);
+        runner.setProperty(PublishAMQP.ROUTING_KEY, "${routing.key}");
+
+        final Map<String, String> attributes = Collections.singletonMap("routing.key", "   ");
+
+        runner.enqueue("Hello Joe".getBytes(), attributes);
+
+        runner.run();
+
+        assertTrue(runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).isEmpty());
+        final MockFlowFile failureFlowFile = runner.getFlowFilesForRelationship(PublishAMQP.REL_FAILURE).getFirst();
+        assertNotNull(failureFlowFile);
+        assertFalse(failureFlowFile.isPenalized());
+        runner.assertPenalizeCount(0);
+        assertEquals(0, runner.getQueueSize().getObjectCount());
+    }
+
+    @Test
+    public void validateEmptyRoutingKeyAndTransferToFailure() {
+        setConnectionProperties(runner);
+        runner.setProperty(PublishAMQP.ROUTING_KEY, "${routing.key}");
+
+        final Map<String, String> attributes = Collections.singletonMap("routing.key", "");
+        runner.enqueue("Hello Joe".getBytes(), attributes);
+
+        runner.run();
+
+        assertTrue(runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).isEmpty());
+        final MockFlowFile failureFlowFile = runner.getFlowFilesForRelationship(PublishAMQP.REL_FAILURE).getFirst();
+        assertNotNull(failureFlowFile);
+        assertFalse(failureFlowFile.isPenalized());
+        runner.assertPenalizeCount(0);
+        assertEquals(0, runner.getQueueSize().getObjectCount());
+    }
+
+    @Test
+    public void validateMissingRoutingKeyAttributeAndTransferToFailure() {
+        setConnectionProperties(runner);
+        runner.setProperty(PublishAMQP.ROUTING_KEY, "${missing.routing.key}");
+
+        runner.enqueue("Hello Joe".getBytes());
+
+        runner.run();
+
+        assertTrue(runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).isEmpty());
+        final MockFlowFile failureFlowFile = runner.getFlowFilesForRelationship(PublishAMQP.REL_FAILURE).getFirst();
+        assertNotNull(failureFlowFile);
+        assertFalse(failureFlowFile.isPenalized());
+        runner.assertPenalizeCount(0);
+        assertEquals(0, runner.getQueueSize().getObjectCount());
+    }
+
+    @Test
     public void validateFailedPublishAndTransferToFailure() {
         setConnectionProperties(runner);
         runner.setProperty(PublishAMQP.EXCHANGE, "nonExistentExchange");


### PR DESCRIPTION
# Summary

[NIFI-16241](https://issues.apache.org/jira/browse/NIFI-16241)

This pull request updates `PublishAMQP` to route FlowFiles to the failure relationship when the evaluated Routing Key is null, empty, or whitespace-only. This prevents invalid FlowFiles from being rolled back and repeatedly processed.

## Changes

- Fix PublishAMQP handling of blank Routing Key

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-16241) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [x] Pull request contains commits signed with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

- Added regression tests for missing, empty, and whitespace-only evaluated Routing Keys.
- Verified that affected FlowFiles are transferred to failure and removed from the input queue.
- Not run locally because Java/JAVA_HOME is not available in the environment.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

Module-level verification performed:

`.\mvnw.cmd -pl :nifi-amqp-processors -am test`

Additional verification performed:

`.\mvnw.cmd -pl :nifi-amqp-processors -am -P contrib-check install -DskipTests`

`.\mvnw.cmd -pl :nifi-amqp-nar -am install -DskipTests`

### Licensing

- [x] New dependencies are compatible with the Apache License 2.0
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

No new dependencies were added.

### Documentation

- [x] Documentation formatting appears as expected in rendered files

No user-facing documentation files were changed.

 
