### PR TITLE
NIFI-16243 Added DetectBase64Content Processor

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DetectBase64Content.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DetectBase64Content.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.SideEffectFree;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.documentation.UseCase;
+import org.apache.nifi.components.DescribedValue;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.DataUnit;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Set;
+
+@SideEffectFree
+@SupportsBatching
+@InputRequirement(Requirement.INPUT_REQUIRED)
+@Tags({"base64", "detect", "identify", "encoding", "content"})
+@CapabilityDescription("""
+        Checks whether FlowFile content is Base64 encoded and writes either true or false to a configurable attribute. The content is inspected rather \
+        than decoded, so content that is not Base64 is reported instead of causing a decoding failure. Every FlowFile is routed to success, allowing \
+        downstream processors such as RouteOnAttribute to branch on the attribute.""")
+@WritesAttribute(attribute = "<Base64 Attribute Name>",
+        description = "Set to true when the evaluated content is Base64 encoded, otherwise set to false. The attribute name is configured using the "
+                + "Base64 Attribute Name property")
+@UseCase(
+        description = "Route FlowFiles based on whether the content is Base64 encoded",
+        configuration = """
+                Leave "Base64 Attribute Name" set to the default of "content.base64", or set it to the attribute name of your choosing.
+                Set "Detection Scope" to "Entire Content" when the result must be certain, or to "Sample" for a faster check on large content.
+
+                Connect the "success" relationship to a RouteOnAttribute processor and add a property such as "base64" with the value \
+                "${content.base64:equals('true')}" to send Base64 encoded content down its own branch.
+                """
+)
+public class DetectBase64Content extends AbstractProcessor {
+
+    public static final PropertyDescriptor BASE64_ATTRIBUTE_NAME = new PropertyDescriptor.Builder()
+            .name("Base64 Attribute Name")
+            .description("Name of the FlowFile attribute to which the detection result of either true or false will be written.")
+            .required(true)
+            .defaultValue("content.base64")
+            .addValidator(StandardValidators.ATTRIBUTE_KEY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor DETECTION_SCOPE = new PropertyDescriptor.Builder()
+            .name("Detection Scope")
+            .description("Amount of FlowFile content to evaluate when determining whether the content is Base64 encoded.")
+            .required(true)
+            .allowableValues(DetectionScope.class)
+            .defaultValue(DetectionScope.ENTIRE_CONTENT)
+            .build();
+
+    public static final PropertyDescriptor SAMPLE_SIZE = new PropertyDescriptor.Builder()
+            .name("Sample Size")
+            .description("Maximum number of bytes read from the beginning of the FlowFile content when Detection Scope is set to Sample.")
+            .required(true)
+            .defaultValue("4 KB")
+            .addValidator(StandardValidators.createDataSizeBoundsValidator(1, Long.MAX_VALUE))
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .dependsOn(DETECTION_SCOPE, DetectionScope.SAMPLE)
+            .build();
+
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            BASE64_ATTRIBUTE_NAME,
+            DETECTION_SCOPE,
+            SAMPLE_SIZE
+    );
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("Every FlowFile is routed to success after the detection result has been written to the configured attribute")
+            .build();
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+
+    private static final int BUFFER_SIZE = 8192;
+
+    /** Number of Base64 characters that encode three bytes of input */
+    private static final int ENCODING_QUANTUM = 4;
+
+    private static final int MAXIMUM_PADDING_CHARACTERS = 2;
+
+    private static final byte PADDING = '=';
+
+    private static final byte CARRIAGE_RETURN = '\r';
+
+    private static final byte LINE_FEED = '\n';
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return RELATIONSHIPS;
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        final String attributeName = context.getProperty(BASE64_ATTRIBUTE_NAME).evaluateAttributeExpressions(flowFile).getValue();
+        final long scanLimit = getScanLimit(context, flowFile);
+
+        final boolean base64Encoded;
+        try (InputStream inputStream = session.read(flowFile)) {
+            base64Encoded = isBase64Encoded(inputStream, scanLimit);
+        } catch (final IOException e) {
+            throw new ProcessException("Base64 detection failed reading content of %s".formatted(flowFile), e);
+        }
+
+        getLogger().debug("Base64 detection completed with result [{}] for {}", base64Encoded, flowFile);
+
+        flowFile = session.putAttribute(flowFile, attributeName, Boolean.toString(base64Encoded));
+
+        session.getProvenanceReporter().modifyAttributes(flowFile);
+        session.transfer(flowFile, REL_SUCCESS);
+    }
+
+    private long getScanLimit(final ProcessContext context, final FlowFile flowFile) {
+        final DetectionScope detectionScope = context.getProperty(DETECTION_SCOPE).asAllowableValue(DetectionScope.class);
+        if (detectionScope == DetectionScope.ENTIRE_CONTENT) {
+            return Long.MAX_VALUE;
+        }
+        return context.getProperty(SAMPLE_SIZE).evaluateAttributeExpressions(flowFile).asDataSize(DataUnit.B).longValue();
+    }
+
+    /**
+     * Evaluate content for Base64 encoding without decoding, reading no more than the requested number of bytes.
+     *
+     * @param inputStream Content to be evaluated
+     * @param scanLimit Maximum number of bytes to read
+     * @return Detection result
+     * @throws IOException Thrown on failures reading content
+     */
+    private static boolean isBase64Encoded(final InputStream inputStream, final long scanLimit) throws IOException {
+        final byte[] buffer = new byte[BUFFER_SIZE];
+        long scanned = 0;
+        long alphabetCharacters = 0;
+        int paddingCharacters = 0;
+        boolean contentCompleted = false;
+
+        while (scanned < scanLimit) {
+            final int requested = (int) Math.min(buffer.length, scanLimit - scanned);
+            final int read = inputStream.read(buffer, 0, requested);
+            if (read == -1) {
+                contentCompleted = true;
+                break;
+            }
+            scanned += read;
+
+            for (int i = 0; i < read; i++) {
+                final byte character = buffer[i];
+
+                if (character == CARRIAGE_RETURN || character == LINE_FEED) {
+                    continue;
+                }
+
+                if (character == PADDING) {
+                    paddingCharacters++;
+                    if (paddingCharacters > MAXIMUM_PADDING_CHARACTERS) {
+                        return false;
+                    }
+                } else if (isAlphabetCharacter(character)) {
+                    // Base64 characters cannot follow padding characters
+                    if (paddingCharacters > 0) {
+                        return false;
+                    }
+                    alphabetCharacters++;
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        if (alphabetCharacters == 0) {
+            return false;
+        }
+
+        if (!contentCompleted) {
+            // The scan limit was reached before the end of the content, so read one more byte to determine whether content remains
+            contentCompleted = inputStream.read() == -1;
+        }
+
+        // The number of characters can only be evaluated when the entire content has been read
+        return !contentCompleted || (alphabetCharacters + paddingCharacters) % ENCODING_QUANTUM == 0;
+    }
+
+    private static boolean isAlphabetCharacter(final byte character) {
+        return (character >= 'A' && character <= 'Z')
+                || (character >= 'a' && character <= 'z')
+                || (character >= '0' && character <= '9')
+                || character == '+'
+                || character == '/';
+    }
+
+    enum DetectionScope implements DescribedValue {
+        SAMPLE(
+                "Sample",
+                "Evaluates the number of bytes configured in Sample Size read from the beginning of the content. This avoids reading large content in "
+                        + "full, but content that is not Base64 encoded beyond the sample will not be detected."
+        ),
+        ENTIRE_CONTENT(
+                "Entire Content",
+                "Evaluates the entire content, streamed instead of buffered in memory. This provides a certain result at the cost of reading all content."
+        );
+
+        private final String value;
+
+        private final String description;
+
+        DetectionScope(final String value, final String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return value;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+    }
+}

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -24,6 +24,7 @@ org.apache.nifi.processors.standard.CryptographicHashContent
 org.apache.nifi.processors.standard.DebugFlow
 org.apache.nifi.processors.standard.DeleteFile
 org.apache.nifi.processors.standard.DeleteSFTP
+org.apache.nifi.processors.standard.DetectBase64Content
 org.apache.nifi.processors.standard.DetectDuplicate
 org.apache.nifi.processors.standard.DeduplicateRecord
 org.apache.nifi.processors.standard.DistributeLoad

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.DetectBase64Content/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.DetectBase64Content/additionalDetails.md
@@ -1,0 +1,67 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# DetectBase64Content
+
+This processor reports whether FlowFile content looks like Base64 without decoding it. Attempting a decode is an
+unreliable way to answer that question: some content that is not Base64 decodes without error, and some content
+that is Base64 fails to decode for unrelated reasons. Inspecting the characters avoids both problems, and the
+FlowFile is always routed to `success` so that the answer arrives as an attribute rather than as a failed route.
+
+## Detection Rules
+
+Content is reported as `true` when all of the following hold:
+
+* It contains at least one Base64 character.
+* Every character is either from the Base64 alphabet, a padding character, or a line separator.
+* No Base64 characters appear after a padding character.
+* There are no more than two padding characters.
+* The number of Base64 and padding characters is a multiple of four. This is only checked when the entire content
+  is read — see [Detection Scope](#detection-scope) below.
+
+Anything else is reported as `false`.
+
+The alphabet is the standard one from [RFC 4648 Section 4](https://datatracker.ietf.org/doc/html/rfc4648#section-4):
+`A-Z`, `a-z`, `0-9`, `+` and `/`, with `=` as the padding character. Carriage return and line feed are accepted
+anywhere so that content wrapped into fixed-width lines, as MIME Base64 is, still matches. Other whitespace is not
+accepted: a space would make ordinary prose such as `the quick brown fox` look like Base64.
+
+The URL-safe alphabet, which uses `-` and `_` in place of `+` and `/`, is not recognised and is reported as `false`.
+
+## Detection Scope
+
+`Entire Content` reads the whole content and gives a definitive answer. The content is streamed, not buffered, so
+memory use stays flat no matter how large the FlowFile is. Reading also stops at the first character that rules
+Base64 out, so content that is obviously not Base64 costs very little even when it is large.
+
+`Sample` reads at most `Sample Size` bytes from the beginning. This bounds the read on large content, at the cost
+of certainty: content that starts with valid Base64 characters but turns invalid later is reported as `true`. When
+the content turns out to be smaller than the sample size, the entire content has been read and the result is
+definitive.
+
+## A Note on Short Content
+
+Detection works on the characters alone, so any run of alphabet characters whose length is a multiple of four is
+valid Base64. The word `test` decodes to three bytes and is reported as `true`. No content-only check can
+distinguish that from intentionally encoded data, so treat a `true` result on very short content accordingly.
+
+## Branching on the Result
+
+The result is written to the attribute named by `Base64 Attribute Name`, which defaults to `content.base64`. To act
+on it, connect `success` to a RouteOnAttribute processor and add a property whose value is an expression such as:
+
+```
+${content.base64:equals('true')}
+```

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDetectBase64Content.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDetectBase64Content.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.processors.standard.DetectBase64Content.DetectionScope;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestDetectBase64Content {
+
+    private static final String DEFAULT_ATTRIBUTE = "content.base64";
+
+    private static final String CUSTOM_ATTRIBUTE = "encoded";
+
+    private static final String TRUE = "true";
+
+    private static final String FALSE = "false";
+
+    private TestRunner runner;
+
+    @BeforeEach
+    void setRunner() {
+        runner = TestRunners.newTestRunner(DetectBase64Content.class);
+    }
+
+    @Test
+    void testDefaultConfigurationValid() {
+        runner.assertValid();
+    }
+
+    @Test
+    void testZeroSampleSizeInvalid() {
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.SAMPLE);
+        runner.setProperty(DetectBase64Content.SAMPLE_SIZE, "0 B");
+        runner.assertNotValid();
+    }
+
+    @Test
+    void testSampleSizeValid() {
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.SAMPLE);
+        runner.setProperty(DetectBase64Content.SAMPLE_SIZE, "1 MB");
+        runner.assertValid();
+    }
+
+    @Test
+    void testDefaultDetectionScopeEvaluatesEntireContent() {
+        final String content = "QUJD".repeat(4096) + "!!! not base64 !!!";
+        runner.enqueue(content);
+        runner.run();
+
+        assertResult(FALSE, DEFAULT_ATTRIBUTE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "QQ==",
+            "QUJD",
+            "YWJjZGVmZ2hpams=",
+            "MTIzNDU2Nzg5MA==",
+            "c3RyaW5nIHdpdGggc3BhY2Vz"
+    })
+    void testBase64Detected(final String content) {
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.ENTIRE_CONTENT);
+        runner.enqueue(content);
+        runner.run();
+
+        assertResult(TRUE, DEFAULT_ATTRIBUTE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "not base64!",
+            "QUJD$",
+            "QUJ",
+            "QUJDR",
+            "Q=QJD",
+            "QUJD===",
+            "{\"field\": \"value\"}",
+            "The quick brown fox jumps over the lazy dog"
+    })
+    void testBase64NotDetected(final String content) {
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.ENTIRE_CONTENT);
+        runner.enqueue(content);
+        runner.run();
+
+        assertResult(FALSE, DEFAULT_ATTRIBUTE);
+    }
+
+    @ParameterizedTest
+    @EnumSource(DetectionScope.class)
+    void testEmptyContentNotDetected(final DetectionScope detectionScope) {
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, detectionScope);
+        runner.enqueue(new byte[0]);
+        runner.run();
+
+        assertResult(FALSE, DEFAULT_ATTRIBUTE);
+    }
+
+    @ParameterizedTest
+    @EnumSource(DetectionScope.class)
+    void testLineSeparatorsOnlyNotDetected(final DetectionScope detectionScope) {
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, detectionScope);
+        runner.enqueue("\r\n\r\n");
+        runner.run();
+
+        assertResult(FALSE, DEFAULT_ATTRIBUTE);
+    }
+
+    @Test
+    void testLineSeparatorsDetected() {
+        final String content = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXow\r\nYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXow\r\n";
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.ENTIRE_CONTENT);
+        runner.enqueue(content);
+        runner.run();
+
+        assertResult(TRUE, DEFAULT_ATTRIBUTE);
+    }
+
+    @Test
+    void testBinaryContentNotDetected() {
+        final byte[] content = new byte[4096];
+        new Random(0).nextBytes(content);
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.ENTIRE_CONTENT);
+        runner.enqueue(content);
+        runner.run();
+
+        assertResult(FALSE, DEFAULT_ATTRIBUTE);
+    }
+
+    @Test
+    void testEncodedBinaryContentDetected() {
+        final byte[] binary = new byte[8192];
+        new Random(0).nextBytes(binary);
+        final byte[] encoded = Base64.getEncoder().encode(binary);
+
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.ENTIRE_CONTENT);
+        runner.enqueue(encoded);
+        runner.run();
+
+        assertResult(TRUE, DEFAULT_ATTRIBUTE);
+    }
+
+    @Test
+    void testCustomAttributeName() {
+        runner.setProperty(DetectBase64Content.BASE64_ATTRIBUTE_NAME, CUSTOM_ATTRIBUTE);
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.ENTIRE_CONTENT);
+        runner.enqueue("QUJD");
+        runner.run();
+
+        final MockFlowFile flowFile = assertResult(TRUE, CUSTOM_ATTRIBUTE);
+        flowFile.assertAttributeNotExists(DEFAULT_ATTRIBUTE);
+    }
+
+    @Test
+    void testCustomAttributeNameExpressionLanguage() {
+        runner.setProperty(DetectBase64Content.BASE64_ATTRIBUTE_NAME, "${attribute.name}");
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.ENTIRE_CONTENT);
+        runner.enqueue("QUJD", Map.of("attribute.name", CUSTOM_ATTRIBUTE));
+        runner.run();
+
+        assertResult(TRUE, CUSTOM_ATTRIBUTE);
+    }
+
+    @Test
+    void testSampleScopeIgnoresContentBeyondSampleSize() {
+        final String content = "QUJD".repeat(16) + "!!! not base64 !!!";
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.SAMPLE);
+        runner.setProperty(DetectBase64Content.SAMPLE_SIZE, "16 B");
+        runner.enqueue(content);
+        runner.run();
+
+        assertResult(TRUE, DEFAULT_ATTRIBUTE);
+    }
+
+    @Test
+    void testEntireContentScopeEvaluatesContentBeyondSampleSize() {
+        final String content = "QUJD".repeat(16) + "!!! not base64 !!!";
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.ENTIRE_CONTENT);
+        runner.enqueue(content);
+        runner.run();
+
+        assertResult(FALSE, DEFAULT_ATTRIBUTE);
+    }
+
+    @Test
+    void testSampleScopeDetectsNonBase64WithinSampleSize() {
+        final String content = "!!! not base64 !!!" + "QUJD".repeat(16);
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.SAMPLE);
+        runner.setProperty(DetectBase64Content.SAMPLE_SIZE, "16 B");
+        runner.enqueue(content);
+        runner.run();
+
+        assertResult(FALSE, DEFAULT_ATTRIBUTE);
+    }
+
+    @Test
+    void testSampleScopeAppliesLengthCheckWhenContentSmallerThanSampleSize() {
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.SAMPLE);
+        runner.setProperty(DetectBase64Content.SAMPLE_SIZE, "4 KB");
+        runner.enqueue("QUJDR");
+        runner.run();
+
+        assertResult(FALSE, DEFAULT_ATTRIBUTE);
+    }
+
+    @Test
+    void testSampleSizeExpressionLanguage() {
+        final String content = "QUJD".repeat(16) + "!!! not base64 !!!";
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.SAMPLE);
+        runner.setProperty(DetectBase64Content.SAMPLE_SIZE, "${sample.size}");
+        runner.enqueue(content, Map.of("sample.size", "16 B"));
+        runner.run();
+
+        assertResult(TRUE, DEFAULT_ATTRIBUTE);
+    }
+
+    @Test
+    void testContentNotModified() {
+        final String content = "QUJD";
+        runner.setProperty(DetectBase64Content.DETECTION_SCOPE, DetectionScope.ENTIRE_CONTENT);
+        runner.enqueue(content);
+        runner.run();
+
+        final MockFlowFile flowFile = assertResult(TRUE, DEFAULT_ATTRIBUTE);
+        flowFile.assertContentEquals(content, StandardCharsets.UTF_8);
+    }
+
+    private MockFlowFile assertResult(final String expected, final String attributeName) {
+        runner.assertAllFlowFilesTransferred(DetectBase64Content.REL_SUCCESS, 1);
+        final List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(DetectBase64Content.REL_SUCCESS);
+        final MockFlowFile flowFile = flowFiles.getFirst();
+        assertEquals(expected, flowFile.getAttribute(attributeName));
+        return flowFile;
+    }
+}


