### PR TITLE
NIFI-16250 Treat an unconfigured SECRET_REFERENCE as unset

### DIFF
--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/property-group-card/property-group-card.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/property-group-card/property-group-card.component.spec.ts
@@ -199,6 +199,23 @@ describe('PropertyGroupCard', () => {
             expect(component.hasValue('Password')).toBe(true);
         });
 
+        it('should return false for a SECRET_REFERENCE that names a provider but selects no secret', async () => {
+            const { component } = await setup({
+                propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Password: { name: 'Password', type: 'SECRET', required: true }
+                    },
+                    propertyValues: {
+                        Password: {
+                            valueType: 'SECRET_REFERENCE',
+                            secretProviderName: 'Vault'
+                        }
+                    }
+                })
+            });
+            expect(component.hasValue('Password')).toBe(false);
+        });
+
         it('should return false for a SECRET with only a descriptor default and no saved reference', async () => {
             const { component } = await setup({
                 propertyGroup: makeGroup({
@@ -422,6 +439,27 @@ describe('PropertyGroupCard', () => {
             const unsetLabels = query('mat-card-content').queryAll(By.css('.unset'));
             expect(unsetLabels.length).toBe(2);
             expect(unsetLabels[0].nativeElement.textContent.trim()).toBe('No value set');
+        });
+
+        it('should show "No value set" rather than the mask for a SECRET with no secret selected', async () => {
+            const { query } = await setup({
+                propertyGroup: makeGroup({
+                    propertyDescriptors: {
+                        Password: { name: 'Password', type: 'SECRET', required: true }
+                    },
+                    propertyValues: {
+                        Password: {
+                            valueType: 'SECRET_REFERENCE',
+                            secretProviderName: 'Vault'
+                        }
+                    }
+                })
+            });
+            const content = query('mat-card-content');
+            const unsetLabels = content.queryAll(By.css('.unset'));
+            expect(unsetLabels.length).toBe(1);
+            expect(unsetLabels[0].nativeElement.textContent.trim()).toBe('No value set');
+            expect(content.nativeElement.textContent).not.toContain('••••••••');
         });
 
         it('should display descriptor defaults when property values are absent', async () => {

--- a/nifi-frontend/src/main/frontend/libs/shared/src/services/value-reference.helper.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/services/value-reference.helper.spec.ts
@@ -44,5 +44,42 @@ describe('Value Reference Helper', () => {
         it('preserves a null BOOLEAN value so callers can use the descriptor default', () => {
             expect(fromValueReference({ value: null, valueType: 'STRING_LITERAL' }, 'BOOLEAN')).toBeNull();
         });
+
+        describe('SECRET type', () => {
+            it('should return composite key for populated SECRET_REFERENCE', () => {
+                const valueRef = {
+                    valueType: 'SECRET_REFERENCE' as const,
+                    secretProviderId: 'provider-123',
+                    secretProviderName: 'My Provider',
+                    secretName: 'my-secret',
+                    fullyQualifiedSecretName: 'My Provider.group.my-secret'
+                };
+
+                const result = fromValueReference(valueRef, 'SECRET');
+
+                expect(result).toBe('provider-123::My Provider::My Provider.group.my-secret');
+            });
+
+            it('should return undefined for unconfigured SECRET_REFERENCE with providerName only', () => {
+                const valueRef = {
+                    valueType: 'SECRET_REFERENCE' as const,
+                    secretProviderName: 'Local Parameter Provider'
+                };
+
+                const result = fromValueReference(valueRef, 'SECRET');
+
+                expect(result).toBeUndefined();
+            });
+
+            it('should return undefined for SECRET_REFERENCE with all null fields', () => {
+                const valueRef = {
+                    valueType: 'SECRET_REFERENCE' as const
+                };
+
+                const result = fromValueReference(valueRef);
+
+                expect(result).toBeUndefined();
+            });
+        });
     });
 });

--- a/nifi-frontend/src/main/frontend/libs/shared/src/services/value-reference.helper.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/services/value-reference.helper.ts
@@ -172,13 +172,19 @@ export function fromValueReference(
                 break;
             }
             case 'SECRET_REFERENCE':
-                // Return composite key to uniquely identify the secret
-                // Format: providerId::providerName::fullyQualifiedName
-                rawValue = buildSecretKey(
-                    valueRef.secretProviderId,
-                    valueRef.secretProviderName,
-                    valueRef.fullyQualifiedSecretName
-                );
+                // If no secret has been selected yet (no FQN and no secret name),
+                // return undefined so the select shows placeholder instead of "(no longer available)"
+                if (!valueRef.fullyQualifiedSecretName && !valueRef.secretName) {
+                    rawValue = undefined;
+                } else {
+                    // Return composite key to uniquely identify the secret
+                    // Format: providerId::providerName::fullyQualifiedName
+                    rawValue = buildSecretKey(
+                        valueRef.secretProviderId,
+                        valueRef.secretProviderName,
+                        valueRef.fullyQualifiedSecretName
+                    );
+                }
                 break;
             default:
                 // Fallback for unknown types - try to get value

--- a/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-validation.utils.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-validation.utils.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { hasPropertyValue } from './connector-validation.utils';
+import { ConnectorValueReference } from '../types';
+
+describe('hasPropertyValue', () => {
+    describe('SECRET type', () => {
+        it('should return true for secret reference with value', () => {
+            const valueRef: ConnectorValueReference = {
+                valueType: 'SECRET_REFERENCE',
+                secretName: 'my-secret',
+                secretProviderId: 'provider-1',
+                secretProviderName: 'AWS Secrets Manager',
+                fullyQualifiedSecretName: 'group/my-secret'
+            };
+            expect(hasPropertyValue(valueRef, 'SECRET')).toBe(true);
+        });
+
+        it('should return false for unconfigured secret with providerName only', () => {
+            const valueRef: ConnectorValueReference = {
+                valueType: 'SECRET_REFERENCE',
+                secretProviderName: 'Local Parameter Provider'
+            };
+            expect(hasPropertyValue(valueRef, 'SECRET')).toBe(false);
+        });
+
+        it('should return false for secret reference with all empty strings', () => {
+            const valueRef: ConnectorValueReference = {
+                valueType: 'SECRET_REFERENCE',
+                secretProviderId: '',
+                secretProviderName: '',
+                fullyQualifiedSecretName: ''
+            };
+            expect(hasPropertyValue(valueRef, 'SECRET')).toBe(false);
+        });
+
+        it('should return true when secretName is set but fullyQualifiedSecretName is not', () => {
+            const valueRef: ConnectorValueReference = {
+                valueType: 'SECRET_REFERENCE',
+                secretProviderName: 'My Provider',
+                secretName: 'my-secret'
+            };
+            expect(hasPropertyValue(valueRef, 'SECRET')).toBe(true);
+        });
+
+        it('should return false for cleared secret (STRING_LITERAL with null)', () => {
+            const valueRef: ConnectorValueReference = {
+                valueType: 'STRING_LITERAL',
+                value: null
+            };
+            expect(hasPropertyValue(valueRef, 'SECRET')).toBe(false);
+        });
+
+        it('should return false for undefined value reference', () => {
+            expect(hasPropertyValue(undefined, 'SECRET')).toBe(false);
+        });
+    });
+});

--- a/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-validation.utils.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/utils/connector-validation.utils.ts
@@ -48,6 +48,11 @@ export function hasPropertyValue(
         if (valueRef.valueType !== 'SECRET_REFERENCE') {
             return false;
         }
+        // An unconfigured secret may carry a provider name but no secret selection,
+        // so it has neither a fullyQualifiedSecretName nor a secretName. Treat as unset.
+        if (!valueRef.fullyQualifiedSecretName && !valueRef.secretName) {
+            return false;
+        }
         const secretKey = buildSecretKey(
             valueRef.secretProviderId,
             valueRef.secretProviderName,


### PR DESCRIPTION
A SECRET property with no secret selected can be stored as a SECRET_REFERENCE carrying only a provider name. Both helpers relied on buildSecretKey, which never returns an empty string, so the select showed an unmatched key like "::Some Provider::" and hasPropertyValue reported the property as configured.

Both now check fullyQualifiedSecretName and secretName directly.

# Summary

[NIFI-16250](https://issues.apache.org/jira/browse/NIFI-16250)

A SECRET property with no secret selected can be stored as a `SECRET_REFERENCE`
carrying only a provider name. `fromValueReference` and `hasPropertyValue` both
relied on `buildSecretKey`, which never returns an empty string, so the secret
select showed an unmatched key like `::Some Provider::` instead of its
placeholder, and `hasPropertyValue` reported the property as configured.

Both now check `fullyQualifiedSecretName` and `secretName` directly. A reference
carrying a `secretName` but no `fullyQualifiedSecretName` is still considered
configured.

Because `PropertyGroupCard` resolves `hasValue` through `hasPropertyValue`, the
configuration summary and connector details pages previously showed such a
property as having a value. They now show "No value set".

Verified with `nx test shared` (941 tests), `nx lint shared`, and `nx build shared`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files