### PR TITLE
NIFI-16275 Add Parameter Context regression coverage

### DIFF
--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/parameters/ParameterContextIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/parameters/ParameterContextIT.java
@@ -56,6 +56,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1167,6 +1168,62 @@ public class ParameterContextIT extends NiFiSystemIT {
         final ParameterContextEntity updatedParent = getNifiClient().getParamContextClient().getParamContext(parentContext.getId(), false);
         assertEquals(1, updatedParent.getComponent().getInheritedParameterContexts().size());
         assertEquals(childContext2.getId(), updatedParent.getComponent().getInheritedParameterContexts().get(0).getId());
+    }
+
+    @Test
+    public void testDeleteLocalParameterOverrideRevealsInheritedParameter() throws NiFiClientException, IOException, InterruptedException {
+        final ParameterContextEntity parentContext = getClientUtil().createParameterContext("overrideParent", Map.of("shared", "parent-value"));
+        final ParameterContextEntity childContext = getClientUtil().createParameterContext("overrideChild",
+                Map.of("shared", "child-value"), List.of(parentContext.getId()), null);
+
+        final ParameterContextEntity fetchedChild = getNifiClient().getParamContextClient().getParamContext(childContext.getId(), true);
+        final ParameterEntity localOverride = fetchedChild.getComponent().getParameters().stream()
+                .filter(parameter -> "shared".equals(parameter.getParameter().getName()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(localOverride);
+        assertFalse(localOverride.getParameter().getInherited());
+        assertEquals("child-value", localOverride.getParameter().getValue());
+
+        final ParameterDTO deletionDto = new ParameterDTO();
+        deletionDto.setName("shared");
+        final ParameterEntity deletionEntity = new ParameterEntity();
+        deletionEntity.setParameter(deletionDto);
+        fetchedChild.getComponent().setParameters(Set.of(deletionEntity));
+
+        final ParameterContextUpdateRequestEntity deleteRequest = getNifiClient().getParamContextClient().updateParamContext(fetchedChild);
+        getClientUtil().waitForParameterContextRequestToComplete(childContext.getId(), deleteRequest.getRequest().getRequestId());
+
+        final ParameterContextEntity updatedChildLocal = getNifiClient().getParamContextClient().getParamContext(childContext.getId(), false);
+        assertTrue(updatedChildLocal.getComponent().getParameters().stream()
+                .noneMatch(parameter -> "shared".equals(parameter.getParameter().getName())));
+
+        final ParameterContextEntity updatedChildEffective = getNifiClient().getParamContextClient().getParamContext(childContext.getId(), true);
+        final ParameterEntity inheritedParameter = updatedChildEffective.getComponent().getParameters().stream()
+                .filter(parameter -> "shared".equals(parameter.getParameter().getName()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(inheritedParameter);
+        assertTrue(inheritedParameter.getParameter().getInherited());
+        assertEquals("parent-value", inheritedParameter.getParameter().getValue());
+        assertEquals(parentContext.getId(), inheritedParameter.getParameter().getParameterContext().getId());
+    }
+
+    @Test
+    public void testUpdateReferencedLocalParameterPreservesRawReference() throws NiFiClientException, IOException, InterruptedException {
+        final ParameterContextEntity context = getClientUtil().createParameterContext("localReferenceContext",
+                Map.of("X", "original", "Y", "#{X}"));
+
+        final ParameterContextUpdateRequestEntity updateRequest = updateParameterContext(context, "X", "updated");
+        getClientUtil().waitForParameterContextRequestToComplete(context.getId(), updateRequest.getRequest().getRequestId());
+
+        final ParameterContextEntity updatedContext = getNifiClient().getParamContextClient().getParamContext(context.getId(), false);
+        final Map<String, ParameterDTO> parameters = updatedContext.getComponent().getParameters().stream()
+                .map(ParameterEntity::getParameter)
+                .collect(Collectors.toMap(ParameterDTO::getName, Function.identity()));
+
+        assertEquals("updated", parameters.get("X").getValue());
+        assertEquals("#{X}", parameters.get("Y").getValue());
     }
 
     @Test


### PR DESCRIPTION
Verify deleting a local override reveals its inherited value and updating a referenced local Parameter preserves the raw reference expression.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16275](https://issues.apache.org/jira/browse/NIFI-16275)

Add system test coverage for two Parameter Context update scenarios adjacent to the provider-backed inheritance fix from NIFI-16226:

- Deleting a local Parameter override reveals the inherited Parameter with its source context and value intact.
- Updating a referenced local Parameter preserves the referencing Parameter's raw `#{...}` expression instead of persisting the resolved value.

Both tests run through `ParameterContextIT` and are inherited by `ClusteredParameterContextIT`, providing standalone and clustered coverage.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [x] Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

Local test execution was attempted, but Maven dependency resolution was blocked before compilation by repeated HTTP 429 responses while resolving `software.amazon.awssdk:bom:2.54.7` from Maven Central.

Targeted tests pending execution:

- [ ] `ParameterContextIT#testDeleteLocalParameterOverrideRevealsInheritedParameter`
- [ ] `ClusteredParameterContextIT#testDeleteLocalParameterOverrideRevealsInheritedParameter`
- [ ] `ParameterContextIT#testUpdateReferencedLocalParameterPreservesRawReference`
- [ ] `ClusteredParameterContextIT#testUpdateReferencedLocalParameterPreservesRawReference`

### Licensing

- [x] No new dependencies introduced
- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] No documentation changes required
- [x] Documentation formatting appears as expected in rendered files
