### PR TITLE
NIFI-16251 Bump AWS SDK to 2.54.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.4.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.54.2</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.54.3</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.2</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.8</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 


### PR DESCRIPTION
## Summary
- Bumps `software.amazon.awssdk.version` from 2.54.2 to 2.54.3 ([release notes](https://github.com/aws/aws-sdk-java-v2/releases/tag/2.54.3)).
- [NIFI-16251](https://issues.apache.org/jira/browse/NIFI-16251) also asked for a Spring Security bump. Spring Security is already at 7.1.1 on `main` from [NIFI-16245](https://issues.apache.org/jira/browse/NIFI-16245); no further Spring Security update is available.

## Test plan
- [ ] Confirm parent POM property is 2.54.3
- [ ] `./mvnw -N versions:display-property-updates` no longer reports an AWS SDK bump
- [ ] contrib-check / JDK builds (not run locally in this change)


Made with [Cursor](https://cursor.com)