### PR TITLE
NIFI-16294 Guard against null controller status in SiteToSiteStatusReportingTask

### DIFF
--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
+++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
@@ -124,7 +124,11 @@ public class SiteToSiteStatusReportingTask extends AbstractSiteToSiteReportingTa
         processGroupIDToPath = new HashMap<>();
 
         final ProcessGroupStatus procGroupStatus = context.getEventAccess().getControllerStatus();
-        final String rootGroupName = procGroupStatus == null ? null : procGroupStatus.getName();
+        if (procGroupStatus == null) {
+            getLogger().debug("Controller status is not yet available; will report status on a subsequent trigger.");
+            return;
+        }
+        final String rootGroupName = procGroupStatus.getName();
 
         final String nifiUrl = context.getProperty(SiteToSiteUtils.INSTANCE_URL).evaluateAttributeExpressions().getValue();
         URL url;

--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
+++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/test/java/org/apache/nifi/reporting/TestSiteToSiteStatusReportingTask.java
@@ -126,6 +126,20 @@ public class TestSiteToSiteStatusReportingTask {
     }
 
     @Test
+    public void testNullControllerStatus() throws IOException, InitializationException {
+        final Map<PropertyDescriptor, String> properties = new HashMap<>();
+        properties.put(SiteToSiteUtils.BATCH_SIZE, "4");
+        properties.put(SiteToSiteStatusReportingTask.COMPONENT_NAME_FILTER_REGEX, "Awesome.*");
+        properties.put(SiteToSiteStatusReportingTask.COMPONENT_TYPE_FILTER_REGEX, ".*");
+
+        // The controller status is not yet available (e.g. during startup before the flow is initialized)
+        MockSiteToSiteStatusReportingTask task = initTask(properties, null);
+        assertDoesNotThrow(() -> task.onTrigger(context));
+
+        assertTrue(task.dataSent.isEmpty());
+    }
+
+    @Test
     public void testComponentTypeFilter() throws IOException, InitializationException {
         final ProcessGroupStatus pgStatus = generateProcessGroupStatus("root", "Awesome", 1, 0);
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16294](https://issues.apache.org/jira/browse/NIFI-16294) NPE in SiteToSiteStatusReportingTask when root flow is unavailable

Return early when getControllerStatus() is null (flow not yet initialized) instead of passing it unguarded into serialization and throwing a NullPointerException.

Log this event at debug level, this is a transient error that'll correct itself when the cluster is stable again and should arguably not clutter the logs.

This differs from the null guard in SiteToSiteMetricsReportingTask.java:227 which chose to log at the error level, but I'd argue that debug is more appropriate here.


# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
