### PR TITLE
NIFI-16296 Remove connected_nodes label from cluster_connected_node_count

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/prometheusutil/ClusterMetricsRegistry.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/prometheusutil/ClusterMetricsRegistry.java
@@ -40,7 +40,7 @@ public class ClusterMetricsRegistry extends AbstractMetricsRegistry {
         nameToGaugeMap.put("CONNECTED_NODE_COUNT", Gauge.build()
                 .name("cluster_connected_node_count")
                 .help("The number of connected nodes in this cluster")
-                .labelNames("instance", "connected_nodes")
+                .labelNames("instance")
                 .register(registry));
 
         nameToGaugeMap.put("TOTAL_NODE_COUNT", Gauge.build()

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/prometheusutil/PrometheusMetricsUtil.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/prometheusutil/PrometheusMetricsUtil.java
@@ -500,11 +500,11 @@ public class PrometheusMetricsUtil {
     }
 
     public static CollectorRegistry createClusterMetrics(final ClusterMetricsRegistry clusterMetricsRegistry, final String instId, final boolean isClustered, final boolean isConnectedToCluster,
-                                                         final String connectedNodes, final int connectedNodeCount, final int totalNodeCount) {
+                                                         final int connectedNodeCount, final int totalNodeCount) {
         final String instanceId = StringUtils.isEmpty(instId) ? DEFAULT_LABEL_STRING : instId;
         clusterMetricsRegistry.setDataPoint(isClustered ? 1 : 0, "IS_CLUSTERED", instanceId);
         clusterMetricsRegistry.setDataPoint(isConnectedToCluster ? 1 : 0, "IS_CONNECTED_TO_CLUSTER", instanceId);
-        clusterMetricsRegistry.setDataPoint(connectedNodeCount, "CONNECTED_NODE_COUNT", instanceId, connectedNodes);
+        clusterMetricsRegistry.setDataPoint(connectedNodeCount, "CONNECTED_NODE_COUNT", instanceId);
         clusterMetricsRegistry.setDataPoint(totalNodeCount, "TOTAL_NODE_COUNT", instanceId);
 
         return clusterMetricsRegistry.getRegistry();

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -8158,7 +8158,6 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         // Collect cluster summary metrics
         int connectedNodeCount = 0;
         int totalNodeCount = 0;
-        String connectedNodesLabel = "Not clustered";
         if (clusterCoordinator != null && clusterCoordinator.isConnected()) {
             final Map<NodeConnectionState, List<NodeIdentifier>> stateMap = clusterCoordinator.getConnectionStates();
             for (final List<NodeIdentifier> nodeList : stateMap.values()) {
@@ -8166,12 +8165,10 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
             }
             final List<NodeIdentifier> connectedNodeIds = stateMap.get(NodeConnectionState.CONNECTED);
             connectedNodeCount = (connectedNodeIds == null) ? 0 : connectedNodeIds.size();
-
-            connectedNodesLabel = connectedNodeCount + " / " + totalNodeCount;
         }
         final boolean isClustered = clusterCoordinator != null;
         final boolean isConnectedToCluster = isClustered() && clusterCoordinator.isConnected();
-        PrometheusMetricsUtil.createClusterMetrics(clusterMetricsRegistry, instanceId, isClustered, isConnectedToCluster, connectedNodesLabel, connectedNodeCount, totalNodeCount);
+        PrometheusMetricsUtil.createClusterMetrics(clusterMetricsRegistry, instanceId, isClustered, isConnectedToCluster, connectedNodeCount, totalNodeCount);
         Collection<AbstractMetricsRegistry> metricsRegistries = Arrays.asList(
                 nifiMetricsRegistry,
                 jvmMetricsRegistry,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/TestFlowResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/TestFlowResource.java
@@ -834,7 +834,7 @@ public class TestFlowResource {
 
         clusterMetricsRegistry.setDataPoint(1, "IS_CLUSTERED", "B1Id");
         clusterMetricsRegistry.setDataPoint(1, "IS_CONNECTED_TO_CLUSTER", "B1Id");
-        clusterMetricsRegistry.setDataPoint(2, "CONNECTED_NODE_COUNT", "B1Id", "2 / 3");
+        clusterMetricsRegistry.setDataPoint(2, "CONNECTED_NODE_COUNT", "B1Id");
         clusterMetricsRegistry.setDataPoint(3, "TOTAL_NODE_COUNT", "B1Id");
 
         return clusterMetricsRegistry.getRegistry();


### PR DESCRIPTION
### Summary

[NIFI-16296](https://issues.apache.org/jira/browse/NIFI-16296) - Stale Prometheus cluster_connected_node_count metrics accumulate indefinitely due to unbounded connected_nodes label values

The Prometheus flow metrics endpoint (`/nifi-api/flow/metrics/prometheus`) exposes `cluster_connected_node_count` with a `connected_nodes` label containing a human-readable ratio string, e.g. `connected_nodes="3 / 4"`. Because `ClusterMetricsRegistry` is a long-lived singleton on `StandardNiFiServiceFacade` that is never cleared, and this label's value changes every time cluster membership changes, every distinct ratio the cluster has ever reported over the process's lifetime remains permanently exposed as a separate, frozen time series alongside the current one — e.g. a fully-connected 4-node cluster can still show a stale `connected_nodes="3 / 4"` series from an earlier transient disconnect, in addition to the correct `connected_nodes="4 / 4"` series. This makes the metric unreliable for dashboards/alerts without manually filtering out label combinations that can't be distinguished from current ones.

This is the same class of bug fixed twice before in this file for other registries (NIFI-8272, NIFI-11899), both times by no longer using a churning/derived value as a metric label.

### What this PR does

Removes `connected_nodes` from the gauge's label set entirely, since it's purely a cosmetic rendering of `connectedNodeCount`/`totalNodeCount`, both of which are already exposed numerically (`cluster_connected_node_count`'s own value, and the separate `cluster_total_node_count` gauge). This brings `CONNECTED_NODE_COUNT` in line with its sibling gauges in the same registry (`cluster_is_clustered`, `cluster_is_connected_to_cluster`, `cluster_total_node_count`), none of which carry a churning label.

- `ClusterMetricsRegistry`: `.labelNames("instance", "connected_nodes")` → `.labelNames("instance")`
- `PrometheusMetricsUtil#createClusterMetrics`: drop the now-unused `connectedNodes` parameter
- `StandardNiFiServiceFacade#populateFlowMetrics`: drop the now-unused `connectedNodesLabel` string assembly
- `TestFlowResource`: update the corresponding test fixture call

No information is lost — clients relying on the ratio can compute it from the two existing numeric gauges instead. This is technically a breaking change to the metric's label surface for anyone rendering the `connected_nodes` label text directly (e.g. a Grafana table column), documented here for visibility.

## Verification

### Build
- [x] Build completed using `./mvnw clean install -P contrib-check`:
  - [x] JDK 21
  - [ ] JDK 25

### Licensing
- [x] No new dependencies added
- [x] N/A — no LICENSE/NOTICE changes required

### Documentation
- [x] N/A — no documentation changes in this PR
