### PR TITLE
NIFI-16244 Set HttpClient 5 to 5.6.4 and ignore Jackson for Hazelcast 5

### DIFF
--- a/.github/workflows/code-compliance.yml
+++ b/.github/workflows/code-compliance.yml
@@ -124,4 +124,5 @@ jobs:
           sbom: nifi-${{ env.PROJECT_VERSION }}.spdx.json
           severity-cutoff: 'medium'
           only-fixed: true
+          output-format: table
           fail-build: ${{ github.ref_name == 'main' && 'true' || 'false' }}

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -13,3 +13,130 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+ignore:
+  - vulnerability: GHSA-r7wm-3cxj-wff9
+    reason: Jackson 2 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-core
+      version: 2.21.2
+      type: java-archive
+  - vulnerability: GHSA-j3rv-43j4-c7qm
+    reason: Jackson 2 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 2.21.2
+      type: java-archive
+  - vulnerability: GHSA-rmj7-2vxq-3g9f
+    reason: Jackson 2 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 2.21.2
+      type: java-archive
+  - vulnerability: GHSA-hgj6-7826-r7m5
+    reason: Jackson 2 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 2.21.2
+      type: java-archive
+  - vulnerability: GHSA-5gvw-p9qm-jgwh
+    reason: Jackson 2 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 2.21.2
+      type: java-archive
+  - vulnerability: GHSA-5hh8-q8hv-fr38
+    reason: Jackson 2 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 2.21.2
+      type: java-archive
+  - vulnerability: GHSA-rcqc-6cw3-h962
+    reason: Jackson 2 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 2.21.2
+      type: java-archive
+  - vulnerability: GHSA-mhm7-754m-9p8w
+    reason: Jackson 2 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 2.21.2
+      type: java-archive
+  - vulnerability: GHSA-5jmj-h7xm-6q6v
+    reason: Jackson 2 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 2.21.2
+      type: java-archive
+  - vulnerability: GHSA-9fxm-vc8v-hj55
+    reason: Jackson 2 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 2.21.2
+      type: java-archive
+  - vulnerability: GHSA-3pjw-73gf-8qr5
+    reason: Jackson 2 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 2.21.2
+      type: java-archive
+  - vulnerability: GHSA-r7wm-3cxj-wff9
+    reason: Jackson 3 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-core
+      version: 3.1.2
+      type: java-archive
+  - vulnerability: GHSA-j3rv-43j4-c7qm
+    reason: Jackson 3 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 3.1.2
+      type: java-archive
+  - vulnerability: GHSA-rmj7-2vxq-3g9f
+    reason: Jackson 3 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 3.1.2
+      type: java-archive
+  - vulnerability: GHSA-hgj6-7826-r7m5
+    reason: Jackson 3 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 3.1.2
+      type: java-archive
+  - vulnerability: GHSA-5gvw-p9qm-jgwh
+    reason: Jackson 3 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 3.1.2
+      type: java-archive
+  - vulnerability: GHSA-5hh8-q8hv-fr38
+    reason: Jackson 3 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 3.1.2
+      type: java-archive
+  - vulnerability: GHSA-rcqc-6cw3-h962
+    reason: Jackson 3 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 3.1.2
+      type: java-archive
+  - vulnerability: GHSA-5jmj-h7xm-6q6v
+    reason: Jackson 3 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 3.1.2
+      type: java-archive
+  - vulnerability: GHSA-9fxm-vc8v-hj55
+    reason: Jackson 3 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 3.1.2
+      type: java-archive
+  - vulnerability: GHSA-3pjw-73gf-8qr5
+    reason: Jackson 3 shaded by hazelcast 5.7.0
+    package:
+      name: jackson-databind
+      version: 3.1.2
+      type: java-archive

--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -53,12 +53,6 @@
                 <version>2.12.0-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
-            <!-- Override httpclient 5.6 from apache5-client -->
-            <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5</artifactId>
-                <version>5.6.4</version>
-            </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>sts</artifactId>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
@@ -69,12 +69,6 @@
                 <artifactId>aircompressor</artifactId>
                 <version>2.0.3</version>
             </dependency>
-            <!-- Override httpclient 5.6 from iceberg-core -->
-            <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5</artifactId>
-                <version>5.6.4</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,7 @@
         <okhttp.version>5.5.0</okhttp.version>
         <okio.version>3.18.1</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
+        <org.apache.httpcomponents.httpclient5.version>5.6.4</org.apache.httpcomponents.httpclient5.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
         <org.apache.httpcomponents.httpcore5.version>5.4.3</org.apache.httpcomponents.httpcore5.version>
         <org.apache.sshd.version>2.19.0</org.apache.sshd.version>
@@ -369,6 +370,16 @@
                 <groupId>org.apache.httpcomponents.core5</groupId>
                 <artifactId>httpcore5-h2</artifactId>
                 <version>${org.apache.httpcomponents.httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${org.apache.httpcomponents.httpclient5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5-cache</artifactId>
+                <version>${org.apache.httpcomponents.httpclient5.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
# Summary

[NIFI-16244](https://issues.apache.org/jira/browse/NIFI-16244) Sets the version of HttpClient 5 dependencies to 5.6.4 at the project root level and adds Grype ignore statements for Jackson 2 and 3 dependencies shaded by Hazelcast 5.7.0.

The dependency changes for HttpClient 5 move the version pinning from the Iceberg and AWS modules to the root configuration along with other HttpClient 5 versions, avoiding transitive dependencies from earlier versions.

Hazelcast 5.7.0 shades Jackson 2 and Jackson 3, and does not provide a newer version at the time of this writing. Adding the specific versions and vulnerabilities to the Grype configuration supports targeted warning suppression while allowing other vulnerabilities to surface when applicable.

Additional changes to the code-compliance workflow include adjusting the output format to print findings in a table for easier reading in GitHub workflow results.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
