### PR TITLE
NIFI-16285 Allow existing illegal Parameter names to load

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/parameter/ParameterNameValidator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/parameter/ParameterNameValidator.java
@@ -24,8 +24,12 @@ public final class ParameterNameValidator {
     private ParameterNameValidator() {
     }
 
+    public static boolean isValid(final String parameterName) {
+        return parameterName != null && VALID_PARAMETER_NAME_PATTERN.matcher(parameterName).matches();
+    }
+
     public static void validate(final String parameterName) {
-        if (parameterName == null || !VALID_PARAMETER_NAME_PATTERN.matcher(parameterName).matches()) {
+        if (!isValid(parameterName)) {
             throw new IllegalArgumentException("Request contains an illegal Parameter Name (" + parameterName
                     + "). Parameter names may only include letters, numbers, spaces, and the special characters .-_");
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/test/java/org/apache/nifi/parameter/ParameterNameValidatorTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/test/java/org/apache/nifi/parameter/ParameterNameValidatorTest.java
@@ -19,12 +19,14 @@ package org.apache.nifi.parameter;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ParameterNameValidatorTest {
     @Test
     void testValidParameterName() {
+        assertTrue(ParameterNameValidator.isValid("Parameter Name-1.0"));
         assertDoesNotThrow(() -> ParameterNameValidator.validate("Parameter Name-1.0"));
     }
 
@@ -32,6 +34,7 @@ class ParameterNameValidatorTest {
     void testInvalidParameterName() {
         final String parameterName = "PARAMETER_{{ ENVIRONMENT }}";
 
+        assertFalse(ParameterNameValidator.isValid(parameterName));
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> ParameterNameValidator.validate(parameterName));
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
@@ -87,7 +87,6 @@ import org.apache.nifi.parameter.ParameterContext;
 import org.apache.nifi.parameter.ParameterContextManager;
 import org.apache.nifi.parameter.ParameterDescriptor;
 import org.apache.nifi.parameter.ParameterGroup;
-import org.apache.nifi.parameter.ParameterNameValidator;
 import org.apache.nifi.parameter.ParameterProviderConfiguration;
 import org.apache.nifi.parameter.StandardParameterProviderConfiguration;
 import org.apache.nifi.persistence.FlowConfigurationArchiveManager;
@@ -954,7 +953,6 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
 
         final Map<String, Parameter> parameters = new HashMap<>();
         for (final VersionedParameter versioned : versionedParameterContext.getParameters()) {
-            ParameterNameValidator.validate(versioned.getName());
             final boolean provided = providerBacked || versioned.isProvided();
             final String parameterValue;
             final String rawValue = versioned.getValue();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
@@ -87,6 +87,7 @@ import org.apache.nifi.parameter.ParameterContext;
 import org.apache.nifi.parameter.ParameterContextManager;
 import org.apache.nifi.parameter.ParameterDescriptor;
 import org.apache.nifi.parameter.ParameterGroup;
+import org.apache.nifi.parameter.ParameterNameValidator;
 import org.apache.nifi.parameter.ParameterProviderConfiguration;
 import org.apache.nifi.parameter.StandardParameterProviderConfiguration;
 import org.apache.nifi.persistence.FlowConfigurationArchiveManager;
@@ -953,13 +954,16 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
 
         final Map<String, Parameter> parameters = new HashMap<>();
         for (final VersionedParameter versioned : versionedParameterContext.getParameters()) {
+            final String name = versioned.getName();
+            if (!ParameterNameValidator.isValid(name)) {
+                logger.warn("An invalid Parameter name was found and will be loaded so it can be removed");
+            }
             final boolean provided = providerBacked || versioned.isProvided();
             final String parameterValue;
             final String rawValue = versioned.getValue();
             if (rawValue == null) {
                 parameterValue = null;
             } else if (provided) {
-                final String name = versioned.getName();
                 final Parameter providedParameter = providedParameters.get(name);
                 if (providedParameter == null) {
                     logger.warn("Parameter Context [{}] Provided Parameter [{}] not found", versionedParameterContext.getIdentifier(), name);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizerTest.java
@@ -48,6 +48,7 @@ import org.apache.nifi.groups.BundleUpdateStrategy;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.nar.ExtensionManager;
 import org.apache.nifi.parameter.Parameter;
+import org.apache.nifi.parameter.ParameterContext;
 import org.apache.nifi.parameter.ParameterDescriptor;
 import org.apache.nifi.parameter.ParameterGroup;
 import org.apache.nifi.parameter.ParameterProvider;
@@ -82,7 +83,6 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -370,7 +370,7 @@ class VersionedFlowSynchronizerTest {
     }
 
     @Test
-    void testSyncRejectsInvalidParameterName() {
+    void testSyncLoadsInvalidParameterName() {
         setRootGroup();
         setFlowController();
 
@@ -382,6 +382,19 @@ class VersionedFlowSynchronizerTest {
             invocation.getArgument(0, Runnable.class).run();
             return null;
         }).when(flowManager).withParameterContextResolution(any());
+        when(flowManager.createParameterContext(any(), any(), any(), any(), any(), any())).thenAnswer(invocation -> {
+            final String contextId = invocation.getArgument(0);
+            final String contextName = invocation.getArgument(1);
+            final Map<String, Parameter> parameters = invocation.getArgument(3);
+            final StandardParameterContext created = new StandardParameterContext.Builder()
+                    .id(contextId)
+                    .name(contextName)
+                    .parameterReferenceManager(ParameterReferenceManager.EMPTY)
+                    .build();
+            created.setParameters(parameters);
+            contextManager.addParameterContext(created);
+            return created;
+        });
 
         final VersionedParameter versionedParameter = new VersionedParameter();
         versionedParameter.setName(invalidParameterName);
@@ -394,10 +407,13 @@ class VersionedFlowSynchronizerTest {
         versionedParameterContext.setParameters(Collections.singleton(versionedParameter));
         when(versionedDataflow.getParameterContexts()).thenReturn(List.of(versionedParameterContext));
 
-        final FlowSynchronizationException exception = assertThrows(FlowSynchronizationException.class, () ->
+        assertDoesNotThrow(() ->
                 versionedFlowSynchronizer.sync(flowController, dataFlow, flowService, BundleUpdateStrategy.USE_SPECIFIED_OR_GHOST));
-        final IllegalArgumentException cause = assertInstanceOf(IllegalArgumentException.class, exception.getCause());
-        assertTrue(cause.getMessage().contains(invalidParameterName));
+
+        final ParameterContext loadedContext = contextManager.getParameterContext("parameter-context-id");
+        final Optional<Parameter> loaded = loadedContext.getParameter(invalidParameterName);
+        assertTrue(loaded.isPresent(), "Illegal Parameter already present in the flow must be loaded so it can be removed");
+        assertEquals("parameter-value", loaded.get().getValue());
     }
 
     private void setRootGroup() {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizerTest.java
@@ -375,45 +375,91 @@ class VersionedFlowSynchronizerTest {
         setFlowController();
 
         final String invalidParameterName = "PARAMETER_{{ ENVIRONMENT }}";
+        final String parameterValue = "parameter-value";
+        final String contextId = "parameter-context-id";
+        final String contextName = "parameter-context";
 
         final StandardParameterContextManager contextManager = new StandardParameterContextManager();
+        stubParameterContextResolution(contextManager);
+        when(flowManager.createParameterContext(any(), any(), any(), any(), any(), any())).thenAnswer(invocation -> {
+            final StandardParameterContext created = new StandardParameterContext.Builder()
+                    .id(invocation.getArgument(0))
+                    .name(invocation.getArgument(1))
+                    .parameterReferenceManager(ParameterReferenceManager.EMPTY)
+                    .build();
+            created.setParameters(invocation.getArgument(3));
+            contextManager.addParameterContext(created);
+            return created;
+        });
+
+        stubInvalidVersionedParameterContext(invalidParameterName, parameterValue, contextId, contextName);
+
+        assertDoesNotThrow(() ->
+                versionedFlowSynchronizer.sync(flowController, dataFlow, flowService, BundleUpdateStrategy.USE_SPECIFIED_OR_GHOST));
+
+        final ParameterContext loadedContext = contextManager.getParameterContext(contextId);
+        assertLoadedInvalidParameter(loadedContext, invalidParameterName, parameterValue);
+    }
+
+    @Test
+    void testSyncReconcilesExistingInvalidParameterName() {
+        setRootGroup();
+        setFlowController();
+
+        final String invalidParameterName = "PARAMETER_{{ ENVIRONMENT }}";
+        final String parameterValue = "parameter-value";
+        final String contextId = "parameter-context-id";
+        final String contextName = "parameter-context";
+
+        final StandardParameterContext existingContext = new StandardParameterContext.Builder()
+                .id(contextId)
+                .name(contextName)
+                .parameterReferenceManager(ParameterReferenceManager.EMPTY)
+                .build();
+        existingContext.setParameters(Collections.singletonMap(invalidParameterName,
+                new Parameter.Builder()
+                        .name(invalidParameterName)
+                        .value("previous-value")
+                        .sensitive(true)
+                        .build()));
+
+        final StandardParameterContextManager contextManager = new StandardParameterContextManager();
+        contextManager.addParameterContext(existingContext);
+        stubParameterContextResolution(contextManager);
+        stubInvalidVersionedParameterContext(invalidParameterName, parameterValue, contextId, contextName);
+
+        assertDoesNotThrow(() ->
+                versionedFlowSynchronizer.sync(flowController, dataFlow, flowService, BundleUpdateStrategy.USE_SPECIFIED_OR_GHOST));
+
+        assertLoadedInvalidParameter(existingContext, invalidParameterName, parameterValue);
+    }
+
+    private void stubParameterContextResolution(final StandardParameterContextManager contextManager) {
         when(flowManager.getParameterContextManager()).thenReturn(contextManager);
         doAnswer(invocation -> {
             invocation.getArgument(0, Runnable.class).run();
             return null;
         }).when(flowManager).withParameterContextResolution(any());
-        when(flowManager.createParameterContext(any(), any(), any(), any(), any(), any())).thenAnswer(invocation -> {
-            final String contextId = invocation.getArgument(0);
-            final String contextName = invocation.getArgument(1);
-            final Map<String, Parameter> parameters = invocation.getArgument(3);
-            final StandardParameterContext created = new StandardParameterContext.Builder()
-                    .id(contextId)
-                    .name(contextName)
-                    .parameterReferenceManager(ParameterReferenceManager.EMPTY)
-                    .build();
-            created.setParameters(parameters);
-            contextManager.addParameterContext(created);
-            return created;
-        });
+    }
 
+    private void stubInvalidVersionedParameterContext(final String invalidParameterName, final String parameterValue,
+            final String contextId, final String contextName) {
         final VersionedParameter versionedParameter = new VersionedParameter();
         versionedParameter.setName(invalidParameterName);
         versionedParameter.setSensitive(true);
-        versionedParameter.setValue("parameter-value");
+        versionedParameter.setValue(parameterValue);
 
         final VersionedParameterContext versionedParameterContext = new VersionedParameterContext();
-        versionedParameterContext.setInstanceIdentifier("parameter-context-id");
-        versionedParameterContext.setName("parameter-context");
+        versionedParameterContext.setInstanceIdentifier(contextId);
+        versionedParameterContext.setName(contextName);
         versionedParameterContext.setParameters(Collections.singleton(versionedParameter));
         when(versionedDataflow.getParameterContexts()).thenReturn(List.of(versionedParameterContext));
+    }
 
-        assertDoesNotThrow(() ->
-                versionedFlowSynchronizer.sync(flowController, dataFlow, flowService, BundleUpdateStrategy.USE_SPECIFIED_OR_GHOST));
-
-        final ParameterContext loadedContext = contextManager.getParameterContext("parameter-context-id");
-        final Optional<Parameter> loaded = loadedContext.getParameter(invalidParameterName);
+    private void assertLoadedInvalidParameter(final ParameterContext context, final String invalidParameterName, final String parameterValue) {
+        final Optional<Parameter> loaded = context.getParameter(invalidParameterName);
         assertTrue(loaded.isPresent(), "Illegal Parameter already present in the flow must be loaded so it can be removed");
-        assertEquals("parameter-value", loaded.get().getValue());
+        assertEquals(parameterValue, loaded.get().getValue());
     }
 
     private void setRootGroup() {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16285](https://issues.apache.org/jira/browse/NIFI-16285)

NIFI-16236 / #11579 validates Parameter names so illegal names cannot be created. The same check was also applied in `VersionedFlowSynchronizer.createParameterMap`, which runs on every flow inherit, including standalone load of `flow.json.gz`.

A persisted flow that already contains a legacy illegal Parameter name (for example `PARAMETER_{{ ENVIRONMENT }}`) now throws `FlowSynchronizationException` during startup, so NiFi never comes up and the REST deletion path from NIFI-16236 is unreachable.

This change removes Parameter name validation from flow inherit. REST create/update still reject illegal names. Existing illegal names load so they can be deleted.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-16285) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- [ ] Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

Focused verification using JDK 21:

- `VersionedFlowSynchronizerTest#testSyncLoadsInvalidParameterName` passed
- Local NiFi 2.12.0-SNAPSHOT assembly built from this branch started with a `flow.json.gz` containing `PARAMETER_{{ ENVIRONMENT }}` (`Added Parameter Context repro-context`, `Successfully synchronized dataflow`)

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

No new dependencies were added, so no `LICENSE` or `NOTICE` changes are required.

### Documentation

- [x] Documentation formatting appears as expected in rendered files

No documentation files were changed.