### PR TITLE
NIFI-16245 - Bump Spring to 7.0.9, Spring Security to 7.1.1, Guava to 33.7.1-jre, and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -122,7 +122,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>4.35.1</version>
+                <version>4.36.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-commons/nifi-calcite-utils/pom.xml
+++ b/nifi-commons/nifi-calcite-utils/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>4.35.1</version>
+            <version>4.36.0</version>
         </dependency>
     </dependencies>
 

--- a/nifi-commons/pom.xml
+++ b/nifi-commons/pom.xml
@@ -71,7 +71,7 @@
         <module>nifi-connector-common</module>
     </modules>
     <properties>
-        <guava.version>33.7.0-jre</guava.version>
+        <guava.version>33.7.1-jre</guava.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
@@ -20,7 +20,7 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <amqp-client.version>5.34.0</amqp-client.version>
+        <amqp-client.version>5.35.0</amqp-client.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -27,8 +27,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <guava.version>33.7.0-jre</guava.version>
-        <protobuf.version>4.35.1</protobuf.version>
+        <guava.version>33.7.1-jre</guava.version>
+        <protobuf.version>4.36.0</protobuf.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -60,7 +60,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.7.0-jre</version>
+                <version>33.7.1-jre</version>
             </dependency>
             <!-- Override Apache Qpid Proton J for Azure EventHubs to resolve PROTON-2347 -->
             <dependency>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>9.5.1</elasticsearch.client.version>
+        <elasticsearch.client.version>9.5.2</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>nifi-email-processors</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <spring.integration.version>7.1.0</spring.integration.version>
+        <spring.integration.version>7.1.1</spring.integration.version>
     </properties>
 
     <dependencies>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
-            <version>2.1.12</version>
+            <version>2.1.13</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.7.0-jre</version>
+            <version>33.7.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.7.0-jre</version>
+                <version>33.7.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -26,8 +26,8 @@
     <packaging>jar</packaging>
     <properties>
         <janusgraph.version>1.2.0-20260818-222253.cbd6fc2</janusgraph.version>
-        <guava.version>33.7.0-jre</guava.version>
-        <amqp-client.version>5.34.0</amqp-client.version>
+        <guava.version>33.7.1-jre</guava.version>
+        <amqp-client.version>5.35.0</amqp-client.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.7.0-jre</version>
+                <version>33.7.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tika.version>3.3.2</tika.version>
+        <tika.version>4.0.0</tika.version>
     </properties>
     <dependencies>
         <dependency>
@@ -43,6 +43,7 @@
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers-standard-package</artifactId>
             <version>${tika.version}</version>
+            <type>pom</type>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/test/java/org/apache/nifi/processors/media/TestExtractMediaMetadata.java
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/test/java/org/apache/nifi/processors/media/TestExtractMediaMetadata.java
@@ -79,7 +79,7 @@ public class TestExtractMediaMetadata {
         flowFile0.assertAttributeExists("txt.Content-Type");
         assertTrue(flowFile0.getAttribute("txt.Content-Type").startsWith("text/plain"));
         flowFile0.assertAttributeExists("txt.Content-Encoding");
-        flowFile0.assertAttributeEquals("txt.Content-Encoding", "ISO-8859-1");
+        flowFile0.assertAttributeEquals("txt.Content-Encoding", "windows-1252");
         flowFile0.assertContentEquals("test1".getBytes(StandardCharsets.UTF_8));
     }
 
