### PR TITLE
NIFI-16326 Corrected subsequent Parameter Context inheritance updates

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/parameter/TestStandardParameterContext.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/parameter/TestStandardParameterContext.java
@@ -54,6 +54,9 @@ public class TestStandardParameterContext {
     private static final String PARAM_VALUE_UPDATED = "new-value";
     private static final String DESCRIPTION_ORIGINAL = "original description";
     private static final String DESCRIPTION_UPDATED = "updated description";
+    private static final String TEST_PARAMETER = "test.parameter";
+    private static final String VALUE_A = "VALUE_A";
+    private static final String VALUE_B = "VALUE_B";
 
     @Test
     public void testUpdatesApply() {
@@ -846,6 +849,58 @@ public class TestStandardParameterContext {
 
         assertEquals("c.child", effectiveParameters.get(child).getValue());
         assertEquals("c", effectiveParameters.get(child).getParameterContextId());
+    }
+
+    @Test
+    public void testSubsequentInheritanceReorderUpdatesEffectiveParameterValue() {
+        final StandardParameterContextManager parameterContextLookup = new StandardParameterContextManager();
+        final ParameterContext contextA = createParameterContext("a", parameterContextLookup);
+        final ParameterDescriptor testParameter = addParameter(contextA, TEST_PARAMETER, VALUE_A);
+
+        final ParameterContext contextB = createParameterContext("b", parameterContextLookup);
+        addParameter(contextB, TEST_PARAMETER, VALUE_B);
+
+        final ParameterContext contextC = createParameterContext("c", parameterContextLookup);
+        contextC.setInheritedParameterContexts(List.of(contextA, contextB));
+        assertEquals(VALUE_A, contextC.getParameter(testParameter).orElseThrow().getValue());
+        assertEquals("a", contextC.getParameter(testParameter).orElseThrow().getParameterContextId());
+
+        final Map<String, Parameter> firstReorderUpdates = contextC.getEffectiveParameterUpdates(Map.of(), List.of(contextB, contextA));
+        assertEquals(VALUE_B, firstReorderUpdates.get(TEST_PARAMETER).getValue());
+        assertEquals("b", firstReorderUpdates.get(TEST_PARAMETER).getParameterContextId());
+
+        contextC.setInheritedParameterContexts(List.of(contextB, contextA));
+        assertEquals(VALUE_B, contextC.getParameter(testParameter).orElseThrow().getValue());
+        assertEquals("b", contextC.getParameter(testParameter).orElseThrow().getParameterContextId());
+
+        final Map<String, Parameter> secondReorderUpdates = contextC.getEffectiveParameterUpdates(Map.of(), List.of(contextA, contextB));
+        assertEquals(VALUE_A, secondReorderUpdates.get(TEST_PARAMETER).getValue());
+        assertEquals("a", secondReorderUpdates.get(TEST_PARAMETER).getParameterContextId());
+
+        contextC.setInheritedParameterContexts(List.of(contextA, contextB));
+        assertEquals(VALUE_A, contextC.getParameter(testParameter).orElseThrow().getValue());
+        assertTrue(contextC.getParameters().isEmpty());
+    }
+
+    @Test
+    public void testSubsequentInheritanceAddRemoveUpdatesEffectiveParameterValue() {
+        final StandardParameterContextManager parameterContextLookup = new StandardParameterContextManager();
+        final ParameterContext contextA = createParameterContext("a", parameterContextLookup);
+        final ParameterDescriptor testParameter = addParameter(contextA, TEST_PARAMETER, VALUE_A);
+
+        final ParameterContext contextB = createParameterContext("b", parameterContextLookup);
+        addParameter(contextB, TEST_PARAMETER, VALUE_B);
+
+        final ParameterContext contextC = createParameterContext("c", parameterContextLookup);
+        contextC.setInheritedParameterContexts(List.of(contextB));
+        assertEquals(VALUE_B, contextC.getParameter(testParameter).orElseThrow().getValue());
+
+        contextC.setInheritedParameterContexts(List.of(contextA, contextB));
+        assertEquals(VALUE_A, contextC.getParameter(testParameter).orElseThrow().getValue());
+
+        contextC.setInheritedParameterContexts(List.of(contextB));
+        assertEquals(VALUE_B, contextC.getParameter(testParameter).orElseThrow().getValue());
+        assertTrue(contextC.getParameters().isEmpty());
     }
 
     @Test

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardParameterContextDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardParameterContextDAO.java
@@ -197,8 +197,8 @@ public class StandardParameterContextDAO implements ParameterContextDAO {
         for (final ParameterEntity parameterEntity : parameterEntities) {
             final ParameterDTO parameterDto = parameterEntity.getParameter();
 
-            // Inherited parameters are only included for referencing components, but we should not save them as direct parameters
-            if (parameterDto.getInherited() != null && parameterDto.getInherited()) {
+            // Inherited parameters are included for referencing-component analysis and must not be saved locally
+            if (isInheritedParameterUpdate(parameterDto, context)) {
                 continue;
             }
 
@@ -216,6 +216,29 @@ public class StandardParameterContextDAO implements ParameterContextDAO {
         }
 
         return parameterMap;
+    }
+
+    /**
+     * Returns whether the Parameter should be omitted from local persistence.
+     * Effective inherited values may be present on an update DTO so that referencing components can be identified.
+     * Those values must not become local Parameters, or later inheritance changes would be shadowed.
+     * The {@code inherited} flag is authoritative when set. When it is absent, a source Parameter Context other than
+     * the context being updated is treated as inherited. An explicit {@code inherited=false} remains a local override.
+     *
+     * @param parameterDto the Parameter from the update request
+     * @param context the Parameter Context being updated, or {@code null} when creating Parameters without a current context
+     * @return true when the Parameter is inherited and should not be stored on the current context
+     */
+    private boolean isInheritedParameterUpdate(final ParameterDTO parameterDto, final ParameterContext context) {
+        if (Boolean.TRUE.equals(parameterDto.getInherited())) {
+            return true;
+        }
+        if (Boolean.FALSE.equals(parameterDto.getInherited()) || context == null || parameterDto.getParameterContext() == null) {
+            return false;
+        }
+
+        final String sourceContextId = parameterDto.getParameterContext().getId();
+        return sourceContextId != null && !sourceContextId.equals(context.getIdentifier());
     }
 
     private Parameter createParameter(final ParameterDTO dto, final ParameterContext context) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/TestStandardParameterContextDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/dao/impl/TestStandardParameterContextDAO.java
@@ -77,6 +77,9 @@ public class TestStandardParameterContextDAO {
     private static final String CONTEXT_ID = "id";
     private static final String CONTEXT_NAME = "Context";
     private static final String INHERITED_CONTEXT_ID = "inherited-id";
+    private static final String TEST_PARAMETER = "test.parameter";
+    private static final String VALUE_A = "VALUE_A";
+    private static final String VALUE_B = "VALUE_B";
 
     private StandardParameterContextDAO dao;
 
@@ -259,6 +262,123 @@ public class TestStandardParameterContextDAO {
         assertEquals(Collections.singletonList(asset), parameter.getReferencedAssets());
         assertDoesNotThrow(() -> dao.verifyAssets(parameterContextDto, parameters));
         verify(assetManager).getAsset(eq("asset-1"));
+    }
+
+    @Test
+    public void testSubsequentInheritanceReorderUpdatesEffectiveParameterValue() {
+        final ParameterContext contextA = createNamedContext("context-a", "Context A");
+        final ParameterContext contextB = createNamedContext("context-b", "Context B");
+        final ParameterContext contextC = dao.getParameterContext(CONTEXT_ID);
+
+        setParameter(contextA, TEST_PARAMETER, VALUE_A);
+        setParameter(contextB, TEST_PARAMETER, VALUE_B);
+
+        dao.updateParameterContext(createInheritanceUpdateDto(contextC, List.of(contextA, contextB), Set.of()));
+        assertEquals(VALUE_A, contextC.getParameter(TEST_PARAMETER).orElseThrow().getValue());
+
+        dao.updateParameterContext(createInheritanceUpdateDto(contextC, List.of(contextB, contextA), Set.of()));
+        assertEquals(VALUE_B, contextC.getParameter(TEST_PARAMETER).orElseThrow().getValue());
+        assertTrue(contextC.getParameters().isEmpty());
+
+        dao.updateParameterContext(createInheritanceUpdateDto(contextC, List.of(contextA, contextB), Set.of()));
+        assertEquals(VALUE_A, contextC.getParameter(TEST_PARAMETER).orElseThrow().getValue());
+        assertTrue(contextC.getParameters().isEmpty());
+    }
+
+    @Test
+    public void testSubsequentInheritanceReorderIgnoresInjectedEffectiveInheritedParameters() {
+        final ParameterContext contextA = createNamedContext("context-a", "Context A");
+        final ParameterContext contextB = createNamedContext("context-b", "Context B");
+        final ParameterContext contextC = dao.getParameterContext(CONTEXT_ID);
+
+        setParameter(contextA, TEST_PARAMETER, VALUE_A);
+        setParameter(contextB, TEST_PARAMETER, VALUE_B);
+
+        dao.updateParameterContext(createInheritanceUpdateDto(contextC, List.of(contextA, contextB), Set.of()));
+        assertEquals(VALUE_A, contextC.getParameter(TEST_PARAMETER).orElseThrow().getValue());
+
+        final ParameterEntity firstEffectiveUpdate = createInheritedParameterEntity(TEST_PARAMETER, VALUE_B, contextB.getIdentifier(), true);
+        dao.updateParameterContext(createInheritanceUpdateDto(contextC, List.of(contextB, contextA), Set.of(firstEffectiveUpdate)));
+        assertEquals(VALUE_B, contextC.getParameter(TEST_PARAMETER).orElseThrow().getValue());
+        assertTrue(contextC.getParameters().isEmpty());
+
+        final ParameterEntity secondEffectiveUpdate = createInheritedParameterEntity(TEST_PARAMETER, VALUE_A, contextA.getIdentifier(), true);
+        dao.updateParameterContext(createInheritanceUpdateDto(contextC, List.of(contextA, contextB), Set.of(secondEffectiveUpdate)));
+        assertEquals(VALUE_A, contextC.getParameter(TEST_PARAMETER).orElseThrow().getValue());
+        assertTrue(contextC.getParameters().isEmpty());
+    }
+
+    @Test
+    public void testSubsequentInheritanceReorderDoesNotPersistEffectiveValueWhenInheritedFlagMissing() {
+        final ParameterContext contextA = createNamedContext("context-a", "Context A");
+        final ParameterContext contextB = createNamedContext("context-b", "Context B");
+        final ParameterContext contextC = dao.getParameterContext(CONTEXT_ID);
+
+        setParameter(contextA, TEST_PARAMETER, VALUE_A);
+        setParameter(contextB, TEST_PARAMETER, VALUE_B);
+
+        dao.updateParameterContext(createInheritanceUpdateDto(contextC, List.of(contextA, contextB), Set.of()));
+        assertEquals(VALUE_A, contextC.getParameter(TEST_PARAMETER).orElseThrow().getValue());
+
+        // Simulate an update DTO that includes the new effective value without inherited=true
+        final ParameterEntity firstEffectiveUpdate = createInheritedParameterEntity(TEST_PARAMETER, VALUE_B, contextB.getIdentifier(), null);
+        dao.updateParameterContext(createInheritanceUpdateDto(contextC, List.of(contextB, contextA), Set.of(firstEffectiveUpdate)));
+        assertEquals(VALUE_B, contextC.getParameter(TEST_PARAMETER).orElseThrow().getValue());
+
+        dao.updateParameterContext(createInheritanceUpdateDto(contextC, List.of(contextA, contextB), Set.of()));
+        assertEquals(VALUE_A, contextC.getParameter(TEST_PARAMETER).orElseThrow().getValue());
+        assertTrue(contextC.getParameters().isEmpty());
+    }
+
+    @Test
+    public void testGetParametersAcceptsExplicitLocalOverrideWithForeignSource() {
+        final ParameterEntity parameterEntity = createInheritedParameterEntity(TEST_PARAMETER, VALUE_B, "foreign-context", false);
+
+        final Map<String, Parameter> parameters = dao.getParameters(createParameterContextDto(parameterEntity), dao.getParameterContext(CONTEXT_ID));
+
+        final Parameter parameter = parameters.get(TEST_PARAMETER);
+        assertEquals(VALUE_B, parameter.getValue());
+        assertNull(parameter.getParameterContextId());
+    }
+
+    private ParameterContext createNamedContext(final String id, final String name) {
+        final ParameterContext parameterContext = new StandardParameterContext.Builder()
+                .id(id)
+                .name(name)
+                .parameterReferenceManager(ParameterReferenceManager.EMPTY)
+                .build();
+        flowController.getFlowManager().getParameterContextManager().addParameterContext(parameterContext);
+        return parameterContext;
+    }
+
+    private void setParameter(final ParameterContext context, final String name, final String value) {
+        context.setParameters(Map.of(name, new Parameter.Builder().name(name).value(value).build()));
+    }
+
+    private ParameterEntity createInheritedParameterEntity(final String name, final String value, final String sourceContextId, final Boolean inherited) {
+        final ParameterEntity parameterEntity = createParameterEntity(name, value, false, null, false, sourceContextId, null);
+        parameterEntity.getParameter().setInherited(inherited);
+        return parameterEntity;
+    }
+
+    private ParameterContextDTO createInheritanceUpdateDto(final ParameterContext context, final List<ParameterContext> inheritedContexts,
+                                                           final Set<ParameterEntity> parameters) {
+        final ParameterContextDTO dto = new ParameterContextDTO();
+        dto.setId(context.getIdentifier());
+        dto.setName(context.getName());
+        dto.setParameters(parameters);
+        dto.setInheritedParameterContexts(inheritedContexts.stream()
+                .map(inherited -> {
+                    final ParameterContextReferenceEntity ref = new ParameterContextReferenceEntity();
+                    ref.setId(inherited.getIdentifier());
+                    final ParameterContextReferenceDTO refDto = new ParameterContextReferenceDTO();
+                    refDto.setId(inherited.getIdentifier());
+                    refDto.setName(inherited.getName());
+                    ref.setComponent(refDto);
+                    return ref;
+                })
+                .toList());
+        return dto;
     }
 
     private ParameterContextDTO createParameterContextDto(final ParameterEntity... parameterEntities) {

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/parameters/ParameterContextIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/parameters/ParameterContextIT.java
@@ -1311,6 +1311,75 @@ public class ParameterContextIT extends NiFiSystemIT {
         waitForStoppedProcessor(ingest.getId());
     }
 
+    @Test
+    public void testSubsequentInheritanceReorderUpdatesEffectiveParameterValues() throws NiFiClientException, IOException, InterruptedException {
+        final String parameterName = "test.parameter";
+        final ParameterContextEntity contextA = getClientUtil().createParameterContext(getTestName() + " A", Map.of(parameterName, "VALUE_A"));
+        final ParameterContextEntity contextB = getClientUtil().createParameterContext(getTestName() + " B", Map.of(parameterName, "VALUE_B"));
+        ParameterContextEntity contextC = getClientUtil().createParameterContext(getTestName() + " C", Map.of(), List.of(contextA.getId(), contextB.getId()), null);
+
+        assertEffectiveParameter(contextC.getId(), parameterName, "VALUE_A", contextA.getId());
+        assertNoLocalParameter(contextC.getId(), parameterName);
+
+        contextC = updateInheritedParameterContexts(contextC, List.of(contextB.getId(), contextA.getId()));
+        assertEffectiveParameter(contextC.getId(), parameterName, "VALUE_B", contextB.getId());
+        assertNoLocalParameter(contextC.getId(), parameterName);
+
+        updateInheritedParameterContexts(contextC, List.of(contextA.getId(), contextB.getId()));
+        assertEffectiveParameter(contextC.getId(), parameterName, "VALUE_A", contextA.getId());
+        assertNoLocalParameter(contextC.getId(), parameterName);
+    }
+
+    @Test
+    public void testSubsequentInheritanceAddRemoveUpdatesEffectiveParameterValues() throws NiFiClientException, IOException, InterruptedException {
+        final String parameterName = "test.parameter";
+        final ParameterContextEntity contextA = getClientUtil().createParameterContext(getTestName() + " A", Map.of(parameterName, "VALUE_A"));
+        final ParameterContextEntity contextB = getClientUtil().createParameterContext(getTestName() + " B", Map.of(parameterName, "VALUE_B"));
+        ParameterContextEntity contextC = getClientUtil().createParameterContext(getTestName() + " C", Map.of(), List.of(contextB.getId()), null);
+
+        assertEffectiveParameter(contextC.getId(), parameterName, "VALUE_B", contextB.getId());
+
+        contextC = updateInheritedParameterContexts(contextC, List.of(contextA.getId(), contextB.getId()));
+        assertEffectiveParameter(contextC.getId(), parameterName, "VALUE_A", contextA.getId());
+        assertNoLocalParameter(contextC.getId(), parameterName);
+
+        updateInheritedParameterContexts(contextC, List.of(contextB.getId()));
+        assertEffectiveParameter(contextC.getId(), parameterName, "VALUE_B", contextB.getId());
+        assertNoLocalParameter(contextC.getId(), parameterName);
+    }
+
+    private ParameterContextEntity updateInheritedParameterContexts(final ParameterContextEntity existing, final List<String> inheritedContextIds)
+            throws NiFiClientException, IOException, InterruptedException {
+        final ParameterContextEntity current = getNifiClient().getParamContextClient().getParamContext(existing.getId(), true);
+        final ParameterContextUpdateRequestEntity updateRequest = getClientUtil().updateParameterContext(current, Map.of(), inheritedContextIds);
+        getClientUtil().waitForParameterContextRequestToComplete(existing.getId(), updateRequest.getRequest().getRequestId());
+        return getNifiClient().getParamContextClient().getParamContext(existing.getId(), true);
+    }
+
+    private void assertEffectiveParameter(final String contextId, final String parameterName, final String expectedValue, final String expectedSourceContextId)
+            throws NiFiClientException, IOException {
+        final ParameterDTO parameter = getNifiClient().getParamContextClient().getParamContext(contextId, true)
+                .getComponent()
+                .getParameters()
+                .stream()
+                .map(ParameterEntity::getParameter)
+                .filter(dto -> parameterName.equals(dto.getName()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(parameter);
+        assertEquals(expectedValue, parameter.getValue());
+        assertSame(Boolean.TRUE, parameter.getInherited());
+        assertEquals(expectedSourceContextId, parameter.getParameterContext().getId());
+    }
+
+    private void assertNoLocalParameter(final String contextId, final String parameterName) throws NiFiClientException, IOException {
+        assertTrue(getNifiClient().getParamContextClient().getParamContext(contextId, false)
+                .getComponent()
+                .getParameters()
+                .stream()
+                .noneMatch(parameter -> parameterName.equals(parameter.getParameter().getName())));
+    }
+
     private Map<String, Long> waitForCounter(final String context, final String counterName, final long expectedValue) throws NiFiClientException, IOException, InterruptedException {
         return getClientUtil().waitForCounter(context, counterName, expectedValue);
     }


### PR DESCRIPTION
# Summary

[NIFI-16326](https://issues.apache.org/jira/browse/NIFI-16326) Subsequent Parameter Context inheritance changes do not update effective parameter values.

The first inheritance change on a Parameter Context (reorder, add, or remove) updates effective values as expected. Later inheritance changes update the configured inheritance list, but NiFi continues using the value that became effective after the first change. Process Groups and components bound to that context see the same stale value.

This happens because Parameter Context update analysis injects effective inherited Parameter DTOs into the request so referencing components can be identified. Those DTOs were persisted as local Parameters whenever `inherited` was not explicitly `true`. A local Parameter then shadows inheritance, so later reorders and add/remove operations cannot change the effective value.

`StandardParameterContextDAO.getParameters()` now omits inherited Parameters from local persistence when:

- `inherited` is `true`, or
- `inherited` is unset and the Parameter's source context is not the context being updated

An explicit local override (`inherited=false`) is still accepted.

Coverage includes unit tests for repeated reorder and add/remove on `StandardParameterContext`, DAO tests for injected effective Parameters with and without the `inherited` flag, and system tests that replay the Jira reproduction through the REST update API.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-16326) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] `./mvnw -P contrib-check -DskipTests package` completed on the changed modules and their reactor dependencies (JDK 21)
  - [x] JDK 21
  - [ ] JDK 25
- Unit tests: `TestStandardParameterContext` (inheritance reorder/add-remove), `TestStandardParameterContextDAO` (11 tests)

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files