### PR TITLE
NIFI-16264 Set order for Resource Types and Scopes in Manifest

### DIFF
--- a/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/StandardRuntimeManifestBuilder.java
+++ b/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/StandardRuntimeManifestBuilder.java
@@ -80,6 +80,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
@@ -624,10 +625,11 @@ public class StandardRuntimeManifestBuilder implements RuntimeManifestBuilder {
             final org.apache.nifi.c2.protocol.component.api.Stateful componentStateful = new org.apache.nifi.c2.protocol.component.api.Stateful();
             componentStateful.setDescription(stateful.getDescription());
             if (stateful.getScopes() != null) {
+                // Collect to LinkedHashSet for deterministic ordering of Scopes
                 componentStateful.setScopes(
                         stateful.getScopes().stream()
                                 .map(this::getScope)
-                                .collect(Collectors.toSet())
+                                .collect(Collectors.toCollection(LinkedHashSet::new))
                 );
                 extensionComponent.setStateful(componentStateful);
             }
@@ -755,10 +757,11 @@ public class StandardRuntimeManifestBuilder implements RuntimeManifestBuilder {
         };
         propertyResourceDefinition.setCardinality(cardinality);
 
+        // Collect to LinkedHashSet for deterministic ordering of Resource Types
         propertyResourceDefinition.setResourceTypes(
                 resourceDefinition.getResourceTypes().stream()
                         .map(this::getResourceType)
-                        .collect(Collectors.toSet())
+                        .collect(Collectors.toCollection(LinkedHashSet::new))
         );
 
         return propertyResourceDefinition;


### PR DESCRIPTION
# Summary

[NIFI-16264](https://issues.apache.org/jira/browse/NIFI-16264) Sets a deterministic order for enum Resource Type and Scope values in the Runtime Manifest. This approach ensures multiple builds of the same commit hash produce the same results.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
