### PR TITLE
NIFI-16304 Retain connector verification and purge results for one minute

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ConnectorResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ConnectorResource.java
@@ -175,11 +175,11 @@ public class ConnectorResource extends ApplicationResource {
     private UploadRequestReplicator uploadRequestReplicator;
 
     private final RequestManager<VerifyConnectorConfigStepRequestEntity, List<ConfigVerificationResultDTO>> configVerificationRequestManager =
-            new AsyncRequestManager<>(100, 1L, "Connector Configuration Step Verification");
+            new AsyncRequestManager<>(100, TimeUnit.MINUTES.toMillis(1L), "Connector Configuration Step Verification");
     private final RequestManager<MigrationRequestEntity, ConnectorEntity> migrationRequestManager =
             new AsyncRequestManager<>(100, MIGRATION_REQUEST_TTL_MILLIS, "Connector Migration");
 
-    private final RequestManager<ConnectorEntity, Void> purgeRequestManager = new AsyncRequestManager<>(100, 1L, "Connector FlowFile Purge");
+    private final RequestManager<ConnectorEntity, Void> purgeRequestManager = new AsyncRequestManager<>(100, TimeUnit.MINUTES.toMillis(1L), "Connector FlowFile Purge");
 
     /**
      * Uploaded migration payloads keyed by their server-assigned identifier. Each entry's age is tracked alongside

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/connectors/ConnectorCrudIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/connectors/ConnectorCrudIT.java
@@ -23,12 +23,16 @@ import org.apache.nifi.components.ConfigVerificationResult.Outcome;
 import org.apache.nifi.components.connector.BundleCompatibility;
 import org.apache.nifi.components.connector.ConnectorState;
 import org.apache.nifi.tests.system.NiFiSystemIT;
+import org.apache.nifi.toolkit.client.ConnectorClient;
 import org.apache.nifi.toolkit.client.NiFiClientException;
 import org.apache.nifi.web.api.dto.BundleDTO;
 import org.apache.nifi.web.api.dto.ConfigVerificationResultDTO;
+import org.apache.nifi.web.api.dto.ConfigurationStepConfigurationDTO;
 import org.apache.nifi.web.api.dto.ConnectorConfigurationDTO;
 import org.apache.nifi.web.api.dto.ConnectorValueReferenceDTO;
 import org.apache.nifi.web.api.dto.ProcessorDTO;
+import org.apache.nifi.web.api.dto.PropertyGroupConfigurationDTO;
+import org.apache.nifi.web.api.dto.VerifyConnectorConfigStepRequestDTO;
 import org.apache.nifi.web.api.dto.flow.FlowDTO;
 import org.apache.nifi.web.api.dto.flow.ProcessGroupFlowDTO;
 import org.apache.nifi.web.api.entity.ConnectorEntity;
@@ -37,7 +41,9 @@ import org.apache.nifi.web.api.entity.ParameterProviderEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupFlowEntity;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
+import org.apache.nifi.web.api.entity.VerifyConnectorConfigStepRequestEntity;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -51,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -114,6 +121,66 @@ public class ConnectorCrudIT extends NiFiSystemIT {
         final ConfigVerificationResultDTO resultDto = resultDtos.get(1);
         assertEquals("Nop Verification", resultDto.getVerificationStepName());
         assertTrue(resultDto.getExplanation().contains("Test Value"));
+    }
+
+    @Test
+    @Timeout(30)
+    public void testCompletedConfigVerificationRetainedWhenAnotherConnectorIsVerified() throws NiFiClientException, IOException, InterruptedException {
+        final ConnectorEntity firstConnector = getClientUtil().createConnector("NopConnector");
+        final ConnectorEntity secondConnector = getClientUtil().createConnector("NopConnector");
+        final ConnectorClient connectorClient = getNifiClient().getConnectorClient();
+        final String stepName = "Ignored Step";
+
+        final ConnectorValueReferenceDTO propertyValue = new ConnectorValueReferenceDTO();
+        propertyValue.setValueType("STRING_LITERAL");
+        propertyValue.setValue("First Verification");
+        final PropertyGroupConfigurationDTO propertyGroupConfiguration = new PropertyGroupConfigurationDTO();
+        propertyGroupConfiguration.setPropertyValues(Map.of("Ignored Property", propertyValue));
+        final ConfigurationStepConfigurationDTO stepConfiguration = new ConfigurationStepConfigurationDTO();
+        stepConfiguration.setConfigurationStepName(stepName);
+        stepConfiguration.setPropertyGroupConfigurations(List.of(propertyGroupConfiguration));
+        final VerifyConnectorConfigStepRequestDTO request = new VerifyConnectorConfigStepRequestDTO();
+        request.setConnectorId(firstConnector.getId());
+        request.setConfigurationStepName(stepName);
+        request.setConfigurationStep(stepConfiguration);
+        final VerifyConnectorConfigStepRequestEntity requestEntity = new VerifyConnectorConfigStepRequestEntity();
+        requestEntity.setRequest(request);
+
+        // The usual verification helper deletes completed requests. Keep this request so another submission can exercise expiration.
+        final String requestId = connectorClient.submitConfigStepVerificationRequest(requestEntity).getRequest().getRequestId();
+        try {
+            waitFor(() -> connectorClient.getConfigStepVerificationRequest(firstConnector.getId(), stepName, requestId).getRequest().isComplete());
+
+            // Completed requests remain available during the retention interval.
+            Thread.sleep(100L);
+            final VerifyConnectorConfigStepRequestDTO completedRequest = connectorClient.getConfigStepVerificationRequest(firstConnector.getId(), stepName, requestId).getRequest();
+            assertTrue(completedRequest.isComplete());
+            assertNull(completedRequest.getFailureReason());
+            assertEquals(2, completedRequest.getResults().size());
+            assertTrue(completedRequest.getResults().stream().allMatch(result -> Outcome.SUCCESSFUL.name().equals(result.getOutcome())));
+            assertTrue(completedRequest.getResults().get(1).getExplanation().contains("First Verification"));
+
+            // A new submission triggers cleanup in the request manager shared by all connectors.
+            final List<ConfigVerificationResultDTO> secondResults = getClientUtil().verifyConnectorStepConfig(secondConnector.getId(), stepName,
+                Map.of("Ignored Property", "Second Verification"));
+            assertEquals(2, secondResults.size());
+            assertTrue(secondResults.stream().allMatch(result -> Outcome.SUCCESSFUL.name().equals(result.getOutcome())));
+
+            final VerifyConnectorConfigStepRequestEntity retainedRequest =
+                connectorClient.getConfigStepVerificationRequest(firstConnector.getId(), stepName, requestId);
+            assertEquals(requestId, retainedRequest.getRequest().getRequestId());
+            assertTrue(retainedRequest.getRequest().isComplete());
+            assertEquals(completedRequest.getResults().get(1).getExplanation(), retainedRequest.getRequest().getResults().get(1).getExplanation());
+        } finally {
+            try {
+                connectorClient.deleteConfigStepVerificationRequest(firstConnector.getId(), stepName, requestId);
+            } catch (final NiFiClientException e) {
+                // Cleanup accepts a request that expired while the test was running.
+                if (!(e.getCause() instanceof WebApplicationException cause) || cause.getResponse().getStatus() != Response.Status.NOT_FOUND.getStatusCode()) {
+                    throw e;
+                }
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-16304](https://issues.apache.org/jira/browse/NIFI-16304)

Submitting a connector configuration verification can remove another connector's completed verification result after only one millisecond, causing a subsequent poll to return HTTP 404. The asynchronous request manager expects a retention interval in milliseconds, but the verification and FlowFile purge managers pass `1L`.

Set both retention intervals to one minute. Add a system regression that completes verification on one connector, submits verification on another connector, and confirms the first result remains retrievable.

# Verification

- The regression failed with HTTP 404 before the fix and passed after the fix: 1 test, 0 failures, 0 errors, 0 skipped.
  ```sh
  mvn -pl nifi-system-tests/nifi-system-test-suite -Pintegration-tests,skip-unit-tests '-Dit.test=ConnectorCrudIT#testCompletedConfigVerificationRetainedWhenAnotherConnectorIsVerified' verify
  ```
- Clean-installed `nifi-web-api`, `nifi-server-nar`, and `nifi-system-test-suite` before running the system test. Confirmed the assembled runtime contains the rebuilt server NAR.
- `mvn test` in `nifi-web-api`: 642 tests passed.
- Checkstyle and PMD passed for both changed modules using the repository's configured versions. A temporary Maven Central mirror was used after the primary endpoint returned HTTP 429.
- Verification used JDK 21. The full `./mvnw clean install -P contrib-check` and JDK 25 matrix were not run for this change.

No dependencies or documentation changed. The system regression covers verification-result retention; the identical purge-retention correction is not separately exercised by this test.
