### PR TITLE
NIFI-16288 Allow Connectors to stop while components are starting or enabling

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -190,6 +190,16 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
     private final int hashCode;
     private volatile boolean hasActiveThreads = false;
 
+    // Tracks the callback for the current start so that a stop requested while the Processor is STARTING can cancel the
+    // start future even if the @OnScheduled method never returns. It is cleared with compareAndSet so that an abandoned
+    // start attempt cannot clear a callback belonging to a later start.
+    private final AtomicReference<SchedulingAgentCallback> activeStartCallback = new AtomicReference<>();
+    // Tracks the thread currently invoking @OnScheduled so that a stop can interrupt it.
+    private final AtomicReference<Thread> onScheduledThread = new AtomicReference<>();
+    // Tracks the Future for a scheduled start retry so that a stop can cancel a retry that is waiting between attempts,
+    // rather than leaving the Processor STARTING until the administrative yield elapses.
+    private final AtomicReference<Future<?>> scheduledStartRetry = new AtomicReference<>();
+
     private volatile int retryCount;
     private volatile Set<String> retriedRelationships;
     private volatile BackoffMechanism backoffMechanism;
@@ -1500,21 +1510,24 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
         final ComponentLog procLog = new StandardComponentLog(StandardProcessorNode.this.getIdentifier(), processor, new StandardLoggingContext(StandardProcessorNode.this));
         LOG.debug("Starting {}", this);
 
