### PR TITLE
NIFI-15694 Classify property-migration diffs as environmental changes in versioned flows

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -76,6 +76,7 @@ import org.apache.nifi.logging.LogRepositoryFactory;
 import org.apache.nifi.logging.StandardLoggingContext;
 import org.apache.nifi.migration.ControllerServiceCreationDetails;
 import org.apache.nifi.migration.ControllerServiceFactory;
+import org.apache.nifi.migration.PropertyMigrationPreview;
 import org.apache.nifi.migration.StandardPropertyConfiguration;
 import org.apache.nifi.migration.StandardRelationshipConfiguration;
 import org.apache.nifi.nar.ExtensionManager;
@@ -2294,6 +2295,12 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
         // In order to account for this, we need to refresh our controller service references by removing an previously existing
         // references and establishing new references.
         updateControllerServiceReferences();
+    }
+
+    @Override
+    public Optional<Map<String, String>> previewMigratedProperties(final Map<String, String> originalPropertyValues) {
+        return PropertyMigrationPreview.preview(getProcessor(), getExtensionManager(), getIdentifier(), toString(),
+                this::mapRawValueToEffectiveValue, originalPropertyValues);
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
@@ -64,6 +64,7 @@ import org.apache.nifi.logging.LogRepositoryFactory;
 import org.apache.nifi.logging.StandardLoggingContext;
 import org.apache.nifi.migration.ControllerServiceCreationDetails;
 import org.apache.nifi.migration.ControllerServiceFactory;
+import org.apache.nifi.migration.PropertyMigrationPreview;
 import org.apache.nifi.migration.StandardPropertyConfiguration;
 import org.apache.nifi.nar.ExtensionManager;
 import org.apache.nifi.nar.InstanceClassLoader;
@@ -909,6 +910,12 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
         try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(getExtensionManager(), implementationClass, getIdentifier())) {
             ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnPrimaryNodeStateChange.class, getControllerServiceImplementation(), nodeState);
         }
