### PR TITLE
NIFI-16332 Fixed duplicate Content-Type header on replicated upload requests

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/StandardUploadRequestReplicator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/StandardUploadRequestReplicator.java
@@ -176,7 +176,8 @@ public class StandardUploadRequestReplicator implements UploadRequestReplicator 
      *   <li>Start with any forwarded inbound servlet headers.</li>
      *   <li>Strip all {@link RequestReplicationHeader} names (prevent spoofing).</li>
      *   <li>Strip hop-by-hop / transport-framing headers.</li>
-     *   <li>Apply explicit builder headers (filename, content-type, seed) so upload metadata wins.</li>
+     *   <li>Apply explicit builder headers (filename, content-type, seed) case-insensitively so upload
+     *       metadata wins without leaving a differently-cased inbound duplicate.</li>
      *   <li>Apply user proxy headers and strip credentials (Authorization, auth cookies, Host).</li>
      *   <li>Force-set {@code request-replicated} and {@code execution-continue}.</li>
      * </ol>
@@ -187,7 +188,16 @@ public class StandardUploadRequestReplicator implements UploadRequestReplicator 
         ReplicationHeaderUtils.stripRequestReplicationHeaders(headers);
         ReplicationHeaderUtils.stripHopByHopHeaders(headers);
 
-        headers.putAll(uploadRequest.getHeaders());
+        // Apply explicit builder headers case-insensitively. Inbound header names can arrive in a variety of lower-
+        // and upper-case variations, which we only have limited control over.
+        // So a plain putAll into the case-sensitive header map would risk keeping duplicated headers that only differ
+        // in the capitalization.
+        // In the case of "Content-Type" this can create actual issues, because requests with a duplicate default header
+        // have to be considered malformed and are rejected with http  400.
+        for (final Map.Entry<String, String> builderHeader : uploadRequest.getHeaders().entrySet()) {
+            headers.keySet().removeIf(builderHeader.getKey()::equalsIgnoreCase);
+            headers.put(builderHeader.getKey(), builderHeader.getValue());
+        }
 
         ReplicationHeaderUtils.applyUserProxyAndStripCredentials(headers, uploadRequest.getUser());
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestStandardUploadRequestReplicatorHeaders.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/TestStandardUploadRequestReplicatorHeaders.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -179,6 +180,93 @@ class TestStandardUploadRequestReplicatorHeaders {
 
         final Map<String, String> result = replicator.buildOutboundHeaders(request);
         assertEquals("explicit-name.txt", result.get(FILENAME_HEADER));
+    }
+
+    @Test
+    void testForwardedContentTypeCaseVariantCollapsesToSingleHeader() {
+        // Regression for the NAR upload 400 in cluster mode: HTTP/2 (and Envoy) lowercase header names,
+        // so the forwarded inbound header arrives as "content-type" while the builder adds "Content-Type".
+        // Without case-insensitive merging both survive in the outbound request, and a duplicate singleton
+        // field such as Content-Type is rejected by the receiving node with 400.
+        final Map<String, String> forwarded = new HashMap<>();
+        forwarded.put("content-type", CONTENT_TYPE_VALUE);
+
+        final UploadRequest<String> request = buildUploadRequest(forwarded);
+        final Map<String, String> result = replicator.buildOutboundHeaders(request);
+
+        final List<String> contentTypeKeys = result.keySet().stream()
+                .filter(CONTENT_TYPE_HEADER::equalsIgnoreCase)
+                .toList();
+        assertEquals(List.of(CONTENT_TYPE_HEADER), contentTypeKeys,
+                "Expected a single Content-Type header, but got: " + result.keySet());
+        assertEquals(CONTENT_TYPE_VALUE, result.get(CONTENT_TYPE_HEADER));
+    }
+
+    @Test
+    void testMultipleForwardedContentTypeCaseVariantsAllCollapseToSingleHeader() {
+        // Defensive: a single servlet request cannot deliver multiple case-variants of one header
+        // (the container collapses them), but buildOutboundHeaders must still remove every inbound
+        // case-variant, not just the first, so a differently-cased builder header cannot leave strays.
+        final Map<String, String> forwarded = new HashMap<>();
+        forwarded.put("content-type", CONTENT_TYPE_VALUE);
+        forwarded.put("Content-TYPE", CONTENT_TYPE_VALUE);
+        forwarded.put("CONTENT-type", CONTENT_TYPE_VALUE);
+
+        final UploadRequest<String> request = buildUploadRequest(forwarded);
+        final Map<String, String> result = replicator.buildOutboundHeaders(request);
+
+        final List<String> contentTypeKeys = result.keySet().stream()
+                .filter(CONTENT_TYPE_HEADER::equalsIgnoreCase)
+                .toList();
+        assertEquals(List.of(CONTENT_TYPE_HEADER), contentTypeKeys,
+                "Expected a single Content-Type header, but got: " + result.keySet());
+        assertEquals(CONTENT_TYPE_VALUE, result.get(CONTENT_TYPE_HEADER));
+    }
+
+    @Test
+    void testUnrelatedForwardedHeadersUntouchedWhileCollisionCollapses() {
+        // The case-insensitive removal must be scoped to the builder's own header names: a Content-Type
+        // collision collapses to one, while unrelated forwarded headers pass through verbatim - exact key
+        // case preserved and value unchanged.
+        final Map<String, String> forwarded = new HashMap<>();
+        forwarded.put("content-type", CONTENT_TYPE_VALUE);   // collides with builder "Content-Type"
+        forwarded.put("Content-TYPE", CONTENT_TYPE_VALUE);   // a second variant
+        forwarded.put(CUSTOM_HEADER, CUSTOM_HEADER_VALUE);   // unrelated, mixed case
+        forwarded.put(CUSTOM_TOKEN_HEADER, CUSTOM_TOKEN_VALUE);
+
+        final UploadRequest<String> request = buildUploadRequest(forwarded);
+        final Map<String, String> result = replicator.buildOutboundHeaders(request);
+
+        // Content-Type collapses to a single canonical entry with the builder's value.
+        final List<String> contentTypeKeys = result.keySet().stream()
+                .filter(CONTENT_TYPE_HEADER::equalsIgnoreCase)
+                .toList();
+        assertEquals(List.of(CONTENT_TYPE_HEADER), contentTypeKeys,
+                "Expected a single Content-Type header, but got: " + result.keySet());
+        assertEquals(CONTENT_TYPE_VALUE, result.get(CONTENT_TYPE_HEADER));
+
+        // Unrelated forwarded headers are untouched: exact key case preserved and value unchanged.
+        assertTrue(result.containsKey(CUSTOM_HEADER));
+        assertEquals(CUSTOM_HEADER_VALUE, result.get(CUSTOM_HEADER));
+        assertTrue(result.containsKey(CUSTOM_TOKEN_HEADER));
+        assertEquals(CUSTOM_TOKEN_VALUE, result.get(CUSTOM_TOKEN_HEADER));
+    }
+
+    @Test
+    void testLowercaseForwardedFilenameCollapsesToSingleCanonicalHeader() {
+        // Same case-collision guard for the Filename header (lowercased inbound + canonical builder header).
+        final Map<String, String> forwarded = new HashMap<>();
+        forwarded.put("filename", "forwarded-name.txt");
+
+        final UploadRequest<String> request = buildUploadRequest(forwarded);
+        final Map<String, String> result = replicator.buildOutboundHeaders(request);
+
+        final List<String> filenameKeys = result.keySet().stream()
+                .filter(FILENAME_HEADER::equalsIgnoreCase)
+                .toList();
+        assertEquals(List.of(FILENAME_HEADER), filenameKeys,
+                "Expected a single, canonically-cased Filename header, but got: " + result.keySet());
+        assertEquals(TEST_FILENAME, result.get(FILENAME_HEADER));
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-16332](https://issues.apache.org/jira/browse/NIFI-16332)

Upload replication (NIFI-15784) forwards inbound request headers and then adds an explicit Content-Type into a case-sensitive HashMap. When the inbound request carried a differently-cased name (e.g. lowercase "content-type" over HTTP/2 or via a gateway), both variants survived and the replicated request was sent with a duplicate Content-Type, which the receiving node rejects with 400 Bad Request.

Before applying each explicit builder header, remove every inbound case-variant of that header name so the builder's header replaces them rather than joining them. The header casing is left unchanged. Adds regression tests covering the case-variant collision for Content-Type and Filename, multiple simultaneous variants, and that unrelated forwarded headers are passed through untouched.

I considered using `ReplicationHeaderUtils.removeHeader` for removing the headers because it exists and is intended for this operation, but the current code makes it more obvious that we remove case insensitive, plus it has the benefit of also removing duplicate entries, not just the first matching one. 
This should not be relevant, as duplicate headers are caught upstream of us in the server component, but it also doesn't hurt I daresay. Happy to refactor to use  `ReplicationHeaderUtils.removeHeader` if that is preferred.


I decided against normalizing the header to `content-type` as stated in the issue, because all other headers are uppercase and I didn't want to make Content-Type be the odd one out. 
At some point we might consider making this a broader change, but it effectively doesn't matter, as that is handled in downstream http client code anyway.

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [X] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [X] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
