### PR TITLE
NIFI-14126 Remove unstable TestPutUDP.testSendChangePropertiesAndSend

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutUDP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutUDP.java
@@ -114,30 +114,6 @@ public class TestPutUDP {
                         + PutUDP.MAX_IPV4_UDP_PAYLOAD_LENGTH)));
     }
 
-    @Test
-    public void testSendChangePropertiesAndSend() throws Exception {
-        configureProperties();
-        sendMessages(VALID_FILES);
-        assertMessagesReceived(VALID_FILES);
-        reset();
-
-        configureProperties();
-        sendMessages(VALID_FILES);
-        assertMessagesReceived(VALID_FILES);
-        reset();
-
-        configureProperties();
-        sendMessages(VALID_FILES);
-        assertMessagesReceived(VALID_FILES);
-        runner.assertQueueEmpty();
-    }
-
-    private void reset() throws Exception {
-        runner.clearTransferState();
-        removeTestServer();
-        createTestServer(MAX_FRAME_LENGTH);
-    }
-
     private void configureProperties() {
         runner.setProperty(PutUDP.HOSTNAME, UDP_SERVER_ADDRESS);
         runner.setProperty(PutUDP.PORT, Integer.toString(port));


### PR DESCRIPTION
# Summary

[NIFI-14126](https://issues.apache.org/jira/browse/NIFI-14126) Removes the unstable method `TestPutUDP.testSendChangePropertiesAndSend`. Now that `PutUDP` is deprecated for removal, this test method has little value and should be removed.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`
- Pull request contains [commits signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) with a registered key indicating `Verified` status

### Pull Request Formatting

- Pull Request based on current revision of the `main` branch
- Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21
  - [ ] JDK 25

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
