### PR TITLE
NIFI-16276 fix: Updating process group version should not clear parameter context

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -2193,9 +2193,9 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
         // Update the Parameter Context
         final ParameterContext currentParamContext = group.getParameterContext();
         final String proposedParameterContextName = proposed.getParameterContextName();
-        if (proposedParameterContextName == null && currentParamContext != null) {
-            group.setParameterContext(null);
-        } else if (proposedParameterContextName != null) {
+        // A group's own versioned definition may never carry a Parameter Context if it's meant to be bound locally by
+        // whatever parent embeds it, so a null name here must not clear an existing binding.
+        if (proposedParameterContextName != null) {
             final VersionedParameterContext versionedParameterContext = versionedParameterContexts.get(proposedParameterContextName);
             if (versionedParameterContext != null) {
                 createMissingParameterProvider(versionedParameterContext, versionedParameterContext.getParameterProvider(), parameterProviderReferences, componentIdGenerator);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizerTest.java
@@ -1793,6 +1793,39 @@ public class StandardVersionedComponentSynchronizerTest {
     }
 
     @Test
+    public void testLocallyAssignedParameterContextPreservedWhenChildGroupUpdatedFromOwnStandaloneVersion() {
+        // Updating a child group directly to its own standalone version, which never declared a Parameter Context, must not clear a Parameter Context locally assigned to it by a parent.
+        final ProcessGroup processGroup = mock(ProcessGroup.class);
+        when(processGroup.getIdentifier()).thenReturn("pg1");
+        when(processGroup.getPosition()).thenReturn(new org.apache.nifi.connectable.Position(0, 0));
+        when(processGroup.getFlowFileConcurrency()).thenReturn(FlowFileConcurrency.UNBOUNDED);
+        when(processGroup.getFlowFileOutboundPolicy()).thenReturn(FlowFileOutboundPolicy.BATCH_OUTPUT);
+        when(processGroup.getExecutionEngine()).thenReturn(ExecutionEngine.STANDARD);
+
+        // A Parameter Context already bound to the child group, simulating a parent's local assignment.
+        final ParameterContext existingParameterContext = new StandardParameterContext.Builder()
+            .id("existing-pc")
+            .name("HTTP ReceiverB")
+            .parameterReferenceManager(parameterReferenceManager)
+            .build();
+        when(processGroup.getParameterContext()).thenReturn(existingParameterContext);
+
+        // The child group's own standalone versioned flow definition never had a Parameter Context of its own.
+        final VersionedProcessGroup rootGroup = new VersionedProcessGroup();
+        rootGroup.setIdentifier("pg1");
+        rootGroup.setParameterContextName(null);
+
+        final VersionedExternalFlow externalFlow = new VersionedExternalFlow();
+        externalFlow.setFlowContents(rootGroup);
+        externalFlow.setParameterContexts(Collections.emptyMap());
+
+        synchronizer.synchronize(processGroup, externalFlow, synchronizationOptions);
+
+        // The locally-assigned Parameter Context must survive the update.
+        verify(processGroup, never()).setParameterContext(null);
+    }
+
+    @Test
     public void testNewParameterInInheritedContextAddedDuringSync() throws FlowSynchronizationException, InterruptedException, TimeoutException {
         // Create P2 with paramA
         final VersionedParameterContext versionedP2 = createVersionedParameterContext("P2", Map.of("paramA", "valueA"), Collections.emptySet());

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
@@ -1154,7 +1154,10 @@ public class NiFiClientUtil {
 
     public ProcessGroupEntity setParameterContext(final String groupId, final ParameterContextEntity parameterContext) throws NiFiClientException, IOException {
         final ProcessGroupEntity processGroup = nifiClient.getProcessGroupClient().getProcessGroup(groupId);
-        processGroup.getComponent().setParameterContext(createReferenceEntity(parameterContext.getId()));
+        ProcessGroupDTO component = new ProcessGroupDTO();
+        component.setId(processGroup.getId());
+        component.setParameterContext(createReferenceEntity(parameterContext.getId()));
+        processGroup.setComponent(component);
         return nifiClient.getProcessGroupClient().updateProcessGroup(processGroup);
     }
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/ParameterContextPreservationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/ParameterContextPreservationIT.java
@@ -601,4 +601,41 @@ class ParameterContextPreservationIT extends NiFiSystemIT {
         assertNotNull(childAfterUpdate.getComponent().getVersionControlInformation(),
                 "Versioned child Process Group should remain under version control after a recursive Parameter Context change");
     }
+
+    /**
+     * Verifies that a Parameter Context locally assigned to a shared, independently version-controlled child Process Group survives a version upgrade of that child.
+     */
+    @Test
+    void testLocallyAssignedParameterContextPreservedWhenVersionedChildUpgraded() throws NiFiClientException, IOException, InterruptedException {
+        final FlowRegistryClientEntity clientEntity = registerClient();
+        final NiFiClientUtil util = getClientUtil();
+
+        final ParameterContextEntity locallyAssignedContext = util.createParameterContext("locally-assigned-context", Map.of(PARAMETER_NAME, PARAMETER_VALUE));
+
+        // Shared child Process Group, version-controlled on its own, deliberately without a Parameter Context of its own.
+        final ProcessGroupEntity versionedGroup = util.createProcessGroup("shared-utility", "root");
+        //util.setParameterContext(versionedGroup.getId(), emptyContext);
+        final VersionControlInformationEntity childVciV1 = util.startVersionControl(versionedGroup, clientEntity, TEST_FLOWS_BUCKET, "SharedUtility");
+
+        final ProcessGroupEntity instance = util.importFlowFromRegistry("root", childVciV1.getVersionControlInformation());
+
+        // Assign a Parameter Context to the child locally, outside its own versioned definition.
+        util.setParameterContext(instance.getId(), locallyAssignedContext);
+
+        // Modify the child's own definition and commit version 2 so there's a newer version to upgrade to.
+        final ProcessorEntity processor = util.createProcessor(PROCESSOR_TYPE, versionedGroup.getId());
+        util.setAutoTerminatedRelationships(processor, RELATIONSHIP_SUCCESS);
+        final ProcessGroupEntity refreshedChildGroup = getNifiClient().getProcessGroupClient().getProcessGroup(versionedGroup.getId());
+        util.saveFlowVersion(refreshedChildGroup, clientEntity, childVciV1);
+
+        // Update the child directly to version 2, fetching its own standalone snapshot which still declares no Parameter Context.
+        util.changeFlowVersion(instance.getId(), VERSION_2);
+
+        final ProcessGroupEntity instanceAfterUpgrade = getNifiClient().getProcessGroupClient().getProcessGroup(instance.getId());
+        assertEquals(VERSION_2, instanceAfterUpgrade.getComponent().getVersionControlInformation().getVersion());
+        assertNotNull(instanceAfterUpgrade.getComponent().getParameterContext(),
+                "Parameter Context locally assigned to the child should survive the version upgrade");
+        assertEquals(locallyAssignedContext.getId(), instanceAfterUpgrade.getComponent().getParameterContext().getId(),
+                "Child Process Group should remain bound to the locally-assigned Parameter Context after upgrading to a new version");
+    }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16276](https://issues.apache.org/jira/browse/NIFI-16276)

Under certain circumstances an instance of a versioned process group could have its parameter context overwritten to null if the proposed new version of the process group doesn't have a parameter context. The fix is simple. Just remove the leading if block that sets the parameter context to null when the proposed version has no parameter context but the current version does. 

The rationale is that users might make versions of common components which they version without a specific parameter context and then when they place instances of them on the canvas, they will assign a parameter context to that instance, but on every version upgrade that parameter context gets set back to null.

There is a workaround to the problem that might not be obvious. Versioning a process group with an empty parameter context is enough, but there's no easy path to push users in that direction either.

It is worth noting that thins change would alter the behaviour when it comes to publishing a new version of a process group where you remove the parameter context from version control. No longer would instances of a process group also null out their parameter context.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21
  - [x] JDK 25

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