### PR DESCRIPTION
 Adds DetectBase64Content, a processor that determines whether FlowFile content is Base64 encoded by inspecting its characters rather than attempting a decode. The result is written as true or false to a configurable attribute, and the FlowFile is always routed to success — downstream flows can branch with RouteOnAttribute instead of relying on a decode failure as the signal.

Detection Scope selects between two modes:

Entire Content — reads the full FlowFile for a definitive result.
Sample Size — reads a configurable number of bytes for a bounded check on large content.

Content is streamed in both modes, so heap usage stays constant regardless of FlowFile size.

Detection rules

Content is reported as Base64 when all of the following hold:

It contains at least one character from the standard alphabet defined in RFC 4648 §4.
It contains no characters outside that alphabet, other than line separators and terminating padding.
It has no more than two padding characters.
When the entire content is read, the character count is a multiple of four.

Alternatives considered

ValidatingBase64InputStream — considered, but doesn't fit this use case. It delegates to Commons Codec's Base64.isBase64(), which only checks alphabet membership and treats whitespace as valid — so plain text like hello world passes. It also doesn't check padding placement, padding count, or content length. Detection still needs to inspect every byte against those additional rules, so the wrapper would only be useful for rejecting out-of-alphabet characters — not for the rest of the validation.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16243](https://issues.apache.org/jira/browse/NIFI-16243)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ X] Build completed using `./mvnw clean install -P contrib-check`
  - [ X] JDK 21
  - [ X] JDK 25

### Licensing

- [ X] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ X] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ X] Documentation formatting appears as expected in rendered files
