### PR TITLE
NIFI-16311 Initialize ParseSyslog parser in @OnScheduled

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseSyslog.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseSyslog.java
@@ -26,6 +26,7 @@ import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.AbstractProcessor;
@@ -91,7 +92,7 @@ public class ParseSyslog extends AbstractProcessor {
             REL_SUCCESS
     );
 
-    private SyslogParser parser;
+    private volatile SyslogParser parser;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -103,18 +104,16 @@ public class ParseSyslog extends AbstractProcessor {
         return RELATIONSHIPS;
     }
 
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        parser = new SyslogParser(Charset.forName(context.getProperty(CHARSET).getValue()));
+    }
+
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
         FlowFile flowFile = session.get();
         if (flowFile == null) {
             return;
-        }
-
-        final String charsetName = context.getProperty(CHARSET).getValue();
-
-        // If the parser already exists and uses the same charset, it does not need to be re-initialized
-        if (parser == null || !parser.getCharsetName().equals(charsetName)) {
-            parser = new SyslogParser(Charset.forName(charsetName));
         }
 
         final byte[] buffer = new byte[(int) flowFile.getSize()];

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestParseSyslog.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestParseSyslog.java
@@ -94,4 +94,25 @@ public class TestParseSyslog {
 
         runner.assertAllFlowFilesTransferred(ParseSyslog.REL_FAILURE, 1);
     }
+
+    @Test
+    public void testConcurrentTasksShareScheduledParser() {
+        final TestRunner runner = TestRunners.newTestRunner(new ParseSyslog());
+        final int numThreads = 8;
+        final int flowFiles = 32;
+        runner.setThreadCount(numThreads);
+
+        for (int i = 0; i < flowFiles; i++) {
+            runner.enqueue(VALID_MESSAGE_RFC3164_0.getBytes());
+        }
+
+        runner.run(flowFiles);
+
+        runner.assertAllFlowFilesTransferred(ParseSyslog.REL_SUCCESS, flowFiles);
+        for (final MockFlowFile mff : runner.getFlowFilesForRelationship(ParseSyslog.REL_SUCCESS)) {
+            mff.assertAttributeEquals(SyslogAttributes.SYSLOG_BODY.key(), BODY);
+            mff.assertAttributeEquals(SyslogAttributes.SYSLOG_HOSTNAME.key(), HOST);
+            mff.assertAttributeEquals(SyslogAttributes.SYSLOG_PRIORITY.key(), PRI);
+        }
+    }
 }


### PR DESCRIPTION
CHARSET cannot change between triggers, so lazy construction in onTrigger was an unsynchronized check-then-act on the shared processor instance. Match ParseSyslog5424: build once at schedule time and publish the parser as volatile.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16311](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
