### PR TITLE
NIFI-16252 Add Reproducible Build workflow

### DIFF
--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: reproducible-build
+
+on:
+  push:
+    branches-ignore:
+      - dependabot/*
+  pull_request:
+
+env:
+  DEFAULT_MAVEN_OPTS: >-
+    -Xms6g
+    -Xmx6g
+    -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
+
+permissions:
+  contents: read
+
+jobs:
+  reproducible-build:
+    timeout-minutes: 120
+    runs-on: ubuntu-24.04
+    name: Verify Build Reproducibility
+    env:
+      MAVEN_REPRODUCIBLE_ARGUMENTS: >-
+        --show-version
+        --no-snapshot-updates
+        --no-transfer-progress
+        --fail-fast
+        --activate-profiles apache-release
+        -D skipTests
+        -D gpg.skip=true
+        -D maven.javadoc.skip=true
+        -D develocity.cache.local.enabled=false
+        -D develocity.cache.remote.enabled=false
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Set up Java 21
+        uses: actions/setup-java@v6
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: 'maven'
+      - name: Install Reference Build
+        env:
+          MAVEN_OPTS: >-
+            ${{ env.DEFAULT_MAVEN_OPTS }}
+        run: >
+          ./mvnw
+          ${{ env.MAVEN_REPRODUCIBLE_ARGUMENTS }}
+          --threads 1C
+          clean install
+      - name: Restore Original Work Tree
+        run: git clean -d -x -f -f
+      - name: Rebuild and Compare Artifacts
+        env:
+          MAVEN_OPTS: >-
+            ${{ env.DEFAULT_MAVEN_OPTS }}
+        run: >
+          ./mvnw
+          ${{ env.MAVEN_REPRODUCIBLE_ARGUMENTS }}
+          -D compare.aggregate.only=true
+          -D buildinfo.reproducible=true
+          clean verify artifact:compare
+      - name: Upload Build Information
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: build-information
+          path: |
+            ./**/target/*.buildinfo
+            ./**/target/*.buildcompare
+          retention-days: 3

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 [![docker-tests](https://github.com/apache/nifi/actions/workflows/docker-tests.yml/badge.svg)](https://github.com/apache/nifi/actions/workflows/docker-tests.yml)
 [![code-compliance](https://github.com/apache/nifi/actions/workflows/code-compliance.yml/badge.svg)](https://github.com/apache/nifi/actions/workflows/code-compliance.yml)
 [![code-coverage](https://github.com/apache/nifi/actions/workflows/code-coverage.yml/badge.svg)](https://github.com/apache/nifi/actions/workflows/code-coverage.yml)
+[![reproducible-build](https://github.com/apache/nifi/workflows/reproducible-build/badge.svg)](https://github.com/apache/nifi/actions/workflows/reproducible-build.yml)
 [![codecov](https://codecov.io/gh/apache/nifi/branch/main/graph/badge.svg)](https://codecov.io/gh/apache/nifi)
 
 ### Resources

--- a/pom.xml
+++ b/pom.xml
@@ -1148,6 +1148,17 @@
                 <buildBranch>main</buildBranch>
                 <maven.build.timestamp>${project.build.outputTimestamp}</maven.build.timestamp>
             </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-artifact-plugin</artifactId>
+                            <version>3.6.1</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
# Summary

[NIFI-16252](https://issues.apache.org/jira/browse/NIFI-16252) Adds a `reproducible-build` GitHub workflow that uses the Maven [Artifact Compare](https://maven.apache.org/plugins/maven-artifact-plugin/compare-mojo.html) plugin goal to evaluate binary hashes of build packages.

The workflow performs a Maven install build with the `apache-release` profile activated to align with release build processes. After the reference build, the `artifact:compare` goal runs a subsequent build to compare original artifact hashes with repeated build hashes.

The workflow is scheduled to run on pull requests as an independent workflow. Initial runs on a project fork show successful status for all artifacts, taking around 45 minutes. This amount of time aligns with or falls under the existing `build` workflow, so it will not block completion of workflow evaluation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