+    }
+
+    @Override
+    public Optional<Map<String, String>> previewMigratedProperties(final Map<String, String> originalPropertyValues) {
+        return PropertyMigrationPreview.preview(getControllerServiceImplementation(), getExtensionManager(), getIdentifier(), toString(),
+                super::mapRawValueToEffectiveValue, originalPropertyValues);
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/migration/PropertyMigrationPreview.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/migration/PropertyMigrationPreview.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.migration;
+
+import org.apache.nifi.components.ConfigurableComponent;
+import org.apache.nifi.controller.ControllerService;
+import org.apache.nifi.controller.service.ControllerServiceNode;
+import org.apache.nifi.nar.ExtensionManager;
+import org.apache.nifi.nar.NarCloseable;
+import org.apache.nifi.parameter.ParameterProvider;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.registry.flow.FlowRegistryClient;
+import org.apache.nifi.reporting.ReportingTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Runs {@code migrateProperties} against a copy of a property map so callers can compare the
+ * migrated result with the live configuration without persisting changes or creating Controller Services.
+ */
+public final class PropertyMigrationPreview {
+    private static final Logger logger = LoggerFactory.getLogger(PropertyMigrationPreview.class);
+
+    private static final ControllerServiceFactory NO_OP_FACTORY = new ControllerServiceFactory() {
+        @Override
+        public ControllerServiceCreationDetails getCreationDetails(final String implementationClassName, final Map<String, String> propertyValues) {
+            return new ControllerServiceCreationDetails("property-migration-preview", implementationClassName, null, propertyValues,
+                    ControllerServiceCreationDetails.CreationState.SERVICE_ALREADY_EXISTS);
+        }
+
+        @Override
+        public ControllerServiceNode create(final ControllerServiceCreationDetails creationDetails) {
+            return null;
+        }
+    };
+
+    private PropertyMigrationPreview() {
+    }
+
+    /**
+     * @param component the component whose {@code migrateProperties} implementation should be invoked
+     * @param extensionManager the extension manager used to jail the call to the component NAR; may be {@code null} in tests
+     * @param componentId the component instance identifier
+     * @param componentDescription a description used in log messages
+     * @param effectiveValueResolver maps raw property values to effective values (parameter substitution)
+     * @param originalPropertyValues the snapshot property values to migrate
+     * @return the migrated raw properties when migration modifies the configuration; otherwise empty
+     */
+    public static Optional<Map<String, String>> preview(final ConfigurableComponent component, final ExtensionManager extensionManager,
+                                                        final String componentId, final String componentDescription,
+                                                        final Function<String, String> effectiveValueResolver,
+                                                        final Map<String, String> originalPropertyValues) {
+        if (component == null || originalPropertyValues == null) {
+            return Optional.empty();
+        }
+
+        try {
+            final Map<String, String> rawProperties = new LinkedHashMap<>(originalPropertyValues);
+            final Map<String, String> effectiveProperties = new LinkedHashMap<>();
+            rawProperties.forEach((key, value) -> effectiveProperties.put(key, effectiveValueResolver.apply(value)));
+
+            final StandardPropertyConfiguration propertyConfig = new StandardPropertyConfiguration(
+                    effectiveProperties, rawProperties, effectiveValueResolver, componentDescription, NO_OP_FACTORY);
+
+            if (extensionManager == null) {
+                migrateProperties(component, propertyConfig);
+            } else {
+                try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(extensionManager, component.getClass(), componentId)) {
+                    migrateProperties(component, propertyConfig);
+                }
+            }
+
+            if (!propertyConfig.isModified()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(new LinkedHashMap<>(propertyConfig.getRawProperties()));
+        } catch (final Exception e) {
+            logger.debug("Failed to preview property migration for {}", componentDescription, e);
+            return Optional.empty();
+        }
+    }
+
+    private static void migrateProperties(final ConfigurableComponent component, final PropertyConfiguration propertyConfig) {
+        switch (component) {
+            case Processor processor -> processor.migrateProperties(propertyConfig);
+            case ControllerService controllerService -> controllerService.migrateProperties(propertyConfig);
+            case ReportingTask reportingTask -> reportingTask.migrateProperties(propertyConfig);
+            case ParameterProvider parameterProvider -> parameterProvider.migrateProperties(propertyConfig);
+            case FlowRegistryClient flowRegistryClient -> flowRegistryClient.migrateProperties(propertyConfig);
+            default -> logger.debug("Cannot preview property migration for {}", component.getClass().getName());
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
@@ -108,7 +108,8 @@ public class FlowDifferenceFilters {
             || isPropertyRenameWithMatchingValue(difference, evaluatedContext)
             || isSelectedRelationshipChangeForNewRelationship(difference, flowManager)
             || isPropertyAddedFromMigration(difference, flowManager)
-            || isExternalControllerServiceReferenceChange(difference, flowManager, evaluatedContext);
+            || isExternalControllerServiceReferenceChange(difference, flowManager, evaluatedContext)
+            || isPropertyExplainedByMigration(difference, evaluatedContext);
     }
 
     /**
@@ -582,15 +583,18 @@ public class FlowDifferenceFilters {
     /**
      * Determines whether a property difference is caused by a statically defined property being removed from the component definition.
      * When a processor or controller service drops a property (for example, as part of a version upgrade that invokes {@code removeProperty}
-     * during migration), the reconciled component in NiFi should not report a "local change" so long as the component does not support
-     * dynamic properties. This applies whether the registry-side value was a literal value (yielding {@link DifferenceType#PROPERTY_REMOVED})
-     * or a parameter reference (yielding {@link DifferenceType#PROPERTY_PARAMETERIZATION_REMOVED}); both represent the same underlying
-     * scenario of a property no longer exposed by the component definition.
+     * during migration), the reconciled component in NiFi should not report a "local change". This applies whether the registry-side
+     * value was a literal value (yielding {@link DifferenceType#PROPERTY_REMOVED}) or a parameter reference (yielding
+     * {@link DifferenceType#PROPERTY_PARAMETERIZATION_REMOVED}); both represent the same underlying scenario of a property no longer
+     * exposed by the component definition.
+     *
+     * <p>Components that support dynamic properties are excluded unless the versioned snapshot recorded the removed property as
+     * non-dynamic. That exception distinguishes a dropped static property (for example {@code AvroSchemaRegistry}'s
+     * {@code Validate Field Names}) from a user-deleted dynamic property such as a named schema.</p>
      *
      * @param difference the flow difference under evaluation
      * @param flowManager the flow manager used to resolve instantiated components
-     * @return {@code true} if the property is no longer exposed by the component definition and the component does not support dynamic
-     * properties; {@code false} otherwise
+     * @return {@code true} if the property is no longer exposed by the component definition; {@code false} otherwise
      */
     public static boolean isStaticPropertyRemoved(final FlowDifference difference, final FlowManager flowManager) {
         final DifferenceType differenceType = difference.getDifferenceType();
@@ -607,16 +611,16 @@ public class FlowDifferenceFilters {
 
         if (componentB instanceof final InstantiatedVersionedProcessor instantiatedProcessor) {
             final ProcessorNode processorNode = flowManager.getProcessorNode(instantiatedProcessor.getInstanceIdentifier());
-            return isStaticPropertyRemoved(fieldName.get(), processorNode);
+            return isStaticPropertyRemoved(difference, fieldName.get(), processorNode);
         } else if (componentB instanceof final InstantiatedVersionedControllerService instantiatedControllerService) {
             final ControllerServiceNode controllerService = flowManager.getControllerServiceNode(instantiatedControllerService.getInstanceIdentifier());
-            return isStaticPropertyRemoved(fieldName.get(), controllerService);
+            return isStaticPropertyRemoved(difference, fieldName.get(), controllerService);
         }
 
         return false;
     }
 
-    private static boolean isStaticPropertyRemoved(String propertyName, ComponentNode componentNode) {
+    private static boolean isStaticPropertyRemoved(final FlowDifference difference, final String propertyName, final ComponentNode componentNode) {
         if (componentNode == null) {
             return false;
         }
@@ -634,7 +638,8 @@ public class FlowDifferenceFilters {
         }
 
         if (supportsDynamicProperties(configurableComponent)) {
-            return false;
+            final Optional<VersionedPropertyDescriptor> snapshotDescriptor = getVersionedPropertyDescriptor(difference, true);
+            return snapshotDescriptor.isPresent() && !snapshotDescriptor.get().isDynamic();
         }
 
         return true;
@@ -875,13 +880,15 @@ public class FlowDifferenceFilters {
             }
         }
 
+        final Set<FlowDifference> propertiesExplainedByMigration = explainPropertyMigrations(differences, flowManager);
+
         if (serviceIdsWithMatchingAdditions.isEmpty() && parameterizedPropertyRenameDifferences.isEmpty() && propertyRenamesWithMatchingValues.isEmpty()
-                && ancestorControllerServiceIds.isEmpty()) {
+                && ancestorControllerServiceIds.isEmpty() && propertiesExplainedByMigration.isEmpty()) {
             return EnvironmentalChangeContext.empty();
         }
 
         return new EnvironmentalChangeContext(serviceIdsWithMatchingAdditions, parameterizedPropertyRenameDifferences, propertyRenamesWithMatchingValues,
-                ancestorControllerServiceIds);
+                ancestorControllerServiceIds, propertiesExplainedByMigration);
     }
 
     /**
@@ -1026,6 +1033,11 @@ public class FlowDifferenceFilters {
     public static boolean isPropertyRenameWithMatchingValue(final FlowDifference difference, final EnvironmentalChangeContext context) {
         final EnvironmentalChangeContext evaluatedContext = Objects.requireNonNull(context, "EnvironmentalChangeContext required");
         return evaluatedContext.propertyRenamesWithMatchingValues().isEmpty() ? false : evaluatedContext.propertyRenamesWithMatchingValues().contains(difference);
+    }
+
+    public static boolean isPropertyExplainedByMigration(final FlowDifference difference, final EnvironmentalChangeContext context) {
+        final EnvironmentalChangeContext evaluatedContext = Objects.requireNonNull(context, "EnvironmentalChangeContext required");
+        return evaluatedContext.propertiesExplainedByMigration().isEmpty() ? false : evaluatedContext.propertiesExplainedByMigration().contains(difference);
     }
 
     /**
@@ -1292,6 +1304,121 @@ public class FlowDifferenceFilters {
         return propertyValue != null && PARAMETER_REFERENCE_PATTERN.matcher(propertyValue).matches();
     }
 
+    private static Set<FlowDifference> explainPropertyMigrations(final Collection<FlowDifference> differences, final FlowManager flowManager) {
+        if (differences == null || differences.isEmpty() || flowManager == null) {
+            return Collections.emptySet();
+        }
+
+        final Map<String, List<FlowDifference>> propertyDiffsByComponent = new HashMap<>();
+        for (final FlowDifference difference : differences) {
+            if (!isPropertyMigrationDifferenceType(difference.getDifferenceType())) {
+                continue;
+            }
+
+            final Optional<String> componentIdOptional = getComponentInstanceIdentifier(difference);
+            if (componentIdOptional.isEmpty()) {
+                continue;
+            }
+
+            propertyDiffsByComponent.computeIfAbsent(componentIdOptional.get(), key -> new ArrayList<>()).add(difference);
+        }
+
+        if (propertyDiffsByComponent.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        final Set<FlowDifference> explained = new HashSet<>();
+        for (final Map.Entry<String, List<FlowDifference>> entry : propertyDiffsByComponent.entrySet()) {
+            explained.addAll(explainPropertyMigrations(entry.getKey(), entry.getValue(), flowManager));
+        }
+        return explained;
+    }
+
+    private static boolean isPropertyMigrationDifferenceType(final DifferenceType differenceType) {
+        return differenceType == DifferenceType.PROPERTY_ADDED
+                || differenceType == DifferenceType.PROPERTY_REMOVED
+                || differenceType == DifferenceType.PROPERTY_CHANGED
+                || differenceType == DifferenceType.PROPERTY_PARAMETERIZED
+                || differenceType == DifferenceType.PROPERTY_PARAMETERIZATION_REMOVED;
+    }
+
+    private static Set<FlowDifference> explainPropertyMigrations(final String componentId, final List<FlowDifference> differences, final FlowManager flowManager) {
+        final ComponentNode componentNode = resolveComponentNode(componentId, differences, flowManager);
+        if (componentNode == null) {
+            return Collections.emptySet();
+        }
+
+        final FlowDifference firstDifference = differences.getFirst();
+        final Map<String, String> snapshotProperties = getProperties(firstDifference.getComponentA());
+        final Map<String, String> localProperties = getProperties(firstDifference.getComponentB());
+
+        final Optional<Map<String, String>> migratedProperties;
+        try {
+            migratedProperties = componentNode.previewMigratedProperties(snapshotProperties);
+        } catch (final Exception e) {
+            return Collections.emptySet();
+        }
+
+        if (migratedProperties.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        final Map<String, String> migrated = migratedProperties.get();
+        final Set<FlowDifference> explained = new HashSet<>();
+        for (final FlowDifference difference : differences) {
+            if (isExplainedByMigration(difference, snapshotProperties, migrated, localProperties)) {
+                explained.add(difference);
+            }
+        }
+        return explained;
+    }
+
+    private static ComponentNode resolveComponentNode(final String componentId, final List<FlowDifference> differences, final FlowManager flowManager) {
+        for (final FlowDifference difference : differences) {
+            final VersionedComponent componentB = difference.getComponentB();
+            if (componentB instanceof InstantiatedVersionedProcessor) {
+                return flowManager.getProcessorNode(componentId);
+            }
+            if (componentB instanceof InstantiatedVersionedControllerService) {
+                return flowManager.getControllerServiceNode(componentId);
+            }
+        }
+
+        final ProcessorNode processorNode = flowManager.getProcessorNode(componentId);
+        if (processorNode != null) {
+            return processorNode;
+        }
+        return flowManager.getControllerServiceNode(componentId);
+    }
+
+    private static boolean isExplainedByMigration(final FlowDifference difference, final Map<String, String> snapshotProperties,
+                                                  final Map<String, String> migratedProperties, final Map<String, String> localProperties) {
+        final Optional<String> fieldNameOptional = difference.getFieldName();
+        if (fieldNameOptional.isEmpty()) {
+            return false;
+        }
+
+        final String fieldName = fieldNameOptional.get();
+        return switch (difference.getDifferenceType()) {
+            case PROPERTY_REMOVED, PROPERTY_PARAMETERIZATION_REMOVED ->
+                snapshotProperties.containsKey(fieldName) && !migratedProperties.containsKey(fieldName);
+            case PROPERTY_ADDED, PROPERTY_PARAMETERIZED ->
+                migratedProperties.containsKey(fieldName) && Objects.equals(migratedProperties.get(fieldName), localValue(difference, localProperties, fieldName));
+            case PROPERTY_CHANGED ->
+                Objects.equals(migratedProperties.get(fieldName), localValue(difference, localProperties, fieldName));
+            default -> false;
+        };
+    }
+
+    private static String localValue(final FlowDifference difference, final Map<String, String> localProperties, final String fieldName) {
+        if (localProperties.containsKey(fieldName)) {
+            return localProperties.get(fieldName);
+        }
+
+        final Object valueB = difference.getValueB();
+        return valueB instanceof final String stringValue ? stringValue : null;
+    }
+
     private static final class PropertyDiffInfo {
         private final Optional<String> propertyValue;
         private final FlowDifference difference;
@@ -1312,21 +1439,24 @@ public class FlowDifferenceFilters {
 
     public static final class EnvironmentalChangeContext {
         private static final EnvironmentalChangeContext EMPTY =
-                new EnvironmentalChangeContext(Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+                new EnvironmentalChangeContext(Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
 
         private final Set<String> serviceIdsCreatedForNewProperties;
         private final Set<FlowDifference> parameterizedPropertyRenames;
         private final Set<FlowDifference> propertyRenamesWithMatchingValues;
         private final Set<String> ancestorControllerServiceIds;
+        private final Set<FlowDifference> propertiesExplainedByMigration;
 
         private EnvironmentalChangeContext(final Set<String> serviceIdsCreatedForNewProperties,
                                            final Set<FlowDifference> parameterizedPropertyRenames,
                                            final Set<FlowDifference> propertyRenamesWithMatchingValues,
-                                           final Set<String> ancestorControllerServiceIds) {
+                                           final Set<String> ancestorControllerServiceIds,
+                                           final Set<FlowDifference> propertiesExplainedByMigration) {
             this.serviceIdsCreatedForNewProperties = Collections.unmodifiableSet(new HashSet<>(serviceIdsCreatedForNewProperties));
             this.parameterizedPropertyRenames = Collections.unmodifiableSet(new HashSet<>(parameterizedPropertyRenames));
             this.propertyRenamesWithMatchingValues = Collections.unmodifiableSet(new HashSet<>(propertyRenamesWithMatchingValues));
             this.ancestorControllerServiceIds = Collections.unmodifiableSet(new HashSet<>(ancestorControllerServiceIds));
+            this.propertiesExplainedByMigration = Collections.unmodifiableSet(new HashSet<>(propertiesExplainedByMigration));
         }
 
         static EnvironmentalChangeContext empty() {
@@ -1347,6 +1477,10 @@ public class FlowDifferenceFilters {
 
         Set<String> ancestorControllerServiceIds() {
             return ancestorControllerServiceIds;
+        }
+
+        Set<FlowDifference> propertiesExplainedByMigration() {
+            return propertiesExplainedByMigration;
         }
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/migration/TestPropertyMigrationPreview.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/migration/TestPropertyMigrationPreview.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.migration;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestPropertyMigrationPreview {
+
+    @Test
+    public void testPreviewMapsObsoleteBooleanToReplacementAndDoesNotMutateFurtherCalls() {
+        final ReplacingProcessor processor = new ReplacingProcessor();
+
+        final Optional<Map<String, String>> migratedTrue = PropertyMigrationPreview.preview(
+                processor, null, "id", "test", Function.identity(), Map.of(ReplacingProcessor.OBSOLETE, "true"));
+        assertTrue(migratedTrue.isPresent());
+        assertEquals(ReplacingProcessor.VALIDATE, migratedTrue.get().get(ReplacingProcessor.REPLACEMENT));
+        assertFalse(migratedTrue.get().containsKey(ReplacingProcessor.OBSOLETE));
+
+        final Optional<Map<String, String>> migratedFalse = PropertyMigrationPreview.preview(
+                processor, null, "id", "test", Function.identity(), Map.of(ReplacingProcessor.OBSOLETE, "false"));
+        assertTrue(migratedFalse.isPresent());
+        assertEquals(ReplacingProcessor.NONE, migratedFalse.get().get(ReplacingProcessor.REPLACEMENT));
+
+        final Optional<Map<String, String>> alreadyMigrated = PropertyMigrationPreview.preview(
+                processor, null, "id", "test", Function.identity(), Map.of(ReplacingProcessor.REPLACEMENT, ReplacingProcessor.VALIDATE));
+        assertTrue(alreadyMigrated.isEmpty());
+    }
+
+    @Test
+    public void testPreviewReturnsEmptyWhenComponentIsNull() {
+        assertTrue(PropertyMigrationPreview.preview(null, null, "id", "test", Function.identity(), Map.of("a", "b")).isEmpty());
+    }
+
+    private static class ReplacingProcessor extends AbstractProcessor {
+        static final String OBSOLETE = "Validate Field Names";
+        static final String REPLACEMENT = "Validation Strategy";
+        static final String VALIDATE = "VALIDATE";
+        static final String NONE = "NONE";
+
+        @Override
+        public void onTrigger(final ProcessContext context, final ProcessSession session) {
+        }
+
+        @Override
+        protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+            return List.of(new PropertyDescriptor.Builder().name(REPLACEMENT).defaultValue(VALIDATE).build());
+        }
+
+        @Override
+        public void migrateProperties(final PropertyConfiguration config) {
+            if (config.hasProperty(OBSOLETE) && config.isPropertySet(OBSOLETE)) {
+                final boolean validate = Boolean.parseBoolean(config.getRawPropertyValue(OBSOLETE).orElse(Boolean.TRUE.toString()));
+                config.setProperty(REPLACEMENT, validate ? VALIDATE : NONE);
+            }
+            config.removeProperty(OBSOLETE);
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
@@ -36,6 +36,8 @@ import org.apache.nifi.flow.VersionedProcessor;
 import org.apache.nifi.flow.VersionedPropertyDescriptor;
 import org.apache.nifi.flow.VersionedRemoteGroupPort;
 import org.apache.nifi.groups.ProcessGroup;
+import org.apache.nifi.migration.PropertyConfiguration;
+import org.apache.nifi.migration.PropertyMigrationPreview;
 import org.apache.nifi.migration.StandardControllerServiceFactory;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
@@ -56,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -291,6 +294,149 @@ public class TestFlowDifferenceFilters {
                 null,
                 "Dynamic property parameterization removed");
         assertFalse(FlowDifferenceFilters.isStaticPropertyRemoved(parameterizationRemovedDifference, flowManager));
+    }
+
+    @Test
+    public void testIsStaticPropertyRemovedWhenSnapshotDescriptorIsNonDynamicOnDynamicComponent() {
+        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final ProcessorNode processorNode = Mockito.mock(ProcessorNode.class);
+
+        final String propertyName = "Validate Field Names";
+        final String instanceId = "processor-instance";
+
+        Mockito.when(flowManager.getProcessorNode(instanceId)).thenReturn(processorNode);
+        Mockito.when(processorNode.getComponent()).thenReturn(new DynamicAnnotationProcessor());
+
+        final VersionedPropertyDescriptor snapshotDescriptor = new VersionedPropertyDescriptor();
+        snapshotDescriptor.setName(propertyName);
+        snapshotDescriptor.setDisplayName(propertyName);
+        snapshotDescriptor.setDynamic(false);
+
+        final VersionedProcessor registryProcessor = new VersionedProcessor();
+        registryProcessor.setPropertyDescriptors(Map.of(propertyName, snapshotDescriptor));
+        registryProcessor.setProperties(Map.of(propertyName, "true"));
+
+        final InstantiatedVersionedProcessor localProcessor = new InstantiatedVersionedProcessor(instanceId, "group-id");
+        final FlowDifference difference = new StandardFlowDifference(
+                DifferenceType.PROPERTY_REMOVED,
+                registryProcessor,
+                localProcessor,
+                propertyName,
+                "true",
+                null,
+                "Static property removed after upgrade");
+
+        assertTrue(FlowDifferenceFilters.isStaticPropertyRemoved(difference, flowManager));
+        assertTrue(FlowDifferenceFilters.isEnvironmentalChange(difference, null, flowManager));
+    }
+
+    @Test
+    public void testIsStaticPropertyRemovedWhenSnapshotDescriptorIsDynamicOnDynamicComponent() {
+        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final ProcessorNode processorNode = Mockito.mock(ProcessorNode.class);
+
+        final String propertyName = "user-schema";
+        final String instanceId = "processor-instance";
+
+        Mockito.when(flowManager.getProcessorNode(instanceId)).thenReturn(processorNode);
+        Mockito.when(processorNode.getComponent()).thenReturn(new DynamicAnnotationProcessor());
+
+        final VersionedPropertyDescriptor snapshotDescriptor = new VersionedPropertyDescriptor();
+        snapshotDescriptor.setName(propertyName);
+        snapshotDescriptor.setDisplayName(propertyName);
+        snapshotDescriptor.setDynamic(true);
+
+        final VersionedProcessor registryProcessor = new VersionedProcessor();
+        registryProcessor.setPropertyDescriptors(Map.of(propertyName, snapshotDescriptor));
+        registryProcessor.setProperties(Map.of(propertyName, "{\"type\":\"record\"}"));
+
+        final InstantiatedVersionedProcessor localProcessor = new InstantiatedVersionedProcessor(instanceId, "group-id");
+        final FlowDifference difference = new StandardFlowDifference(
+                DifferenceType.PROPERTY_REMOVED,
+                registryProcessor,
+                localProcessor,
+                propertyName,
+                "{\"type\":\"record\"}",
+                null,
+                "User-removed dynamic property");
+
+        assertFalse(FlowDifferenceFilters.isStaticPropertyRemoved(difference, flowManager));
+        assertFalse(FlowDifferenceFilters.isEnvironmentalChange(difference, null, flowManager));
+    }
+
+    @Test
+    public void testBooleanToEnumReplacementWithDefaultValueIsEnvironmentalChange() {
+        assertBooleanToEnumReplacement("true", MigratingDynamicProcessor.VALIDATE, true);
+    }
+
+    @Test
+    public void testBooleanToEnumReplacementWithNonDefaultValueIsEnvironmentalChange() {
+        assertBooleanToEnumReplacement("false", MigratingDynamicProcessor.NONE, true);
+    }
+
+    @Test
+    public void testUserEditOfMigratedReplacementIsNotEnvironmentalChange() {
+        assertBooleanToEnumReplacement("true", MigratingDynamicProcessor.NONE, false);
+    }
+
+    private void assertBooleanToEnumReplacement(final String obsoleteValue, final String localStrategy, final boolean addedIsEnvironmental) {
+        final FlowManager flowManager = Mockito.mock(FlowManager.class);
+        final ProcessorNode processorNode = Mockito.mock(ProcessorNode.class);
+        final MigratingDynamicProcessor migratingProcessor = new MigratingDynamicProcessor();
+
+        final String instanceId = "processor-instance";
+        final String groupId = "group-id";
+        final String versionedId = "versioned-id";
+
+        Mockito.when(flowManager.getProcessorNode(instanceId)).thenReturn(processorNode);
+        Mockito.when(processorNode.getComponent()).thenReturn(migratingProcessor);
+        Mockito.when(processorNode.getPropertyDescriptor(MigratingDynamicProcessor.NEW_PROPERTY)).thenReturn(migratingProcessor.getPropertyDescriptor(MigratingDynamicProcessor.NEW_PROPERTY));
+        Mockito.when(processorNode.previewMigratedProperties(Mockito.any())).thenAnswer(invocation ->
+                PropertyMigrationPreview.preview(migratingProcessor, null, instanceId, "test", Function.identity(), invocation.getArgument(0)));
+
+        final VersionedPropertyDescriptor obsoleteDescriptor = new VersionedPropertyDescriptor();
+        obsoleteDescriptor.setName(MigratingDynamicProcessor.OBSOLETE_PROPERTY);
+        obsoleteDescriptor.setDisplayName(MigratingDynamicProcessor.OBSOLETE_PROPERTY);
+        obsoleteDescriptor.setDynamic(false);
+
+        final VersionedProcessor registryProcessor = new VersionedProcessor();
+        registryProcessor.setComponentType(ComponentType.PROCESSOR);
+        registryProcessor.setIdentifier(versionedId);
+        registryProcessor.setProperties(Map.of(MigratingDynamicProcessor.OBSOLETE_PROPERTY, obsoleteValue));
+        registryProcessor.setPropertyDescriptors(Map.of(MigratingDynamicProcessor.OBSOLETE_PROPERTY, obsoleteDescriptor));
+
+        final InstantiatedVersionedProcessor localProcessor = new InstantiatedVersionedProcessor(instanceId, groupId);
+        localProcessor.setComponentType(ComponentType.PROCESSOR);
+        localProcessor.setIdentifier(versionedId);
+        localProcessor.setProperties(Map.of(MigratingDynamicProcessor.NEW_PROPERTY, localStrategy));
+
+        final FlowDifference propertyRemoved = new StandardFlowDifference(
+                DifferenceType.PROPERTY_REMOVED,
+                registryProcessor,
+                localProcessor,
+                MigratingDynamicProcessor.OBSOLETE_PROPERTY,
+                obsoleteValue,
+                null,
+                "Obsolete property removed");
+
+        final FlowDifference propertyAdded = new StandardFlowDifference(
+                DifferenceType.PROPERTY_ADDED,
+                registryProcessor,
+                localProcessor,
+                MigratingDynamicProcessor.NEW_PROPERTY,
+                null,
+                localStrategy,
+                "Replacement property added");
+
+        final List<FlowDifference> differences = List.of(propertyRemoved, propertyAdded);
+        final FlowDifferenceFilters.EnvironmentalChangeContext context = FlowDifferenceFilters.buildEnvironmentalChangeContext(differences, flowManager);
+
+        assertTrue(FlowDifferenceFilters.isEnvironmentalChange(propertyRemoved, null, flowManager, context));
+        if (addedIsEnvironmental) {
+            assertTrue(FlowDifferenceFilters.isEnvironmentalChange(propertyAdded, null, flowManager, context));
+        } else {
+            assertFalse(FlowDifferenceFilters.isEnvironmentalChange(propertyAdded, null, flowManager, context));
+        }
     }
 
     @Test
@@ -1171,6 +1317,39 @@ public class TestFlowDifferenceFilters {
 
         // The dedicated predicate, on the other hand, excludes the public-port name change so opt-in callers can preserve the local name.
         assertFalse(FlowDifferenceFilters.FILTER_PUBLIC_PORT_NAME_CHANGES.test(nameChange));
+    }
+
+    @DynamicProperty(name = "Schema", value = "Avro schema", description = "Named schema")
+    private static class MigratingDynamicProcessor extends AbstractProcessor {
+        static final String OBSOLETE_PROPERTY = "Validate Field Names";
+        static final String NEW_PROPERTY = "Validation Strategy";
+        static final String VALIDATE = "VALIDATE";
+        static final String NONE = "NONE";
+
+        static final PropertyDescriptor VALIDATION_STRATEGY = new PropertyDescriptor.Builder()
+                .name(NEW_PROPERTY)
+                .defaultValue(VALIDATE)
+                .required(true)
+                .build();
+
+        @Override
+        public void onTrigger(final ProcessContext context, final ProcessSession session) {
+            // No-op for testing
+        }
+
+        @Override
+        protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+            return List.of(VALIDATION_STRATEGY);
+        }
+
+        @Override
+        public void migrateProperties(final PropertyConfiguration config) {
+            if (config.hasProperty(OBSOLETE_PROPERTY) && config.isPropertySet(OBSOLETE_PROPERTY)) {
+                final boolean validate = Boolean.parseBoolean(config.getRawPropertyValue(OBSOLETE_PROPERTY).orElse(Boolean.TRUE.toString()));
+                config.setProperty(NEW_PROPERTY, validate ? VALIDATE : NONE);
+            }
+            config.removeProperty(OBSOLETE_PROPERTY);
+        }
     }
 
     @DynamicProperty(name = "Dynamic Property", value = "Value", description = "Allows dynamic properties")

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ComponentNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ComponentNode.java
@@ -151,6 +151,18 @@ public interface ComponentNode extends ComponentAuthorizable {
 
     ConfigurableComponent getComponent();
 
+    /**
+     * Returns the property map that {@code migrateProperties} would produce for the given original values, without
+     * mutating this component. An empty result means the component's migration is a no-op, the preview could not be
+     * computed, or the component type does not support property migration preview.
+     *
+     * @param originalPropertyValues the property values from the versioned snapshot
+     * @return the migrated properties when migration would change the configuration; otherwise empty
+     */
+    default Optional<Map<String, String>> previewMigratedProperties(Map<String, String> originalPropertyValues) {
+        return Optional.empty();
+    }
+
     TerminationAwareLogger getLogger();
 
     boolean isExtensionMissing();


### PR DESCRIPTION
# Summary

This addresses [NIFI-15694](https://issues.apache.org/jira/browse/NIFI-15694): after a NiFi upgrade, property migrations on processors/controller services are reported as **local modifications** on version-controlled process groups. That blocks Change Version / Git deploy, and Revert does not stick because `migrateProperties` is applied again.

## Use case

A customer is upgrading **NiFi 2.9.0 → 2.11.0** with process groups tracked in Git.

`AvroSchemaRegistry` (NIFI-15960) replaced:

| 2.9 | 2.11 |
| --- | --- |
| `Validate Field Names` / `avro-reg-validated-field-names` = `true` / `false` | `Validation Strategy` = `VALIDATE` / `NONE` |

On startup / flow sync, `migrateProperties()` rewrites the live flow and `flow.json`. The Git (or Registry) snapshot for the currently tracked version still has the old property. `getModifications()` then reports:

- `PROPERTY_REMOVED` `Validate Field Names`
- `PROPERTY_ADDED` `Validation Strategy`

The group becomes `LOCALLY_MODIFIED` (or `LOCALLY_MODIFIED_AND_STALE` if Git also has newer commits). **Change Version is refused** because the group is dirty.

**Revert** applies the Git snapshot (old property), then `StandardVersionedComponentSynchronizer` re-runs `migrateProperties` on the updated component so it remains valid. The new property comes back and the group is still dirty. Revert looks successful in the UI, then the local change reappears.

This is the same general failure mode described on NIFI-15694 (also seen with e.g. ConsumeAzureEventHub `Authentication Strategy`). `AvroSchemaRegistry` is an especially sharp instance because it is `@DynamicProperty` (named schemas): `isStaticPropertyRemoved` previously refused to treat the dropped **static** property as environmental, so it looked like a user-deleted dynamic property.

Re-running migration after loading Git content is correct. The bug is classifying those diffs as user edits.

## Changes

No change to `AvroSchemaRegistry.migrateProperties` itself.

1. **`isStaticPropertyRemoved`**  
   If the versioned snapshot recorded the removed property as **non-dynamic**, treat it as a dropped static property even when the live component supports dynamic properties. User-deleted schemas (`dynamic=true`) remain local changes.

2. **Dry-run `migrateProperties`**  
   `ComponentNode.previewMigratedProperties()` (implemented for processors and controller services via `PropertyMigrationPreview`) runs `migrateProperties` on a copy of the snapshot properties. It does not persist and does not create controller services (NAR classloader is used in production).  
   `FlowDifferenceFilters.buildEnvironmentalChangeContext` marks a property diff environmental only when that dry-run **explains** it **and** the local value equals the migrated value:
   - `true` → `VALIDATE` and `false` → `NONE` are both environmental
   - a later user edit of the new property (dry-run `VALIDATE`, local `NONE`) stays a local change (NIFI-15863 preserved more accurately)

3. **Tests** in `TestFlowDifferenceFilters` and `TestPropertyMigrationPreview` covering snapshot-static removal on a `@DynamicProperty` component, user-removed dynamic properties, both boolean→enum mappings, and post-migration user edits.

## Customer workarounds (until this is released)

Revert cannot clear the dirty state on an upgraded node.

1. **After this change:** upgrade every stage, then Change Version / deploy from Git. Committing the property rename first is not required for deploy to work.
2. **Today, if every stage is already on 2.11:** commit the migrated flow from one environment so Git contains `Validation Strategy`, then on the other environments **stop version control and start it again** from that commit (or rewrite the stored version identifier as described on the Jira). Revert will not help.
3. **Do not** commit the migrated properties from 2.11 and deploy that commit onto a node still on 2.9: `Validation Strategy` would be stored as a **dynamic schema** on 2.9 `AvroSchemaRegistry`.

# Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-15694) issue created
- [x] Pull Request title starts with Apache NiFi Jira issue number
- [x] Pull Request commit message starts with Apache NiFi Jira issue number

# Verification

- [x] `./mvnw -pl nifi-framework-bundle/nifi-framework/nifi-framework-components -am test -Dtest=TestFlowDifferenceFilters,TestPropertyMigrationPreview -Dsurefire.failIfNoSpecifiedTests=false`
- [ ] Full `contrib-check` not run on this draft (happy to run if reviewers want it)

# Review

This is a **draft** — I would very much appreciate a code review on the approach before we treat it as ready to merge.

In particular I would like feedback on:

- Using a dry-run of `migrateProperties` as the source of truth vs. more value-matching heuristics
- The snapshot `dynamic=false` exemption in `isStaticPropertyRemoved` for `@DynamicProperty` components
- Whether `previewMigratedProperties` belongs on `ComponentNode` (default no-op) with processor/CS overrides

Thank you in advance for taking a look.