### PR TITLE
NIFI-16202 Switch Mockito attachment to Java Agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,7 +330,6 @@ jobs:
             -Duser.timezone=Asia/Tokyo
           MAVEN_OPTS: >-
             ${{ env.DEFAULT_MAVEN_OPTS }}
-            -DargLine=${env.SUREFIRE_OPTS}
         run: >-
           ${{ env.MAVEN_COMMAND }}
           ${{ env.MAVEN_VERIFY_COMMAND }}
@@ -405,7 +404,6 @@ jobs:
             -Duser.timezone=Europe/Paris
           MAVEN_OPTS: >-
             ${{ env.DEFAULT_MAVEN_OPTS }}
-            -DargLine=${env.SUREFIRE_OPTS}
         run: >-
           ${{ env.MAVEN_COMMAND_WINDOWS }}
           ${{ env.MAVEN_VERIFY_COMMAND }}

--- a/nifi-manifest/nifi-runtime-manifest/pom.xml
+++ b/nifi-manifest/nifi-runtime-manifest/pom.xml
@@ -69,6 +69,11 @@
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
+                    <!-- This module has no tests and does not need the Mockito Java Agent -->
+                    <execution>
+                        <id>resolve-mockito-agent-path</id>
+                        <phase>none</phase>
+                    </execution>
                     <execution>
                         <id>extract-extension-manifests</id>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,10 @@
         <checkstyle.version>14.0.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
+
+        <!-- Surefire argument properties for plugin and environment wiring -->
+        <argLine/>
+        <surefire.opts/>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -742,6 +746,8 @@
                             <exclude>**/*ITSpec.class</exclude>
                         </excludes>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <!-- Runs Mockito as a Java Agent instead of relying on self-attachment -->
+                        <argLine>@{argLine} ${surefire.opts} -javaagent:"${org.mockito:mockito-core:jar}"</argLine>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1012,6 +1018,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <!-- Sets org.mockito:mockito-core:jar to the resolved artifact path for the Surefire argument line -->
+                    <execution>
+                        <id>resolve-mockito-agent-path</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <ignoredPackagings>
                         <ignoredPackaging>nar</ignoredPackaging>
@@ -1103,6 +1119,19 @@
         </plugins>
     </build>
     <profiles>
+        <!-- Apply Java arguments from the SUREFIRE_OPTS environment variable to forked Surefire processes -->
+        <profile>
+            <id>surefire-opts</id>
+            <activation>
+                <property>
+                    <name>env.SUREFIRE_OPTS</name>
+                </property>
+            </activation>
+            <properties>
+                <surefire.opts>${env.SUREFIRE_OPTS}</surefire.opts>
+            </properties>
+        </profile>
+
         <!-- Configure build properties for modules with NAR packaging -->
         <profile>
             <id>nar-packaging</id>

--- a/pom.xml
+++ b/pom.xml
@@ -752,6 +752,14 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <configuration>
+                        <!-- Runs Mockito as a Java Agent instead of relying on self-attachment -->
+                        <argLine>@{argLine} ${surefire.opts} -javaagent:"${org.mockito:mockito-core:jar}"</argLine>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <configuration>
                         <tarLongFileMode>gnu</tarLongFileMode>


### PR DESCRIPTION
# Summary

[NIFI-16202](https://issues.apache.org/jira/browse/NIFI-16202) Changes the Mockito attachement strategy to use the explicit Java Agent approach instead of the default self-attachment, which results in warnings when building.

The changes adjust the GitHub build workflow, removing the `argLine` System Property and instead wiring the `SUREFIRE_OPTS` environment variable through late property resolution in the Maven Surefire Plugin configuration. Together with a build profile that is activated on the presence of `SUREFIRE_OPTS`, this approach ensures the wiring of additional Locale-specific environment variables to exercise behavior specific to different languages and regions.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21
  - [X] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
