### PR TITLE
NIFI-16306 - Bump SLF4J to 2.0.19, Jetty to 12.1.13, Parquet to 1.18.1, and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -27,7 +27,7 @@
     <description>Apache NiFi reporting module for aggregating code coverage information</description>
 
     <properties>
-        <ant.version>1.10.17</ant.version>
+        <ant.version>1.10.18</ant.version>
         <mime4j.version>0.8.14</mime4j.version>
     </properties>
 

--- a/nifi-commons/nifi-xml-processing/pom.xml
+++ b/nifi-commons/nifi-xml-processing/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.10.4.0</version>
+                <version>4.10.4.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/nifi-extension-bom/pom.xml
+++ b/nifi-extension-bom/pom.xml
@@ -248,7 +248,7 @@
             <dependency>
                 <groupId>org.eclipse.jdt</groupId>
                 <artifactId>ecj</artifactId>
-                <version>3.46.0</version>
+                <version>3.46.100</version>
                 <scope>provided</scope>
             </dependency>
             <!-- Jetty EE11 Glassfish JSTL and deps -->

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-kinesis/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
-            <version>3.5.1</version>
+            <version>3.5.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/nifi-extension-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.box</groupId>
                 <artifactId>box-java-sdk</artifactId>
-                <version>5.15.1</version>
+                <version>5.15.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/pom.xml
@@ -32,7 +32,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>mysql-binlog-connector-java</artifactId>
-            <version>0.41.3</version>
+            <version>0.41.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>9.5.2</elasticsearch.client.version>
+        <elasticsearch.client.version>9.5.3</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20260823-2.0.0</version>
+            <version>v3-rev20260901-2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.tdunning</groupId>

--- a/nifi-extension-bundles/nifi-groovyx-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/pom.xml
@@ -26,7 +26,7 @@
     <description>NiFi Groovy Extended Processor</description>
 
     <properties>
-        <ant.version>1.10.17</ant.version>
+        <ant.version>1.10.18</ant.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-parquet-writer/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-parquet-writer/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>1.18.0</version>
+            <version>1.18.1</version>
         </dependency>
         <!-- Avro provided in shared NAR -->
         <dependency>

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <activemq.version>6.3.1</activemq.version>
+        <activemq.version>6.3.2</activemq.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/pom.xml
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>software.amazon.msk</groupId>
             <artifactId>aws-msk-iam-auth</artifactId>
-            <version>2.3.7</version>
+            <version>2.3.8</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/nifi-extension-bundles/nifi-parquet-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-parquet-bundle/pom.xml
@@ -31,7 +31,7 @@
         <module>nifi-parquet-nar</module>
     </modules>
     <properties>
-        <parquet.version>1.18.0</parquet.version>
+        <parquet.version>1.18.1</parquet.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-poi-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-poi-bundle/pom.xml
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>com.github.pjfanning</groupId>
                 <artifactId>excel-streaming-reader</artifactId>
-                <version>5.2.0</version>
+                <version>5.3.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>clojure</artifactId>
-            <version>1.12.5</version>
+            <version>1.12.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-extension-bundles/nifi-scripting-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-scripting-bundle/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>nifi-scripting-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <ant.version>1.10.17</ant.version>
+        <ant.version>1.10.18</ant.version>
     </properties>
     <modules>
         <module>nifi-scripting-processors</module>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -24,7 +24,7 @@
         <guava.version>33.7.1-jre</guava.version>
         <protobuf.version>4.36.1</protobuf.version>
         <grpc.version>1.84.0</grpc.version>
-        <snowflake-jdbc-thin.version>4.3.3</snowflake-jdbc-thin.version>
+        <snowflake-jdbc-thin.version>4.3.4</snowflake-jdbc-thin.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -147,7 +147,7 @@
             <dependency>
                 <groupId>com.github.wnameless.json</groupId>
                 <artifactId>json-flattener</artifactId>
-                <version>0.18.2</version>
+                <version>0.18.3</version>
             </dependency>
             <dependency>
                 <groupId>io.krakens</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,11 +36,11 @@
     </modules>
     <properties>
         <spring.boot.version>4.1.1</spring.boot.version>
-        <flyway.version>13.4.0</flyway.version>
+        <flyway.version>13.5.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.7.1.202607240634-r</jgit.version>
-        <h2.version>2.4.240</h2.version>
+        <h2.version>2.5.250</h2.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <jline.version>4.4.1</jline.version>
+        <jline.version>4.4.2</jline.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.4.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.54.10</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.54.13</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.2</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.8</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -143,7 +143,7 @@
         <ozone.version>1.4.1</ozone.version>
 
         <!-- Kubernetes -->
-        <io.fabric8.kubernetes.client.version>7.8.0</io.fabric8.kubernetes.client.version>
+        <io.fabric8.kubernetes.client.version>7.9.0</io.fabric8.kubernetes.client.version>
 
         <!-- Data access -->
         <commons.dbcp2.version>2.14.0</commons.dbcp2.version>
@@ -165,20 +165,20 @@
 
         <!-- JVM languages and bytecode -->
         <aspectj.version>1.9.25.1</aspectj.version>
-        <groovy.version>5.1.1</groovy.version>
+        <groovy.version>5.1.2</groovy.version>
         <kotlin.version>2.4.10</kotlin.version>
 
         <!-- Logging and observability -->
         <log4j2.version>2.26.1</log4j2.version>
         <logback.version>1.6.3</logback.version>
