### PR TITLE
NIFI-16300 Fix deprecated usage in BearerTokenAuthenticationFilter

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtAuthenticationSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtAuthenticationSecurityConfiguration.java
@@ -46,6 +46,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 
 import java.security.KeyPairGenerator;
@@ -97,14 +98,17 @@ public class JwtAuthenticationSecurityConfiguration {
      * Bearer Token Authentication Filter responsible for reading and authenticating Bearer JSON Web Tokens from HTTP Requests
      *
      * @param authenticationManager Authentication Manager configured with JWT Authentication Provider
+     * @param authenticationDetailsSource Authentication Details Source for Converter
      * @return Bearer Token Authentication Filter
      */
     @Bean
     public BearerTokenAuthenticationFilter bearerTokenAuthenticationFilter(final AuthenticationManager authenticationManager,
         final AuthenticationDetailsSource<HttpServletRequest, NiFiWebAuthenticationDetails> authenticationDetailsSource) {
-        final BearerTokenAuthenticationFilter bearerTokenAuthenticationFilter = new BearerTokenAuthenticationFilter(authenticationManager);
-        bearerTokenAuthenticationFilter.setAuthenticationDetailsSource(authenticationDetailsSource);
-        bearerTokenAuthenticationFilter.setBearerTokenResolver(bearerTokenResolver());
+        final BearerTokenAuthenticationConverter authenticationConverter = new BearerTokenAuthenticationConverter();
+        authenticationConverter.setAuthenticationDetailsSource(authenticationDetailsSource);
+        authenticationConverter.setBearerTokenResolver(bearerTokenResolver());
+
+        final BearerTokenAuthenticationFilter bearerTokenAuthenticationFilter = new BearerTokenAuthenticationFilter(authenticationManager, authenticationConverter);
         bearerTokenAuthenticationFilter.setAuthenticationEntryPoint(authenticationEntryPoint());
         return bearerTokenAuthenticationFilter;
     }


### PR DESCRIPTION
# Summary

[NIFI-16300](https://issues.apache.org/jira/browse/NIFI-16300) Corrects and replaces use of deprecated methods in the Spring Security configuration of the `BearerTokenAuthenticationFilter` without altering behavior. Configuring the `BearerTokenAuthenticationConverter` with the collaborating services provides the supported approach.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