@@ -279,10 +279,10 @@ public class TestExtractMediaMetadata {
         flowFile0.assertAttributeEquals("filename", "16color-10x10.bmp");
         flowFile0.assertAttributeExists("bmp.Content-Type");
         flowFile0.assertAttributeEquals("bmp.Content-Type", "image/bmp");
-        flowFile0.assertAttributeExists("bmp.height");
-        flowFile0.assertAttributeEquals("bmp.height", "10");
-        flowFile0.assertAttributeExists("bmp.width");
-        flowFile0.assertAttributeEquals("bmp.width", "10");
+        flowFile0.assertAttributeExists("bmp.tiff:ImageLength");
+        flowFile0.assertAttributeEquals("bmp.tiff:ImageLength", "10");
+        flowFile0.assertAttributeExists("bmp.tiff:ImageWidth");
+        flowFile0.assertAttributeEquals("bmp.tiff:ImageWidth", "10");
     }
 
     @Test
@@ -324,8 +324,8 @@ public class TestExtractMediaMetadata {
         flowFile0.assertAttributeEquals("filename", "testWAV.wav");
         flowFile0.assertAttributeExists("wav.Content-Type");
         assertTrue(flowFile0.getAttribute("wav.Content-Type").startsWith("audio/vnd.wave"));
-        flowFile0.assertAttributeExists("wav.encoding");
-        flowFile0.assertAttributeEquals("wav.encoding", "PCM_SIGNED");
+        flowFile0.assertAttributeExists("wav.xmpDM:audioSampleType");
+        flowFile0.assertAttributeEquals("wav.xmpDM:audioSampleType", "16Int");
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.hivemq</groupId>
             <artifactId>hivemq-mqtt-client</artifactId>
-            <version>1.3.17</version>
+            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
@@ -32,7 +32,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
-                <version>4.35.1</version>
+                <version>4.36.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -40,7 +40,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.7.0-jre</version>
+                <version>33.7.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>nifi-protobuf-services</artifactId>
 
     <properties>
-        <protobuf.version>4.35.1</protobuf.version>
+        <protobuf.version>4.36.0</protobuf.version>
         <wire.version>6.4.6</wire.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-protobuf-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/pom.xml
@@ -37,7 +37,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.7.0-jre</version>
+                <version>33.7.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/service/SimpleRedisDistributedMapCacheClientService.java
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/service/SimpleRedisDistributedMapCacheClientService.java
@@ -31,7 +31,7 @@ import org.apache.nifi.redis.RedisConnectionPool;
 import org.apache.nifi.redis.util.RedisAction;
 import org.apache.nifi.util.Tuple;
 import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.RedisStringCommands;
+import org.springframework.data.redis.connection.SetCondition;
 import org.springframework.data.redis.core.types.Expiration;
 
 import java.io.ByteArrayOutputStream;
@@ -149,7 +149,7 @@ public class SimpleRedisDistributedMapCacheClientService extends AbstractControl
     public <K, V> void put(final K key, final V value, final Serializer<K> keySerializer, final Serializer<V> valueSerializer) throws IOException {
         withConnection(redisConnection -> {
             final Tuple<byte[], byte[]> kv = serialize(key, value, keySerializer, valueSerializer);
-            redisConnection.stringCommands().set(kv.getKey(), kv.getValue(), Expiration.seconds(ttl), RedisStringCommands.SetOption.upsert());
+            redisConnection.stringCommands().set(kv.getKey(), kv.getValue(), SetCondition.upsert(), Expiration.seconds(ttl));
             return null;
         });
     }

--- a/nifi-extension-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring.data.redis.version>4.0.6</spring.data.redis.version>
+        <spring.data.redis.version>4.1.1</spring.data.redis.version>
         <jedis.version>8.0.0</jedis.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
@@ -56,7 +56,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-smb-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-smb-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.hierynomus</groupId>
                 <artifactId>smbj</artifactId>
-                <version>0.14.0</version>
+                <version>0.15.0</version>
             </dependency>
             <dependency>
                 <groupId>net.engio</groupId>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -21,8 +21,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <guava.version>33.7.0-jre</guava.version>
-        <protobuf.version>4.35.1</protobuf.version>
+        <guava.version>33.7.1-jre</guava.version>
+        <protobuf.version>4.36.0</protobuf.version>
         <grpc.version>1.83.1</grpc.version>
         <snowflake-jdbc-thin.version>4.3.3</snowflake-jdbc-thin.version>
     </properties>

--- a/nifi-extension-bundles/nifi-sql-reporting-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-sql-reporting-bundle/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>nifi-sql-reporting-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <guava.version>33.7.0-jre</guava.version>
+        <guava.version>33.7.1-jre</guava.version>
     </properties>
     <modules>
         <module>nifi-sql-reporting-tasks</module>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/IdentifyMimeType.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/IdentifyMimeType.java
@@ -43,9 +43,11 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.tika.config.TikaConfig;
+import org.apache.tika.detect.DefaultDetector;
+import org.apache.tika.detect.DefaultEncodingDetector;
 import org.apache.tika.detect.Detector;
 import org.apache.tika.detect.EncodingDetector;
+import org.apache.tika.detect.EncodingResult;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.HttpHeaders;
 import org.apache.tika.metadata.Metadata;
@@ -55,6 +57,7 @@ import org.apache.tika.mime.MimeType;
 import org.apache.tika.mime.MimeTypeException;
 import org.apache.tika.mime.MimeTypes;
 import org.apache.tika.mime.MimeTypesFactory;
+import org.apache.tika.parser.ParseContext;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -134,14 +137,9 @@ public class IdentifyMimeType extends AbstractProcessor {
 
     private static final String CUSTOM_MIME_TYPES_FILENAME = "custom-mimetypes.xml";
     private static final String DEFAULT_MIME_TYPES_PATH = "org/apache/tika/mime/tika-mimetypes.xml";
-    private final TikaConfig config;
     private Detector detector;
     private EncodingDetector encodingDetector;
     private MimeTypes mimeTypes;
-
-    public IdentifyMimeType() {
-        this.config = TikaConfig.getDefaultConfig();
-    }
 
     @Override
     public void migrateProperties(PropertyConfiguration config) {
@@ -172,8 +170,8 @@ public class IdentifyMimeType extends AbstractProcessor {
         String configStrategy = context.getProperty(CONFIG_STRATEGY).getValue();
 
         if (configStrategy.equals(PRESET.getValue())) {
-            this.detector = config.getDetector();
-            this.mimeTypes = config.getMimeRepository();
+            this.mimeTypes = MimeTypes.getDefaultMimeTypes();
+            this.detector = new DefaultDetector(mimeTypes);
         } else {
             try {
                 this.detector = createCustomMimeTypes(configStrategy, context);
@@ -184,7 +182,7 @@ public class IdentifyMimeType extends AbstractProcessor {
             }
         }
 
-        this.encodingDetector = config.getEncodingDetector();
+        this.encodingDetector = new DefaultEncodingDetector();
     }
 
     @Override
@@ -219,10 +217,11 @@ public class IdentifyMimeType extends AbstractProcessor {
                 metadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, filename);
             }
 
-            final MediaType mediaType = detector.detect(tikaStream, metadata);
+            final ParseContext parseContext = new ParseContext();
+            final MediaType mediaType = detector.detect(tikaStream, metadata, parseContext);
             mediaTypeString = mediaType.getBaseType().toString();
             extension = lookupExtension(mediaTypeString, logger);
-            charset = identifyCharset(tikaStream, metadata, mediaType);
+            charset = identifyCharset(tikaStream, metadata, mediaType, parseContext);
         } catch (IOException e) {
             throw new ProcessException("Failed to identify MIME type from content stream", e);
         }
@@ -254,12 +253,13 @@ public class IdentifyMimeType extends AbstractProcessor {
         return extension;
     }
 
-    private Charset identifyCharset(TikaInputStream tikaStream, Metadata metadata, MediaType mediaType) throws IOException {
+    private Charset identifyCharset(TikaInputStream tikaStream, Metadata metadata, MediaType mediaType, ParseContext parseContext) throws IOException {
         // only mime-types text/* have a charset parameter
         if (mediaType.getType().equals("text")) {
             metadata.add(HttpHeaders.CONTENT_TYPE, mediaType.toString());
 
-            return encodingDetector.detect(tikaStream, metadata);
+            final List<EncodingResult> encodingResults = encodingDetector.detect(tikaStream, metadata, parseContext);
+            return encodingResults.isEmpty() ? null : encodingResults.getFirst().getCharset();
         } else {
             return null;
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestIdentifyMimeType.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestIdentifyMimeType.java
@@ -108,7 +108,7 @@ class TestIdentifyMimeType {
         expectedCharsets.put("bgBannerFoot.png", null);
         expectedCharsets.put("blueBtnBg.jpg", null);
         expectedCharsets.put("grid.gif", null);
-        expectedCharsets.put("2.custom", "ISO-8859-1");
+        expectedCharsets.put("2.custom", "windows-1252");
 
         return Arrays.stream(getTestFiles())
                 .map(testFile -> Arguments.argumentSet(testFile.getName(), testFile, expectedMimeTypes, expectedExtensions, expectedCharsets));
@@ -452,8 +452,8 @@ class TestIdentifyMimeType {
         final Map<String, String> expectedCharsets = new HashMap<>();
         expectedCharsets.put("1.7z", null);
         expectedCharsets.put("1.accdb", null);
-        expectedCharsets.put("1.txt", "ISO-8859-1");
-        expectedCharsets.put("1.csv", "ISO-8859-1");
+        expectedCharsets.put("1.txt", "windows-1252");
+        expectedCharsets.put("1.csv", "windows-1252");
         expectedCharsets.put("1.txt.bz2", null);
         expectedCharsets.put("1.txt.gz", null);
         expectedCharsets.put("1.zip", null);
@@ -466,7 +466,7 @@ class TestIdentifyMimeType {
         expectedCharsets.put("flowfilev3", null);
         expectedCharsets.put("flowfilev3WithXhtml", null);
         expectedCharsets.put("flowfilev1.tar", null);
-        expectedCharsets.put("fake.csv", "ISO-8859-1");
+        expectedCharsets.put("fake.csv", "windows-1252");
         expectedCharsets.put("charset-utf-8.txt", "UTF-8");
         return expectedCharsets;
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -34,7 +34,7 @@
         <module>nifi-standard-content-viewer-nar</module>
     </modules>
     <properties>
-        <tika.version>3.3.2</tika.version>
+        <tika.version>4.0.0</tika.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -219,12 +219,12 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.7.0-jre</version>
+                <version>33.7.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.networknt</groupId>
                 <artifactId>json-schema-validator</artifactId>
-                <version>2.0.4</version>
+                <version>2.0.7</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/pom.xml
@@ -22,7 +22,7 @@ language governing permissions and limitations under the License. -->
 
     <properties>
         <jna.version>5.19.1</jna.version>
-        <javassist.version>3.32.0-GA</javassist.version>
+        <javassist.version>3.33.0-GA</javassist.version>
     </properties>
 
     <build>

--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -24,7 +24,7 @@
     <packaging>pom</packaging>
     <description>NiFi: Framework Bundle</description>
     <properties>
-        <guava.version>33.7.0-jre</guava.version>
+        <guava.version>33.7.1-jre</guava.version>
         <org.opensaml.version>5.1.6</org.opensaml.version>
     </properties>
     <modules>

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
@@ -244,7 +244,7 @@
         <dependency>
             <groupId>org.springframework.ldap</groupId>
             <artifactId>spring-ldap-core</artifactId>
-            <version>4.1.0</version>
+            <version>4.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -114,7 +114,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.7.0-jre</version>
+                <version>33.7.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -35,7 +35,7 @@
         <module>nifi-registry-docker-maven</module>
     </modules>
     <properties>
-        <spring.boot.version>4.1.0</spring.boot.version>
+        <spring.boot.version>4.1.1</spring.boot.version>
         <flyway.version>13.3.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.54.0</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.54.2</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.2</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.8</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -205,8 +205,8 @@
         <jersey.bom.version>4.0.2</jersey.bom.version>
         <jetty.version>12.1.12</jetty.version>
         <servlet-api.version>6.1.0</servlet-api.version>
-        <spring.security.version>7.1.0</spring.security.version>
-        <spring.version>7.0.8</spring.version>
+        <spring.security.version>7.1.1</spring.security.version>
+        <spring.version>7.0.9</spring.version>
         <swagger.annotations.version>2.2.54</swagger.annotations.version>
 
         <!-- Testing and quality -->

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <junit.version>6.1.3</junit.version>
         <mockito.version>5.23.0</mockito.version>
         <pmd.version>7.26.0</pmd.version>
-        <checkstyle.version>13.11.0</checkstyle.version>
+        <checkstyle.version>14.0.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
     </properties>


### PR DESCRIPTION
# Summary

NIFI-16245 - Bump Spring to 7.0.9, Spring Security to 7.1.1, Guava to 33.7.1-jre, and others

**Important - note to be added in migration guidance:**

> Apache Tika has been upgraded to version 4.0.0. This upgrade can change metadata produced by `ExtractMediaMetadata` and character encodings reported by `IdentifyMimeType`. In particular, some text content previously identified as `ISO-8859-1` can now be identified as `windows-1252`, and metadata attribute names for some media formats, including BMP and WAV, have changed. Review downstream flows that depend on exact `mime.charset` values or Tika-generated metadata attribute names.

- Protobuf from 4.35.1 to 4.36.0 - https://github.com/protocolbuffers/protobuf/releases/tag/v36.0
- Guava from 33.7.0-jre to 33.7.1-jre - https://github.com/google/guava/releases/tag/v33.7.1
- RabbitMQ AMQP Client from 5.34.0 to 5.35.0 - https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.35.0
- Elasticsearch client from 9.5.1 to 9.5.2 - https://github.com/elastic/elasticsearch-java/releases/tag/v9.5.2
- Spring Integration from 7.1.0 to 7.1.1 - https://github.com/spring-projects/spring-integration/releases/tag/v7.1.1
- Spring Data Redis from 4.0.6 to 4.1.1 - https://github.com/spring-projects/spring-data-redis/releases/tag/4.1.1
- Spring LDAP from 4.1.0 to 4.1.1 - https://github.com/spring-projects/spring-ldap/releases/tag/4.1.1
- Spring Boot from 4.1.0 to 4.1.1 - https://github.com/spring-projects/spring-boot/releases/tag/v4.1.1
- Spring Security from 7.1.0 to 7.1.1 - https://github.com/spring-projects/spring-security/releases/tag/7.1.1
- Spring from 7.0.8 to 7.0.9 - https://github.com/spring-projects/spring-framework/releases/tag/v7.0.9
- Greenmail from 2.1.12 to 2.1.13 - https://github.com/greenmail-mail-test/greenmail/releases/tag/release-2.1.13
- Apache Tika from 3.3.2 to 4.0.0 - https://github.com/apache/tika/releases/tag/4.0.0
- HiveMQ MQTT Client from 1.3.17 to 1.4.0 - https://github.com/hivemq/hivemq-mqtt-client/releases/tag/v1.4.0
- JSON Schema Validator from 2.0.4 to 2.0.7 - https://github.com/networknt/json-schema-validator/releases/tag/2.0.7
- SMBJ from 0.14.0 to 0.15.0 - https://github.com/hierynomus/smbj/releases/tag/v0.15.0
- Javassist from 3.32.0-GA to 3.33.0-GA - https://github.com/jboss-javassist/javassist/releases/tag/rel_3_33_0_ga
- AWS SDK from 2.54.0 to 2.54.2 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.54.2

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