-        <org.slf4j.version>2.0.18</org.slf4j.version>
+        <org.slf4j.version>2.0.19</org.slf4j.version>
         <prometheus.version>0.16.0</prometheus.version>
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
 
         <!-- Networking and transport -->
         <netty.4.version>4.2.17.Final</netty.4.version>
         <okhttp.version>5.5.0</okhttp.version>
-        <okio.version>3.18.1</okio.version>
+        <okio.version>3.18.2</okio.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpclient5.version>5.6.4</org.apache.httpcomponents.httpclient5.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
@@ -203,7 +203,7 @@
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jaxb.runtime.version>4.0.9</jaxb.runtime.version>
         <jersey.bom.version>4.0.2</jersey.bom.version>
-        <jetty.version>12.1.12</jetty.version>
+        <jetty.version>12.1.13</jetty.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.security.version>7.1.1</spring.security.version>
         <spring.version>7.0.9</spring.version>
@@ -212,8 +212,8 @@
         <!-- Testing and quality -->
         <junit.version>6.1.3</junit.version>
         <mockito.version>5.23.0</mockito.version>
-        <pmd.version>7.26.0</pmd.version>
-        <checkstyle.version>14.0.0</checkstyle.version>
+        <pmd.version>7.27.0</pmd.version>
+        <checkstyle.version>14.1.0</checkstyle.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jacoco.version>0.8.15</jacoco.version>
 


### PR DESCRIPTION
# Summary

NIFI-16306 - Bump SLF4J to 2.0.19, Jetty to 12.1.13, Parquet to 1.18.1, and others

- Apache Ant from 1.10.17 to 1.10.18 - https://github.com/apache/ant/releases/tag/rel%2F1.10.18
- Spotbugs Maven Plugin from 4.10.4.0 to 4.10.4.1 - https://github.com/spotbugs/spotbugs-maven-plugin/releases/tag/spotbugs-maven-plugin-4.10.4.1
- Eclipse ECJ from 3.46.0 to 3.46.100 - https://github.com/eclipse-jdt/eclipse.jdt.core
- AWS Kinesis Client from 3.5.1 to 3.5.2 - https://github.com/awslabs/amazon-kinesis-client/releases/tag/v3.5.2
- AWS MSK IAM Auth from 2.3.7 to 2.3.8 - https://github.com/aws/aws-msk-iam-auth/releases/tag/v2.3.8
- AWS SDK from 2.54.10 to 2.54.13 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.54.13
- Box Java SDK from 5.15.1 to 5.15.2 - https://github.com/box/box-java-sdk/releases#release-v5.15.2
- Debezium MySQL Binlog Connector from 0.41.3 to 0.41.4 - https://github.com/debezium/mysql-binlog-connector-java/tags
- Elasticsearch Client from 9.5.2 to 9.5.3 - https://github.com/elastic/elasticsearch-java/releases/tag/v9.5.3
- Google Drive from v3-rev20260823-2.0.0 to v3-rev20260901-2.0.0 - https://github.com/googleapis/google-api-java-client-services/blob/main/clients/google-api-services-drive/v3/README.md
- Apache Parquet from 1.18.0 to 1.18.1 - https://github.com/apache/parquet-java/releases/tag/apache-parquet-1.18.1
- Apache ActiveMQ from 6.3.1 to 6.3.2 - https://github.com/apache/activemq/releases/tag/activemq-6.3.2
- Excel Streaming Reader from 5.2.0 to 5.3.0 - https://github.com/pjfanning/excel-streaming-reader/releases/tag/v5.3.0
- Clojure from 1.12.5 to 1.12.6 - https://clojure.org/news/2026/09/02/clojure-1-12-6
- Snowflake JDBC from 4.3.3 to 4.3.4 - https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc-2026#version-434-sep-03-2026
- JSON Flattener from 0.18.2 to 0.18.3 - https://github.com/wnameless/json-flattener/releases/tag/json-flattener-0.18.3
- FlywayDB from 13.4.0 to 13.5.0 - https://github.com/flyway/flyway/releases/tag/flyway-13.5.0
- H2 from 2.4.240 to 2.5.250 - https://github.com/h2database/h2database/releases/tag/version-2.5.250
- JLine from 4.4.1 to 4.4.2 - https://github.com/jline/jline3/releases/tag/4.4.2
- Fabric8 k8s client from 7.8.0 to 7.9.0 - https://github.com/fabric8io/kubernetes-client/releases/tag/v7.9.0
- Apache Groovy from 5.1.1 to 5.1.2 - https://github.com/apache/groovy/releases/tag/GROOVY_5_1_2
- SLF4J from 2.0.18 to 2.0.19 - https://github.com/qos-ch/slf4j/releases/tag/v_2.0.19
- Okio from 3.18.1 to 3.18.2 - https://github.com/lysine-dev/okio/releases/tag/parent-3.18.2
- Jetty from 12.1.12 to 12.1.13 - https://github.com/jetty/jetty.project/releases/tag/jetty-12.1.13
- PMD from 7.26.0 to 7.27.0 - https://github.com/pmd/pmd/releases/tag/pmd_releases%2F7.27.0
- Checkstyle from 14.0.0 to 14.1.0 - https://github.com/checkstyle/checkstyle/releases/tag/checkstyle-14.1.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
