### PR TITLE
NIFI-16328 - Bump GCP to 26.88.0, Kotlin to 2.4.20, jGit to 7.8.0, and others

### DIFF
--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.87.0</google.libraries.version>
+        <google.libraries.version>26.88.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-graph-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <gremlin.version>3.8.1</gremlin.version>
+        <gremlin.version>3.8.2</gremlin.version>
     </properties>
 
     <modules>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -39,7 +39,7 @@
         <flyway.version>13.5.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
-        <jgit.version>7.7.1.202607240634-r</jgit.version>
+        <jgit.version>7.8.0.202609011348-r</jgit.version>
         <h2.version>2.5.250</h2.version>
     </properties>
     <dependencyManagement>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <jline.version>4.4.2</jline.version>
+        <jline.version>4.4.3</jline.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <nifi.nar.maven.plugin.version>2.4.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.54.13</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.54.14</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.2</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.8</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 
@@ -166,7 +166,7 @@
         <!-- JVM languages and bytecode -->
         <aspectj.version>1.9.25.1</aspectj.version>
         <groovy.version>5.1.2</groovy.version>
-        <kotlin.version>2.4.10</kotlin.version>
+        <kotlin.version>2.4.20</kotlin.version>
 
         <!-- Logging and observability -->
         <log4j2.version>2.26.1</log4j2.version>


### PR DESCRIPTION
# Summary

NIFI-16328 - Bump GCP to 26.88.0, Kotlin to 2.4.20, jGit to 7.8.0, and others

- GCP BOM from 26.87.0 to 26.88.0 - https://github.com/googleapis/google-cloud-java/releases#release-libraries-bom/v26.88.0
- Apache Tinkerpop from 3.8.1 to 3.8.2 - https://github.com/apache/tinkerpop/releases/tag/3.8.2
- jGit from 7.7.1.202607240634-r to 7.8.0.202609011348-r - https://github.com/eclipse-jgit/jgit/releases/tag/v7.8.0.202609011348-r
- JLine from 4.4.2 to 4.4.3 - https://github.com/jline/jline3/releases/tag/4.4.3
- AWS SDK from 2.54.13 to 2.54.14 - https://github.com/aws/aws-sdk-java-v2/releases/tag/2.54.14
- Kotlin from 2.4.10 to 2.4.20 - https://github.com/JetBrains/kotlin/releases/tag/v2.4.20

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
