### PR TITLE
fix(nifi): use equals for JNDI scheme allowlist not contains

### DIFF
--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProperties.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProperties.java
@@ -192,7 +192,7 @@ public class JndiJmsConnectionFactoryProperties {
             boolean allowed = false;
 
             for (final String allowedScheme : allowedSchemes) {
-                if (allowedScheme.contains(scheme)) {
+                if (allowedScheme.equalsIgnoreCase(scheme)) {
                     allowed = true;
                     break;
                 }


### PR DESCRIPTION
JNDI Provider URL allowlist bypass via substring check.

Bug: JndiJmsConnectionFactoryProperties.isSchemeAllowed uses allowedScheme.contains(scheme). Any substring of an allowed scheme passes, for example s:// passes because ssl.contains(s) is true, and fi:// passes via file.contains(fi).

Fix: Replace contains with equalsIgnoreCase for exact case-insensitive match. One line change at line 195.

Evidence:
* Manual verification shows s:// and fi:// correctly rejected after fix, while valid schemes ssl, tcp, file, etc still pass.
* Existing tests pass: JndiJmsConnectionFactoryProviderTest, 7 tests, 0 failures before and after.
* Blast radius: 1 file, 1 line changed, no formatter changes.