### PR TITLE
NIFI-16289 Wait for Couchbase bucket readiness in integration tests

### DIFF
--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/integration/AbstractCouchbaseIT.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/integration/AbstractCouchbaseIT.java
@@ -44,7 +44,7 @@ public class AbstractCouchbaseIT {
     protected static final String COUCHBASE_IMAGE_COMMUNITY_RECENT = "couchbase/server:community-7.6.2";
     protected static final String SERVICE_ID = "couchbaseConnectionService";
     protected static final String TEST_DOCUMENT_ID = "test-document-id";
-    private static final Duration CLIENT_READY_TIMEOUT = Duration.ofSeconds(60);
+    protected static final Duration CLIENT_READY_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration CLIENT_READY_POLL_INTERVAL = Duration.ofMillis(100);
 
     protected static final String TEST_DATA = """

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/integration/GetCouchbaseIT.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/integration/GetCouchbaseIT.java
@@ -88,6 +88,7 @@ public class GetCouchbaseIT extends AbstractCouchbaseIT {
                 CONTAINER.getPassword()
         )) {
             final Bucket bucket = cluster.bucket(TEST_BUCKET_NAME);
+            bucket.waitUntilReady(CLIENT_READY_TIMEOUT);
             final Collection collection = bucket.defaultCollection();
 
             collection.upsert(TEST_DOCUMENT_ID, JsonObject.fromJson(TEST_DATA));

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/integration/PutCouchbaseIT.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/integration/PutCouchbaseIT.java
@@ -87,6 +87,7 @@ public class PutCouchbaseIT extends AbstractCouchbaseIT {
                 CONTAINER.getPassword()
         )) {
             final Bucket bucket = cluster.bucket(TEST_BUCKET_NAME);
+            bucket.waitUntilReady(CLIENT_READY_TIMEOUT);
             final Collection collection = bucket.defaultCollection();
 
             final GetResult result = collection.get(TEST_DOCUMENT_ID);


### PR DESCRIPTION
## Summary

Wait for each direct Couchbase test client to finish opening its bucket before reading or writing test data. This avoids the intermittent 2.5-second KV request timeout with `BUCKET_OPEN_IN_PROGRESS`.

## Verification

- `git diff --check`
- Not run: the local Maven repository is missing required `2.12.0-SNAPSHOT` dependencies, preventing the Couchbase processors module from resolving dependencies.