### PR TITLE
NIFI-16318 Preserve existing Parameter Contexts on registry import

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -2423,14 +2423,16 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
             return;
         }
 
+        // NIFI-16318: Never overwrite existing local parameter values or materialize local overrides for inherited parameters.
+        // Description-only updates apply to locally defined parameters and must be built from the local raw parameter
+        // so that parameter references (e.g. #{other}) are preserved and not flattened to literal resolved values.
         final Map<String, Parameter> parameters = new HashMap<>();
         for (final VersionedParameter versionedParameter : versionedParameterContext.getParameters()) {
-            final Optional<Parameter> parameterOption = currentParameterContext.getParameter(versionedParameter.getName());
-            if (parameterOption.isPresent()) {
-                final Parameter existingParameter = parameterOption.get();
-                if (!Objects.equals(existingParameter.getDescriptor().getDescription(), versionedParameter.getDescription())) {
+            final Parameter localParameter = currentParameterContext.getParameters().get(parameterDescriptor(versionedParameter.getName()));
+            if (localParameter != null) {
+                if (!Objects.equals(localParameter.getDescriptor().getDescription(), versionedParameter.getDescription())) {
                     final Parameter updatedParameter = new Parameter.Builder()
-                        .fromParameter(existingParameter)
+                        .fromParameter(localParameter)
                         .description(versionedParameter.getDescription())
                         .build();
                     parameters.put(versionedParameter.getName(), updatedParameter);
@@ -2438,11 +2440,20 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                 continue;
             }
 
+            final Parameter inheritedParameter = currentParameterContext.getRawEffectiveParameters().get(parameterDescriptor(versionedParameter.getName()));
+            if (inheritedParameter != null) {
+                // The parameter is provided by inheritance. Do not materialize a local override from the snapshot,
+                // which would shadow the inherited value with the registry value.
+                continue;
+            }
+
             final Parameter parameter = createParameter(currentParameterContext.getIdentifier(), versionedParameter, versionedParameterContext.getParameterProvider() != null);
             parameters.put(versionedParameter.getName(), parameter);
         }
 
-        currentParameterContext.setParameters(parameters);
+        if (!parameters.isEmpty()) {
+            currentParameterContext.setParameters(parameters);
+        }
 
         if (!Objects.equals(currentParameterContext.getDescription(), versionedParameterContext.getDescription())) {
             currentParameterContext.setDescription(versionedParameterContext.getDescription());
@@ -2486,6 +2497,10 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
             createMissingParameterProvider(versionedParameterContext, versionedParameterContext.getParameterProvider(), parameterProviderReferences, componentIdGenerator);
             currentParameterContext.configureParameterProvider(getParameterProviderConfiguration(versionedParameterContext));
         }
+    }
+
+    private static ParameterDescriptor parameterDescriptor(final String name) {
+        return new ParameterDescriptor.Builder().name(name).build();
     }
 
     private Parameter createParameter(final String contextId, final VersionedParameter versionedParameter, final boolean providerBacked) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizerTest.java
@@ -1919,6 +1919,167 @@ public class StandardVersionedComponentSynchronizerTest {
     }
 
     @Test
+    public void testExistingLocalParameterValuePreservedWhenDescriptionUpdated() throws FlowSynchronizationException, InterruptedException, TimeoutException {
+        final VersionedParameterContext versionedContext = createVersionedParameterContextWithDescriptions(CONTEXT_NAME_PARAMS,
+            SINGLE_PARAMETER, ORIGINAL_DESCRIPTION_MAP, Collections.emptySet());
+        synchronizer.synchronize(null, versionedContext, synchronizationOptions);
+
+        final ParameterContext paramContext = parameterContextManager.getParameterContextNameMapping().get(CONTEXT_NAME_PARAMS);
+        assertEquals(VALUE_XYZ, paramContext.getParameter(PARAM_ABC).get().getValue());
+        assertEquals(ORIGINAL_PARAMETER_DESCRIPTION, paramContext.getParameter(PARAM_ABC).get().getDescriptor().getDescription());
+
+        final ProcessGroup processGroup = createMockProcessGroup();
+        when(processGroup.getParameterContext()).thenReturn(paramContext);
+
+        final VersionedParameterContext proposedParams = createVersionedParameterContextWithDescriptions(CONTEXT_NAME_PARAMS,
+            Map.of(PARAM_ABC, VALUE_123), UPDATED_DESCRIPTION_MAP, Collections.emptySet());
+        proposedParams.setDescription(UPDATED_CONTEXT_DESCRIPTION);
+
+        final VersionedProcessGroup rootGroup = new VersionedProcessGroup();
+        rootGroup.setIdentifier(processGroup.getIdentifier());
+        rootGroup.setParameterContextName(CONTEXT_NAME_PARAMS);
+
+        final VersionedExternalFlow externalFlow = new VersionedExternalFlow();
+        externalFlow.setFlowContents(rootGroup);
+        externalFlow.setParameterContexts(Map.of(CONTEXT_NAME_PARAMS, proposedParams));
+
+        synchronizer.synchronize(processGroup, externalFlow, synchronizationOptions);
+
+        assertEquals(VALUE_XYZ, paramContext.getParameter(PARAM_ABC).get().getValue(),
+            "Existing parameter value must not be overwritten by versioned flow value");
+        assertEquals(UPDATED_DESCRIPTION_MAP.get(PARAM_ABC), paramContext.getParameter(PARAM_ABC).get().getDescriptor().getDescription(),
+            "Parameter description should be updated from versioned flow");
+        assertEquals(UPDATED_CONTEXT_DESCRIPTION, paramContext.getDescription(),
+            "Parameter context description should be updated from versioned flow");
+    }
+
+    @Test
+    public void testInheritedParameterNotMaterializedAsLocalOverrideWhenDescriptionDiffers()
+            throws FlowSynchronizationException, InterruptedException, TimeoutException {
+        final VersionedParameterContext versionedParent = createVersionedParameterContextWithDescriptions("P2",
+            Map.of("paramA", "prod-value"), Map.of("paramA", "parent-description"), Collections.emptySet());
+        synchronizer.synchronize(null, versionedParent, synchronizationOptions);
+        final ParameterContext parent = parameterContextManager.getParameterContextNameMapping().get("P2");
+
+        final VersionedParameterContext versionedChild = createVersionedParameterContext("P1", Map.of("paramOwn", "ownValue"), Collections.emptySet());
+        synchronizer.synchronize(null, versionedChild, synchronizationOptions);
+        final ParameterContext child = parameterContextManager.getParameterContextNameMapping().get("P1");
+        child.setInheritedParameterContexts(List.of(parent));
+
+        assertFalse(child.getParameters().containsKey(new ParameterDescriptor.Builder().name("paramA").build()),
+            "paramA should be inherited, not local, before sync");
+        assertEquals("prod-value", child.getParameter("paramA").get().getValue());
+        assertEquals("parent-description", child.getParameter("paramA").get().getDescriptor().getDescription());
+
+        final ProcessGroup processGroup = createMockProcessGroup();
+        when(processGroup.getParameterContext()).thenReturn(child);
+
+        // Versioned flow has child and parent contexts, with paramA having a dev value and a different description
+        final VersionedParameterContext proposedParent = createVersionedParameterContextWithDescriptions("P2",
+            Map.of("paramA", "dev-value"), Map.of("paramA", "dev-description"), Collections.emptySet());
+        final VersionedParameterContext proposedChild = createVersionedParameterContextWithDescriptions("P1",
+            Map.of("paramOwn", "ownValue", "paramA", "dev-value"), Map.of("paramA", "dev-description"), Collections.emptySet());
+        proposedChild.setInheritedParameterContexts(List.of("P2"));
+
+        final VersionedProcessGroup rootGroup = new VersionedProcessGroup();
+        rootGroup.setIdentifier(processGroup.getIdentifier());
+        rootGroup.setParameterContextName("P1");
+
+        final VersionedExternalFlow externalFlow = new VersionedExternalFlow();
+        externalFlow.setFlowContents(rootGroup);
+        externalFlow.setParameterContexts(Map.of("P1", proposedChild, "P2", proposedParent));
+
+        synchronizer.synchronize(processGroup, externalFlow, synchronizationOptions);
+
+        assertFalse(child.getParameters().containsKey(new ParameterDescriptor.Builder().name("paramA").build()),
+            "Synchronization must not create a local override on child for an inherited parameter even when descriptions differ");
+        assertEquals("prod-value", child.getParameter("paramA").get().getValue());
+        assertEquals("prod-value", parent.getParameter("paramA").get().getValue(),
+            "Synchronization must not overwrite the inherited parameter's value on the parent context");
+        assertEquals("dev-description", parent.getParameter("paramA").get().getDescriptor().getDescription(),
+            "Parent context parameter description should be updated");
+    }
+
+    @Test
+    public void testParameterReferencePreservedWhenDescriptionUpdated()
+            throws FlowSynchronizationException, InterruptedException, TimeoutException {
+        // Parent context defines targetParam
+        final VersionedParameterContext versionedParent = createVersionedParameterContext("ParentContext",
+            Map.of("targetParam", "targetValue"), Collections.emptySet());
+        synchronizer.synchronize(null, versionedParent, synchronizationOptions);
+        final ParameterContext parentContext = parameterContextManager.getParameterContextNameMapping().get("ParentContext");
+
+        // Child context inherits ParentContext and defines aliasParam referencing #{targetParam}
+        final VersionedParameterContext versionedChild = createVersionedParameterContextWithDescriptions("ChildContext",
+            Map.of("aliasParam", "#{targetParam}"),
+            Map.of("aliasParam", "old alias description"),
+            Collections.emptySet());
+        synchronizer.synchronize(null, versionedChild, synchronizationOptions);
+        final ParameterContext childContext = parameterContextManager.getParameterContextNameMapping().get("ChildContext");
+        childContext.setInheritedParameterContexts(List.of(parentContext));
+
+        // Effective value resolves to targetValue, but raw local value is #{targetParam}
+        assertEquals("targetValue", childContext.getParameter("aliasParam").get().getValue());
+        assertEquals("#{targetParam}", childContext.getParameters().get(new ParameterDescriptor.Builder().name("aliasParam").build()).getValue());
+
+        final ProcessGroup processGroup = createMockProcessGroup();
+        when(processGroup.getParameterContext()).thenReturn(childContext);
+
+        // Versioned flow has aliasParam with a new description and literal value
+        final VersionedParameterContext proposedChild = createVersionedParameterContextWithDescriptions("ChildContext",
+            Map.of("aliasParam", "devLiteral"),
+            Map.of("aliasParam", "new alias description"),
+            Collections.emptySet());
+        proposedChild.setInheritedParameterContexts(List.of("ParentContext"));
+
+        final VersionedProcessGroup rootGroup = new VersionedProcessGroup();
+        rootGroup.setIdentifier(processGroup.getIdentifier());
+        rootGroup.setParameterContextName("ChildContext");
+
+        final VersionedExternalFlow externalFlow = new VersionedExternalFlow();
+        externalFlow.setFlowContents(rootGroup);
+        externalFlow.setParameterContexts(Map.of("ChildContext", proposedChild, "ParentContext", versionedParent));
+
+        synchronizer.synchronize(processGroup, externalFlow, synchronizationOptions);
+
+        assertEquals("new alias description", childContext.getParameter("aliasParam").get().getDescriptor().getDescription(),
+            "Parameter description should be updated from versioned flow");
+        assertEquals("#{targetParam}", childContext.getParameters().get(new ParameterDescriptor.Builder().name("aliasParam").build()).getValue(),
+            "Raw parameter value must preserve the '#{targetParam}' reference syntax and not flatten to a resolved literal");
+        assertEquals("targetValue", childContext.getParameter("aliasParam").get().getValue(),
+            "Effective parameter value must still resolve through the reference");
+    }
+
+    @Test
+    public void testMissingParameterStillAddedWhenPreserveExistingEntries() throws FlowSynchronizationException, InterruptedException, TimeoutException {
+        final VersionedParameterContext versionedContext = createVersionedParameterContext(CONTEXT_NAME_PARAMS, SINGLE_PARAMETER, Collections.emptySet());
+        synchronizer.synchronize(null, versionedContext, synchronizationOptions);
+
+        final ParameterContext paramContext = parameterContextManager.getParameterContextNameMapping().get(CONTEXT_NAME_PARAMS);
+
+        final ProcessGroup processGroup = createMockProcessGroup();
+        when(processGroup.getParameterContext()).thenReturn(paramContext);
+
+        final VersionedParameterContext proposedParams = createVersionedParameterContext(CONTEXT_NAME_PARAMS,
+            Map.of(PARAM_ABC, VALUE_123, "paramNew", "new-value"), Collections.emptySet());
+
+        final VersionedProcessGroup rootGroup = new VersionedProcessGroup();
+        rootGroup.setIdentifier(processGroup.getIdentifier());
+        rootGroup.setParameterContextName(CONTEXT_NAME_PARAMS);
+
+        final VersionedExternalFlow externalFlow = new VersionedExternalFlow();
+        externalFlow.setFlowContents(rootGroup);
+        externalFlow.setParameterContexts(Map.of(CONTEXT_NAME_PARAMS, proposedParams));
+
+        synchronizer.synchronize(processGroup, externalFlow, synchronizationOptions);
+
+        assertEquals(VALUE_XYZ, paramContext.getParameter(PARAM_ABC).get().getValue(),
+            "Existing parameter value must be preserved");
+        assertTrue(paramContext.getParameter("paramNew").isPresent(), "Missing parameters should still be added");
+        assertEquals("new-value", paramContext.getParameter("paramNew").get().getValue());
+    }
+
+    @Test
     public void testParameterDescriptionUnchangedWhenValueSame() throws FlowSynchronizationException, InterruptedException, TimeoutException {
         final VersionedParameterContext versionedContext = createVersionedParameterContextWithDescriptions(CONTEXT_NAME_1,
             SINGLE_PARAMETER, ORIGINAL_DESCRIPTION_MAP, Collections.emptySet());

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/import-from-registry/import-from-registry.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/import-from-registry/import-from-registry.component.html
@@ -106,7 +106,7 @@
                             class="fa fa-info-circle primary-color"
                             nifiTooltip
                             [tooltipComponentType]="TextTip"
-                            tooltipInputData="When not selected, only directly associated Parameter Contexts will be copied, inherited Contexts with no direct assignment to a Process Group are ignored."></i>
+                            tooltipInputData="When selected, Process Groups bind to existing Parameter Contexts with the same name. Existing parameter values and inheritance are left unchanged; only parameters that do not already exist (locally or via inheritance) are added. When not selected, only directly associated Parameter Contexts will be copied; inherited Contexts with no direct assignment to a Process Group are ignored."></i>
                     </mat-checkbox>
                 </div>
                 <div class="flex flex-col mb-5">

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/ParameterContextPreservationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/ParameterContextPreservationIT.java
@@ -549,6 +549,110 @@ class ParameterContextPreservationIT extends NiFiSystemIT {
         return getNifiClient().getProcessGroupClient().createProcessGroup("root", groupEntity, true);
     }
 
+    /**
+     * NIFI-16318: Importing a versioned flow with KEEP_EXISTING must not overwrite existing parameter values,
+     * even when a Controller Service in another process group references the parameter and is ENABLED.
+     */
+    @Test
+    void testKeepExistingImportDoesNotOverwriteParameterReferencedByEnabledService() throws NiFiClientException, IOException, InterruptedException {
+        final FlowRegistryClientEntity clientEntity = registerClient();
+        final NiFiClientUtil util = getClientUtil();
+
+        final String contextName = "SharedKeepExistingParams";
+        final String registryValue = "dev-driver";
+        final String liveValue = "prod-driver";
+
+        final ParameterContextEntity sourceContext = util.createParameterContext(contextName, Map.of(PARAMETER_NAME, registryValue, COUNT_PARAMETER_NAME, COUNT_PARAMETER_VALUE));
+        final ProcessGroupEntity sourceGroup = util.createProcessGroup("KeepExistingSource", "root");
+        util.setParameterContext(sourceGroup.getId(), sourceContext);
+
+        final ProcessorEntity sourceProcessor = util.createProcessor(PROCESSOR_TYPE, sourceGroup.getId());
+        util.updateProcessorProperties(sourceProcessor, Collections.singletonMap(PROCESSOR_PROPERTY_TEXT, PARAMETER_REFERENCE));
+        util.setAutoTerminatedRelationships(sourceProcessor, RELATIONSHIP_SUCCESS);
+
+        final VersionControlInformationEntity vci = util.startVersionControl(sourceGroup, clientEntity, TEST_FLOWS_BUCKET, "KeepExistingValueFlow");
+        final String flowId = vci.getVersionControlInformation().getFlowId();
+
+        final ProcessGroupEntity sourceForStopVc = getNifiClient().getProcessGroupClient().getProcessGroup(sourceGroup.getId());
+        getNifiClient().getVersionsClient().stopVersionControl(sourceForStopVc);
+        util.deleteAll(sourceGroup.getId());
+        final ProcessGroupEntity sourceToDelete = getNifiClient().getProcessGroupClient().getProcessGroup(sourceGroup.getId());
+        getNifiClient().getProcessGroupClient().deleteProcessGroup(sourceToDelete);
+
+        final ParameterContextEntity currentContext = getNifiClient().getParamContextClient().getParamContext(sourceContext.getId(), false);
+        final ParameterContextUpdateRequestEntity valueUpdate = util.updateParameterContext(currentContext,
+                Map.of(PARAMETER_NAME, liveValue, COUNT_PARAMETER_NAME, COUNT_PARAMETER_VALUE));
+        util.waitForParameterContextRequestToComplete(sourceContext.getId(), valueUpdate.getRequest().getRequestId());
+
+        final ProcessGroupEntity runningGroup = util.createProcessGroup("KeepExistingRunning", "root");
+        util.setParameterContext(runningGroup.getId(), sourceContext);
+
+        final ControllerServiceEntity runningService = util.createControllerService(COUNT_SERVICE_TYPE, runningGroup.getId());
+        util.updateControllerServiceProperties(runningService, Map.of(COUNT_SERVICE_START_VALUE_PROPERTY, COUNT_PARAMETER_REFERENCE));
+        final ControllerServiceEntity runningServiceForEnable = getNifiClient().getControllerServicesClient().getControllerService(runningService.getId());
+        util.enableControllerService(runningServiceForEnable);
+        util.waitForControllerServicesEnabled(runningGroup.getId(), List.of(runningService.getId()));
+
+        importFlowWithKeepExisting(clientEntity.getId(), flowId, VERSION_1);
+
+        final ParameterContextEntity contextAfterImport = getNifiClient().getParamContextClient().getParamContext(sourceContext.getId(), false);
+        assertEquals(liveValue, getParameterValue(contextAfterImport, PARAMETER_NAME),
+                "KEEP_EXISTING import must not overwrite existing parameter values with registry values");
+        assertEquals(COUNT_PARAMETER_VALUE, getParameterValue(contextAfterImport, COUNT_PARAMETER_NAME));
+
+        final ControllerServiceEntity serviceAfterImport = getNifiClient().getControllerServicesClient().getControllerService(runningService.getId());
+        assertEquals(CONTROLLER_SERVICE_STATE_ENABLED, serviceAfterImport.getComponent().getState(),
+                "Referencing Controller Service must remain ENABLED after KEEP_EXISTING import");
+    }
+
+    /**
+     * NIFI-16318: When a snapshot parameter exists only via inheritance on the target, KEEP_EXISTING import must
+     * not create a local override (which would replace the inherited production value with the registry value).
+     */
+    @Test
+    void testKeepExistingImportDoesNotOverrideInheritedParameter() throws NiFiClientException, IOException, InterruptedException {
+        final FlowRegistryClientEntity clientEntity = registerClient();
+        final NiFiClientUtil util = getClientUtil();
+
+        final String parentName = "KeepExistingRootParams";
+        final String childName = "KeepExistingChildParams";
+        final String registryValue = "dev-driver";
+        final String liveValue = "prod-driver";
+
+        final ParameterContextEntity parentContext = util.createParameterContext(parentName, Map.of(PARAMETER_NAME, registryValue));
+        final ParameterContextEntity childContext = util.createParameterContext(childName, Map.of("ownParam", "ownValue"), List.of(parentContext.getId()), null);
+
+        final ProcessGroupEntity sourceGroup = util.createProcessGroup("KeepExistingInheritedSource", "root");
+        util.setParameterContext(sourceGroup.getId(), childContext);
+
+        final ProcessorEntity sourceProcessor = util.createProcessor(PROCESSOR_TYPE, sourceGroup.getId());
+        util.updateProcessorProperties(sourceProcessor, Collections.singletonMap(PROCESSOR_PROPERTY_TEXT, PARAMETER_REFERENCE));
+        util.setAutoTerminatedRelationships(sourceProcessor, RELATIONSHIP_SUCCESS);
+
+        final VersionControlInformationEntity vci = util.startVersionControl(sourceGroup, clientEntity, TEST_FLOWS_BUCKET, "KeepExistingInheritedFlow");
+        final String flowId = vci.getVersionControlInformation().getFlowId();
+
+        final ProcessGroupEntity sourceForStopVc = getNifiClient().getProcessGroupClient().getProcessGroup(sourceGroup.getId());
+        getNifiClient().getVersionsClient().stopVersionControl(sourceForStopVc);
+        util.deleteAll(sourceGroup.getId());
+        final ProcessGroupEntity sourceToDelete = getNifiClient().getProcessGroupClient().getProcessGroup(sourceGroup.getId());
+        getNifiClient().getProcessGroupClient().deleteProcessGroup(sourceToDelete);
+
+        final ParameterContextEntity currentParent = getNifiClient().getParamContextClient().getParamContext(parentContext.getId(), false);
+        final ParameterContextUpdateRequestEntity parentUpdate = util.updateParameterContext(currentParent, Map.of(PARAMETER_NAME, liveValue));
+        util.waitForParameterContextRequestToComplete(parentContext.getId(), parentUpdate.getRequest().getRequestId());
+
+        importFlowWithKeepExisting(clientEntity.getId(), flowId, VERSION_1);
+
+        final ParameterContextEntity parentAfterImport = getNifiClient().getParamContextClient().getParamContext(parentContext.getId(), false);
+        assertEquals(liveValue, getParameterValue(parentAfterImport, PARAMETER_NAME),
+                "KEEP_EXISTING import must not overwrite an inherited parameter on the parent context");
+
+        final ParameterContextEntity childAfterImport = getNifiClient().getParamContextClient().getParamContext(childContext.getId(), false);
+        assertFalse(getParameterNames(childAfterImport).contains(PARAMETER_NAME),
+                "KEEP_EXISTING import must not materialize a local override for an inherited parameter");
+    }
+
     private ProcessGroupEntity getNestedProcessGroup(final ProcessGroupEntity parent, final String name) throws NiFiClientException, IOException {
         final ProcessGroupFlowEntity flowEntity = getNifiClient().getFlowClient().getProcessGroup(parent.getId());
         final FlowDTO flowDto = flowEntity.getProcessGroupFlow().getFlow();


### PR DESCRIPTION
# Summary

[NIFI-16318](https://issues.apache.org/jira/browse/NIFI-16318)

When importing a versioned flow or upgrading flow versions with Parameter Contexts, `StandardVersionedComponentSynchronizer.addMissingConfiguration` previously used `currentParameterContext.getParameter()` to check for parameter existence. Because `getParameter()` returns the resolved effective parameter (resolving across inherited contexts and dereferencing parameter references `#{...}`):

1. For an inherited parameter whose description differed in the versioned flow, `addMissingConfiguration` constructed an update and called `setParameters()` on the child context. This materialized an unwanted local override on the child context, severing parent inheritance.
2. During `verifyCanSetParameters()`, because the parameter was inherited and not in the child's local map (`this.parameters`), it was treated as a runtime-affecting addition. If a referencing component (such as a Controller Service) was active (`ENABLED`), the import failed with an `IllegalStateException`.
3. For parameter references (`#{otherParam}`), using `getParameter()` returned the resolved literal string value. Updating the description with `fromParameter()` replaced the reference syntax with the literal string, destroying the alias reference.

## Root cause

`StandardVersionedComponentSynchronizer.addMissingConfiguration`:
1. Checked existence with `currentParameterContext.getParameter(name)` (effective) rather than checking local parameters (`getParameters()`) and inherited parameters (`getRawEffectiveParameters()`) separately.
2. Materialized local overrides on child contexts for inherited parameters when descriptions differed.
3. Dereferenced alias syntax (`#{...}`) into literal values during description updates.
4. Invoked `setParameters()` even when no additions or modifications were present.

## Fix

In `StandardVersionedComponentSynchronizer.addMissingConfiguration`:
- Check local parameters using `currentParameterContext.getParameters().get(...)` and build description updates using `fromParameter(localParameter)`. This preserves the raw local value and reference syntax (`#{otherParam}`).
- Check inherited parameters using `currentParameterContext.getRawEffectiveParameters().get(...)` and skip them (`continue;`). This prevents materializing local overrides on child contexts for inherited parameters, preserves parent inheritance, and avoids triggering component state verification on active referencing components.
- Continue adding parameters that are absent from the effective set.
- Only invoke `setParameters()` when `parameters` is non-empty.
- Updated the UI tooltip in `import-from-registry.component.html` to clarify that parameter values and inheritance chains are preserved.

# Tracking

- Apache NiFi Jira issue: NIFI-16318
- Pull Request title starts with NIFI-16318
- Pull Request commit message starts with NIFI-16318
- Single signed commit on a feature branch from current `main`

# Verification

- CheckStyle: `./mvnw -pl nifi-framework-bundle/nifi-framework/nifi-framework-components,nifi-system-tests/nifi-system-test-suite checkstyle:check`
- Unit tests: `StandardVersionedComponentSynchronizerTest` (all 60 tests passing, including tests for inherited parameters with diverging descriptions, and parameter reference `#{...}` preservation)
- System tests: `ParameterContextPreservationIT`