-        ScheduledState currentState;
-        boolean starting;
-        synchronized (this) {
-            currentState = this.scheduledState.get();
+        final ScheduledState currentState;
+        final boolean starting;
+        synchronized (onScheduledThread) {
+            synchronized (this) {
+                currentState = this.scheduledState.get();
 
-            if (currentState == ScheduledState.STOPPED) {
-                starting = this.scheduledState.compareAndSet(ScheduledState.STOPPED, scheduledState);
-                if (starting) {
+                if (currentState == ScheduledState.STOPPED) {
+                    starting = this.scheduledState.compareAndSet(ScheduledState.STOPPED, scheduledState);
+                    if (starting) {
+                        setDesiredState(desiredState);
+                        activeStartCallback.set(schedulingAgentCallback);
+                    }
+                } else if (currentState == ScheduledState.STOPPING && !failIfStopping) {
                     setDesiredState(desiredState);
+                    return;
+                } else {
+                    starting = false;
                 }
-            } else if (currentState == ScheduledState.STOPPING && !failIfStopping) {
-                setDesiredState(desiredState);
-                return;
-            } else {
-                starting = false;
             }
         }
 
@@ -1692,6 +1705,16 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
 
         // Create a task to invoke the @OnScheduled annotation of the processor
         final Callable<Void> startupTask = () -> {
+            // If a newer start has replaced the callback for this Processor, this attempt has been abandoned and must not
+            // invoke @OnScheduled, schedule another retry, or complete a stop, because a different start now owns the
+            // Processor's lifecycle. Treating a non-current callback as dead prevents an orphaned retry that was published
+            // just before a stop from interfering with a subsequent start whose physical state is again STARTING.
+            if (activeStartCallback.get() != schedulingAgentCallback) {
+                LOG.info("Abandoning start attempt of {} because a newer start now owns the Processor", StandardProcessorNode.this);
+                schedulingAgentCallback.onTaskComplete();
+                return null;
+            }
+
             final ScheduledState currentScheduleState = scheduledState.get();
             if (currentScheduleState == ScheduledState.STOPPING || currentScheduleState == ScheduledState.STOPPED || getDesiredState() == ScheduledState.STOPPED) {
                 LOG.info("Aborting start of {}: scheduledState={}, desiredState={}, validationStatus={}",
@@ -1725,11 +1748,8 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
                     LOG.debug("Cannot start {} because Processor is currently not valid; will try again after 500 ms", StandardProcessorNode.this);
                 }
 
-                // re-initiate the entire process
-                final Runnable initiateStartTask = () -> initiateStart(taskScheduler, administrativeYieldMillis, timeoutMillis, startupAttemptCount,
-                    processContextFactory, schedulingAgentCallback, triggerLifecycleMethods);
-
-                taskScheduler.schedule(initiateStartTask, 500, TimeUnit.MILLISECONDS);
+                // Re-initiate the entire process after a short delay while the Processor remains invalid.
+                scheduleStartRetry(taskScheduler, administrativeYieldMillis, timeoutMillis, startupAttemptCount, processContextFactory, schedulingAgentCallback, triggerLifecycleMethods, 500);
 
                 schedulingAgentCallback.onTaskComplete();
                 return null;
@@ -1742,9 +1762,36 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
 
             try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(getExtensionManager(), processor.getClass(), processor.getIdentifier())) {
                 try {
-                    hasActiveThreads = true;
-
                     if (triggerLifecycleMethods) {
+                        // Register the thread that is about to invoke @OnScheduled under the same lock that stop() uses to
+                        // transition STARTING to STOPPING. Rechecking the state here ensures that a stop which has already
+                        // transitioned the Processor to STOPPING is observed before @OnScheduled is invoked, so that either
+                        // the invocation is skipped or the registered thread is guaranteed to be interrupted by that stop.
+                        final boolean invokeOnScheduled;
+                        synchronized (onScheduledThread) {
+                            final ScheduledState stateBeforeInvocation = scheduledState.get();
+                            final boolean startCurrent = activeStartCallback.get() == schedulingAgentCallback && !schedulingAgentCallback.isStartTerminated();
+                            invokeOnScheduled = startCurrent && (stateBeforeInvocation == ScheduledState.STARTING || stateBeforeInvocation == ScheduledState.RUN_ONCE);
+                            if (invokeOnScheduled) {
+                                // Claim active threads together with registering the invoking thread, under the same lock a
+                                // stop uses. A stop that has already completed leaves the Processor STOPPED without any active
+                                // thread, so hasActiveThreads must only be set when this attempt actually commits to invoking
+                                // @OnScheduled while still STARTING.
+                                hasActiveThreads = true;
+                                onScheduledThread.set(Thread.currentThread());
+                            }
+                        }
+
+                        if (!invokeOnScheduled) {
+                            // A stop transitioned this Processor away from STARTING before @OnScheduled could be invoked. The
+                            // stop path completed the stop itself once it observed that no @OnScheduled thread was registered,
+                            // so this abandoned attempt must not claim a successful @OnScheduled, must not invoke @OnUnscheduled
+                            // or @OnStopped, and must not complete the stop again. hasActiveThreads was never set here, so the
+                            // Processor is left STOPPED with no active thread.
+                            LOG.info("Aborting start of {} because this start no longer owns a Processor in STARTING state; current state = {}", processor, scheduledState.get());
+                            return null;
+                        }
+
                         LOG.debug("Invoking @OnScheduled methods of {}", processor);
                         activateThread();
                         try {
@@ -1753,14 +1800,25 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
                             deactivateThread();
                         }
                     } else {
+                        hasActiveThreads = true;
                         LOG.debug("Will not invoke @OnScheduled methods of {} because triggerLifecycleMethods = false", processor);
                     }
 
-                    if (
-                        (desiredState == ScheduledState.RUNNING && scheduledState.compareAndSet(ScheduledState.STARTING, ScheduledState.RUNNING))
-                            || (desiredState == ScheduledState.RUN_ONCE && scheduledState.compareAndSet(ScheduledState.RUN_ONCE, ScheduledState.RUN_ONCE))
-                    ) {
+                    final boolean startTerminated;
+                    final boolean started;
+                    synchronized (onScheduledThread) {
+                        startTerminated = schedulingAgentCallback.isStartTerminated() || activeStartCallback.get() != schedulingAgentCallback;
+                        started = !startTerminated
+                            && ((desiredState == ScheduledState.RUNNING && scheduledState.compareAndSet(ScheduledState.STARTING, ScheduledState.RUNNING))
+                                || (desiredState == ScheduledState.RUN_ONCE && scheduledState.compareAndSet(ScheduledState.RUN_ONCE, ScheduledState.RUN_ONCE)));
+                        onScheduledThread.compareAndSet(Thread.currentThread(), null);
+                    }
+
+                    if (startTerminated) {
+                        LOG.info("Completed @OnScheduled methods of {} but this start's LifecycleState has been terminated, so a newer start owns the Processor", processor);
+                    } else if (started) {
                         LOG.debug("Successfully completed the @OnScheduled methods of {}; will now start triggering processor to run", processor);
+                        activeStartCallback.compareAndSet(schedulingAgentCallback, null);
                         schedulingAgentCallback.trigger(); // callback provided by StandardProcessScheduler to essentially initiate component's onTrigger() cycle
                     } else {
                         LOG.info("Successfully invoked @OnScheduled methods of {} but scheduled state is no longer STARTING so will stop processor now; current state = {}, desired state = {}",
@@ -1772,7 +1830,6 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
                             try {
                                 ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnUnscheduled.class, processor, processContext);
                                 ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnStopped.class, processor, processContext);
-                                hasActiveThreads = false;
                             } finally {
                                 deactivateThread();
                             }
@@ -1780,12 +1837,18 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
                             LOG.debug("Will not trigger @OnUnscheduled / @OnStopped methods on {} because triggerLifecycleMethods = false", processor);
                         }
 
-                        completeStopAction();
+                        synchronized (onScheduledThread) {
+                            if (!schedulingAgentCallback.isStartTerminated() && activeStartCallback.get() == schedulingAgentCallback) {
+                                hasActiveThreads = false;
+                                activeStartCallback.compareAndSet(schedulingAgentCallback, null);
+                                completeStopAction();
 
-                        if (desiredState == ScheduledState.DISABLED) {
-                            final boolean disabled = scheduledState.compareAndSet(ScheduledState.STOPPED, ScheduledState.DISABLED);
-                            if (disabled) {
-                                LOG.info("After stopping {}, determined that Desired State is DISABLED so disabled processor", processor);
+                                if (desiredState == ScheduledState.DISABLED) {
+                                    final boolean disabled = scheduledState.compareAndSet(ScheduledState.STOPPED, ScheduledState.DISABLED);
+                                    if (disabled) {
+                                        LOG.info("After stopping {}, determined that Desired State is DISABLED so disabled processor", processor);
+                                    }
+                                }
                             }
                         }
                     }
@@ -1794,8 +1857,15 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
                 }
             } catch (Exception e) {
                 final Throwable cause = (e instanceof InvocationTargetException) ? e.getCause() : e;
-                procLog.error("Failed to properly initialize Processor. If still scheduled to run, NiFi will attempt to "
-                    + "initialize and run the Processor again after the 'Administrative Yield Duration' has elapsed. Failure is due to " + cause, cause);
+                final boolean interruptedWhileStopping = cause instanceof InterruptedException
+                    && (scheduledState.get() != ScheduledState.STARTING || getDesiredState() == ScheduledState.STOPPED);
+                if (interruptedWhileStopping) {
+                    Thread.interrupted();
+                    LOG.debug("@OnScheduled method of {} was interrupted while stopping", processor);
+                } else {
+                    procLog.error("Failed to properly initialize Processor. If still scheduled to run, NiFi will attempt to "
+                        + "initialize and run the Processor again after the 'Administrative Yield Duration' has elapsed. Failure is due to " + cause, cause);
+                }
 
                 // If processor's task completed Exceptionally, then we want to retry initiating the start (if Processor is still scheduled to run).
                 try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(getExtensionManager(), processor.getClass(), processor.getIdentifier())) {
@@ -1803,21 +1873,25 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
                     try {
                         ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnUnscheduled.class, processor, processContext);
                         ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnStopped.class, processor, processContext);
-                        hasActiveThreads = false;
                     } finally {
                         deactivateThread();
                     }
                 }
 
-                // make sure we only continue retry loop if STOP action wasn't initiated
-                if (scheduledState.get() != ScheduledState.STOPPING && scheduledState.get() != ScheduledState.RUN_ONCE) {
-                    // re-initiate the entire process
-                    final Runnable initiateStartTask = () -> initiateStart(taskScheduler, administrativeYieldMillis, timeoutMillis, startupAttemptCount,
-                        processContextFactory, schedulingAgentCallback, triggerLifecycleMethods);
-
-                    taskScheduler.schedule(initiateStartTask, administrativeYieldMillis, TimeUnit.MILLISECONDS);
-                } else {
-                    completeStopAction();
+                synchronized (onScheduledThread) {
+                    onScheduledThread.compareAndSet(Thread.currentThread(), null);
+                    if (schedulingAgentCallback.isStartTerminated() || activeStartCallback.get() != schedulingAgentCallback) {
+                        LOG.info("@OnScheduled methods of {} failed but this start's LifecycleState has been terminated, so this attempt will neither retry nor complete a stop", processor);
+                    } else {
+                        hasActiveThreads = false;
+                        if (scheduleStartRetry(taskScheduler, administrativeYieldMillis, timeoutMillis, startupAttemptCount, processContextFactory, schedulingAgentCallback,
+                                triggerLifecycleMethods, administrativeYieldMillis)) {
+                            LOG.debug("Rescheduled start of {} after its @OnScheduled method failed", processor);
+                        } else {
+                            activeStartCallback.compareAndSet(schedulingAgentCallback, null);
+                            completeStopAction();
+                        }
+                    }
                 }
             }
 
@@ -1851,6 +1925,28 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
 
         final Future<?> future = taskScheduler.scheduleWithFixedDelay(monitoringTask, 1, 10, TimeUnit.MILLISECONDS);
         futureRef.set(future);
+    }
+
+    private boolean scheduleStartRetry(final ScheduledExecutorService taskScheduler, final long administrativeYieldMillis, final long timeoutMillis,
+            final AtomicLong startupAttemptCount, final Supplier<ProcessContext> processContextFactory, final SchedulingAgentCallback schedulingAgentCallback,
+            final boolean triggerLifecycleMethods, final long retryDelayMillis) {
+        final Runnable initiateStartTask = () -> initiateStart(taskScheduler, administrativeYieldMillis, timeoutMillis, startupAttemptCount,
+            processContextFactory, schedulingAgentCallback, triggerLifecycleMethods);
+
+        synchronized (onScheduledThread) {
+            // Publish the retry under the same lock that stop() uses to transition STARTING to STOPPING, and only if this
+            // start still owns the Processor and it is still STARTING. If a stop has already transitioned the Processor
+            // away from STARTING, or a newer start has replaced the callback, no retry is scheduled. This guarantees that
+            // a stop which emptied and cancelled the retry slot can never be followed by an orphaned retry.
+            final ScheduledState currentState = scheduledState.get();
+            if (currentState != ScheduledState.STARTING || activeStartCallback.get() != schedulingAgentCallback) {
+                LOG.debug("Not scheduling another start attempt of {} because it is no longer STARTING or a newer start now owns it; current state = {}", this, currentState);
+                return false;
+            }
+
+            scheduledStartRetry.set(taskScheduler.schedule(initiateStartTask, retryDelayMillis, TimeUnit.MILLISECONDS));
+            return true;
+        }
     }
 
     /**
@@ -1993,9 +2089,43 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
             // before stop() was called. If that happens the stop processor
             // routine will be initiated in start() method, otherwise the IF
             // part will handle the stop processor routine.
-            final boolean updated = this.scheduledState.compareAndSet(ScheduledState.STARTING, ScheduledState.STOPPING);
-            if (updated) {
-                LOG.debug("Transitioned state of {} from STARTING to STOPPING", this);
+            final boolean updated;
+            boolean completeStopDirectly = false;
+            synchronized (onScheduledThread) {
+                updated = this.scheduledState.compareAndSet(ScheduledState.STARTING, ScheduledState.STOPPING);
+                if (updated) {
+                    LOG.debug("Transitioned state of {} from STARTING to STOPPING", this);
+
+                    // Cancel the in-flight start so that a caller waiting on the start future is released even if the
+                    // @OnScheduled method never returns.
+                    final SchedulingAgentCallback startCallback = activeStartCallback.get();
+                    if (startCallback != null) {
+                        startCallback.cancelStart();
+                    }
+
+                    // Cancel any start retry that is waiting between attempts so that the stop does not have to wait for
+                    // the administrative yield to elapse before the retry observes the STOPPING state.
+                    final Future<?> pendingRetry = scheduledStartRetry.getAndSet(null);
+                    if (pendingRetry != null) {
+                        pendingRetry.cancel(false);
+                    }
+
+                    final Thread invocationThread = onScheduledThread.get();
+                    if (invocationThread == null) {
+                        // No @OnScheduled invocation is running, and none can start now because a starting invocation
+                        // rechecks the state under this same lock and observes STOPPING. Complete the stop directly rather
+                        // than waiting for the next retry to observe the STOPPING state.
+                        completeStopDirectly = true;
+                    } else {
+                        // Interrupt the thread invoking @OnScheduled so that an interruptible invocation can exit and allow
+                        // the normal lifecycle cleanup to finish the stop without requiring termination.
+                        invocationThread.interrupt();
+                    }
+                }
+            }
+
+            if (completeStopDirectly) {
+                completeStopAction();
             }
         }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/ServiceStateTransition.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/ServiceStateTransition.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -108,18 +109,29 @@ public class ServiceStateTransition {
         return true;
     }
 
-    public boolean transitionToDisabling(final ControllerServiceState expectedState, final CompletableFuture<?> disabledFuture) {
+    public ControllerServiceState transitionToDisabling(final CompletableFuture<?> disabledFuture) {
         writeLock.lock();
         try {
-            if (expectedState != state) {
-                logger.debug("{} cannot be transitioned to DISABLING because its state is {}, not the expected {}", controllerServiceNode, state, expectedState);
-                return false;
+            final ControllerServiceState previousState = state;
+            if (previousState == ControllerServiceState.DISABLED) {
+                disabledFuture.complete(null);
+            } else if (previousState == ControllerServiceState.DISABLING) {
+                disabledFutures.add(disabledFuture);
+            } else {
+                state = ControllerServiceState.DISABLING;
+                stateChangeCondition.signalAll();
+                disabledFutures.add(disabledFuture);
             }
 
-            state = ControllerServiceState.DISABLING;
-            stateChangeCondition.signalAll();
-            disabledFutures.add(disabledFuture);
-            return true;
+            if (previousState == ControllerServiceState.ENABLING) {
+                for (final CompletableFuture<?> enabledFuture : enabledFutures) {
+                    enabledFuture.completeExceptionally(new CancellationException("Controller Service enablement cancelled by disable request"));
+                }
+
+                enabledFutures.clear();
+            }
+
+            return previousState;
         } finally {
             writeLock.unlock();
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
@@ -94,7 +94,9 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -132,6 +134,10 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
     private final VerifiableComponentFactory verifiableComponentFactory;
 
     private final AtomicBoolean active;
+
+    // Represents the current enable cycle. A disable request cancels this attempt so that the running enable task can
+    // recognize it has been superseded and hand the DISABLING to DISABLED transition off to the correct owner.
+    private final AtomicReference<EnableAttempt> currentEnableAttempt = new AtomicReference<>();
 
     public StandardControllerServiceNode(final LoggableComponent<ControllerService> implementation, final LoggableComponent<ControllerService> proxiedControllerService,
                                          final ControllerServiceInvocationHandler invocationHandler, final String id, final ValidationContextFactory validationContextFactory,
@@ -629,9 +635,10 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
      * Upon successful invocation of @OnEnabled this service will be transitioned to
      * ENABLED state.
      * <br>
-     * In the event where enabling took longer then expected by the user and such user
-     * initiated disable operation, this service will be automatically disabled as soon
-     * as it reached ENABLED state.
+     * When a disable operation is initiated during enabling, the enable future is completed exceptionally with a
+     * {@link CancellationException} and the current enable attempt is cancelled. If the @OnEnabled method is running, the
+     * enable task is interrupted and, once it returns, invokes @OnDisabled before the service transitions to DISABLED. If
+     * no @OnEnabled invocation is running, the disable request transitions the service to DISABLED directly.
      */
     @Override
     public CompletableFuture<Void> enable(final ScheduledExecutorService scheduler, final long administrativeYieldMillis, final boolean completeExceptionallyOnFailure) {
@@ -642,15 +649,22 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
     public CompletableFuture<Void> enable(final ScheduledExecutorService scheduler, final long administrativeYieldMillis, final boolean completeExceptionallyOnFailure,
             final ConfigurationContext providedConfigurationContext) {
 
-        final CompletableFuture<Void> future = new CompletableFuture<>();
-
-        if (!stateTransition.transitionToEnabling(ControllerServiceState.DISABLED, future)) {
-            future.complete(null);
-            return future;
-        }
+        final EnableAttempt attempt = new EnableAttempt();
+        final CompletableFuture<Void> future = attempt.getFuture();
 
         synchronized (active) {
+            // Publish the enable attempt and the active flag under the same lock that guards the ENABLING transition so
+            // that a concurrent disable either transitions this service to DISABLING and observes this attempt in order to
+            // cancel it, or fails to enable and leaves the service DISABLED. Performing the transition and the publication
+            // together prevents a disable from moving the service to DISABLED while a non-cancelled attempt and an active
+            // flag remain published for the same enable cycle.
+            if (!stateTransition.transitionToEnabling(ControllerServiceState.DISABLED, future)) {
+                future.complete(null);
+                return future;
+            }
+
             this.active.set(true);
+            currentEnableAttempt.set(attempt);
         }
 
         final AtomicLong enablingDelay = new AtomicLong(0);
@@ -660,16 +674,14 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
         scheduler.execute(new Runnable() {
             @Override
             public void run() {
+                if (attempt.isCancelled() || currentEnableAttempt.get() != attempt) {
+                    LOG.debug("Not proceeding with enabling {} because this enable attempt has been cancelled or superseded", serviceNode);
+                    return;
+                }
+
                 final ConfigurationContext configContext = providedConfigurationContext == null
                     ? new StandardConfigurationContext(serviceNode, controllerServiceProvider, null)
                     : providedConfigurationContext;
-
-                if (!isActive()) {
-                    LOG.warn("Enabling {} stopped: no active status", serviceNode);
-                    stateTransition.disable();
-                    future.complete(null);
-                    return;
-                }
 
                 // Perform validation - if a ConfigurationContext was provided, validate against its properties
                 final ValidationState validationState;
@@ -683,9 +695,7 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
                 }
 
                 final ValidationStatus validationStatus = validationState.getStatus();
-                if (validationStatus == ValidationStatus.VALID) {
-                    LOG.debug("Enabling {} proceeding after performing validation", serviceNode);
-                } else {
+                if (validationStatus != ValidationStatus.VALID) {
                     final Collection<ValidationResult> errors = validationState.getValidationErrors();
                     if (completeExceptionallyOnFailure) {
                         future.completeExceptionally(new IllegalStateException("Enabling %s failed: Validation Status [%s] Errors %s".formatted(serviceNode, validationStatus, errors)));
@@ -698,56 +708,141 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
                         LOG.warn("Validation rescheduled in {} ms for {} Errors {}", selectedValidationDelay, serviceNode, errors);
                     }
 
-                    try {
-                        scheduler.schedule(this, selectedValidationDelay, TimeUnit.MILLISECONDS);
-                        LOG.debug("Validation rescheduled in {} ms for {}", selectedValidationDelay, serviceNode);
-                    } catch (final RejectedExecutionException e) {
-                        LOG.debug("Validation rescheduling rejected for {}", serviceNode, e);
-                        future.completeExceptionally(new IllegalStateException("Enabling %s rejected: Validation Status [%s] Errors %s".formatted(serviceNode, validationStatus, errors)));
+                    synchronized (active) {
+                        // Recheck ownership and cancellation under the active lock before publishing the retry so that a
+                        // disable which cancelled this attempt is never followed by a newly scheduled retry. When the
+                        // attempt has been cancelled or superseded, the disable request owns completing the lifecycle.
+                        if (attempt.isCancelled() || currentEnableAttempt.get() != attempt) {
+                            LOG.debug("Not rescheduling validation for {} because the enable attempt was cancelled or superseded", serviceNode);
+                            return;
+                        }
+
+                        try {
+                            attempt.setScheduledTask(scheduler.schedule(this, selectedValidationDelay, TimeUnit.MILLISECONDS));
+                            LOG.debug("Validation rescheduled in {} ms for {}", selectedValidationDelay, serviceNode);
+                        } catch (final RejectedExecutionException e) {
+                            LOG.debug("Validation rescheduling rejected for {}", serviceNode, e);
+                            future.completeExceptionally(new IllegalStateException("Enabling %s rejected: Validation Status [%s] Errors %s".formatted(serviceNode, validationStatus, errors)));
+                        }
                     }
 
                     // Enable command rescheduled or rejected
                     return;
                 }
 
+                LOG.debug("Enabling {} proceeding after performing validation", serviceNode);
+
+                // Register this thread as the one invoking @OnEnabled and claim ownership of terminal cleanup, rechecking under
+                // the active lock that the attempt has not been cancelled and that the service is still ENABLING. Once this
+                // attempt owns cleanup, a concurrent disable interrupts this thread (to unblock @OnEnabled) and defers the
+                // transition to DISABLED to this task rather than performing it directly. When the attempt does not claim
+                // ownership, the disable request completes the lifecycle itself. Exactly one path performs the transition.
+                final boolean invokeOnEnabled;
+                synchronized (active) {
+                    invokeOnEnabled = active.get() && !attempt.isCancelled() && stateTransition.getState() == ControllerServiceState.ENABLING;
+                    if (invokeOnEnabled) {
+                        attempt.setInvocationThread(Thread.currentThread());
+                        attempt.setOwnsCleanup(true);
+                    }
+                }
+
+                if (!invokeOnEnabled) {
+                    LOG.debug("Not invoking @OnEnabled methods of {} because the enable attempt was cancelled; the disable request will complete the lifecycle", serviceNode);
+                    return;
+                }
+
                 final ControllerService controllerService = getControllerServiceImplementation();
+                boolean invocationFailed = false;
                 try {
                     try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(getExtensionManager(), controllerService.getClass(), getIdentifier())) {
                         ReflectionUtils.invokeMethodsWithAnnotation(OnEnabled.class, controllerService, configContext);
                     }
-
-                    boolean shouldEnable;
-                    synchronized (active) {
-                        shouldEnable = active.get() && stateTransition.enable(getReferences()); // Transitioning the state to ENABLED will complete our future.
-                    }
-
-                    if (!shouldEnable) {
-                        LOG.info("Disabling {} after enabled due to disable action initiated", serviceNode);
-                        // Can only happen if user initiated DISABLE operation before service finished enabling. It's state will be
-                        // set to DISABLING (see disable() operation)
-                        invokeDisable(configContext);
-                        stateTransition.disable();
-                        future.complete(null);
-                    } else {
-                        LOG.info("Enabled {}", serviceNode);
-                    }
                 } catch (final Exception e) {
-                    if (completeExceptionallyOnFailure) {
-                        future.completeExceptionally(e);
+                    invocationFailed = true;
+
+                    // A disable request interrupts the @OnEnabled invocation, so a failure on a cancelled attempt is the
+                    // expected result of shutting the service down and is not logged as an enable failure.
+                    if (!attempt.isCancelled()) {
+                        if (completeExceptionallyOnFailure) {
+                            future.completeExceptionally(e);
+                        }
+
+                        final Throwable cause = e instanceof InvocationTargetException ? e.getCause() : e;
+                        final ComponentLog componentLog = new StandardComponentLog(getIdentifier(), controllerService, new StandardLoggingContext(serviceNode));
+                        componentLog.error("Failed to invoke @OnEnabled method", cause);
                     }
+                } finally {
+                    synchronized (active) {
+                        // @OnEnabled has returned, so release the interrupt target. A disable that raced this invocation
+                        // interrupts this thread to unblock @OnEnabled; consume any such interrupt here so it neither leaks into
+                        // the @OnDisabled cleanup below nor into a subsequent task that reuses this pooled thread. This attempt
+                        // still owns terminal cleanup (ownsCleanup remains set) until the decision below is committed.
+                        attempt.setInvocationThread(null);
+                        if (attempt.isCancelled()) {
+                            Thread.interrupted();
+                        }
+                    }
+                }
 
-                    final Throwable cause = e instanceof InvocationTargetException ? e.getCause() : e;
-                    final ComponentLog componentLog = new StandardComponentLog(getIdentifier(), controllerService, new StandardLoggingContext(serviceNode));
-                    componentLog.error("Failed to invoke @OnEnabled method", cause);
-                    invokeDisable(configContext);
-
-                    if (isActive()) {
-                        // Increment enabling delay to avoid excessive retries
-                        final long selectedEnablingDelay = getDelay(enablingDelay, administrativeYieldMillis);
-                        scheduler.schedule(this, selectedEnablingDelay, TimeUnit.MILLISECONDS);
+                // Decide the outcome of this invocation under the active lock while this attempt still owns terminal cleanup.
+                // A concurrent disable either acquires the lock first (cancelling this attempt, so this task performs the
+                // @OnDisabled cleanup and transition) or acquires it afterward (observing the committed ENABLED state). A
+                // disable never transitions the service to DISABLED on its own while this attempt still owes @OnDisabled;
+                // ownership of cleanup is released only once the terminal decision has been made.
+                final boolean enableSucceeded;
+                final boolean enableCancelled;
+                synchronized (active) {
+                    if (attempt.isCancelled()) {
+                        enableSucceeded = false;
+                        enableCancelled = true;
+                    } else if (invocationFailed) {
+                        enableSucceeded = false;
+                        enableCancelled = false;
+                    } else if (active.get() && stateTransition.enable(getReferences())) { // Transitioning the state to ENABLED completes the enable future.
+                        enableSucceeded = true;
+                        enableCancelled = false;
+                        attempt.setOwnsCleanup(false);
+                        currentEnableAttempt.compareAndSet(attempt, null);
                     } else {
-                        stateTransition.disable();
+                        enableSucceeded = false;
+                        enableCancelled = true;
                     }
+                }
+
+                if (enableSucceeded) {
+                    LOG.info("Enabled {}", serviceNode);
+                    return;
+                }
+
+                if (enableCancelled) {
+                    // A disable cancelled this attempt. Because @OnEnabled ran (successfully or was interrupted), this task owns
+                    // the cleanup: invoke @OnDisabled, release the invocation thread, and transition to DISABLED so the disable
+                    // future completes only after @OnDisabled returns.
+                    LOG.info("Enable of {} was cancelled by a disable request; invoking @OnDisabled and disabling", serviceNode);
+                    completeCancelledEnable(attempt, configContext);
+                    return;
+                }
+
+                // @OnEnabled failed without a disable. Invoke @OnDisabled to clean up partial state while this attempt still
+                // owns cleanup, then decide under the active lock whether a disable arrived meanwhile (transition to DISABLED
+                // after @OnDisabled) or the enable should be retried after the administrative yield. Ownership of cleanup is
+                // released only inside the lock: if a disable then arrives it transitions directly, which is correct because
+                // @OnDisabled has already been invoked for this failed attempt.
+                invokeDisable(configContext);
+
+                final boolean disabledByRequest;
+                synchronized (active) {
+                    disabledByRequest = attempt.isCancelled() || currentEnableAttempt.get() != attempt;
+                    if (!disabledByRequest) {
+                        final long selectedEnablingDelay = getDelay(enablingDelay, administrativeYieldMillis);
+                        attempt.setScheduledTask(scheduler.schedule(this, selectedEnablingDelay, TimeUnit.MILLISECONDS));
+                    }
+                    attempt.setOwnsCleanup(false);
+                }
+
+                if (disabledByRequest) {
+                    LOG.debug("Enable of {} failed and a disable request cancelled the attempt; transitioning to DISABLED after invoking @OnDisabled", serviceNode);
+                    transitionToDisabledAfterCancellation(attempt);
                 }
             }
         });
@@ -756,18 +851,11 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
     }
 
     /**
-     * Will atomically disable this service by invoking its @OnDisabled operation.
-     * It uses CAS operation on {@link #stateTransition} to transition this service
-     * from ENABLED to DISABLING state. If such transition succeeds the service
-     * will be de-activated (see {@link ControllerServiceNode#isActive()}).
-     * If such transition doesn't succeed (the service is still in ENABLING state)
-     * then the service will still be transitioned to DISABLING state to ensure that
-     * no other transition could happen on this service. However in such event
-     * (e.g., its @OnEnabled finally succeeded), the {@link #enable(ScheduledExecutorService, long, boolean)}
-     * operation will initiate service disabling javadoc for (see {@link #enable(ScheduledExecutorService, long, boolean)}
-     * <br>
-     * Upon successful invocation of @OnDisabled this service will be transitioned to
-     * DISABLED state.
+     * Atomically transitions this service to DISABLING. Services that are ENABLING complete pending enable futures
+     * exceptionally with a {@link CancellationException} and cancel the current enable attempt. If the @OnEnabled method is
+     * running it is interrupted and invokes @OnDisabled before the service transitions to DISABLED; otherwise the disable
+     * request transitions the service to DISABLED directly. Services that are ENABLED invoke their @OnDisabled methods
+     * before transitioning to DISABLED. All callers receive a future that completes when the service is DISABLED.
      */
     @Override
     public CompletableFuture<Void> disable(final ScheduledExecutorService scheduler) {
@@ -777,35 +865,50 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
          * service since it will attempt to transition service state from
          * ENABLING to ENABLED but only if it's active.
          */
+        final CompletableFuture<Void> future = new CompletableFuture<>();
+        final ControllerServiceState previousState;
+        final EnableAttempt cancelledAttempt;
+        final boolean enableTaskOwnsCleanup;
         synchronized (this.active) {
             this.active.set(false);
-        }
 
-        final CompletableFuture<Void> future = new CompletableFuture<>();
-        // If already disabled, complete immediately
-        if (getState() == ControllerServiceState.DISABLED) {
-            future.complete(null);
-            return future;
-        }
+            cancelledAttempt = currentEnableAttempt.get();
+            previousState = stateTransition.transitionToDisabling(future);
 
-        final boolean transitioned = this.stateTransition.transitionToDisabling(ControllerServiceState.ENABLING, future);
-        if (transitioned) {
-            // If we transitioned from ENABLING to DISABLING, we need to immediately complete the disable
-            // because the enable task may be scheduled to run far in the future (up to 10 minutes) due to
-            // validation retries. Rather than making the user wait, we immediately transition to DISABLED.
-            scheduler.execute(() -> {
-                stateTransition.disable();
+            if (cancelledAttempt == null) {
+                enableTaskOwnsCleanup = false;
+            } else {
+                cancelledAttempt.cancel();
 
-                // Now all components that reference this service will be invalid. Trigger validation to occur so that
-                // this is reflected in any response that may go back to a user/client.
-                for (final ComponentNode component : getReferences().getReferencingComponents()) {
-                    component.performValidation();
+                final Future<?> scheduledTask = cancelledAttempt.getScheduledTask();
+                if (scheduledTask != null) {
+                    // Cancel any retry that is waiting between attempts so the disable does not wait for it to run.
+                    scheduledTask.cancel(false);
                 }
-            });
+
+                final Thread invocationThread = cancelledAttempt.getInvocationThread();
+                if (invocationThread != null) {
+                    // The enable task is running @OnEnabled. Interrupt it so it can exit; that task owns the lifecycle cleanup.
+                    invocationThread.interrupt();
+                }
+
+                enableTaskOwnsCleanup = cancelledAttempt.ownsCleanup();
+            }
+        }
+
+        if (previousState == ControllerServiceState.ENABLING) {
+            // The enable task may be scheduled far in the future due to validation or enabling retries. If the current attempt
+            // owns cleanup, it has begun invoking @OnEnabled and still owes @OnDisabled, so it invokes @OnDisabled and
+            // transitions to DISABLED once it returns. Otherwise no invocation owes @OnDisabled, so the disable transitions the
+            // service to DISABLED directly.
+            if (!enableTaskOwnsCleanup) {
+                scheduler.execute(() -> transitionToDisabledAfterCancellation(cancelledAttempt));
+            }
+
             return future;
         }
 
-        if (this.stateTransition.transitionToDisabling(ControllerServiceState.ENABLED, future)) {
+        if (previousState == ControllerServiceState.ENABLED) {
             final ConfigurationContext configContext = new StandardConfigurationContext(this, this.serviceProvider, null);
             scheduler.execute(() -> {
                 try {
@@ -823,6 +926,32 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
         }
 
         return future;
+    }
+
+    /**
+     * Invoked by the enable task when a disable request cancelled the current enable attempt while its @OnEnabled method
+     * was running. Invokes @OnDisabled and then transitions the service to DISABLED.
+     */
+    private void completeCancelledEnable(final EnableAttempt attempt, final ConfigurationContext configContext) {
+        invokeDisable(configContext);
+        synchronized (active) {
+            attempt.setOwnsCleanup(false);
+        }
+        transitionToDisabledAfterCancellation(attempt);
+    }
+
+    /**
+     * Transitions the service to DISABLED after an enable attempt was cancelled, clears the attempt, and triggers
+     * validation of referencing components so that their state reflects the now-disabled service. This is invoked either
+     * by the disable request when no @OnEnabled invocation is running, or by the enable task after it invokes @OnDisabled.
+     */
+    private void transitionToDisabledAfterCancellation(final EnableAttempt attempt) {
+        stateTransition.disable();
+        currentEnableAttempt.compareAndSet(attempt, null);
+
+        for (final ComponentNode component : getReferences().getReferencingComponents()) {
+            component.performValidation();
+        }
     }
 
     private void invokeDisable(ConfigurationContext configContext) {
@@ -1051,6 +1180,60 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
         }
 
         return selectedDelay;
+    }
+
+    /**
+     * Represents a single enable cycle. The attempt owns the enable {@link CompletableFuture} that completes when this
+     * cycle finishes, a cancelled flag that a disable request sets so that the enable task can detect that it has been
+     * superseded, the scheduled retry task that is waiting between attempts, the thread currently invoking @OnEnabled, and a
+     * cleanup-ownership flag. The enable task sets cleanup ownership before invoking @OnEnabled and clears it once it has
+     * committed the terminal outcome (ENABLED, a retry after a failure whose @OnDisabled cleanup already ran, or a
+     * cancelled-driven transition to DISABLED). While the attempt owns cleanup, a disable interrupts the invoking thread and
+     * defers the transition to DISABLED to the enable task; otherwise the disable transitions the service directly. The
+     * invocation thread and the cleanup-ownership flag are both read and written while holding the {@code active} monitor.
+     */
+    private static final class EnableAttempt {
+        private final CompletableFuture<Void> future = new CompletableFuture<>();
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+        private volatile Future<?> scheduledTask;
+        private volatile Thread invocationThread;
+        private boolean ownsCleanup = false;
+
+        private CompletableFuture<Void> getFuture() {
+            return future;
+        }
+
+        private boolean isCancelled() {
+            return cancelled.get();
+        }
+
+        private void cancel() {
+            cancelled.set(true);
+        }
+
+        private void setScheduledTask(final Future<?> scheduledTask) {
+            this.scheduledTask = scheduledTask;
+        }
+
+        private Future<?> getScheduledTask() {
+            return scheduledTask;
+        }
+
+        private void setInvocationThread(final Thread invocationThread) {
+            this.invocationThread = invocationThread;
+        }
+
+        private Thread getInvocationThread() {
+            return invocationThread;
+        }
+
+        private void setOwnsCleanup(final boolean ownsCleanup) {
+            this.ownsCleanup = ownsCleanup;
+        }
+
+        private boolean ownsCleanup() {
+            return ownsCleanup;
+        }
     }
 
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/SchedulingAgentCallback.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/SchedulingAgentCallback.java
@@ -25,4 +25,21 @@ public interface SchedulingAgentCallback {
     Future<?> scheduleTask(Callable<?> task);
 
     void trigger();
+
+    /**
+     * Cancels the start that this callback represents by completing its start future exceptionally. This allows a caller
+     * that is waiting on the start future to be released when a Processor is stopped while it is still starting, even if
+     * its {@code @OnScheduled} method never returns.
+     */
+    default void cancelStart() {
+    }
+
+    /**
+     * @return {@code true} if the LifecycleState captured for this start has been terminated. A start whose LifecycleState
+     * has been terminated must not transition the Processor to RUNNING, invoke {@link #trigger()}, schedule another start
+     * attempt, or complete a later stop, because the Processor instance and context it holds have been abandoned.
+     */
+    default boolean isStartTerminated() {
+        return false;
+    }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/StandardConnectorNode.java
@@ -27,8 +27,10 @@ import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.ConfigVerificationResult.Outcome;
 import org.apache.nifi.components.DescribedValue;
 import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.connector.components.ComponentHierarchyScope;
 import org.apache.nifi.components.connector.components.FlowContext;
 import org.apache.nifi.components.connector.components.ParameterContextFacade;
+import org.apache.nifi.components.connector.components.ProcessGroupLifecycle;
 import org.apache.nifi.components.connector.migration.ConnectorMigrationContext;
 import org.apache.nifi.components.connector.migration.MigratableConnector;
 import org.apache.nifi.components.state.Scope;
@@ -90,6 +92,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -127,6 +130,8 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
     private volatile String name;
     private volatile FrameworkConnectorInitializationContext initializationContext;
 
+    // Serializes Connector start and stop invocations so that a stop request cannot complete before an in-flight start invocation returns.
+    private final ReentrantLock componentLifecycleLock = new ReentrantLock();
     private final Object loggingAttributesLock = new Object();
     private volatile Map<String, String> customLoggingAttributes = Map.of();
     private volatile Map<String, String> mergedLoggingAttributes = Map.of();
@@ -861,8 +866,8 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
 
             // Check current state for existing start request in progress
             if (stateUpdated && currentState == ConnectorState.STARTING) {
-                logger.info("{} is currently starting so will not stop the Connector until the start has completed", this);
                 stateTransition.addPendingStopFuture(stopCompleteFuture);
+                cancelInFlightStartForStop(scheduler);
                 return stopCompleteFuture;
             }
         }
@@ -870,6 +875,63 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
         scheduler.schedule(() -> stopComponent(scheduler, stopCompleteFuture), 0, TimeUnit.SECONDS);
 
         return stopCompleteFuture;
+    }
+
+    // Cancels an in-progress Connector start so that the Connector can stop. AbstractConnector.start() starts Processors
+    // and enables Controller Services in child groups too, so both are addressed recursively. Stopping the Processors
+    // completes their start futures, which releases AbstractConnector.start() and lets it run its own stop, including the
+    // termination fallback for any Processor whose @OnScheduled does not respond to interruption. This method only
+    // initiates that cancellation; startComponent owns completing the deferred stop after Connector.start() returns.
+    private void cancelInFlightStartForStop(final FlowEngine scheduler) {
+        if (getCurrentState() != ConnectorState.STOPPING) {
+            return;
+        }
+
+        logger.info("Stopping Processors and disabling Controller Services for {} so that its in-progress start is cancelled and the Connector can stop", this);
+        final CompletableFuture<Void> cancelFuture;
+        try {
+            final ProcessGroupLifecycle lifecycle = activeFlowContext.getRootGroup().getLifecycle();
+            final CompletableFuture<Void> stopProcessorsFuture = lifecycle.stopProcessors(ComponentHierarchyScope.INCLUDE_CHILD_GROUPS);
+            final CompletableFuture<Void> disableServicesFuture = lifecycle.disableControllerServices(ComponentHierarchyScope.INCLUDE_CHILD_GROUPS);
+            cancelFuture = CompletableFuture.allOf(stopProcessorsFuture, disableServicesFuture);
+        } catch (final Exception e) {
+            logger.warn("Failed to cancel the in-progress start of {}. The Connector cannot finish stopping until the start is cancelled, so this will be tried again in 10 seconds", this, e);
+            scheduler.schedule(() -> cancelInFlightStartForStop(scheduler), 10, TimeUnit.SECONDS);
+            return;
+        }
+
+        cancelFuture.whenComplete((result, failure) -> {
+            if (failure != null) {
+                logger.warn("Failed to cancel the in-progress start of {}. The Connector cannot finish stopping until the start is cancelled, so it will be tried again in 10 seconds", this, failure);
+                scheduler.schedule(() -> cancelInFlightStartForStop(scheduler), 10, TimeUnit.SECONDS);
+                return;
+            }
+
+            reassertStartCancellationIfStillStarting(scheduler);
+        });
+    }
+
+    private void reassertStartCancellationIfStillStarting(final FlowEngine scheduler) {
+        if (getCurrentState() != ConnectorState.STOPPING) {
+            return;
+        }
+
+        if (componentLifecycleLock.tryLock()) {
+            try {
+                // Acquiring the lock means Connector.start() is not currently running. It may have already returned, or it
+                // may be waiting between scheduled start retries. Complete the deferred stop now rather than waiting for a
+                // scheduled retry of startComponent to observe that the desired state is no longer RUNNING.
+                completeDeferredStop(scheduler);
+            } finally {
+                componentLifecycleLock.unlock();
+            }
+            return;
+        }
+
+        // The start invocation is still running and can schedule Processors or enable Controller Services again after an
+        // earlier stop completed, so the cancellation is reasserted until the start invocation has returned.
+        logger.debug("{} has not finished starting yet, so its Processors will be stopped and Controller Services disabled again before the Connector stops", this);
+        scheduler.schedule(() -> cancelInFlightStartForStop(scheduler), 100, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -990,49 +1052,64 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
     }
 
     private void stopComponent(final FlowEngine scheduler, final CompletableFuture<Void> stopCompleteFuture) {
-        logger.debug("Stopping component for {}", this);
-        try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(extensionManager, connectorDetails.getConnector().getClass(), getIdentifier())) {
-            connectorDetails.getConnector().stop(activeFlowContext);
-        } catch (final Exception e) {
-            logger.error("Failed to stop {}. Will try again in 10 seconds", this, e);
-            scheduler.schedule(() -> stopComponent(scheduler, stopCompleteFuture), 10, TimeUnit.SECONDS);
-            return;
-        }
+        componentLifecycleLock.lock();
+        try {
+            if (getCurrentState() != ConnectorState.STOPPING) {
+                return;
+            }
 
-        stateTransition.setCurrentState(ConnectorState.STOPPED);
-        stopCompleteFuture.complete(null);
-        logger.info("Successfully stopped {}", this);
+            logger.debug("Stopping component for {}", this);
+            try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(extensionManager, connectorDetails.getConnector().getClass(), getIdentifier())) {
+                connectorDetails.getConnector().stop(activeFlowContext);
+            } catch (final Exception e) {
+                logger.error("Failed to stop {}. Will try again in 10 seconds", this, e);
+                scheduler.schedule(() -> stopComponent(scheduler, stopCompleteFuture), 10, TimeUnit.SECONDS);
+                return;
+            }
 
-        final ConnectorState desiredState = getDesiredState();
-        if (desiredState == ConnectorState.RUNNING) {
-            logger.info("{} was requested to be RUNNING while it was stopping so will attempt to start again", this);
-            start(scheduler, new CompletableFuture<>());
+            stateTransition.setCurrentState(ConnectorState.STOPPED);
+            stopCompleteFuture.complete(null);
+            logger.info("Successfully stopped {}", this);
+
+            final ConnectorState desiredState = getDesiredState();
+            if (desiredState == ConnectorState.RUNNING) {
+                logger.info("{} was requested to be RUNNING while it was stopping so will attempt to start again", this);
+                start(scheduler, new CompletableFuture<>());
+            }
+        } finally {
+            componentLifecycleLock.unlock();
         }
     }
 
     private void startComponent(final FlowEngine scheduler, final CompletableFuture<Void> startCompleteFuture) {
-        logger.debug("Starting component for {}", this);
-        final ConnectorState desiredState = getDesiredState();
-        if (desiredState != ConnectorState.RUNNING) {
-            logger.info("Will not start {} because the desired state is no longer RUNNING but is now {}", this, desiredState);
-            completeDeferredStop(scheduler);
-            return;
-        }
-
-        try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(extensionManager, connectorDetails.getConnector().getClass(), getIdentifier())) {
-            connectorDetails.getConnector().start(activeFlowContext);
-        } catch (final Exception e) {
-            if (getCurrentState() == ConnectorState.STOPPING) {
-                logger.error("Failed to start {} and a stop has since been requested, so the Connector will be stopped instead of started", this, e);
+        componentLifecycleLock.lock();
+        try {
+            logger.debug("Starting component for {}", this);
+            final ConnectorState desiredState = getDesiredState();
+            if (desiredState != ConnectorState.RUNNING) {
+                logger.info("Will not start {} because the desired state is no longer RUNNING but is now {}", this, desiredState);
                 completeDeferredStop(scheduler);
-            } else {
-                logger.error("Failed to start {} retrying in 10 seconds", this, e);
-                scheduler.schedule(() -> startComponent(scheduler, startCompleteFuture), 10, TimeUnit.SECONDS);
+                return;
             }
 
-            return;
+            try (final NarCloseable ignored = NarCloseable.withComponentNarLoader(extensionManager, connectorDetails.getConnector().getClass(), getIdentifier())) {
+                connectorDetails.getConnector().start(activeFlowContext);
+            } catch (final Exception e) {
+                if (getCurrentState() == ConnectorState.STOPPING) {
+                    logger.error("Failed to start {} and a stop has since been requested, so the Connector will be stopped instead of started", this, e);
+                    completeDeferredStop(scheduler);
+                } else {
+                    logger.error("Failed to start {} retrying in 10 seconds", this, e);
+                    scheduler.schedule(() -> startComponent(scheduler, startCompleteFuture), 10, TimeUnit.SECONDS);
+                }
+
+                return;
+            }
+        } finally {
+            componentLifecycleLock.unlock();
         }
 
+        // Reconcile the state after releasing the lock so a completed disable operation can acquire it and finish a pending stop.
         // A stop requested while the Connector was starting transitioned the current state away from STARTING, so the
         // Connector may be reported as RUNNING only if it is still STARTING. Otherwise, this thread owns the stop that
         // was deferred while the start was in flight.
@@ -1053,7 +1130,6 @@ public class StandardConnectorNode implements ConnectorNode, GroupedComponent {
             stopComponent(scheduler, new CompletableFuture<>());
         }
     }
-
 
     @Override
     public void verifyCanDelete() {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/facades/standalone/StandaloneProcessGroupLifecycle.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/components/connector/facades/standalone/StandaloneProcessGroupLifecycle.java
@@ -425,7 +425,9 @@ public class StandaloneProcessGroupLifecycle implements ProcessGroupLifecycle {
         final Collection<ProcessorNode> processors = recursive ? processGroup.findAllProcessors() : processGroup.getProcessors();
         final List<CompletableFuture<Void>> stopFutures = new ArrayList<>();
         for (final ProcessorNode processor : processors) {
-            final ScheduledState processorState = processor.getScheduledState();
+            // Use the physical state so that a Processor that is still STARTING is stopped. The logical scheduled state
+            // maps STARTING and STOPPING to STOPPED, which would otherwise cause an in-progress start to be skipped.
+            final ScheduledState processorState = processor.getPhysicalScheduledState();
             if (processorState == ScheduledState.DISABLED || processorState == ScheduledState.STOPPED) {
                 logger.debug("Not stopping Processor {} because its state is {}", processor, processorState);
                 continue;

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
@@ -71,6 +71,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -436,6 +437,16 @@ public final class StandardProcessScheduler implements ProcessScheduler {
             @Override
             public void onTaskComplete() {
                 lifecycleState.decrementActiveThreadCount();
+            }
+
+            @Override
+            public void cancelStart() {
+                future.completeExceptionally(new CancellationException("Start of " + procNode + " was cancelled because the Processor was stopped while it was still starting"));
+            }
+
+            @Override
+            public boolean isStartTerminated() {
+                return lifecycleState.isTerminated();
             }
         };
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/ControllerServiceEnablingConnector.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/ControllerServiceEnablingConnector.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.components.connector;
+
+import org.apache.nifi.components.ConfigVerificationResult;
+import org.apache.nifi.components.connector.components.FlowContext;
+import org.apache.nifi.components.connector.processors.CreateDummyFlowFile;
+import org.apache.nifi.components.connector.services.impl.BlockingEnableDisableCounterService;
+import org.apache.nifi.components.connector.services.impl.BlockingEnablingCounterService;
+import org.apache.nifi.components.connector.services.impl.FailingEnablingCounterService;
+import org.apache.nifi.components.connector.util.VersionedFlowUtils;
+import org.apache.nifi.flow.Bundle;
+import org.apache.nifi.flow.VersionedControllerService;
+import org.apache.nifi.flow.VersionedExternalFlow;
+import org.apache.nifi.flow.VersionedProcessGroup;
+import org.apache.nifi.flow.VersionedProcessor;
+
+import java.util.List;
+import java.util.Map;
+
+public class ControllerServiceEnablingConnector extends AbstractConnector {
+
+    static final String BLOCKING_ENABLING = "BLOCKING_ENABLING";
+    static final String FAILING_ENABLING = "FAILING_ENABLING";
+    static final String ORDERED_BLOCKING = "ORDERED_BLOCKING";
+    static final String CONFIGURATION_STEP_NAME = "Configuration";
+
+    static final ConnectorPropertyDescriptor ENABLING_BEHAVIOR = new ConnectorPropertyDescriptor.Builder()
+        .name("Enabling Behavior")
+        .description("How the managed Controller Service should behave while enabling")
+        .type(PropertyType.STRING)
+        .required(true)
+        .defaultValue(BLOCKING_ENABLING)
+        .allowableValues(BLOCKING_ENABLING, FAILING_ENABLING, ORDERED_BLOCKING)
+        .build();
+
+    private static final ConnectorPropertyGroup PROPERTY_GROUP = new ConnectorPropertyGroup.Builder()
+        .name("Controller Service Settings")
+        .addProperty(ENABLING_BEHAVIOR)
+        .build();
+
+    private static final ConfigurationStep CONFIGURATION_STEP = new ConfigurationStep.Builder()
+        .name(CONFIGURATION_STEP_NAME)
+        .propertyGroups(List.of(PROPERTY_GROUP))
+        .build();
+
+    @Override
+    public List<ConfigurationStep> getConfigurationSteps() {
+        return List.of(CONFIGURATION_STEP);
+    }
+
+    @Override
+    public VersionedExternalFlow getInitialFlow() {
+        return VersionedFlowUtils.loadFlowFromResource("flows/generate-duplicate-log-flow.json");
+    }
+
+    @Override
+    public VersionedExternalFlow getActiveFlow(final FlowContext activeFlowContext) {
+        final String enablingBehavior = activeFlowContext.getConfigurationContext().getProperty(CONFIGURATION_STEP, ENABLING_BEHAVIOR).getValue();
+        return buildFlow(enablingBehavior);
+    }
+
+    @Override
+    public void applyUpdate(final FlowContext workingContext, final FlowContext activeContext) throws FlowUpdateException {
+        getInitializationContext().updateFlow(activeContext, getActiveFlow(workingContext));
+    }
+
+    @Override
+    public void onStepConfigured(final String stepName, final FlowContext workingContext) throws FlowUpdateException {
+        getInitializationContext().updateFlow(workingContext, getActiveFlow(workingContext));
+    }
+
+    @Override
+    public List<ConfigVerificationResult> verifyConfigurationStep(final String stepName, final Map<String, String> overrides, final FlowContext flowContext) {
+        return List.of();
+    }
+
+    private VersionedExternalFlow buildFlow(final String enablingBehavior) {
+        final VersionedExternalFlow externalFlow = VersionedFlowUtils.loadFlowFromResource("flows/generate-duplicate-log-flow.json");
+        final VersionedProcessGroup rootGroup = externalFlow.getFlowContents();
+
+        final Bundle systemBundle = new Bundle();
+        systemBundle.setArtifact("system");
+        systemBundle.setGroup("default");
+        systemBundle.setVersion("unversioned");
+
+        final String serviceType = switch (enablingBehavior) {
+            case BLOCKING_ENABLING -> BlockingEnablingCounterService.class.getName();
+            case ORDERED_BLOCKING -> BlockingEnableDisableCounterService.class.getName();
+            default -> FailingEnablingCounterService.class.getName();
+        };
+
+        final VersionedControllerService controllerService = VersionedFlowUtils.addControllerService(rootGroup, serviceType, systemBundle, "Managed Service");
+
+        final VersionedProcessor generateProcessor = VersionedFlowUtils.findProcessor(rootGroup,
+            processor -> processor.getType().equals(CreateDummyFlowFile.class.getName())).orElseThrow();
+
+        generateProcessor.getProperties().put("Counter Service", controllerService.getIdentifier());
+
+        return externalFlow;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/ProcessorStartHangConnector.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/ProcessorStartHangConnector.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.components.connector;
+
+import org.apache.nifi.components.ConfigVerificationResult;
+import org.apache.nifi.components.connector.components.FlowContext;
+import org.apache.nifi.components.connector.processors.ManagedStartHangProcessor;
+import org.apache.nifi.components.connector.util.VersionedFlowUtils;
+import org.apache.nifi.flow.Bundle;
+import org.apache.nifi.flow.Position;
+import org.apache.nifi.flow.ScheduledState;
+import org.apache.nifi.flow.VersionedExternalFlow;
+import org.apache.nifi.flow.VersionedProcessGroup;
+import org.apache.nifi.flow.VersionedProcessor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ProcessorStartHangConnector extends AbstractConnector {
+
+    static final String ROOT_GROUP = "ROOT_GROUP";
+    static final String CHILD_GROUP = "CHILD_GROUP";
+    static final String CONFIGURATION_STEP_NAME = "Configuration";
+    static final String HANGING_PROCESSOR_NAME = "Hanging Start Processor";
+
+    static final ConnectorPropertyDescriptor PROCESSOR_PLACEMENT = new ConnectorPropertyDescriptor.Builder()
+        .name("Processor Placement")
+        .description("Where the hanging Processor should be placed within the managed flow")
+        .type(PropertyType.STRING)
+        .required(true)
+        .defaultValue(ROOT_GROUP)
+        .allowableValues(ROOT_GROUP, CHILD_GROUP)
+        .build();
+
+    private static final ConnectorPropertyGroup PROPERTY_GROUP = new ConnectorPropertyGroup.Builder()
+        .name("Processor Settings")
+        .addProperty(PROCESSOR_PLACEMENT)
+        .build();
+
+    private static final ConfigurationStep CONFIGURATION_STEP = new ConfigurationStep.Builder()
+        .name(CONFIGURATION_STEP_NAME)
+        .propertyGroups(List.of(PROPERTY_GROUP))
+        .build();
+
+    @Override
+    public List<ConfigurationStep> getConfigurationSteps() {
+        return List.of(CONFIGURATION_STEP);
+    }
+
+    @Override
+    public VersionedExternalFlow getInitialFlow() {
+        return buildFlow(ROOT_GROUP);
+    }
+
+    @Override
+    public VersionedExternalFlow getActiveFlow(final FlowContext activeFlowContext) {
+        final String placement = activeFlowContext.getConfigurationContext().getProperty(CONFIGURATION_STEP, PROCESSOR_PLACEMENT).getValue();
+        return buildFlow(placement);
+    }
+
+    @Override
+    public void applyUpdate(final FlowContext workingContext, final FlowContext activeContext) throws FlowUpdateException {
+        getInitializationContext().updateFlow(activeContext, getActiveFlow(workingContext));
+    }
+
+    @Override
+    public void onStepConfigured(final String stepName, final FlowContext workingContext) throws FlowUpdateException {
+        getInitializationContext().updateFlow(workingContext, getActiveFlow(workingContext));
+    }
+
+    @Override
+    public List<ConfigVerificationResult> verifyConfigurationStep(final String stepName, final Map<String, String> overrides, final FlowContext flowContext) {
+        return List.of();
+    }
+
+    private VersionedExternalFlow buildFlow(final String placement) {
+        final VersionedExternalFlow externalFlow = VersionedFlowUtils.loadFlowFromResource("flows/generate-duplicate-log-flow.json");
+        final VersionedProcessGroup rootGroup = externalFlow.getFlowContents();
+
+        final Bundle systemBundle = new Bundle();
+        systemBundle.setArtifact("system");
+        systemBundle.setGroup("default");
+        systemBundle.setVersion("unversioned");
+
+        final VersionedProcessGroup targetGroup = ROOT_GROUP.equals(placement) ? rootGroup : rootGroup.getProcessGroups().iterator().next();
+
+        final VersionedProcessor hangingProcessor = VersionedFlowUtils.addProcessor(targetGroup, ManagedStartHangProcessor.class.getName(),
+            systemBundle, HANGING_PROCESSOR_NAME, new Position(0.0, 0.0));
+        hangingProcessor.setAutoTerminatedRelationships(Set.of("success"));
+        hangingProcessor.setScheduledState(ScheduledState.ENABLED);
+
+        return externalFlow;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/StandardConnectorNodeIT.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/StandardConnectorNodeIT.java
@@ -22,12 +22,16 @@ import org.apache.nifi.components.DescribedValue;
 import org.apache.nifi.components.connector.processors.CreateDummyFlowFile;
 import org.apache.nifi.components.connector.processors.DuplicateFlowFile;
 import org.apache.nifi.components.connector.processors.LogFlowFileContents;
+import org.apache.nifi.components.connector.processors.ManagedStartHangProcessor;
 import org.apache.nifi.components.connector.processors.OnPropertyModifiedTracker;
 import org.apache.nifi.components.connector.processors.OverwriteFlowFile;
 import org.apache.nifi.components.connector.processors.TerminateFlowFile;
 import org.apache.nifi.components.connector.secrets.ParameterProviderSecretsManager;
 import org.apache.nifi.components.connector.secrets.SecretsManager;
 import org.apache.nifi.components.connector.services.CounterService;
+import org.apache.nifi.components.connector.services.impl.BlockingEnableDisableCounterService;
+import org.apache.nifi.components.connector.services.impl.BlockingEnablingCounterService;
+import org.apache.nifi.components.connector.services.impl.FailingEnablingCounterService;
 import org.apache.nifi.components.state.StateManagerProvider;
 import org.apache.nifi.components.validation.StandardVerifiableComponentFactory;
 import org.apache.nifi.components.validation.ValidationState;
@@ -42,6 +46,7 @@ import org.apache.nifi.controller.MockStateManagerProvider;
 import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.controller.ProcessorNode;
 import org.apache.nifi.controller.ReloadComponent;
+import org.apache.nifi.controller.ScheduledState;
 import org.apache.nifi.controller.flow.StandardFlowManager;
 import org.apache.nifi.controller.flowanalysis.FlowAnalyzer;
 import org.apache.nifi.controller.queue.DropFlowFileRequest;
@@ -62,6 +67,8 @@ import org.apache.nifi.controller.scheduling.StandardLifecycleStateManager;
 import org.apache.nifi.controller.scheduling.StandardProcessScheduler;
 import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.apache.nifi.controller.service.ControllerServiceProvider;
+import org.apache.nifi.controller.service.ControllerServiceState;
+import org.apache.nifi.controller.service.StandardControllerServiceProvider;
 import org.apache.nifi.engine.FlowEngine;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.mock.MockNodeTypeProvider;
@@ -93,17 +100,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.IntSupplier;
 import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -121,11 +129,10 @@ public class StandardConnectorNodeIT {
     private StandardFlowManager flowManager;
     private FlowEngine componentLifecycleThreadPool;
     private ConnectorRepository connectorRepository;
+    private ControllerServiceProvider controllerServiceProvider;
 
     @BeforeEach
     public void setup() {
-        final ControllerServiceProvider controllerServiceProvider = mock(ControllerServiceProvider.class);
-        when(controllerServiceProvider.disableControllerServicesAsync(anyCollection())).thenReturn(CompletableFuture.completedFuture(null));
         connectorRepository = new StandardConnectorRepository();
 
         final SecretsManager secretsManager = new ParameterProviderSecretsManager();
@@ -139,7 +146,8 @@ public class StandardConnectorNodeIT {
         final LifecycleStateManager lifecycleStateManager = new StandardLifecycleStateManager();
         final ReloadComponent reloadComponent = mock(ReloadComponent.class);
 
-        final NiFiProperties nifiProperties = NiFiProperties.createBasicNiFiProperties("src/test/resources/conf/nifi.properties");
+        final NiFiProperties nifiProperties = NiFiProperties.createBasicNiFiProperties("src/test/resources/conf/nifi.properties",
+            Map.of(NiFiProperties.ADMINISTRATIVE_YIELD_DURATION, "100 millis"));
 
         final FlowController flowController = mock(FlowController.class);
         when(flowController.isInitialized()).thenReturn(true);
@@ -158,7 +166,6 @@ public class StandardConnectorNodeIT {
 
         when(flowController.getRepositoryContextFactory()).thenReturn(repoContextFactory);
         when(flowController.getGarbageCollectionLog()).thenReturn(mock(GarbageCollectionLog.class));
-        when(flowController.getControllerServiceProvider()).thenReturn(controllerServiceProvider);
         when(flowController.getProvenanceRepository()).thenReturn(provRepo);
         when(flowController.getBulletinRepository()).thenReturn(bulletinRepository);
         when(flowController.getLifecycleStateManager()).thenReturn(lifecycleStateManager);
@@ -186,6 +193,8 @@ public class StandardConnectorNodeIT {
         extensionManager.discoverExtensions(systemBundle, Set.of());
 
         flowManager = new StandardFlowManager(nifiProperties, null, flowController, flowFileEventRepository, parameterContextManager);
+        controllerServiceProvider = new StandardControllerServiceProvider(processScheduler, bulletinRepository, flowManager, extensionManager);
+        when(flowController.getControllerServiceProvider()).thenReturn(controllerServiceProvider);
         flowManager.initialize(controllerServiceProvider, mock(PythonBridge.class), mock(FlowAnalyzer.class), mock(RuleViolationsManager.class));
         final ProcessGroup rootGroup = flowManager.createProcessGroup("root");
         rootGroup.setName("Root");
@@ -395,6 +404,298 @@ public class StandardConnectorNodeIT {
         assertNotNull(serviceNodes);
         assertEquals(1, serviceNodes.size());
         assertInstanceOf(CounterService.class, serviceNodes.iterator().next().getControllerServiceImplementation());
+    }
+
+    @Test
+    @Timeout(20)
+    public void testStopConnectorWhileManagedServiceBlocksInOnEnabled() throws Exception {
+        final ConnectorNode connectorNode = initializeControllerServiceEnablingConnector(ControllerServiceEnablingConnector.BLOCKING_ENABLING);
+        final ControllerServiceNode serviceNode = getManagedControllerService(connectorNode);
+        final BlockingEnablingCounterService service = (BlockingEnablingCounterService) serviceNode.getControllerServiceImplementation();
+
+        connectorNode.start(componentLifecycleThreadPool);
+        try {
+            waitForServiceState(serviceNode, ControllerServiceState.ENABLING);
+            waitForEnableInvocation(service::enableInvocationCount, 1);
+
+            final Future<Void> stopFuture = connectorNode.stop(componentLifecycleThreadPool);
+            stopFuture.get(5, TimeUnit.SECONDS);
+
+            assertEquals(ConnectorState.STOPPED, connectorNode.getCurrentState());
+            assertEquals(ControllerServiceState.DISABLED, serviceNode.getState());
+
+            // Stopping while the service was blocked in @OnEnabled must interrupt that invocation and then invoke @OnDisabled
+            // exactly once before the service reaches DISABLED.
+            assertTrue(service.wasInterrupted());
+            assertEquals(1, service.disableInvocationCount());
+        } finally {
+            service.releaseEnable();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testRestartConnectorAfterStopWhileManagedServiceBlocksInOnEnabled() throws Exception {
+        final ConnectorNode connectorNode = initializeControllerServiceEnablingConnector(ControllerServiceEnablingConnector.BLOCKING_ENABLING);
+        final ControllerServiceNode serviceNode = getManagedControllerService(connectorNode);
+        final BlockingEnablingCounterService service = (BlockingEnablingCounterService) serviceNode.getControllerServiceImplementation();
+
+        connectorNode.start(componentLifecycleThreadPool);
+        waitForServiceState(serviceNode, ControllerServiceState.ENABLING);
+        waitForEnableInvocation(service::enableInvocationCount, 1);
+
+        connectorNode.stop(componentLifecycleThreadPool).get(10, TimeUnit.SECONDS);
+        assertEquals(ConnectorState.STOPPED, connectorNode.getCurrentState());
+        assertEquals(ControllerServiceState.DISABLED, serviceNode.getState());
+        assertEquals(1, service.disableInvocationCount());
+
+        // Starting the Connector again begins a new enable cycle. The second @OnEnabled must not begin until the first
+        // @OnDisabled has completed, which is guaranteed because the service reached DISABLED before the restart.
+        connectorNode.start(componentLifecycleThreadPool);
+        try {
+            waitForEnableInvocation(service::enableInvocationCount, 2);
+            assertEquals(1, service.disableInvocationCount());
+        } finally {
+            service.releaseEnable();
+        }
+
+        waitForServiceState(serviceNode, ControllerServiceState.ENABLED);
+        connectorNode.stop(componentLifecycleThreadPool).get(10, TimeUnit.SECONDS);
+        assertEquals(ControllerServiceState.DISABLED, serviceNode.getState());
+    }
+
+    @Test
+    @Timeout(30)
+    public void testStopConnectorWhileManagedServiceKeepsFailingOnEnabled() throws Exception {
+        final ConnectorNode connectorNode = initializeControllerServiceEnablingConnector(ControllerServiceEnablingConnector.FAILING_ENABLING);
+        final ControllerServiceNode serviceNode = getManagedControllerService(connectorNode);
+
+        connectorNode.start(componentLifecycleThreadPool);
+        final FailingEnablingCounterService service = (FailingEnablingCounterService) serviceNode.getControllerServiceImplementation();
+        waitForEnableInvocation(service::enableInvocationCount, 2);
+
+        final Future<Void> stopFuture = connectorNode.stop(componentLifecycleThreadPool);
+        stopFuture.get(5, TimeUnit.SECONDS);
+
+        assertEquals(ConnectorState.STOPPED, connectorNode.getCurrentState());
+        assertEquals(ControllerServiceState.DISABLED, serviceNode.getState());
+    }
+
+    @Test
+    @Timeout(30)
+    public void testRestartConnectorAfterStopWhileManagedServiceKeepsFailingOnEnabled() throws Exception {
+        final ConnectorNode connectorNode = initializeControllerServiceEnablingConnector(ControllerServiceEnablingConnector.FAILING_ENABLING);
+        final ControllerServiceNode serviceNode = getManagedControllerService(connectorNode);
+        final FailingEnablingCounterService service = (FailingEnablingCounterService) serviceNode.getControllerServiceImplementation();
+
+        connectorNode.start(componentLifecycleThreadPool);
+
+        // Wait until @OnEnabled has been invoked and retried at least once, which proves the failure-retry loop is active and
+        // that a retry has been scheduled by the time the stop arrives.
+        waitForEnableInvocation(service::enableInvocationCount, 2);
+
+        // Stopping the Connector disables the managed service, which cancels the in-flight enable attempt and its pending
+        // retry. The stop future completes only after the service reaches DISABLED, at which point the cancelled retry can no
+        // longer invoke @OnEnabled for this cycle, so the invocation count for the first cycle is final.
+        connectorNode.stop(componentLifecycleThreadPool).get(10, TimeUnit.SECONDS);
+        assertEquals(ConnectorState.STOPPED, connectorNode.getCurrentState());
+        assertEquals(ControllerServiceState.DISABLED, serviceNode.getState());
+        final int invocationsAfterStop = service.enableInvocationCount();
+        Thread.sleep(500L);
+        assertEquals(invocationsAfterStop, service.enableInvocationCount());
+
+        // Restarting the Connector begins a new enable cycle, so @OnEnabled must be invoked again beyond the count reached in
+        // the first cycle.
+        connectorNode.start(componentLifecycleThreadPool);
+        waitForEnableInvocation(service::enableInvocationCount, invocationsAfterStop + 1);
+
+        connectorNode.stop(componentLifecycleThreadPool).get(10, TimeUnit.SECONDS);
+        assertEquals(ControllerServiceState.DISABLED, serviceNode.getState());
+        final int invocationsAfterSecondStop = service.enableInvocationCount();
+        Thread.sleep(500L);
+        assertEquals(invocationsAfterSecondStop, service.enableInvocationCount());
+
+        // A cancelled retry from the first cycle must never run alongside a live @OnEnabled from the second cycle, so the peak
+        // number of concurrent @OnEnabled invocations across both cycles stays exactly one.
+        assertEquals(1, service.maxConcurrentEnableInvocationCount());
+    }
+
+    @Test
+    @Timeout(30)
+    public void testStopThenRestartEnforcesEnableThenDisableThenEnableOrdering() throws Exception {
+        final ConnectorNode connectorNode = initializeControllerServiceEnablingConnector(ControllerServiceEnablingConnector.ORDERED_BLOCKING);
+        final ControllerServiceNode serviceNode = getManagedControllerService(connectorNode);
+        final BlockingEnableDisableCounterService service = (BlockingEnableDisableCounterService) serviceNode.getControllerServiceImplementation();
+
+        try {
+            connectorNode.start(componentLifecycleThreadPool);
+            waitForServiceState(serviceNode, ControllerServiceState.ENABLING);
+            waitForEnableInvocation(service::enableInvocationCount, 1);
+
+            // Stop while the interruption-resistant @OnEnabled is still running. The service moves to DISABLING and stays
+            // there: @OnDisabled has not started and no second @OnEnabled has begun while the stop is pending.
+            final Future<Void> stopFuture = connectorNode.stop(componentLifecycleThreadPool);
+            waitForServiceState(serviceNode, ControllerServiceState.DISABLING);
+            assertTrue(service.wasInterrupted());
+            assertEquals(1, service.enableInvocationCount());
+            assertEquals(0, service.disableInvocationCount());
+            assertFalse(stopFuture.isDone());
+
+            // Requesting a restart while the Connector is stopping records a pending start; no second @OnEnabled may begin yet
+            // because the Connector cannot finish stopping until the managed service is disabled.
+            connectorNode.start(componentLifecycleThreadPool);
+            assertEquals(ControllerServiceState.DISABLING, serviceNode.getState());
+            assertEquals(1, service.enableInvocationCount());
+            assertEquals(0, service.disableInvocationCount());
+            assertFalse(stopFuture.isDone());
+
+            // Releasing @OnEnabled lets the enable task invoke @OnDisabled, which blocks. The service stays DISABLING and no
+            // second @OnEnabled begins until @OnDisabled returns.
+            service.releaseEnable();
+            waitForCount(service::disableInvocationCount, 1);
+            assertEquals(ControllerServiceState.DISABLING, serviceNode.getState());
+            assertEquals(1, service.enableInvocationCount());
+            assertFalse(stopFuture.isDone());
+
+            // Releasing @OnDisabled lets the service reach DISABLED, which completes the stop and begins the pending start's
+            // second @OnEnabled.
+            service.releaseDisable();
+            stopFuture.get(10, TimeUnit.SECONDS);
+            waitForEnableInvocation(service::enableInvocationCount, 2);
+            assertEquals(1, service.disableInvocationCount());
+        } finally {
+            service.releaseEnable();
+            service.releaseDisable();
+        }
+
+        connectorNode.stop(componentLifecycleThreadPool).get(10, TimeUnit.SECONDS);
+        assertEquals(ControllerServiceState.DISABLED, serviceNode.getState());
+    }
+
+    @Test
+    @Timeout(30)
+    public void testStopConnectorWhileManagedProcessorKeepsFailingOnScheduled() throws Exception {
+        final ConnectorNode connectorNode = initializeProcessorStartHangConnector(ProcessorStartHangConnector.ROOT_GROUP);
+        final ProcessorNode processorNode = getManagedHangProcessorNode(connectorNode);
+        final ManagedStartHangProcessor processor = (ManagedStartHangProcessor) processorNode.getProcessor();
+        processor.setStartBehavior(ManagedStartHangProcessor.StartBehavior.REPEATED_FAILURE);
+
+        connectorNode.start(componentLifecycleThreadPool);
+        waitForCount(processor::getOnScheduledInvocationCount, 1);
+
+        final Future<Void> stopFuture = connectorNode.stop(componentLifecycleThreadPool);
+        stopFuture.get(20, TimeUnit.SECONDS);
+
+        assertEquals(ConnectorState.STOPPED, connectorNode.getCurrentState());
+        assertEquals(ScheduledState.STOPPED, processorNode.getPhysicalScheduledState());
+    }
+
+    @Test
+    @Timeout(30)
+    public void testStopConnectorWhileManagedProcessorBlocksInInterruptibleOnScheduled() throws Exception {
+        final ConnectorNode connectorNode = initializeProcessorStartHangConnector(ProcessorStartHangConnector.ROOT_GROUP);
+        final ProcessorNode processorNode = getManagedHangProcessorNode(connectorNode);
+        final ManagedStartHangProcessor processor = (ManagedStartHangProcessor) processorNode.getProcessor();
+        processor.setStartBehavior(ManagedStartHangProcessor.StartBehavior.INTERRUPTIBLE_BLOCK);
+
+        connectorNode.start(componentLifecycleThreadPool);
+        waitForCount(processor::getOnScheduledInvocationCount, 1);
+
+        final Future<Void> stopFuture = connectorNode.stop(componentLifecycleThreadPool);
+        stopFuture.get(20, TimeUnit.SECONDS);
+
+        assertEquals(ConnectorState.STOPPED, connectorNode.getCurrentState());
+        assertEquals(ScheduledState.STOPPED, processorNode.getPhysicalScheduledState());
+        assertTrue(processor.getInterruptionCount() >= 1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void testStopConnectorWhileManagedProcessorInChildGroupKeepsFailingOnScheduled() throws Exception {
+        final ConnectorNode connectorNode = initializeProcessorStartHangConnector(ProcessorStartHangConnector.CHILD_GROUP);
+        final ProcessorNode processorNode = getManagedHangProcessorNode(connectorNode);
+        final ManagedStartHangProcessor processor = (ManagedStartHangProcessor) processorNode.getProcessor();
+        processor.setStartBehavior(ManagedStartHangProcessor.StartBehavior.REPEATED_FAILURE);
+
+        assertNotEquals(connectorNode.getActiveFlowContext().getManagedProcessGroup().getIdentifier(), processorNode.getProcessGroup().getIdentifier());
+
+        connectorNode.start(componentLifecycleThreadPool);
+        waitForCount(processor::getOnScheduledInvocationCount, 1);
+
+        final Future<Void> stopFuture = connectorNode.stop(componentLifecycleThreadPool);
+        stopFuture.get(20, TimeUnit.SECONDS);
+
+        assertEquals(ConnectorState.STOPPED, connectorNode.getCurrentState());
+        assertEquals(ScheduledState.STOPPED, processorNode.getPhysicalScheduledState());
+    }
+
+    private ConnectorNode initializeProcessorStartHangConnector(final String placement) throws FlowUpdateException {
+        final ConnectorNode connectorNode = flowManager.createConnector(ProcessorStartHangConnector.class.getName(),
+                "processor-start-hang-connector", SystemBundle.SYSTEM_BUNDLE_COORDINATE, true, true);
+
+        final StepConfiguration stepConfiguration = new StepConfiguration(Map.of(
+            ProcessorStartHangConnector.PROCESSOR_PLACEMENT.getName(), new StringLiteralValue(placement)));
+
+        final NamedStepConfiguration namedStepConfiguration = new NamedStepConfiguration(ProcessorStartHangConnector.CONFIGURATION_STEP_NAME, stepConfiguration);
+        configure(connectorNode, new ConnectorConfiguration(Set.of(namedStepConfiguration)));
+        return connectorNode;
+    }
+
+    private ProcessorNode getManagedHangProcessorNode(final ConnectorNode connectorNode) {
+        final ProcessGroup managedGroup = connectorNode.getActiveFlowContext().getManagedProcessGroup();
+        for (final ProcessorNode processorNode : managedGroup.findAllProcessors()) {
+            if (processorNode.getProcessor() instanceof ManagedStartHangProcessor) {
+                return processorNode;
+            }
+        }
+
+        throw new IllegalStateException("Managed flow does not contain a ManagedStartHangProcessor");
+    }
+
+    private void waitForCount(final IntSupplier countSupplier, final int expectedCount) throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+        while (countSupplier.getAsInt() < expectedCount && System.nanoTime() < deadline) {
+            Thread.sleep(10L);
+        }
+
+        assertTrue(countSupplier.getAsInt() >= expectedCount);
+    }
+
+    private ConnectorNode initializeControllerServiceEnablingConnector(final String enablingBehavior) throws FlowUpdateException {
+        final ConnectorNode connectorNode = flowManager.createConnector(ControllerServiceEnablingConnector.class.getName(),
+                "controller-service-enabling-connector", SystemBundle.SYSTEM_BUNDLE_COORDINATE, true, true);
+
+        final StepConfiguration stepConfiguration = new StepConfiguration(Map.of(
+            ControllerServiceEnablingConnector.ENABLING_BEHAVIOR.getName(), new StringLiteralValue(enablingBehavior)));
+
+        final NamedStepConfiguration namedStepConfiguration = new NamedStepConfiguration(ControllerServiceEnablingConnector.CONFIGURATION_STEP_NAME, stepConfiguration);
+        configure(connectorNode, new ConnectorConfiguration(Set.of(namedStepConfiguration)));
+        return connectorNode;
+    }
+
+    private ControllerServiceNode getManagedControllerService(final ConnectorNode connectorNode) {
+        final ProcessGroup managedGroup = connectorNode.getActiveFlowContext().getManagedProcessGroup();
+        final Set<ControllerServiceNode> services = managedGroup.getControllerServices(true);
+        assertEquals(1, services.size());
+        return services.iterator().next();
+    }
+
+    private void waitForServiceState(final ControllerServiceNode serviceNode, final ControllerServiceState desiredState) throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (serviceNode.getState() != desiredState && System.nanoTime() < deadline) {
+            Thread.sleep(10L);
+        }
+
+        assertEquals(desiredState, serviceNode.getState());
+    }
+
+    private void waitForEnableInvocation(final IntSupplier enableInvocationCount, final int expectedCount) throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+        while (enableInvocationCount.getAsInt() < expectedCount && System.nanoTime() < deadline) {
+            Thread.sleep(10L);
+        }
+
+        assertTrue(enableInvocationCount.getAsInt() >= expectedCount);
     }
 
     @Test

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/processors/CreateDummyFlowFile.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/processors/CreateDummyFlowFile.java
@@ -57,7 +57,7 @@ public class CreateDummyFlowFile extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return List.of(TEXT);
+        return List.of(TEXT, COUNT_SERVICE);
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/processors/ManagedStartHangProcessor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/processors/ManagedStartHangProcessor.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.components.connector.processors;
+
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A Connector-managed Processor whose {@code @OnScheduled} method can be configured to keep throwing an Exception,
+ * to block until released while responding to interruption, or to block until released while ignoring interruption.
+ * The behavior is controlled through the Processor instance so that a test can select it after the Connector's flow
+ * has been created but before the Connector is started.
+ */
+@InputRequirement(Requirement.INPUT_FORBIDDEN)
+public class ManagedStartHangProcessor extends AbstractProcessor {
+
+    public enum StartBehavior {
+        REPEATED_FAILURE,
+        INTERRUPTIBLE_BLOCK,
+        INTERRUPTION_RESISTANT_BLOCK
+    }
+
+    private static final Relationship SUCCESS = new Relationship.Builder()
+        .name("success")
+        .description("All FlowFiles are routed to this relationship")
+        .build();
+
+    private volatile StartBehavior startBehavior = StartBehavior.REPEATED_FAILURE;
+    private final AtomicInteger onScheduledInvocationCount = new AtomicInteger();
+    private final AtomicInteger interruptionCount = new AtomicInteger();
+    private final CountDownLatch releaseLatch = new CountDownLatch(1);
+
+    @OnScheduled
+    public void onScheduled() throws InterruptedException {
+        onScheduledInvocationCount.incrementAndGet();
+
+        switch (startBehavior) {
+            case REPEATED_FAILURE -> throw new ProcessException("Intentional repeated @OnScheduled failure for test");
+            case INTERRUPTIBLE_BLOCK -> {
+                try {
+                    releaseLatch.await();
+                } catch (final InterruptedException e) {
+                    interruptionCount.incrementAndGet();
+                    Thread.currentThread().interrupt();
+                    throw e;
+                }
+            }
+            case INTERRUPTION_RESISTANT_BLOCK -> {
+                while (releaseLatch.getCount() > 0) {
+                    try {
+                        releaseLatch.await();
+                    } catch (final InterruptedException e) {
+                        interruptionCount.incrementAndGet();
+                    }
+                }
+            }
+        }
+    }
+
+    public void setStartBehavior(final StartBehavior startBehavior) {
+        this.startBehavior = startBehavior;
+    }
+
+    public int getOnScheduledInvocationCount() {
+        return onScheduledInvocationCount.get();
+    }
+
+    public int getInterruptionCount() {
+        return interruptionCount.get();
+    }
+
+    public void release() {
+        while (releaseLatch.getCount() > 0) {
+            releaseLatch.countDown();
+        }
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return Set.of(SUCCESS);
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/services/impl/BlockingEnableDisableCounterService.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/services/impl/BlockingEnableDisableCounterService.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.components.connector.services.impl;
+
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.components.connector.services.CounterService;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A Controller Service whose @OnEnabled and @OnDisabled methods block until released by the test and ignore interruption.
+ * Because @OnEnabled ignores interruption, a disable initiated during enabling leaves the service DISABLING while the
+ * first @OnEnabled invocation is still running, which lets a test observe that @OnDisabled has not yet started and that no
+ * second @OnEnabled has begun. Releasing @OnEnabled lets the service invoke @OnDisabled, which then blocks until released,
+ * keeping the service DISABLING until the test releases it. This models the full enable, disable, re-enable ordering.
+ */
+public class BlockingEnableDisableCounterService extends AbstractControllerService implements CounterService {
+
+    private final AtomicInteger enableCounter = new AtomicInteger();
+    private final AtomicInteger disableCounter = new AtomicInteger();
+    private final AtomicBoolean interrupted = new AtomicBoolean();
+    private final CountDownLatch enableRelease = new CountDownLatch(1);
+    private final CountDownLatch disableRelease = new CountDownLatch(1);
+
+    @OnEnabled
+    public void onEnabled(final ConfigurationContext context) {
+        enableCounter.incrementAndGet();
+        awaitIgnoringInterruption(enableRelease);
+    }
+
+    @OnDisabled
+    public void onDisabled() {
+        disableCounter.incrementAndGet();
+        awaitIgnoringInterruption(disableRelease);
+    }
+
+    private void awaitIgnoringInterruption(final CountDownLatch latch) {
+        boolean released = false;
+        while (!released) {
+            try {
+                released = latch.await(30, TimeUnit.SECONDS);
+                if (!released) {
+                    // Safety limit so that a test which never releases the latch fails on its own timeout rather than hanging.
+                    return;
+                }
+            } catch (final InterruptedException e) {
+                // Record the interruption but keep running until the latch is explicitly released.
+                interrupted.set(true);
+            }
+        }
+    }
+
+    public void releaseEnable() {
+        enableRelease.countDown();
+    }
+
+    public void releaseDisable() {
+        disableRelease.countDown();
+    }
+
+    public int enableInvocationCount() {
+        return enableCounter.get();
+    }
+
+    public int disableInvocationCount() {
+        return disableCounter.get();
+    }
+
+    public boolean wasInterrupted() {
+        return interrupted.get();
+    }
+
+    @Override
+    public long increment() {
+        return 0;
+    }
+
+    @Override
+    public long getCount() {
+        return 0;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/services/impl/BlockingEnablingCounterService.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/services/impl/BlockingEnablingCounterService.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.components.connector.services.impl;
+
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.components.connector.services.CounterService;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BlockingEnablingCounterService extends AbstractControllerService implements CounterService {
+
+    private final AtomicInteger enableCounter = new AtomicInteger();
+    private final AtomicInteger disableCounter = new AtomicInteger();
+    private final AtomicBoolean interrupted = new AtomicBoolean();
+    private final CountDownLatch enableRelease = new CountDownLatch(1);
+
+    @OnEnabled
+    public void onEnabled(final ConfigurationContext context) throws InterruptedException {
+        enableCounter.incrementAndGet();
+        try {
+            enableRelease.await(30, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+            interrupted.set(true);
+            Thread.currentThread().interrupt();
+            throw e;
+        }
+    }
+
+    @OnDisabled
+    public void onDisabled() {
+        disableCounter.incrementAndGet();
+    }
+
+    public int enableInvocationCount() {
+        return enableCounter.get();
+    }
+
+    public int disableInvocationCount() {
+        return disableCounter.get();
+    }
+
+    public boolean wasInterrupted() {
+        return interrupted.get();
+    }
+
+    public void releaseEnable() {
+        enableRelease.countDown();
+    }
+
+    @Override
+    public long increment() {
+        return 0;
+    }
+
+    @Override
+    public long getCount() {
+        return 0;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/services/impl/FailingEnablingCounterService.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/components/connector/services/impl/FailingEnablingCounterService.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.components.connector.services.impl;
+
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.components.connector.services.CounterService;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FailingEnablingCounterService extends AbstractControllerService implements CounterService {
+
+    private final AtomicInteger enableCounter = new AtomicInteger();
+    private final AtomicInteger concurrentEnableInvocations = new AtomicInteger();
+    private final AtomicInteger maxConcurrentEnableInvocations = new AtomicInteger();
+
+    @OnEnabled
+    public void onEnabled(final ConfigurationContext context) {
+        final int concurrentEnableCount = concurrentEnableInvocations.incrementAndGet();
+        maxConcurrentEnableInvocations.accumulateAndGet(concurrentEnableCount, Math::max);
+        try {
+            enableCounter.incrementAndGet();
+            throw new IllegalStateException("Configured to always fail enablement");
+        } finally {
+            concurrentEnableInvocations.decrementAndGet();
+        }
+    }
+
+    public int enableInvocationCount() {
+        return enableCounter.get();
+    }
+
+    public int maxConcurrentEnableInvocationCount() {
+        return maxConcurrentEnableInvocations.get();
+    }
+
+    @Override
+    public long increment() {
+        return 0;
+    }
+
+    @Override
+    public long getCount() {
+        return 0;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/ControllableLifecycleService.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/ControllableLifecycleService.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.controller.scheduling;
+
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A Controller Service whose lifecycle methods can be externally controlled by a test. When configured to block on
+ * enable, its @OnEnabled method blocks until released and ignores interruption, recording that it was interrupted. When
+ * configured to block on disable, its @OnDisabled method blocks until released. This allows a test to observe the service
+ * while it is DISABLING, both while an interruption-resistant @OnEnabled is still running and while @OnDisabled is running.
+ */
+public class ControllableLifecycleService extends AbstractControllerService {
+
+    private final AtomicInteger enableCounter = new AtomicInteger();
+    private final AtomicInteger disableCounter = new AtomicInteger();
+    private final AtomicBoolean interrupted = new AtomicBoolean();
+    private final CountDownLatch enableRelease = new CountDownLatch(1);
+    private final CountDownLatch disableRelease = new CountDownLatch(1);
+
+    private volatile boolean blockOnEnable = false;
+    private volatile boolean blockOnDisable = false;
+
+    @OnEnabled
+    public void onEnabled(final ConfigurationContext context) {
+        enableCounter.incrementAndGet();
+        if (blockOnEnable) {
+            awaitIgnoringInterruption(enableRelease);
+        }
+    }
+
+    @OnDisabled
+    public void onDisabled() {
+        disableCounter.incrementAndGet();
+        if (blockOnDisable) {
+            awaitIgnoringInterruption(disableRelease);
+        }
+    }
+
+    private void awaitIgnoringInterruption(final CountDownLatch latch) {
+        boolean released = false;
+        while (!released) {
+            try {
+                released = latch.await(30, TimeUnit.SECONDS);
+                if (!released) {
+                    // Safety limit so that a test which never releases the latch fails on its own timeout rather than hanging.
+                    return;
+                }
+            } catch (final InterruptedException e) {
+                interrupted.set(true);
+            }
+        }
+    }
+
+    public void setBlockOnEnable(final boolean blockOnEnable) {
+        this.blockOnEnable = blockOnEnable;
+    }
+
+    public void setBlockOnDisable(final boolean blockOnDisable) {
+        this.blockOnDisable = blockOnDisable;
+    }
+
+    public void releaseEnable() {
+        enableRelease.countDown();
+    }
+
+    public void releaseDisable() {
+        disableRelease.countDown();
+    }
+
+    public int enableInvocationCount() {
+        return enableCounter.get();
+    }
+
+    public int disableInvocationCount() {
+        return disableCounter.get();
+    }
+
+    public boolean wasInterrupted() {
+        return interrupted.get();
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/TestStandardProcessScheduler.java
@@ -58,6 +58,10 @@ import org.apache.nifi.engine.FlowEngine;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.lifecycle.ProcessorStopLifecycleMethods;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.logging.LogLevel;
+import org.apache.nifi.logging.LogMessage;
+import org.apache.nifi.logging.LogObserver;
+import org.apache.nifi.logging.LogRepositoryFactory;
 import org.apache.nifi.nar.ExtensionDiscoveringManager;
 import org.apache.nifi.nar.StandardExtensionDiscoveringManager;
 import org.apache.nifi.nar.SystemBundle;
@@ -95,9 +99,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -107,10 +113,13 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -118,6 +127,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -469,38 +479,136 @@ public class TestStandardProcessScheduler {
     }
 
     /**
-     * Validates that service that is infinitely blocking in @OnEnabled can
-     * still have DISABLE operation initiated. The service itself will be set to
-     * DISABLING state at which point UI and all will know that such service can
-     * not be transitioned any more into any other state until it finishes
-     * enabling (which will never happen in our case thus should be addressed by
-     * user). However, regardless of user's mistake NiFi will remain
-     * functioning.
+     * A service blocked in an interruptible @OnEnabled can still be disabled. The disable interrupts the @OnEnabled
+     * invocation, the service then invokes @OnDisabled, and the service transitions to DISABLED. Because the interruption
+     * is the expected result of a disable rather than an enable failure, no enable-failure error is logged for the service.
      */
     @Test
-    public void validateNeverEnablingServiceCanStillBeDisabled() throws Exception {
+    @Timeout(10)
+    public void validateEnablingServiceBlockedInInterruptibleOnEnabledIsInterruptedAndDisabled() throws Exception {
         final StandardProcessScheduler scheduler = createScheduler();
 
+        final String serviceIdentifier = UUID.randomUUID().toString();
         final ControllerServiceNode serviceNode = flowManager.createControllerService(LongEnablingService.class.getName(),
-                "1", systemBundle.getBundleDetails().getCoordinate(), null, false, true, null);
+                serviceIdentifier, systemBundle.getBundleDetails().getCoordinate(), null, false, true, null);
 
-        final LongEnablingService ts = (LongEnablingService) serviceNode.getControllerServiceImplementation();
-        ts.setLimit(Long.MAX_VALUE);
+        final CollectingLogObserver errorObserver = new CollectingLogObserver();
+        LogRepositoryFactory.getRepository(serviceIdentifier).addObserver(LogLevel.ERROR, errorObserver);
+
+        final LongEnablingService service = (LongEnablingService) serviceNode.getControllerServiceImplementation();
+        service.setLimit(Long.MAX_VALUE);
 
         serviceNode.performValidation();
         scheduler.enableControllerService(serviceNode);
 
         assertTrue(serviceNode.isActive());
-        final long maxTime = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
-        while (ts.enableInvocationCount() != 1 && System.nanoTime() <= maxTime) {
+        waitForCondition(() -> service.enableInvocationCount() == 1);
+        assertEquals(1, service.enableInvocationCount());
+        assertSame(ControllerServiceState.ENABLING, serviceNode.getState());
+
+        final CompletableFuture<Void> disableFuture = scheduler.disableControllerService(serviceNode);
+        disableFuture.get(5, TimeUnit.SECONDS);
+
+        assertFalse(serviceNode.isActive());
+        assertSame(ControllerServiceState.DISABLED, serviceNode.getState());
+        assertEquals(1, service.disableInvocationCount());
+        assertFalse(errorObserver.hasEnableFailureMessage(), "A stop-driven interruption of @OnEnabled must not log an enable-failure error");
+    }
+
+    /**
+     * A service blocked in an interruption-resistant @OnEnabled remains DISABLING when a disable is initiated. The disable
+     * interrupts the invocation, but the invocation ignores the interruption and keeps running, so @OnDisabled has not yet
+     * been invoked. Once the @OnEnabled invocation is released, the service invokes @OnDisabled and transitions to DISABLED.
+     */
+    @Test
+    @Timeout(10)
+    public void testDisableOfInterruptionResistantEnablingServiceRemainsDisablingUntilReleased() throws Exception {
+        final StandardProcessScheduler scheduler = createScheduler();
+
+        final ControllerServiceNode serviceNode = flowManager.createControllerService(ControllableLifecycleService.class.getName(),
+                UUID.randomUUID().toString(), systemBundle.getBundleDetails().getCoordinate(), null, false, true, null);
+
+        final ControllableLifecycleService service = (ControllableLifecycleService) serviceNode.getControllerServiceImplementation();
+        service.setBlockOnEnable(true);
+
+        serviceNode.performValidation();
+        scheduler.enableControllerService(serviceNode);
+        waitForCondition(() -> service.enableInvocationCount() == 1);
+
+        final CompletableFuture<Void> disableFuture = scheduler.disableControllerService(serviceNode);
+        waitForCondition(service::wasInterrupted);
+
+        assertSame(ControllerServiceState.DISABLING, serviceNode.getState());
+        assertEquals(0, service.disableInvocationCount());
+        assertFalse(disableFuture.isDone());
+
+        service.releaseEnable();
+        disableFuture.get(5, TimeUnit.SECONDS);
+
+        assertSame(ControllerServiceState.DISABLED, serviceNode.getState());
+        assertEquals(1, service.disableInvocationCount());
+    }
+
+    /**
+     * When a disable is initiated for an ENABLED service whose @OnDisabled blocks, the service remains DISABLING until the
+     * @OnDisabled invocation returns, at which point the service transitions to DISABLED and the disable future completes.
+     */
+    @Test
+    @Timeout(10)
+    public void testDisableRemainsDisablingWhileOnDisabledBlocks() throws Exception {
+        final StandardProcessScheduler scheduler = createScheduler();
+
+        final ControllerServiceNode serviceNode = flowManager.createControllerService(ControllableLifecycleService.class.getName(),
+                UUID.randomUUID().toString(), systemBundle.getBundleDetails().getCoordinate(), null, false, true, null);
+
+        final ControllableLifecycleService service = (ControllableLifecycleService) serviceNode.getControllerServiceImplementation();
+        service.setBlockOnDisable(true);
+
+        serviceNode.performValidation();
+        scheduler.enableControllerService(serviceNode).get(5, TimeUnit.SECONDS);
+        assertSame(ControllerServiceState.ENABLED, serviceNode.getState());
+
+        final CompletableFuture<Void> disableFuture = scheduler.disableControllerService(serviceNode);
+        waitForCondition(() -> service.disableInvocationCount() == 1);
+
+        assertSame(ControllerServiceState.DISABLING, serviceNode.getState());
+        assertFalse(disableFuture.isDone());
+
+        service.releaseDisable();
+        disableFuture.get(5, TimeUnit.SECONDS);
+
+        assertSame(ControllerServiceState.DISABLED, serviceNode.getState());
+        assertEquals(1, service.disableInvocationCount());
+    }
+
+    @Test
+    @Timeout(10)
+    public void testRepeatedDisableWhileEnablingCompletesFutures() throws Exception {
+        final StandardProcessScheduler scheduler = createScheduler();
+        final ControllerServiceNode serviceNode = flowManager.createControllerService(LongEnablingService.class.getName(),
+                "1", systemBundle.getBundleDetails().getCoordinate(), null, false, true, null);
+        final LongEnablingService service = (LongEnablingService) serviceNode.getControllerServiceImplementation();
+        service.setLimit(TimeUnit.SECONDS.toMillis(1));
+
+        serviceNode.performValidation();
+        final CompletableFuture<Void> enableFuture = scheduler.enableControllerService(serviceNode);
+
+        final long enableInvocationDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (service.enableInvocationCount() == 0 && System.nanoTime() < enableInvocationDeadline) {
             Thread.sleep(1L);
         }
-        assertEquals(1, ts.enableInvocationCount());
 
-        scheduler.disableControllerService(serviceNode);
-        assertFalse(serviceNode.isActive());
-        assertEquals(ControllerServiceState.DISABLING, serviceNode.getState());
-        assertEquals(0, ts.disableInvocationCount());
+        assertEquals(1, service.enableInvocationCount());
+        assertEquals(ControllerServiceState.ENABLING, serviceNode.getState());
+
+        final CompletableFuture<Void> firstDisableFuture = scheduler.disableControllerService(serviceNode);
+        final CompletableFuture<Void> secondDisableFuture = scheduler.disableControllerService(serviceNode);
+
+        final ExecutionException enableFailure = assertThrows(ExecutionException.class, () -> enableFuture.get(5, TimeUnit.SECONDS));
+        assertInstanceOf(CancellationException.class, enableFailure.getCause());
+        firstDisableFuture.get(5, TimeUnit.SECONDS);
+        secondDisableFuture.get(5, TimeUnit.SECONDS);
+        assertEquals(ControllerServiceState.DISABLED, serviceNode.getState());
     }
 
     @Test
@@ -639,6 +747,108 @@ public class TestStandardProcessScheduler {
         proc.setAllowSleepInterrupt(true);
     }
 
+    // Stopping a Processor while it is starting must complete the start future exceptionally with a CancellationException,
+    // even if the @OnScheduled method keeps throwing so the start never completes normally.
+    @Test
+    @Timeout(10)
+    public void testStartFutureCancelledWhenStoppedWhileOnScheduledKeepsFailing() throws Exception {
+        final FailOnScheduledProcessor processor = new FailOnScheduledProcessor();
+        processor.setDesiredFailureCount(Integer.MAX_VALUE);
+        final ProcessorNode processorNode = createProcessorNode(processor, scheduler);
+
+        final CompletableFuture<Void> startFuture = scheduler.startProcessor(processorNode, true);
+        waitForCondition(() -> processor.getOnScheduledInvocationCount() >= 1);
+
+        final CompletableFuture<Void> stopFuture = scheduler.stopProcessor(processorNode, ProcessorStopLifecycleMethods.TRIGGER_ALL);
+
+        assertThrows(CancellationException.class, () -> startFuture.get(5, TimeUnit.SECONDS));
+
+        stopFuture.get(5, TimeUnit.SECONDS);
+        assertEquals(ScheduledState.STOPPED, processorNode.getPhysicalScheduledState());
+    }
+
+    @Test
+    @Timeout(10)
+    public void testStartFutureCancelledWhenStoppedWhileOnScheduledIsBlocked() throws Exception {
+        final FailOnScheduledProcessor processor = new FailOnScheduledProcessor();
+        processor.setDesiredFailureCount(0);
+        processor.setOnScheduledSleepDuration(30, TimeUnit.SECONDS, true, 1);
+        final ProcessorNode processorNode = createProcessorNode(processor, scheduler);
+        final CollectingLogObserver errorObserver = new CollectingLogObserver();
+        LogRepositoryFactory.getRepository(processorNode.getIdentifier()).addObserver(LogLevel.ERROR, errorObserver);
+
+        final CompletableFuture<Void> startFuture = scheduler.startProcessor(processorNode, true);
+        waitForCondition(() -> processor.getOnScheduledInvocationCount() >= 1);
+
+        final CompletableFuture<Void> stopFuture = scheduler.stopProcessor(processorNode, ProcessorStopLifecycleMethods.TRIGGER_ALL);
+
+        assertThrows(CancellationException.class, () -> startFuture.get(5, TimeUnit.SECONDS));
+
+        stopFuture.get(5, TimeUnit.SECONDS);
+        waitForCondition(() -> processor.getOnScheduledReturnCount() >= 1);
+        assertEquals(ScheduledState.STOPPED, processorNode.getPhysicalScheduledState());
+        assertFalse(errorObserver.hasMessageContaining("Failed to properly initialize Processor"),
+            "A stop-driven interruption of @OnScheduled must not log a Processor initialization error");
+    }
+
+    // When a Processor is stopped while its @OnScheduled method is blocked and ignores interruption, the start future is
+    // cancelled and terminating the Processor completes the stop. The abandoned invocation, once it finally returns, must
+    // not transition the terminated Processor back to RUNNING.
+    @Test
+    @Timeout(20)
+    public void testStartFutureCancelledAndTerminationCompletesStopWhenOnScheduledIgnoresInterrupt() throws Exception {
+        final TerminationTestHarness harness = createTerminationTestHarness();
+        final StandardProcessScheduler localScheduler = harness.scheduler();
+
+        final FailOnScheduledProcessor processor = new FailOnScheduledProcessor();
+        processor.setDesiredFailureCount(0);
+        processor.setOnScheduledSleepDuration(3, TimeUnit.SECONDS, false, 1);
+        final ProcessorNode processorNode = createProcessorNode(processor, localScheduler);
+
+        final CompletableFuture<Void> startFuture = localScheduler.startProcessor(processorNode, true);
+        waitForCondition(() -> processor.getOnScheduledInvocationCount() >= 1);
+
+        final CompletableFuture<Void> stopFuture = localScheduler.stopProcessor(processorNode, ProcessorStopLifecycleMethods.TRIGGER_ALL);
+
+        assertThrows(CancellationException.class, () -> startFuture.get(2, TimeUnit.SECONDS));
+
+        // The invocation ignores interruption, so terminate the Processor. Termination completes the stop and reloads the
+        // Processor so that a fresh instance replaces the one whose @OnScheduled method is still running.
+        localScheduler.terminateProcessor(processorNode);
+        stopFuture.get(5, TimeUnit.SECONDS);
+        assertEquals(ScheduledState.STOPPED, processorNode.getPhysicalScheduledState());
+        verify(harness.reloadComponent()).reload(same(processorNode), anyString(), any(BundleCoordinate.class), anySet());
+
+        final CompletableFuture<Void> replacementStartFuture = localScheduler.startProcessor(processorNode, true);
+        replacementStartFuture.get(5, TimeUnit.SECONDS);
+        assertEquals(ScheduledState.RUNNING, processorNode.getPhysicalScheduledState());
+
+        // Once the abandoned invocation finally returns, it must not change the state owned by the replacement start.
+        waitForCondition(() -> processor.getOnScheduledReturnCount() >= 2);
+        assertEquals(ScheduledState.RUNNING, processorNode.getPhysicalScheduledState());
+        assertTrue(startFuture.isCompletedExceptionally());
+
+        localScheduler.stopProcessor(processorNode, ProcessorStopLifecycleMethods.TRIGGER_ALL).get(5, TimeUnit.SECONDS);
+        localScheduler.shutdown();
+    }
+
+    private ProcessorNode createProcessorNode(final FailOnScheduledProcessor processor, final StandardProcessScheduler processScheduler) {
+        final String uuid = UUID.randomUUID().toString();
+        processor.initialize(new StandardProcessorInitializationContext(uuid, null, null, null, KerberosConfig.NOT_CONFIGURED));
+        final ReloadComponent reloadComponent = mock(ReloadComponent.class);
+        final VerifiableComponentFactory verifiableComponentFactory = mock(VerifiableComponentFactory.class);
+        final TerminationAwareLogger logger = mock(TerminationAwareLogger.class);
+        final LoggableComponent<Processor> loggableComponent = new LoggableComponent<>(processor, systemBundle.getBundleDetails().getCoordinate(), logger);
+
+        final ProcessorNode processorNode = new StandardProcessorNode(loggableComponent, uuid,
+            new StandardValidationContextFactory(serviceProvider), processScheduler, serviceProvider, reloadComponent,
+            verifiableComponentFactory, extensionManager, new SynchronousValidationTrigger());
+
+        rootGroup.addProcessor(processorNode);
+        processorNode.performValidation();
+        return processorNode;
+    }
+
     public static class FailingService extends AbstractControllerService {
 
         @OnEnabled
@@ -718,6 +928,15 @@ public class TestStandardProcessScheduler {
     private StandardProcessScheduler createScheduler() {
         return new StandardProcessScheduler(new FlowEngine(1, "Unit Test", true), mock(FlowController.class),
             stateMgrProvider, nifiProperties, new StandardLifecycleStateManager());
+    }
+
+    private static void waitForCondition(final BooleanSupplier condition) throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(1L);
+        }
+
+        assertTrue(condition.getAsBoolean());
     }
 
     /**
@@ -809,8 +1028,9 @@ public class TestStandardProcessScheduler {
 
     private TerminationTestHarness createTerminationTestHarness() {
         final FlowController flowController = mock(FlowController.class);
+        final ReloadComponent reloadComponent = mock(ReloadComponent.class);
         when(flowController.getExtensionManager()).thenReturn(extensionManager);
-        when(flowController.getReloadComponent()).thenReturn(mock(ReloadComponent.class));
+        when(flowController.getReloadComponent()).thenReturn(reloadComponent);
         when(flowController.getControllerServiceProvider()).thenReturn(serviceProvider);
 
         final LifecycleStateManager lifecycleStateManager = new StandardLifecycleStateManager();
@@ -820,7 +1040,7 @@ public class TestStandardProcessScheduler {
             stateMgrProvider, nifiProperties, lifecycleStateManager);
         localScheduler.setSchedulingAgent(SchedulingStrategy.TIMER_DRIVEN, mock(SchedulingAgent.class));
 
-        return new TerminationTestHarness(localScheduler, lifecycleStateManager, componentLifeCyclePool);
+        return new TerminationTestHarness(localScheduler, lifecycleStateManager, componentLifeCyclePool, reloadComponent);
     }
 
     private ProcessorNode createSimpleProcessorNode(final TerminationTestHarness harness) {
@@ -851,6 +1071,31 @@ public class TestStandardProcessScheduler {
         }
     }
 
-    private record TerminationTestHarness(StandardProcessScheduler scheduler, LifecycleStateManager lifecycleStateManager, FlowEngine componentLifeCyclePool) {
+    private static class CollectingLogObserver implements LogObserver {
+        private final List<String> errorMessages = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onLogMessage(final LogMessage message) {
+            if (message.getLogLevel() == LogLevel.ERROR) {
+                errorMessages.add(message.getMessage());
+            }
+        }
+
+        @Override
+        public String getComponentDescription() {
+            return "Collecting Log Observer";
+        }
+
+        private boolean hasEnableFailureMessage() {
+            return hasMessageContaining("Failed to invoke @OnEnabled method");
+        }
+
+        private boolean hasMessageContaining(final String searchTerm) {
+            return errorMessages.stream().anyMatch(message -> message != null && message.contains(searchTerm));
+        }
+    }
+
+    private record TerminationTestHarness(StandardProcessScheduler scheduler, LifecycleStateManager lifecycleStateManager, FlowEngine componentLifeCyclePool,
+            ReloadComponent reloadComponent) {
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/processors/FailOnScheduledProcessor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/scheduling/processors/FailOnScheduledProcessor.java
@@ -25,6 +25,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class FailOnScheduledProcessor extends AbstractProcessor {
 
@@ -34,6 +35,7 @@ public class FailOnScheduledProcessor extends AbstractProcessor {
     private volatile int onScheduledSleepIterations = 0;
     private volatile boolean allowSleepInterrupt = true;
     private final AtomicBoolean succeeded = new AtomicBoolean();
+    private final AtomicInteger onScheduledReturnCount = new AtomicInteger();
 
     public void setDesiredFailureCount(final int desiredFailureCount) {
         this.desiredFailureCount = desiredFailureCount;
@@ -53,27 +55,31 @@ public class FailOnScheduledProcessor extends AbstractProcessor {
     public void onScheduled() throws InterruptedException {
         invocationCount++;
 
-        if (invocationCount <= onScheduledSleepIterations && onScheduledSleepMillis > 0L) {
-            final long sleepFinish = System.currentTimeMillis() + onScheduledSleepMillis;
+        try {
+            if (invocationCount <= onScheduledSleepIterations && onScheduledSleepMillis > 0L) {
+                final long sleepFinish = System.currentTimeMillis() + onScheduledSleepMillis;
 
-            while (System.currentTimeMillis() < sleepFinish) {
-                try {
-                    Thread.sleep(Math.max(0, sleepFinish - System.currentTimeMillis()));
-                } catch (final InterruptedException ie) {
-                    if (allowSleepInterrupt) {
-                        Thread.currentThread().interrupt();
-                        throw ie;
-                    } else {
-                        continue;
+                while (System.currentTimeMillis() < sleepFinish) {
+                    try {
+                        Thread.sleep(Math.max(0, sleepFinish - System.currentTimeMillis()));
+                    } catch (final InterruptedException ie) {
+                        if (allowSleepInterrupt) {
+                            Thread.currentThread().interrupt();
+                            throw ie;
+                        } else {
+                            continue;
+                        }
                     }
                 }
             }
-        }
 
-        if (invocationCount < desiredFailureCount) {
-            throw new ProcessException("Intentional failure for unit test");
-        } else {
-            succeeded.set(true);
+            if (invocationCount < desiredFailureCount) {
+                throw new ProcessException("Intentional failure for unit test");
+            } else {
+                succeeded.set(true);
+            }
+        } finally {
+            onScheduledReturnCount.incrementAndGet();
         }
     }
 
@@ -83,6 +89,10 @@ public class FailOnScheduledProcessor extends AbstractProcessor {
 
     public boolean isSucceeded() {
         return succeeded.get();
+    }
+
+    public int getOnScheduledReturnCount() {
+        return onScheduledReturnCount.get();
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/META-INF/services/org.apache.nifi.components.connector.Connector
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/META-INF/services/org.apache.nifi.components.connector.Connector
@@ -16,3 +16,5 @@
 org.apache.nifi.controller.flow.NopConnector
 org.apache.nifi.components.connector.DynamicFlowConnector
 org.apache.nifi.components.connector.DynamicAllowableValuesConnector
+org.apache.nifi.components.connector.ControllerServiceEnablingConnector
+org.apache.nifi.components.connector.ProcessorStartHangConnector

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -20,3 +20,6 @@ org.apache.nifi.controller.service.mock.ServiceC
 org.apache.nifi.controller.service.mock.ServiceD
 
 org.apache.nifi.components.connector.services.impl.StandardCounterService
+org.apache.nifi.components.connector.services.impl.BlockingEnablingCounterService
+org.apache.nifi.components.connector.services.impl.BlockingEnableDisableCounterService
+org.apache.nifi.components.connector.services.impl.FailingEnablingCounterService

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -24,3 +24,4 @@ org.apache.nifi.components.connector.processors.LogFlowFileContents
 org.apache.nifi.components.connector.processors.ExposeFileValues
 org.apache.nifi.components.connector.processors.Sleep
 org.apache.nifi.components.connector.processors.OnPropertyModifiedTracker
+org.apache.nifi.components.connector.processors.ManagedStartHangProcessor


### PR DESCRIPTION
# Summary

[NIFI-16288](https://issues.apache.org/jira/browse/NIFI-16288)

A Connector could remain in `STOPPING` when a managed Controller Service never finished `@OnEnabled` or a managed Processor never finished `@OnScheduled`. This covered both lifecycle methods that block and lifecycle methods that keep throwing while NiFi retries them.

# Changes

- Disabling an `ENABLING` Controller Service now moves it to `DISABLING`, cancels its enable future and pending retry, and interrupts the active `@OnEnabled` invocation. The service remains `DISABLING` until `@OnEnabled` returns and `@OnDisabled` finishes. Controller Service termination is not introduced.
- Stopping a `STARTING` Processor now cancels its start future and pending retry and interrupts the active `@OnScheduled` invocation. If it ignores interruption, the existing Connector stop timeout and Processor termination path can replace the Processor without allowing the abandoned start to change the replacement's state.
- Stopping a Connector during startup recursively stops managed Processors and disables managed Controller Services. Processor selection uses physical scheduled state so `STARTING` Processors are included.
- Connector start and stop calls are coordinated so a stop cannot complete before an in-flight start returns.

# Tests

- Connector tests cover blocked and repeatedly failing Controller Service enablement.
- Controller Service ordering tests verify `ENABLING` → `DISABLING` → `DISABLED`, including blocked `@OnEnabled`, blocked `@OnDisabled`, restart, and stale retry cases.
- Connector tests cover blocked and repeatedly failing Processor startup, including a Processor in a child Process Group.
- Scheduler tests verify start-future cancellation, normal interruption, and replacement safety after Processor termination.

The Connector Processor tests were run against the original production code and both failed with `TimeoutException` while waiting for the Connector stop future. The same tests pass with this change.

# Verification

- `mvn clean install -T 4 -DskipTests`
- `nifi-framework-core-api`: 53 tests passed
- `nifi-framework-components`: 375 tests passed
- `nifi-framework-core`: 734 tests passed, 3 skipped
- Checkstyle and PMD passed for all three affected modules
- `ConnectorLifecycleIT` and `ConnectorProcessorValidationIT`: 2 system tests passed after rebuilding `nifi-server-nar` and the system-test assembly
